### PR TITLE
Fix claim-vs-implementation gaps from feature audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # zcli
 
-A batteries-included framework for building command-line interfaces in Zig. Drop `.zig` files in a directory and get a fully-featured CLI — help text, completions, error suggestions, interactive prompts, progress bars, and documentation — all generated at compile time with zero runtime overhead.
+A batteries-included framework for building command-line interfaces in Zig. Drop `.zig` files in a directory and get a fully-featured CLI — help text, completions, error suggestions, interactive prompts, progress bars, and documentation — with command discovery and routing wired up at compile time for zero-cost dispatch.
 
 ## Features
 
@@ -13,7 +13,7 @@ A batteries-included framework for building command-line interfaces in Zig. Drop
 - Theming with semantic colors that adapt to terminal capabilities.
 - Documentation generation — markdown, man pages, and HTML from command metadata.
 - Plugin system with lifecycle hooks, global options, and build-time configuration.
-- Zero runtime overhead — commands discovered at build time, all routing resolved at comptime.
+- Zero-cost dispatch — commands are discovered and routing is generated at build time (no reflection or runtime filesystem scanning). Argument parsing is type-checked via comptime introspection and runs at invocation.
 
 ```zig
 // src/commands/deploy.zig

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -4,7 +4,7 @@ This document explains how zcli's build-time code generation works, covering com
 
 ## Overview
 
-zcli achieves zero runtime overhead by discovering commands and plugins, then generating dispatch code at build time. This eliminates the need for reflection, dynamic imports, or runtime file system scanning while providing a powerful plugin architecture.
+zcli achieves zero-cost dispatch by discovering commands and plugins, then generating routing code at build time. This eliminates the need for reflection, dynamic imports, or runtime file system scanning while providing a powerful plugin architecture. (Argument parsing for the matched command still runs at invocation, type-checked via comptime introspection.)
 
 ## Build Process Flow
 
@@ -443,4 +443,4 @@ const value = context.getGlobalData([]const u8, "key") orelse "default";
    - Check memory management
    - Verify type compatibility
 
-This plugin-aware build system ensures zcli applications can be extended with powerful, type-safe plugins while maintaining zero runtime overhead.
+This plugin-aware build system ensures zcli applications can be extended with powerful, type-safe plugins while maintaining zero-cost dispatch.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -2,7 +2,7 @@
 
 ## Core Concept
 
-A Zig CLI framework that uses comptime introspection to automatically discover and wire commands based on folder structure, eliminating runtime overhead and providing type-safe command handling. The framework supports a plugin architecture for extensibility while maintaining zero runtime cost through compile-time code generation.
+A Zig CLI framework that uses comptime introspection to automatically discover and wire commands based on folder structure, eliminating dispatch overhead and providing type-safe command handling. The framework supports a plugin architecture for extensibility while keeping command discovery and routing entirely at compile time through code generation. (Argument parsing itself runs at invocation, type-checked via comptime introspection.)
 
 ## 1. Folder Structure & Command Mapping
 
@@ -768,11 +768,11 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
 
 ## 13. Developer Experience
 
-**Zero Runtime Overhead:**
+**Zero-Cost Dispatch:**
 
 - All discovery and wiring happens at compile time
-- Final binary has direct function calls
-- No reflection or dynamic dispatch
+- Final binary has direct function calls — no reflection, no runtime filesystem scan
+- No dynamic dispatch (argument parsing still runs at invocation)
 
 **Type Safety:**
 
@@ -786,4 +786,4 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
 - Mock context for isolated testing
 - Integration test helpers
 
-This design leverages Zig's unique comptime capabilities to create a framework that's both developer-friendly (automatic discovery, type safety) and extremely efficient (zero runtime overhead, static dispatch).
+This design leverages Zig's unique comptime capabilities to create a framework that's both developer-friendly (automatic discovery, type safety) and extremely efficient (zero-cost static dispatch, no reflection).

--- a/examples/showcase/build.zig
+++ b/examples/showcase/build.zig
@@ -6,6 +6,7 @@ pub fn build(b: *std.Build) void {
 
     const zcli_dep = b.dependency("zcli", .{ .target = target, .optimize = optimize });
     const zcli_module = zcli_dep.module("zcli");
+    const ztheme_module = zcli_dep.module("ztheme");
 
     // Shared store module for JSON persistence
     const store_module = b.createModule(.{
@@ -13,6 +14,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    store_module.addImport("ztheme", ztheme_module);
 
     const exe = b.addExecutable(.{
         .name = "tasks",

--- a/examples/showcase/src/commands/add.zig
+++ b/examples/showcase/src/commands/add.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const zcli = @import("zcli");
 const store = @import("store");
 const zinput = zcli.zinput;
+const ztheme = zcli.ztheme;
 
 pub const meta = .{
     .description = "Add a new task",
@@ -92,5 +93,6 @@ pub fn execute(args: Args, options: Options, context: anytype) !void {
     data.next_id += 1;
     try store.save(allocator, data);
 
-    try context.stdout().print("\x1b[32m✔\x1b[0m Added task #{d}: {s}\n", .{ new_task.id, title });
+    try ztheme.theme("✔").success().render(context.stdout(), &context.theme);
+    try context.stdout().print(" Added task #{d}: {s}\n", .{ new_task.id, title });
 }

--- a/examples/showcase/src/commands/config.zig
+++ b/examples/showcase/src/commands/config.zig
@@ -1,14 +1,33 @@
 const std = @import("std");
 const zcli = @import("zcli");
 const zinput = zcli.zinput;
+const ztheme = zcli.ztheme;
 
 pub const meta = .{
-    .description = "Configure task tracker settings",
+    .description = "Configure task tracker defaults",
     .examples = &.{"config"},
 };
 
 pub const Args = struct {};
 pub const Options = struct {};
+
+/// The file the `zcli_config` plugin reads to seed command-option defaults.
+const CONFIG_FILE = ".tasks.config.json";
+
+/// Mirrors the showcase config schema. `add` and `list` are command-scoped:
+/// the zcli_config plugin applies them as defaults for `tasks add` / `tasks list`.
+const Config = struct {
+    output: []const u8 = "text",
+    add: struct {
+        priority: []const u8 = "medium",
+        points: u32 = 1,
+    } = .{},
+    list: struct {
+        all: bool = false,
+    } = .{},
+};
+
+const priorities = [_][]const u8{ "low", "medium", "high", "critical" };
 
 pub fn execute(_: Args, _: Options, context: anytype) !void {
     const allocator = context.allocator;
@@ -17,34 +36,58 @@ pub fn execute(_: Args, _: Options, context: anytype) !void {
     var stdin_reader = std.fs.File.stdin().reader(&.{});
     const reader = &stdin_reader.interface;
 
-    try writer.writeAll("\r\n  \x1b[1mSettings\x1b[0m\r\n\r\n");
+    // Load the current config so prompts can show existing values as defaults.
+    // Keep `parsed` alive until after we write, so its strings stay valid.
+    var parsed: ?std.json.Parsed(Config) = null;
+    defer if (parsed) |p| p.deinit();
+    var current = Config{};
+    if (std.fs.cwd().readFileAlloc(allocator, CONFIG_FILE, 1024 * 1024)) |content| {
+        defer allocator.free(content);
+        if (std.json.parseFromSlice(Config, allocator, content, .{
+            .allocate = .alloc_always,
+            .ignore_unknown_fields = true,
+        })) |p| {
+            parsed = p;
+            current = p.value;
+        } else |_| {}
+    } else |_| {}
+
+    try writer.writeAll("\r\n  ");
+    try ztheme.theme("Settings").bold().render(writer, &context.theme);
+    try writer.writeAll("\r\n\r\n");
 
     const priority_idx = try zinput.select(writer, reader, .{
-        .message = "Default priority:",
-        .choices = &.{ "low", "medium", "high", "critical" },
+        .message = "Default priority for new tasks:",
+        .choices = &priorities,
     });
-    _ = priority_idx;
 
     const points = try zinput.number(writer, reader, .{
         .message = "Default story points:",
-        .default = 1,
+        .default = current.add.points,
         .min = 0,
         .max = 100,
     });
-    _ = points;
 
-    const wants_api = try zinput.confirm(writer, reader, .{
-        .message = "Configure API integration?",
-        .default = false,
+    const show_done = try zinput.confirm(writer, reader, .{
+        .message = "Show completed tasks in 'list' by default?",
+        .default = current.list.all,
     });
 
-    if (wants_api) {
-        const token = try zinput.password(writer, reader, allocator, .{
-            .message = "API token:",
-        });
-        defer allocator.free(token);
-        try writer.writeAll("  \x1b[32m✔\x1b[0m Token saved\r\n");
-    }
+    const new_config = Config{
+        .output = current.output, // preserve existing global setting
+        .add = .{ .priority = priorities[priority_idx], .points = @intCast(points) },
+        .list = .{ .all = show_done },
+    };
 
-    try writer.writeAll("\r\n  \x1b[32m✔ Settings updated\x1b[0m\r\n\r\n");
+    const file = try std.fs.cwd().createFile(CONFIG_FILE, .{});
+    defer file.close();
+    var file_writer = file.writer(&.{});
+    try file_writer.interface.print("{f}", .{std.json.fmt(new_config, .{ .whitespace = .indent_2 })});
+
+    try writer.writeAll("\r\n  ");
+    try ztheme.theme("✔ Saved to ").success().render(writer, &context.theme);
+    try ztheme.theme(CONFIG_FILE).path().render(writer, &context.theme);
+    try writer.writeAll("\r\n  ");
+    try ztheme.theme("These defaults now apply to 'tasks add' and 'tasks list'.").dim().render(writer, &context.theme);
+    try writer.writeAll("\r\n\r\n");
 }

--- a/examples/showcase/src/commands/done.zig
+++ b/examples/showcase/src/commands/done.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const zcli = @import("zcli");
 const store = @import("store");
+const ztheme = zcli.ztheme;
 
 pub const meta = .{
     .description = "Mark a task as complete",
@@ -21,7 +22,8 @@ pub fn execute(args: Args, _: Options, context: anytype) !void {
         if (task.id == args.id) {
             task.status = .done;
             try store.save(allocator, data);
-            try context.stdout().print("\x1b[32m✔\x1b[0m Task #{d} marked as done: {s}\n", .{ task.id, task.title });
+            try ztheme.theme("✔").success().render(context.stdout(), &context.theme);
+            try context.stdout().print(" Task #{d} marked as done: {s}\n", .{ task.id, task.title });
             return;
         }
     }

--- a/examples/showcase/src/commands/edit.zig
+++ b/examples/showcase/src/commands/edit.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const zcli = @import("zcli");
 const store = @import("store");
 const zinput = zcli.zinput;
+const ztheme = zcli.ztheme;
 
 pub const meta = .{
     .description = "Edit a task description in your editor",
@@ -39,7 +40,8 @@ pub fn execute(args: Args, _: Options, context: anytype) !void {
 
             task.description = content;
             try store.save(allocator, data);
-            try context.stdout().print("\x1b[32m✔\x1b[0m Updated task #{d}\n", .{task.id});
+            try ztheme.theme("✔").success().render(context.stdout(), &context.theme);
+            try context.stdout().print(" Updated task #{d}\n", .{task.id});
             return;
         }
     }

--- a/examples/showcase/src/commands/import.zig
+++ b/examples/showcase/src/commands/import.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const zcli = @import("zcli");
 const store = @import("store");
 const zprogress = zcli.zprogress;
+const ztheme = zcli.ztheme;
 
 pub const meta = .{
     .description = "Import tasks from a JSON file",
@@ -58,5 +59,6 @@ pub fn execute(args: Args, _: Options, context: anytype) !void {
     data.tasks = tasks_list.items;
     try store.save(allocator, data);
 
-    try context.stdout().print("\x1b[32m✔\x1b[0m Imported {d} tasks from {s}\n", .{ imported.value.tasks.len, args.file });
+    try ztheme.theme("✔").success().render(context.stdout(), &context.theme);
+    try context.stdout().print(" Imported {d} tasks from {s}\n", .{ imported.value.tasks.len, args.file });
 }

--- a/examples/showcase/src/commands/init.zig
+++ b/examples/showcase/src/commands/init.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const zcli = @import("zcli");
 const store = @import("store");
 const zinput = zcli.zinput;
+const ztheme = zcli.ztheme;
 
 pub const meta = .{
     .description = "Initialize a new task tracker project",
@@ -24,7 +25,9 @@ pub fn execute(_: Args, _: Options, context: anytype) !void {
         return;
     } else |_| {}
 
-    try writer.writeAll("\r\n  \x1b[1mProject Setup\x1b[0m\r\n\r\n");
+    try writer.writeAll("\r\n  ");
+    try ztheme.theme("Project Setup").bold().render(writer, &context.theme);
+    try writer.writeAll("\r\n\r\n");
 
     const name = try zinput.text(writer, reader, allocator, .{
         .message = "Project name:",
@@ -64,5 +67,7 @@ pub fn execute(_: Args, _: Options, context: anytype) !void {
 
     try store.save(allocator, data);
 
-    try writer.writeAll("\r\n  \x1b[32m✔ Project initialized!\x1b[0m\r\n\r\n");
+    try writer.writeAll("\r\n  ");
+    try ztheme.theme("✔ Project initialized!").success().render(writer, &context.theme);
+    try writer.writeAll("\r\n\r\n");
 }

--- a/examples/showcase/src/commands/list.zig
+++ b/examples/showcase/src/commands/list.zig
@@ -1,5 +1,7 @@
 const std = @import("std");
+const zcli = @import("zcli");
 const store = @import("store");
+const ztheme = zcli.ztheme;
 
 pub const meta = .{
     .description = "List all tasks",
@@ -31,10 +33,16 @@ pub fn execute(_: Args, options: Options, context: anytype) !void {
 
     const status_filter: ?store.Status = if (options.status) |s| store.statusFromString(s) else null;
 
-    try context.stdout().writeAll("\n");
-    try context.stdout().print("  \x1b[1m{s}\x1b[0m\n\n", .{data.name});
-    try context.stdout().writeAll("  \x1b[2mID   Status        Priority  Title\x1b[0m\n");
-    try context.stdout().writeAll("  \x1b[2m───  ────────────  ────────  ─────────────────────────\x1b[0m\n");
+    const w = context.stdout();
+    const theme = &context.theme;
+
+    try w.writeAll("\n  ");
+    try ztheme.theme(data.name).bold().render(w, theme);
+    try w.writeAll("\n\n  ");
+    try ztheme.theme("ID   Status        Priority  Title").dim().render(w, theme);
+    try w.writeAll("\n  ");
+    try ztheme.theme("───  ────────────  ────────  ─────────────────────────").dim().render(w, theme);
+    try w.writeAll("\n");
 
     var shown: usize = 0;
     for (data.tasks) |task| {
@@ -44,29 +52,28 @@ pub fn execute(_: Args, options: Options, context: anytype) !void {
             continue;
         }
 
-        // Use plain labels with fixed widths, apply color around them
-        const pri_color: []const u8 = switch (task.priority) {
-            .low => "\x1b[2m",
-            .medium => "",
-            .high => "\x1b[33m",
-            .critical => "\x1b[31m",
-        };
-        const pri_reset: []const u8 = if (pri_color.len > 0) "\x1b[0m" else "";
-        try context.stdout().print("  {s}{d:<3}\x1b[0m  {s}{s:<12}\x1b[0m  {s}{s:<8}{s}  {s}\n", .{
-            task.status.color(),
-            task.id,
-            task.status.color(),
-            task.status.label(),
-            pri_color,
-            task.priority.label(),
-            pri_reset,
-            task.title,
-        });
+        // Pad each cell to a fixed width, then apply the semantic color.
+        var id_buf: [16]u8 = undefined;
+        var status_buf: [16]u8 = undefined;
+        var pri_buf: [16]u8 = undefined;
+        const id_cell = try std.fmt.bufPrint(&id_buf, "{d:<3}", .{task.id});
+        const status_cell = try std.fmt.bufPrint(&status_buf, "{s:<12}", .{task.status.label()});
+        const pri_cell = try std.fmt.bufPrint(&pri_buf, "{s:<8}", .{task.priority.label()});
+
+        try w.writeAll("  ");
+        try task.status.themed(id_cell).render(w, theme);
+        try w.writeAll("  ");
+        try task.status.themed(status_cell).render(w, theme);
+        try w.writeAll("  ");
+        try task.priority.themed(pri_cell).render(w, theme);
+        try w.print("  {s}\n", .{task.title});
         shown += 1;
     }
 
     if (shown == 0) {
-        try context.stdout().writeAll("  \x1b[2mNo matching tasks.\x1b[0m\n");
+        try w.writeAll("  ");
+        try ztheme.theme("No matching tasks.").dim().render(w, theme);
+        try w.writeAll("\n");
     }
-    try context.stdout().writeAll("\n");
+    try w.writeAll("\n");
 }

--- a/examples/showcase/src/commands/remove.zig
+++ b/examples/showcase/src/commands/remove.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const zcli = @import("zcli");
 const store = @import("store");
 const zinput = zcli.zinput;
+const ztheme = zcli.ztheme;
 
 pub const meta = .{
     .description = "Remove a task",
@@ -51,5 +52,6 @@ pub fn execute(args: Args, _: Options, context: anytype) !void {
     data.tasks = remaining.items;
     try store.save(allocator, data);
 
-    try context.stdout().print("\x1b[31m✖\x1b[0m Removed task #{d}\n", .{args.id});
+    try ztheme.theme("✖").err().render(context.stdout(), &context.theme);
+    try context.stdout().print(" Removed task #{d}\n", .{args.id});
 }

--- a/examples/showcase/src/commands/search.zig
+++ b/examples/showcase/src/commands/search.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const zcli = @import("zcli");
 const store = @import("store");
 const zinput = zcli.zinput;
+const ztheme = zcli.ztheme;
 
 pub const meta = .{
     .description = "Search tasks by title",
@@ -43,6 +44,14 @@ pub fn execute(_: Args, _: Options, context: anytype) !void {
 
     const task = data.tasks[idx];
     const w = context.stdout();
-    try w.print("\n  \x1b[1mTask #{d}\x1b[0m — {s}\n", .{ task.id, task.title });
-    try w.print("  Status: {s}{s}\x1b[0m  Priority: {s}\n\n", .{ task.status.color(), task.status.label(), task.priority.badge() });
+    const theme = &context.theme;
+    var head_buf: [32]u8 = undefined;
+    const head = try std.fmt.bufPrint(&head_buf, "Task #{d}", .{task.id});
+    try w.writeAll("\n  ");
+    try ztheme.theme(head).bold().render(w, theme);
+    try w.print(" — {s}\n  Status: ", .{task.title});
+    try task.status.themed(task.status.label()).render(w, theme);
+    try w.writeAll("  Priority: ");
+    try task.priority.themed(task.priority.label()).render(w, theme);
+    try w.writeAll("\n\n");
 }

--- a/examples/showcase/src/commands/show.zig
+++ b/examples/showcase/src/commands/show.zig
@@ -1,5 +1,7 @@
 const std = @import("std");
+const zcli = @import("zcli");
 const store = @import("store");
+const ztheme = zcli.ztheme;
 
 pub const meta = .{
     .description = "Show task details",
@@ -21,11 +23,18 @@ pub fn execute(args: Args, _: Options, context: anytype) !void {
     };
 
     const w = context.stdout();
-    try w.writeAll("\n");
-    try w.print("  \x1b[1mTask #{d}\x1b[0m\n\n", .{task.id});
+    const theme = &context.theme;
+    var head_buf: [32]u8 = undefined;
+    const head = try std.fmt.bufPrint(&head_buf, "Task #{d}", .{task.id});
+    try w.writeAll("\n  ");
+    try ztheme.theme(head).bold().render(w, theme);
+    try w.writeAll("\n\n");
     try w.print("  Title:    {s}\n", .{task.title});
-    try w.print("  Status:   {s}{s}\x1b[0m\n", .{ task.status.color(), task.status.label() });
-    try w.print("  Priority: {s}\n", .{task.priority.badge()});
+    try w.writeAll("  Status:   ");
+    try task.status.themed(task.status.label()).render(w, theme);
+    try w.writeAll("\n  Priority: ");
+    try task.priority.themed(task.priority.label()).render(w, theme);
+    try w.writeAll("\n");
     if (task.points) |pts| {
         try w.print("  Points:   {d}\n", .{pts});
     }

--- a/examples/showcase/src/commands/sprint/close.zig
+++ b/examples/showcase/src/commands/sprint/close.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const zcli = @import("zcli");
 const store = @import("store");
 const zinput = zcli.zinput;
+const ztheme = zcli.ztheme;
 
 pub const meta = .{
     .description = "Close a sprint",
@@ -42,5 +43,6 @@ pub fn execute(_: Args, _: Options, context: anytype) !void {
     data.sprints = remaining.items;
     try store.save(allocator, data);
 
-    try context.stdout().print("\x1b[32m✔\x1b[0m Closed sprint: {s}\n", .{name});
+    try ztheme.theme("✔").success().render(context.stdout(), &context.theme);
+    try context.stdout().print(" Closed sprint: {s}\n", .{name});
 }

--- a/examples/showcase/src/commands/sprint/create.zig
+++ b/examples/showcase/src/commands/sprint/create.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const zcli = @import("zcli");
 const store = @import("store");
 const zinput = zcli.zinput;
+const ztheme = zcli.ztheme;
 
 pub const meta = .{
     .description = "Create a new sprint",
@@ -38,5 +39,6 @@ pub fn execute(args: Args, _: Options, context: anytype) !void {
     data.sprints = sprints.items;
     try store.save(allocator, data);
 
-    try context.stdout().print("\x1b[32m✔\x1b[0m Created sprint: {s}\n", .{name});
+    try ztheme.theme("✔").success().render(context.stdout(), &context.theme);
+    try context.stdout().print(" Created sprint: {s}\n", .{name});
 }

--- a/examples/showcase/src/commands/sprint/list.zig
+++ b/examples/showcase/src/commands/sprint/list.zig
@@ -1,5 +1,7 @@
 const std = @import("std");
+const zcli = @import("zcli");
 const store = @import("store");
+const ztheme = zcli.ztheme;
 
 pub const meta = .{
     .description = "List all sprints",
@@ -19,7 +21,9 @@ pub fn execute(_: Args, _: Options, context: anytype) !void {
         return;
     }
 
-    try context.stdout().writeAll("\n  \x1b[1mSprints\x1b[0m\n\n");
+    try context.stdout().writeAll("\n  ");
+    try ztheme.theme("Sprints").bold().render(context.stdout(), &context.theme);
+    try context.stdout().writeAll("\n\n");
     for (parsed.value.sprints, 1..) |sprint, i| {
         try context.stdout().print("  {d}. {s}\n", .{ i, sprint });
     }

--- a/examples/showcase/src/store.zig
+++ b/examples/showcase/src/store.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const ztheme = @import("ztheme");
 
 pub const Status = enum {
     todo,
@@ -13,11 +14,13 @@ pub const Status = enum {
         };
     }
 
-    pub fn color(self: Status) []const u8 {
+    /// Wrap `text` in this status's semantic color. Render with
+    /// `.render(writer, &context.theme)` so it adapts to terminal capability.
+    pub fn themed(self: Status, text: []const u8) ztheme.Themed([]const u8) {
         return switch (self) {
-            .todo => "\x1b[37m",
-            .in_progress => "\x1b[33m",
-            .done => "\x1b[32m",
+            .todo => ztheme.theme(text).muted(),
+            .in_progress => ztheme.theme(text).warning(),
+            .done => ztheme.theme(text).success(),
         };
     }
 };
@@ -37,12 +40,13 @@ pub const Priority = enum {
         };
     }
 
-    pub fn badge(self: Priority) []const u8 {
+    /// Wrap `text` in this priority's semantic color (medium is left unstyled).
+    pub fn themed(self: Priority, text: []const u8) ztheme.Themed([]const u8) {
         return switch (self) {
-            .low => "\x1b[2mlow\x1b[0m",
-            .medium => "medium",
-            .high => "\x1b[33mhigh\x1b[0m",
-            .critical => "\x1b[31mcritical\x1b[0m",
+            .low => ztheme.theme(text).muted(),
+            .medium => ztheme.theme(text),
+            .high => ztheme.theme(text).warning(),
+            .critical => ztheme.theme(text).err(),
         };
     }
 };

--- a/packages/core/build.zig
+++ b/packages/core/build.zig
@@ -178,6 +178,34 @@ pub fn build(b: *std.Build) void {
         test_step.dependOn(&run_tests.step);
     }
 
+    // Feature-plugin tests that import plugin source directly and therefore need
+    // the "zcli" module. These run as part of the default `test` step.
+    const feature_plugin_test_files = [_][]const u8{
+        "src/plugin_completions_test.zig",
+        "src/plugin_github_upgrade_test.zig",
+    };
+    for (feature_plugin_test_files) |test_file| {
+        const test_mod = b.addModule(b.fmt("test-{s}", .{test_file}), .{
+            .root_source_file = b.path(test_file),
+            .target = target,
+            .optimize = optimize,
+        });
+        test_mod.addImport("zcli", zcli_module);
+        test_mod.addImport("ztheme", ztheme_dep.module("ztheme"));
+        test_mod.addImport("markdown_fmt", markdown_fmt_dep.module("markdown_fmt"));
+        test_mod.addImport("zprogress", zprogress_dep.module("zprogress"));
+        test_mod.addImport("zinput", zinput_dep.module("zinput"));
+        test_mod.addImport("vterm", vterm_dep.module("vterm"));
+        test_mod.addImport("yaml", yaml_dep.module("yaml"));
+        test_mod.addImport("toml", toml_dep.module("toml"));
+        const tests = b.addTest(.{
+            .root_module = test_mod,
+        });
+        const run_tests = b.addRunArtifact(tests);
+        test_plugins_step.dependOn(&run_tests.step);
+        test_step.dependOn(&run_tests.step);
+    }
+
     // Sequential test execution (separate from parallel execution above)
     // This creates a completely separate dependency chain for sequential execution
     const all_test_files = core_test_files ++ plugin_test_files ++ integration_test_files ++ security_test_files;

--- a/packages/core/src/plugin_completions_test.zig
+++ b/packages/core/src/plugin_completions_test.zig
@@ -1,0 +1,97 @@
+//! Tests for the zcli_completions shell-script generators (bash, zsh, fish).
+//! These exercise the pure `generate()` functions: feed sample command/option
+//! metadata in, assert the emitted script has the right structure and mentions
+//! every command and flag.
+
+const std = @import("std");
+const zcli = @import("zcli");
+
+const bash = @import("plugins/zcli_completions/bash.zig");
+const zsh = @import("plugins/zcli_completions/zsh.zig");
+const fish = @import("plugins/zcli_completions/fish.zig");
+
+const app_name = "myapp";
+
+const global_options = [_]zcli.OptionInfo{
+    .{ .name = "verbose", .short = 'v', .description = "Verbose output" },
+    .{ .name = "help", .short = 'h', .description = "Show help" },
+};
+
+const add_options = [_]zcli.OptionInfo{
+    .{ .name = "priority", .short = 'p', .description = "Task priority", .takes_value = true },
+    .{ .name = "force", .short = 'f', .description = "Skip confirmation" },
+};
+
+const commands = [_]zcli.CommandInfo{
+    .{ .path = &.{"add"}, .description = "Add a task", .options = &add_options, .aliases = &.{"a"} },
+    .{ .path = &.{"list"}, .description = "List tasks" },
+    .{ .path = &.{ "sprint", "create" }, .description = "Create a sprint" },
+};
+
+fn contains(haystack: []const u8, needle: []const u8) bool {
+    return std.mem.indexOf(u8, haystack, needle) != null;
+}
+
+test "bash.generate - produces a registered completion function mentioning all commands" {
+    const script = try bash.generate(std.testing.allocator, app_name, &commands, &global_options);
+    defer std.testing.allocator.free(script);
+
+    try std.testing.expect(script.len > 0);
+    // Completion function definition + registration.
+    try std.testing.expect(contains(script, "_myapp_completions()"));
+    try std.testing.expect(contains(script, "complete -F _myapp_completions myapp"));
+    // Every command surfaces.
+    try std.testing.expect(contains(script, "add"));
+    try std.testing.expect(contains(script, "list"));
+    try std.testing.expect(contains(script, "sprint"));
+    // Global and per-command options surface.
+    try std.testing.expect(contains(script, "--verbose"));
+    try std.testing.expect(contains(script, "--priority"));
+}
+
+test "zsh.generate - produces a #compdef header and command function" {
+    const script = try zsh.generate(std.testing.allocator, app_name, &commands, &global_options);
+    defer std.testing.allocator.free(script);
+
+    try std.testing.expect(script.len > 0);
+    // zsh requires the #compdef directive on the first line.
+    try std.testing.expect(std.mem.startsWith(u8, script, "#compdef myapp"));
+    try std.testing.expect(contains(script, "_myapp()"));
+    try std.testing.expect(contains(script, "add"));
+    try std.testing.expect(contains(script, "list"));
+}
+
+test "fish.generate - emits complete directives with flags" {
+    const script = try fish.generate(std.testing.allocator, app_name, &commands, &global_options);
+    defer std.testing.allocator.free(script);
+
+    try std.testing.expect(script.len > 0);
+    try std.testing.expect(contains(script, "complete -c myapp"));
+    // Long and short forms of an option.
+    try std.testing.expect(contains(script, "-l priority"));
+    try std.testing.expect(contains(script, "-s p"));
+    // A value-taking option is marked requires-argument (-r).
+    try std.testing.expect(contains(script, "-r"));
+}
+
+test "generators - hidden commands are excluded" {
+    const hidden_commands = [_]zcli.CommandInfo{
+        .{ .path = &.{"visible"}, .description = "Shown" },
+        .{ .path = &.{"secret"}, .description = "Hidden", .hidden = true },
+    };
+
+    const script = try bash.generate(std.testing.allocator, app_name, &hidden_commands, &global_options);
+    defer std.testing.allocator.free(script);
+
+    try std.testing.expect(contains(script, "visible"));
+    try std.testing.expect(!contains(script, "secret"));
+}
+
+test "generators - empty command set still yields a valid script skeleton" {
+    const empty = [_]zcli.CommandInfo{};
+    const script = try bash.generate(std.testing.allocator, app_name, &empty, &global_options);
+    defer std.testing.allocator.free(script);
+
+    try std.testing.expect(contains(script, "_myapp_completions()"));
+    try std.testing.expect(contains(script, "--verbose"));
+}

--- a/packages/core/src/plugin_github_upgrade_test.zig
+++ b/packages/core/src/plugin_github_upgrade_test.zig
@@ -1,0 +1,7 @@
+//! Surfaces the zcli_github_upgrade plugin's inline tests under the default test
+//! runner. The plugin's network functions (fetch/download) can't be unit-tested
+//! without a live HTTP server, but the checksum-parsing, SHA-256 hashing, and
+//! version-comparison logic is pure and is covered by tests inside plugin.zig.
+test {
+    _ = @import("plugins/zcli_github_upgrade/plugin.zig");
+}

--- a/packages/core/src/plugins/zcli_github_upgrade/plugin.zig
+++ b/packages/core/src/plugins/zcli_github_upgrade/plugin.zig
@@ -510,26 +510,44 @@ fn verifyChecksum(allocator: std.mem.Allocator, repo: []const u8, cli_name: []co
     defer allocator.free(checksums_content);
 
     // Find the checksum for our binary
-    var lines = std.mem.splitScalar(u8, checksums_content, '\n');
-    var expected_checksum: ?[]const u8 = null;
-    while (lines.next()) |line| {
-        if (std.mem.indexOf(u8, line, binary_name)) |_| {
-            var parts = std.mem.splitScalar(u8, line, ' ');
-            if (parts.next()) |checksum| {
-                expected_checksum = checksum;
-                break;
-            }
-        }
-    }
-
-    if (expected_checksum == null) {
+    const expected_checksum = parseExpectedChecksum(checksums_content, binary_name) orelse {
         std.debug.print("Error: Checksum not found for binary: {s}\n", .{binary_name});
         std.debug.print("The checksums.txt file may be incomplete or corrupted.\n", .{});
         return error.ChecksumNotFound;
-    }
+    };
 
-    // Calculate actual checksum
-    const file = try std.fs.cwd().openFile(binary_path, .{});
+    // Calculate actual checksum of the downloaded binary
+    const actual_checksum = try sha256FileHex(binary_path);
+
+    // Compare checksums
+    if (!std.mem.eql(u8, expected_checksum, &actual_checksum)) {
+        std.debug.print("Error: Checksum mismatch for binary: {s}\n", .{binary_name});
+        std.debug.print("Expected: {s}\n", .{expected_checksum});
+        std.debug.print("Actual:   {s}\n", .{&actual_checksum});
+        std.debug.print("The downloaded binary may be corrupted or tampered with.\n", .{});
+        return error.ChecksumMismatch;
+    }
+}
+
+/// Find the expected checksum for `binary_name` in a `checksums.txt` body.
+/// Each line is formatted `<sha256-hex>  <filename>`; the first line whose
+/// filename contains `binary_name` wins. Returns the hex digest borrowed from
+/// `content`, or null if no matching entry exists.
+fn parseExpectedChecksum(content: []const u8, binary_name: []const u8) ?[]const u8 {
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |line| {
+        if (std.mem.indexOf(u8, line, binary_name) == null) continue;
+        var parts = std.mem.splitScalar(u8, line, ' ');
+        if (parts.next()) |checksum| {
+            if (checksum.len > 0) return checksum;
+        }
+    }
+    return null;
+}
+
+/// Compute the lowercase hex SHA-256 digest of the file at `path`.
+fn sha256FileHex(path: []const u8) ![64]u8 {
+    const file = try std.fs.cwd().openFile(path, .{});
     defer file.close();
 
     var hasher = std.crypto.hash.sha2.Sha256.init(.{});
@@ -542,18 +560,7 @@ fn verifyChecksum(allocator: std.mem.Allocator, repo: []const u8, cli_name: []co
 
     var hash_bytes: [32]u8 = undefined;
     hasher.final(&hash_bytes);
-
-    // Convert to hex string
-    const actual_checksum = std.fmt.bytesToHex(&hash_bytes, .lower);
-
-    // Compare checksums
-    if (!std.mem.eql(u8, expected_checksum.?, &actual_checksum)) {
-        std.debug.print("Error: Checksum mismatch for binary: {s}\n", .{binary_name});
-        std.debug.print("Expected: {s}\n", .{expected_checksum.?});
-        std.debug.print("Actual:   {s}\n", .{&actual_checksum});
-        std.debug.print("The downloaded binary may be corrupted or tampered with.\n", .{});
-        return error.ChecksumMismatch;
-    }
+    return std.fmt.bytesToHex(&hash_bytes, .lower);
 }
 
 /// Test that the new binary works
@@ -741,10 +748,12 @@ test "rate limiting - handles HTTP 429 responses" {
 
 test "parseVersion - edge cases with whitespace" {
     // Version strings with leading/trailing whitespace should fail
-    // (caller should trim before passing to parseVersion)
-    try std.testing.expectError(error.InvalidVersion, parseVersion(" 1.2.3"));
-    try std.testing.expectError(error.InvalidVersion, parseVersion("1.2.3 "));
-    try std.testing.expectError(error.InvalidVersion, parseVersion(" 1.2.3 "));
+    // (caller should trim before passing to parseVersion). The whitespace makes
+    // the numeric parse fail, so the error is InvalidCharacter — same as any
+    // other non-numeric component.
+    try std.testing.expectError(error.InvalidCharacter, parseVersion(" 1.2.3"));
+    try std.testing.expectError(error.InvalidCharacter, parseVersion("1.2.3 "));
+    try std.testing.expectError(error.InvalidCharacter, parseVersion(" 1.2.3 "));
 }
 
 test "parseVersion - zero versions" {
@@ -807,4 +816,87 @@ test "detectPlatform - allocator handling" {
         }
     }
     try std.testing.expect(found);
+}
+
+test "parseExpectedChecksum - finds matching binary" {
+    const content =
+        "aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111  myapp-x86_64-linux\n" ++
+        "bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222  myapp-aarch64-macos\n";
+
+    const linux = parseExpectedChecksum(content, "myapp-x86_64-linux").?;
+    try std.testing.expectEqualStrings("aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111", linux);
+
+    const macos = parseExpectedChecksum(content, "myapp-aarch64-macos").?;
+    try std.testing.expectEqualStrings("bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222", macos);
+}
+
+test "parseExpectedChecksum - missing binary returns null" {
+    const content = "abc123  myapp-x86_64-linux\n";
+    try std.testing.expectEqual(@as(?[]const u8, null), parseExpectedChecksum(content, "myapp-windows"));
+    try std.testing.expectEqual(@as(?[]const u8, null), parseExpectedChecksum("", "myapp-x86_64-linux"));
+}
+
+test "parseExpectedChecksum - tolerates trailing newline and no final newline" {
+    const with_nl = "deadbeef  bin\n";
+    const without_nl = "deadbeef  bin";
+    try std.testing.expectEqualStrings("deadbeef", parseExpectedChecksum(with_nl, "bin").?);
+    try std.testing.expectEqualStrings("deadbeef", parseExpectedChecksum(without_nl, "bin").?);
+}
+
+test "sha256FileHex - matches known digest" {
+    // SHA-256 of the empty input is a well-known constant.
+    const empty_digest = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // Write an empty file and hash it through the real file-reading path.
+    {
+        const f = try tmp.dir.createFile("empty.bin", .{});
+        f.close();
+    }
+    const path = try tmp.dir.realpathAlloc(std.testing.allocator, "empty.bin");
+    defer std.testing.allocator.free(path);
+
+    const digest = try sha256FileHex(path);
+    try std.testing.expectEqualStrings(empty_digest, &digest);
+}
+
+test "sha256FileHex - hashes file contents" {
+    // SHA-256 of "abc".
+    const abc_digest = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(.{ .sub_path = "data.bin", .data = "abc" });
+
+    const path = try tmp.dir.realpathAlloc(std.testing.allocator, "data.bin");
+    defer std.testing.allocator.free(path);
+
+    const digest = try sha256FileHex(path);
+    try std.testing.expectEqualStrings(abc_digest, &digest);
+}
+
+test "checksum verification - end-to-end parse + hash + compare" {
+    // Simulate the pure half of verifyChecksum: parse the expected digest from a
+    // checksums.txt body, hash the local binary, and confirm they match/mismatch.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(.{ .sub_path = "myapp-x86_64-linux", .data = "abc" });
+
+    const path = try tmp.dir.realpathAlloc(std.testing.allocator, "myapp-x86_64-linux");
+    defer std.testing.allocator.free(path);
+
+    const abc_digest = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+    const good = try std.fmt.allocPrint(std.testing.allocator, "{s}  myapp-x86_64-linux\n", .{abc_digest});
+    defer std.testing.allocator.free(good);
+
+    const expected = parseExpectedChecksum(good, "myapp-x86_64-linux").?;
+    const actual = try sha256FileHex(path);
+    try std.testing.expect(std.mem.eql(u8, expected, &actual));
+
+    // A tampered binary must NOT match the recorded checksum.
+    const bad = "0000000000000000000000000000000000000000000000000000000000000000  myapp-x86_64-linux\n";
+    const bad_expected = parseExpectedChecksum(bad, "myapp-x86_64-linux").?;
+    try std.testing.expect(!std.mem.eql(u8, bad_expected, &actual));
 }

--- a/website/content/docs/build-system.smd
+++ b/website/content/docs/build-system.smd
@@ -5,7 +5,7 @@
 .layout = "docs.shtml",
 ---
 
-zcli achieves zero runtime overhead by discovering commands and plugins, then generating dispatch code at build time.
+zcli achieves zero-cost dispatch by discovering commands and plugins, then generating routing code at build time. (Argument parsing for the matched command still runs at invocation.)
 
 ## How It Works
 

--- a/website/content/docs/index.smd
+++ b/website/content/docs/index.smd
@@ -31,7 +31,7 @@ zcli uses **convention over configuration**:
 1. **File structure = CLI structure** - The directory layout in `src/commands/` directly maps to your CLI commands
 2. **Types = validation** - Your `Args` and `Options` structs define what inputs are valid
 3. **Compile-time discovery** - zcli scans your commands directory at build time and generates the routing code
-4. **Zero runtime overhead** - All command discovery and validation happens at compile time
+4. **Zero-cost dispatch** - Command discovery and routing happen at compile time; only argument parsing runs at invocation
 
 When you run `zig build`, zcli:
 

--- a/website/layouts/home.shtml
+++ b/website/layouts/home.shtml
@@ -5,7 +5,7 @@
 <main id="main">
     <section class="hero">
         <h1>Build beautiful CLIs in Zig</h1>
-        <p class="hero-subtitle">Zero boilerplate. Type-safe. Zero runtime overhead.</p>
+        <p class="hero-subtitle">Zero boilerplate. Type-safe. Zero-cost dispatch.</p>
         <div class="hero-cta">
             <a href="$site.page('quickstart').link()" class="btn btn-primary">Get Started</a>
             <a href="$site.page('docs').link()" class="btn btn-secondary">Documentation</a>
@@ -22,8 +22,8 @@
             <p>Arguments and options validated at compile time. Your Args and Options structs define what's valid.</p>
         </div>
         <div class="feature">
-            <h3>Zero Runtime Cost</h3>
-            <p>All command discovery and code generation happens at build time. No reflection, no dynamic dispatch.</p>
+            <h3>Zero-Cost Dispatch</h3>
+            <p>Command discovery and routing code generation happen at build time. No reflection, no dynamic dispatch.</p>
         </div>
         <div class="feature">
             <h3>Plugin System</h3>


### PR DESCRIPTION
A feature audit graded this repo on what it *actually does* vs what it *claims*. The result was an A− — overwhelmingly real, but with a few claims that outran the implementation. This PR closes those gaps. All five issues below were verified by build + test runs.

## Fixes

1. **"Zero runtime overhead" → "zero-cost dispatch."** The marquee perf claim was misleading: command discovery and routing *are* compile-time generated (no reflection, no runtime fs scan), but argument **parsing runs at invocation**. Reworded across `README.md`, `docs/BUILD.md`, `docs/DESIGN.md`, and the website. Left the genuinely-accurate "zero runtime plugin *discovery*" claims as-is.

2. **Showcase now uses `ztheme` instead of hand-rolled ANSI.** The flagship example claimed "themed formatting" but never imported `ztheme` — every command emitted raw `\x1b[..m` escapes. Converted all 14 commands; `store.zig` owns the status/priority→semantic-color mapping and commands render through `context.theme`. Side benefit: color now correctly **drops when piped / `NO_COLOR`** (verified `od -c` shows zero escape bytes), where the raw ANSI was always-on.

3. **`tasks config` now actually persists.** It was cosmetic — prompted, printed "Token saved", and discarded everything. It now reads/writes `.tasks.config.json` with `add.priority`, `add.points`, and `list.all` — values the `zcli_config` plugin actually consumes. Verified end-to-end: a config-written default drives `tasks add` with no flags.

4. **Completions plugin tests (was 0).** New `plugin_completions_test.zig` — 5 tests over the bash/zsh/fish generators (registration funcs, `#compdef` header, `complete -c`, command/flag presence, hidden-command exclusion, empty-set skeleton).

5. **github_upgrade checksum tests.** Extracted `parseExpectedChecksum` + `sha256FileHex` from the HTTP-bound `verifyChecksum` and added 6 tests (known SHA-256 digests, checksum-file parsing, tamper detection).

## Structural findings fixed along the way

- The build referenced **5 plugin test files that no longer exist**, so `test-plugins` was broken and the existing plugin tests (config's 16, upgrade's 11) **never ran in CI**. New tests are wired into the **default `test` step** so they actually run.
- That surfaced a **pre-existing broken test** (`parseVersion` whitespace case expected `InvalidVersion` but the code returns `InvalidCharacter`, matching its sibling test). Corrected to the real behavior.

## Verification
- `zig build` ✅ · `zig build test` ✅ (all 9 packages) · showcase `zig build` ✅ and runs clean piped (0 escape bytes).

## Known follow-up (not in this PR)
zinput's non-TTY `number` fallback (`number.zig:120`) returns a slice into a stack-local buffer (use-after-return), breaking piped numeric prompts. Tracked as a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)