### PR TITLE
Remove dead stringly-typed context remnants

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -746,25 +746,39 @@ const cmd_registry = zcli.build(b, exe, zcli_module, .{
 - Optional REPL for command exploration
 - Tab completion using comptime-generated data
 
-**Type-Safe Context Extensions (Planned):**
+**Type-Safe Context Extensions:**
 
-Replace the current StringHashMap with a strongly-typed extension system:
+Plugins attach their own state to the context with full compile-time type
+safety — there is no `StringHashMap` or runtime key lookup. A plugin declares a
+`plugin_id` and a `ContextData` struct; the generated `Context` contains one
+field per plugin, named by `plugin_id`, and accessed as
+`context.plugins.<plugin_id>`:
 
 ```zig
-// Define extension types at compile time
-const Extensions = struct {
+// In the plugin:
+pub const plugin_id = "my_plugin";
+
+pub const ContextData = struct {
     database: ?*Database = null,
-    logger: Logger,
-    config: Config,
+    verbose: bool = false,
 };
 
-// Access in commands with full type safety
-pub fn execute(args: Args, options: Options, context: *Context) !void {
-    if (context.extensions.database) |db| {
-        // Use database
+// Optional cleanup hook, called from Context.deinit():
+pub fn deinitContextData(data: *ContextData, allocator: std.mem.Allocator) void {
+    if (data.database) |db| db.close(allocator);
+}
+
+// Access in any hook or command (context is `anytype`):
+pub fn execute(args: Args, options: Options, context: anytype) !void {
+    if (context.plugins.my_plugin.database) |db| {
+        // Use db — fully typed, no casts, no lookups
     }
 }
 ```
+
+`ContextData` structs must be default-constructible; the generated `Context`
+initializes each plugin's field to `.{}`. See `ComputedContextType` in
+`packages/core/src/registry.zig`.
 
 ## 13. Developer Experience
 

--- a/packages/core/src/build_utils.zig
+++ b/packages/core/src/build_utils.zig
@@ -420,22 +420,11 @@ const IntegrationMockPlugin = struct {
         };
     }
 
-    // Context extension
-    pub const ContextExtension = struct {
-        initialized: bool,
-        value: i32,
-
-        pub fn init(allocator: std.mem.Allocator) !@This() {
-            _ = allocator;
-            return .{
-                .initialized = true,
-                .value = 42,
-            };
-        }
-
-        pub fn deinit(self: *@This()) void {
-            self.initialized = false;
-        }
+    // Type-safe context data (default-constructed by the generated Context)
+    pub const plugin_id = "integration_mock";
+    pub const ContextData = struct {
+        initialized: bool = true,
+        value: i32 = 42,
     };
 
     // Plugin commands
@@ -463,17 +452,12 @@ const TestData = struct {
 };
 
 
-test "context extension lifecycle" {
-    const allocator = std.testing.allocator;
-
-    // Test initialization
-    var ext = try IntegrationMockPlugin.ContextExtension.init(allocator);
-    try std.testing.expect(ext.initialized == true);
-    try std.testing.expectEqual(@as(i32, 42), ext.value);
-
-    // Test deinit
-    ext.deinit();
-    try std.testing.expect(ext.initialized == false);
+test "context data defaults" {
+    // ContextData is a plain, default-constructible struct. The generated
+    // Context stores one per plugin and exposes it as `context.plugins.<plugin_id>`.
+    const data = IntegrationMockPlugin.ContextData{};
+    try std.testing.expect(data.initialized == true);
+    try std.testing.expectEqual(@as(i32, 42), data.value);
 }
 
 test "plugin command discovery simulation" {
@@ -633,13 +617,9 @@ test "plugin with partial features" {
             };
         }
 
-        pub const ContextExtension = struct {
-            data: []const u8,
-
-            pub fn init(allocator: std.mem.Allocator) !@This() {
-                _ = allocator;
-                return .{ .data = "partial" };
-            }
+        pub const plugin_id = "integration_partial";
+        pub const ContextData = struct {
+            data: []const u8 = "partial",
         };
         // No error transformer, no help transformer, no commands
     };
@@ -647,7 +627,7 @@ test "plugin with partial features" {
     try std.testing.expect(@hasDecl(IntegrationPartialPlugin, "transformCommand"));
     try std.testing.expect(!@hasDecl(IntegrationPartialPlugin, "transformError"));
     try std.testing.expect(!@hasDecl(IntegrationPartialPlugin, "transformHelp"));
-    try std.testing.expect(@hasDecl(IntegrationPartialPlugin, "ContextExtension"));
+    try std.testing.expect(@hasDecl(IntegrationPartialPlugin, "ContextData"));
     try std.testing.expect(!@hasDecl(IntegrationPartialPlugin, "commands"));
 }
 

--- a/packages/core/src/build_utils/plugin_system.zig
+++ b/packages/core/src/build_utils/plugin_system.zig
@@ -729,99 +729,6 @@ test "plugin security: plugin isolation" {
     try testing.expect(result2 == null);
 }
 
-// Test plugin with global options
-const SystemVerbosePlugin = struct {
-    pub const global_options = [_]zcli.GlobalOption{
-        zcli.option("verbose", bool, .{ .short = 'v', .default = false, .description = "Enable verbose output" }),
-        zcli.option("log-level", []const u8, .{ .default = "info", .description = "Set log level (debug, info, warn, error)" }),
-    };
-
-    pub fn handleGlobalOption(
-        context: *zcli.Context,
-        option_name: []const u8,
-        value: anytype,
-    ) !void {
-        if (std.mem.eql(u8, option_name, "verbose")) {
-            const verbose = if (@TypeOf(value) == bool) value else false;
-            context.setVerbosity(verbose);
-        } else if (std.mem.eql(u8, option_name, "log-level")) {
-            const log_level = if (@TypeOf(value) == []const u8) value else "info";
-            try context.setLogLevel(log_level);
-        }
-    }
-};
-
-// Test plugin with lifecycle hooks (using context state instead of static vars)
-const SystemLifecyclePlugin = struct {
-    // No more static state!
-
-    pub fn setHookState(context: *zcli.Context, hook_name: []const u8, called: bool) !void {
-        const value = if (called) "true" else "false";
-        try context.setGlobalData(hook_name, value);
-    }
-
-    pub fn getHookState(context: *zcli.Context, hook_name: []const u8) bool {
-        return context.getGlobalData(bool, hook_name) orelse false;
-    }
-
-    pub fn preParse(
-        context: *zcli.Context,
-        args: []const []const u8,
-    ) ![]const []const u8 {
-        try setHookState(context, "pre_parse_called", true);
-        return args;
-    }
-
-    pub fn postParse(
-        context: *zcli.Context,
-        command_path: []const u8,
-        parsed_args: zcli.ParsedArgs,
-    ) !?zcli.ParsedArgs {
-        _ = command_path;
-        try setHookState(context, "post_parse_called", true);
-        return parsed_args;
-    }
-
-    pub fn preExecute(
-        context: *zcli.Context,
-        command_path: []const u8,
-        args: zcli.ParsedArgs,
-    ) !?zcli.ParsedArgs {
-        _ = command_path;
-        try setHookState(context, "pre_execute_called", true);
-        return args;
-    }
-
-    pub fn postExecute(
-        context: *zcli.Context,
-        command_path: []const u8,
-        success: bool,
-    ) !void {
-        _ = command_path;
-        _ = success;
-        try setHookState(context, "post_execute_called", true);
-    }
-
-    pub fn onError(
-        context: *zcli.Context,
-        err: anyerror,
-        command_path: []const u8,
-    ) !void {
-        _ = command_path;
-        // Handle the error appropriately
-        switch (err) {
-            error.TestError => {
-                // Expected test error, just mark as called
-                try setHookState(context, "on_error_called", true);
-            },
-            else => {
-                // Unexpected error, mark as called and continue
-                try setHookState(context, "on_error_called", true);
-            },
-        }
-    }
-};
-
 // Test plugin with argument transformation
 const SystemAliasPlugin = struct {
     pub const aliases = .{
@@ -918,72 +825,6 @@ const SystemConsumeOptionsPlugin = struct {
         };
     }
 };
-
-// Test for global options registration and handling
-test "plugin global options registration" {
-    const allocator = testing.allocator;
-
-    const TestRegistry = registry.Registry.init(.{
-        .app_name = "test-app",
-        .app_version = "1.0.0",
-        .app_description = "Test application",
-    })
-        .registerPlugin(SystemVerbosePlugin)
-        .build();
-
-    var app = TestRegistry.init();
-    var io = zcli.IO.init();
-    io.finalize();
-
-    var context = zcli.Context.init(allocator, &io);
-    defer context.deinit();
-
-    // Test handling of global options
-    const args = [_][]const u8{ "--verbose", "command", "arg" };
-    const result = try app.parseGlobalOptions(&context, &args);
-    defer context.allocator.free(result.consumed);
-    defer context.allocator.free(result.remaining);
-
-    try testing.expect(result.consumed.len == 1);
-    try testing.expect(result.consumed[0] == 0);
-    try testing.expect(result.remaining.len == 2);
-    try testing.expectEqualStrings(result.remaining[0], "command");
-    try testing.expectEqualStrings(result.remaining[1], "arg");
-}
-
-// Test for lifecycle hooks execution order
-test "plugin lifecycle hooks execution order" {
-    // No longer need to reset static state
-
-    const TestCommand = struct {
-        pub const Args = zcli.NoArgs;
-        pub const Options = zcli.NoOptions;
-
-        pub fn execute(args: Args, options: Options, context: *zcli.Context) !void {
-            _ = args;
-            _ = options;
-            _ = context;
-        }
-    };
-
-    const TestRegistry = registry.Registry.init(.{
-        .app_name = "test-app",
-        .app_version = "1.0.0",
-        .app_description = "Test application",
-    })
-        .register("system-test", TestCommand)
-        .registerPlugin(SystemLifecyclePlugin)
-        .build();
-
-    var app = TestRegistry.init();
-
-    const args = [_][]const u8{"system-test"};
-    try app.execute(&args);
-
-    // NOTE: Since execute() creates its own context internally, we can't easily verify
-    // hook states. For now, the test passes if it completes without hanging.
-    // The elimination of static state prevents race conditions between tests.
-}
 
 // Test for argument transformation
 test "plugin argument transformation" {
@@ -1090,47 +931,6 @@ test "plugin option consumption" {
     try testing.expect(result.consumed_indices.len == 2); // --config and its value
 }
 
-// Test for multiple plugins interaction
-test "multiple plugins interaction" {
-    const allocator = testing.allocator;
-
-    const TestRegistry = registry.Registry.init(.{
-        .app_name = "test-app",
-        .app_version = "1.0.0",
-        .app_description = "Test application",
-    })
-        .registerPlugin(SystemVerbosePlugin)
-        .registerPlugin(SystemAliasPlugin)
-        .registerPlugin(SystemLifecyclePlugin)
-        .build();
-
-    var app = TestRegistry.init();
-    var io = zcli.IO.init();
-    io.finalize();
-
-    var context = zcli.Context.init(allocator, &io);
-    defer context.deinit();
-
-    // No longer need to reset static state
-
-    // Test that multiple plugins can work together
-    const args = [_][]const u8{ "--verbose", "co", "main" };
-
-    // First, global options should be extracted
-    const global_result = try app.parseGlobalOptions(&context, &args);
-    defer context.allocator.free(global_result.consumed);
-    defer context.allocator.free(global_result.remaining);
-    try testing.expect(global_result.consumed.len == 1);
-
-    // Then, aliases should be transformed
-    const transform_result = try app.transformArgs(&context, global_result.remaining);
-    defer if (transform_result.args.ptr != global_result.remaining.ptr) context.allocator.free(transform_result.args);
-    try testing.expectEqualStrings(transform_result.args[0], "checkout");
-
-    // Note: Lifecycle hooks are only called during full execute() flow,
-    // not when calling individual methods like parseGlobalOptions/transformArgs
-}
-
 // Test for plugin priority and ordering
 test "plugin execution priority" {
     // This test verifies plugins are sorted by priority during compilation
@@ -1191,19 +991,15 @@ test "plugin error handling" {
         .app_description = "Test application",
     })
         .register("error", ErrorCommand)
-        .registerPlugin(SystemLifecyclePlugin)
         .build();
 
     var app = TestRegistry.init();
-
-    // No longer need to reset static state
 
     const args = [_][]const u8{"error"};
     const result = app.execute(&args);
 
     // Should return error
     try testing.expectError(error.TestError, result);
-    // NOTE: Can't easily verify onError hook was called since execute() creates its own context
 }
 
 // NOTE: Command override prevention and global option conflict detection

--- a/packages/core/src/plugins/zcli_help/plugin.zig
+++ b/packages/core/src/plugins/zcli_help/plugin.zig
@@ -773,36 +773,6 @@ fn generateOptionsHelp(module_info: zcli.CommandModuleInfo, context: anytype) !?
     return try buffer.toOwnedSlice(context.allocator);
 }
 
-// Context extension - optional configuration for the help plugin
-pub const ContextExtension = struct {
-    show_examples: bool = true,
-    show_tips: bool = true,
-    color_output: bool = true,
-    max_width: usize = 80,
-    // Store command metadata for help generation
-    command_metadata: std.StringHashMap(CommandMetadata),
-
-    pub fn init(allocator: std.mem.Allocator) !@This() {
-        return .{
-            .show_examples = true,
-            .show_tips = true,
-            .color_output = std.io.tty.detectConfig(std.fs.File.stderr()) != .no_color,
-            .max_width = 80,
-            .command_metadata = std.StringHashMap(CommandMetadata).init(allocator),
-        };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        self.command_metadata.deinit();
-    }
-};
-
-/// Metadata about a command for help generation
-const CommandMetadata = struct {
-    description: ?[]const u8 = null,
-    examples: ?[]const []const u8 = null,
-};
-
 test {
     std.testing.refAllDecls(@This());
 }

--- a/packages/core/src/plugins/zcli_not_found/plugin.zig
+++ b/packages/core/src/plugins/zcli_not_found/plugin.zig
@@ -165,80 +165,9 @@ fn findBestSuggestions(
     return result;
 }
 
-// Context extension - stores configuration for suggestions
-pub const ContextExtension = struct {
-    max_suggestions: usize = 3,
-    max_distance: usize = 3,
-    color_output: bool = true,
-    command_list: std.ArrayList([]const u8),
-    allocator: std.mem.Allocator,
-
-    pub fn init(allocator: std.mem.Allocator) !@This() {
-        return .{
-            .max_suggestions = 3,
-            .max_distance = 3,
-            .color_output = std.io.tty.detectConfig(std.io.getStdErr()) != .no_color,
-            .command_list = std.ArrayList([]const u8){},
-            .allocator = allocator,
-        };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        self.command_list.deinit(self.allocator);
-    }
-
-    pub fn addCommand(self: *@This(), command: []const u8) !void {
-        try self.command_list.append(self.allocator, command);
-    }
-};
-
 // Tests
 test "not-found plugin structure" {
     try std.testing.expect(@hasDecl(@This(), "onError"));
-    try std.testing.expect(@hasDecl(@This(), "ContextExtension"));
-}
-
-test "onError handles CommandNotFound" {
-    const allocator = std.testing.allocator;
-    // Create a temporary file to capture stderr output
-    var tmp_dir = std.testing.tmpDir(.{});
-    defer tmp_dir.cleanup();
-
-    var output_file = try tmp_dir.dir.createFile("test_output.txt", .{ .read = true });
-    defer output_file.close();
-
-    // Create IO and set custom stderr for test
-    var io = zcli.IO.init();
-    io.stdout_writer = std.fs.File.stdout().writer(&.{});
-    io.stderr_writer = output_file.writer(&.{});
-    io.stdin_reader = std.fs.File.stdin().reader(&.{});
-
-    // Create context with the temporary file as stderr
-    var context = zcli.Context{
-        .allocator = allocator,
-        .io = &io,
-        .environment = zcli.Environment.init(allocator),
-        .plugin_extensions = zcli.ContextExtensions.init(allocator),
-    };
-    defer context.deinit();
-
-    // Store available commands in context
-    const commands = [_][]const u8{ "list", "search", "create" };
-    try context.setGlobalData("available_commands", @ptrCast(&commands));
-
-    // Test command not found error - should not return error, just print suggestions
-    const handled = try onError(&context, error.CommandNotFound);
-    _ = handled;
-
-    // Read back the captured output
-    try output_file.seekTo(0);
-    const captured_output = try output_file.readToEndAlloc(allocator, 4096);
-    defer allocator.free(captured_output);
-
-    // Validate the captured output
-    try std.testing.expect(captured_output.len > 0);
-    try std.testing.expect(std.mem.indexOf(u8, captured_output, "Error: Unknown command") != null);
-    try std.testing.expect(std.mem.indexOf(u8, captured_output, "Run 'app --help'") != null);
 }
 
 test "find best suggestions" {


### PR DESCRIPTION
## What

Finishes the stringly→type-safe context migration. The type-safe system —
per-plugin `pub const ContextData` exposed as `context.plugins.<plugin_id>` via
`ComputedContextType` (registry.zig) — is already the live runtime path. There is
**no `StringHashMap` context store** anywhere in the generated `Context`.

This PR removes the leftover remnants of the old stringly-typed API
(`setGlobalData` / `getGlobalData` / `ContextExtensions` / `setVerbosity` /
`setLogLevel`). They referenced symbols that no longer exist on any `Context` and
only compiled because they lived in test fixtures Zig never semantically analyzes.

## Changes

- **zcli_help**: delete the dead `ContextExtension` duplicate (which still held a
  `StringHashMap`) and its orphaned `CommandMetadata`. The live `ContextData`
  (`help_requested`) is untouched.
- **zcli_not_found**: delete the unused `ContextExtension` struct + the broken test
  referencing non-existent `zcli.ContextExtensions` / `.plugin_extensions` /
  `setGlobalData`. Live `onError` already uses the type-safe `getAvailableCommandInfo()`.
- **build_utils/plugin_system.zig**: delete the `SystemVerbosePlugin` /
  `SystemLifecyclePlugin` fixtures (and dependent tests) calling the non-existent
  `setVerbosity` / `setLogLevel` / `setGlobalData` / `getGlobalData`. The error-handling
  test is kept (its error-propagation assertion is real) minus the dead plugin.
- **build_utils.zig**: rename the two runnable mock plugins from the old
  `ContextExtension` name to the current `ContextData` convention (+ `plugin_id`), so
  the live test suite reflects reality.
- **DESIGN.md**: document type-safe context extensions as shipped, not "Planned".

Net: +39 / −350 lines.

## Verification

- `zig build test` (core) passes.
- showcase example builds; `--help` and not-found "did you mean" suggestions work at runtime.
- `zig ast-check` passes on all four edited source files (the plugin-level test blocks
  are not wired into any running target — see below).

## Follow-up (not in this PR)

The entire plugin test suite is disconnected: `build.zig`'s `test-plugins` step points
at 5 source files that don't exist, and no plugin `test {}` block runs under `zig build
test`. That's why this rot accumulated unnoticed. Tracking as a separate PR — it also
means the deleted/kept plugin tests here aren't currently executed by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)