### PR TITLE
build: drop phantom plugin_test_files that broke test-plugins

### DIFF
--- a/packages/core/build.zig
+++ b/packages/core/build.zig
@@ -61,14 +61,12 @@ pub fn build(b: *std.Build) void {
         "src/build_utils.zig", // Standalone utility (has its own tests)
     };
 
-    // Plugin test files
-    const plugin_test_files = [_][]const u8{
-        "src/plugin_global_options_test.zig",
-        "src/plugin_system_test.zig",
-        "src/plugin_integration_test.zig",
-        "src/plugin_test.zig",
-        "src/plugin_transformation_test.zig",
-    };
+    // NOTE: A previous `plugin_test_files` list referenced five src/plugin_*_test.zig
+    // files that were dropped in the monorepo refactor (commit 0aa79f7) and never
+    // re-added. They targeted a since-replaced plugin/context API, so they were
+    // removed rather than restored as-is. Plugin behavior is exercised by the
+    // feature-plugin tests below and the inline tests in registry.zig/zcli.zig;
+    // the pipeline-level coverage is being rebuilt in plugin_pipeline_test.zig.
 
     // Integration and edge case tests
     const integration_test_files = [_][]const u8{
@@ -100,25 +98,6 @@ pub fn build(b: *std.Build) void {
         const run_tests = b.addRunArtifact(tests);
         test_core_step.dependOn(&run_tests.step);
         test_step.dependOn(&run_tests.step);
-    }
-
-    // Plugin tests - deadlock issue resolved by using stderr for output
-    for (plugin_test_files) |test_file| {
-        const test_mod = b.addModule(b.fmt("test-{s}", .{test_file}), .{
-            .root_source_file = b.path(test_file),
-            .target = target,
-            .optimize = optimize,
-        });
-        test_mod.addImport("ztheme", ztheme_dep.module("ztheme"));
-        test_mod.addImport("markdown_fmt", markdown_fmt_dep.module("markdown_fmt"));
-        test_mod.addImport("zprogress", zprogress_dep.module("zprogress"));
-        test_mod.addImport("zinput", zinput_dep.module("zinput"));
-                test_mod.addImport("serde", serde_dep.module("serde"));
-        const tests = b.addTest(.{
-            .root_module = test_mod,
-        });
-        const run_tests = b.addRunArtifact(tests);
-        test_plugins_step.dependOn(&run_tests.step);
     }
 
     // Add integration tests (parallel execution)
@@ -188,7 +167,7 @@ pub fn build(b: *std.Build) void {
 
     // Sequential test execution (separate from parallel execution above)
     // This creates a completely separate dependency chain for sequential execution
-    const all_test_files = core_test_files ++ plugin_test_files ++ integration_test_files ++ security_test_files;
+    const all_test_files = core_test_files ++ integration_test_files ++ security_test_files;
     var previous_step: ?*std.Build.Step = null;
 
     for (all_test_files) |test_file| {


### PR DESCRIPTION
## Problem
`packages/core/build.zig` referenced five test files that don't exist:
```
src/plugin_global_options_test.zig
src/plugin_system_test.zig
src/plugin_integration_test.zig
src/plugin_test.zig
src/plugin_transformation_test.zig
```
The monorepo refactor (`0aa79f7`, Sep 2025) deleted them when it moved `core` under `packages/core/`, but the `plugin_test_files` list was carried over. So `zig build test-plugins` and `zig build test-seq` failed to compile (`error: ... file_hash FileNotFound`) and never ran. It stayed hidden because the **default `test` step doesn't include this list**, so `zig build test` was green.

They couldn't be restored as-is anyway — they target a since-replaced API (`@import("zcli.zig")`, `*zcli.Context`, `context.setGlobalData()/setVerbosity()`), now superseded by the type-safe `context: anytype` + `context.plugins.<id>` model.

## Change
Remove the phantom `plugin_test_files` array, its now-dead loop, and the `++ plugin_test_files` in the `test-seq` aggregate. Pure dead-reference removal — no test behavior changes.

After this, `test-plugins` runs the real feature-plugin tests (completions, github_upgrade) and `test-seq` compiles again.

## Coverage note
This unbreaks the build but does **not** restore the lost pipeline-level coverage (hook firing/ordering, transformArgs/transformCommand, multi-plugin integration). That's a deliberate follow-up — rebuilt against the current API in `plugin_pipeline_test.zig` (next PR). Plugin behavior today is still exercised by the feature-plugin tests and inline tests in registry.zig/zcli.zig (global options, onError, routing, aliases).

## Verification
`zig build test` ✅ (all 9 packages) · `zig build test-plugins` ✅ · `zig build test-seq` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)