### PR TITLE
fix: make onError suppression symmetric for command errors

### DIFF
--- a/packages/core/src/plugin_pipeline_test.zig
+++ b/packages/core/src/plugin_pipeline_test.zig
@@ -319,28 +319,54 @@ test "pipeline: postParse can rewrite the args the command receives" {
 }
 
 // ---------------------------------------------------------------------------
-// 8. onError on a command failure: observed, but not suppressible
+// 8. onError on a command failure is symmetric with the CommandNotFound path:
+//    returning true suppresses the error; returning false lets it propagate.
 // ---------------------------------------------------------------------------
 
-const ObserveErrPlugin = struct {
+const SuppressErrPlugin = struct {
     var seen: ?anyerror = null;
+    var post_success: ?bool = null;
     pub fn onError(_: anytype, err: anyerror) !bool {
         seen = err;
-        return true; // claims to handle it...
+        return true; // handle it -> suppressed
+    }
+    pub fn postExecute(_: anytype, success: bool) !void {
+        post_success = success;
     }
 };
 
-test "pipeline: onError observes a command failure but cannot suppress it" {
+test "pipeline: onError returning true suppresses a command-execution error" {
     const App = zcli.Registry.init(test_config)
         .register("fail", Fail)
-        .registerPlugin(ObserveErrPlugin)
+        .registerPlugin(SuppressErrPlugin)
         .build();
 
-    ObserveErrPlugin.seen = null;
-    // A command-execution error always propagates, even when onError returns
-    // true — onError on this path is observe-only (unlike CommandNotFound).
+    SuppressErrPlugin.seen = null;
+    SuppressErrPlugin.post_success = null;
+    // Handled -> the error does NOT propagate (symmetric with CommandNotFound).
+    try run(App, &.{"fail"});
+    try testing.expectEqual(@as(?anyerror, error.Boom), SuppressErrPlugin.seen);
+    // ...and execution falls through to postExecute, told the command failed.
+    try testing.expectEqual(@as(?bool, false), SuppressErrPlugin.post_success);
+}
+
+const PassThroughErrPlugin = struct {
+    var seen: ?anyerror = null;
+    pub fn onError(_: anytype, err: anyerror) !bool {
+        seen = err;
+        return false; // observe only -> error still propagates
+    }
+};
+
+test "pipeline: onError returning false lets a command error propagate" {
+    const App = zcli.Registry.init(test_config)
+        .register("fail", Fail)
+        .registerPlugin(PassThroughErrPlugin)
+        .build();
+
+    PassThroughErrPlugin.seen = null;
     try testing.expectError(error.Boom, run(App, &.{"fail"}));
-    try testing.expectEqual(@as(?anyerror, error.Boom), ObserveErrPlugin.seen);
+    try testing.expectEqual(@as(?anyerror, error.Boom), PassThroughErrPlugin.seen);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/registry.zig
+++ b/packages/core/src/registry.zig
@@ -1230,15 +1230,21 @@ fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const Comma
                             cmd.module.execute(args_instance, options_instance, context) catch |err| {
                                 success = false;
 
-                                // Run error hooks
+                                // Run error hooks. If a plugin handles the error
+                                // (returns true) it is suppressed — symmetric with
+                                // the CommandNotFound path — and execution falls
+                                // through to postExecute with success = false.
+                                var error_handled = false;
                                 inline for (sorted_plugins) |Plugin| {
                                     if (@hasDecl(Plugin, "onError")) {
-                                        const handled = try Plugin.onError(context, err);
-                                        if (handled) break;
+                                        if (try Plugin.onError(context, err)) {
+                                            error_handled = true;
+                                            break;
+                                        }
                                     }
                                 }
 
-                                return err;
+                                if (!error_handled) return err;
                             };
                         } else {
                             // Command group without execute function (metadata-only)
@@ -1468,14 +1474,19 @@ fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const Comma
 
                         CommandModule.execute(cmd_args, cmd_options, context) catch |err| {
                             success = false;
-                            // Run onError hooks
+                            // Run onError hooks. A handled error (returns true) is
+                            // suppressed and falls through to postExecute with
+                            // success = false; otherwise it propagates.
+                            var error_handled = false;
                             inline for (sorted_plugins) |HookPlugin| {
                                 if (@hasDecl(HookPlugin, "onError")) {
-                                    const handled = try HookPlugin.onError(context, err);
-                                    if (handled) break;
+                                    if (try HookPlugin.onError(context, err)) {
+                                        error_handled = true;
+                                        break;
+                                    }
                                 }
                             }
-                            return err;
+                            if (!error_handled) return err;
                         };
 
                         // Run postExecute hooks


### PR DESCRIPTION
Fixes the `onError` asymmetry found while rebuilding the plugin-pipeline tests.

## The bug
`onError`'s `bool` return ("I handled this, don't propagate") was only honored on the **CommandNotFound** path. On a **command-execution** failure, the registry ran `onError` and then `return err` **unconditionally** — the `bool` only short-circuited calling further plugins:

```zig
cmd.module.execute(...) catch |err| {
    inline for (sorted_plugins) |Plugin| {
        if (@hasDecl(Plugin, "onError")) {
            const handled = try Plugin.onError(context, err);
            if (handled) break;   // only stops calling more plugins
        }
    }
    return err;   // ← always propagated, even when handled
};
```

So an error-reporting plugin that returns `true` to swallow, say, `error.NetworkTimeout` worked for unknown commands but silently didn't for a real command failure. Same hook, same return, different outcome.

## The fix
Both command-execute catch blocks (regular commands **and** plugin commands — there are two) now honor the return symmetrically:
- `onError` returns **true** → error suppressed, execution falls through to `postExecute` with `success = false`
- `onError` returns **false** (or no handler) → error propagates as before

## Safety check
Verified the shipped plugins won't start swallowing real errors: `zcli_help.onError` returns `false` for any non-`CommandNotFound` error (plugin.zig:135), and `zcli_not_found.onError` always returns `false`. So genuine command failures still surface in real apps.

## Tests
The PR #11 test that locked in the old *"observes a command failure but cannot suppress it"* behavior is replaced by two:
- `onError` returning **true** suppresses the error **and** `postExecute` is told `success = false`
- `onError` returning **false** lets the error propagate

## Verification
`zig build test` ✅ (all 9 packages; registry's own inline tests unaffected) · `zig build test-plugins` ✅

Note: trivially independent of the open #13 (different regions of `plugin_pipeline_test.zig`), so they merge cleanly in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)