### PR TITLE
Let commands name the generated Context type for editor hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ Every command has up to four exports:
 
 ```zig
 const zcli = @import("zcli");
+// Name your app's generated context type for full editor autocomplete on `context`.
+const Context = @import("command_registry").Context;
 
 pub const meta = .{
     .description = "Add files to the index",
@@ -170,10 +172,25 @@ pub const Options = struct {
     verbose: ?bool = null,              // optional flag
 };
 
-pub fn execute(args: Args, options: Options, context: anytype) !void {
-    // context.stdout(), context.stderr(), context.allocator, context.theme, etc.
+pub fn execute(args: Args, options: Options, context: *Context) !void {
+    // context.stdout(), context.stderr(), context.allocator, context.theme,
+    // context.plugins.<plugin_id>, etc. — all typed and autocompletable.
 }
 ```
+
+#### Typing `context`
+
+`Context` is generated per-app from your config and plugin set, so it carries a
+typed field for every plugin's data (`context.plugins.<plugin_id>`). You can type
+the parameter two ways:
+
+- **`context: *Context`** (above) — import `@import("command_registry").Context`.
+  Best for app-local commands: full autocomplete, go-to-definition, and errors at
+  the definition site. There's no import cycle — `Context` depends only on your
+  config and plugins, not on the command files.
+- **`context: anytype`** — portable across apps with no editor hints. Use this for
+  reusable/library commands and inside plugin hooks (a plugin is compiled
+  independently of the app that hosts it).
 
 ### Command groups
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -124,6 +124,10 @@ The framework uses comptime introspection on this registry to:
 Each command file exports a standardized structure:
 
 ```zig
+// Optional: name the app's generated context type for editor hints.
+// Omit this and use `context: anytype` for a reusable, app-agnostic command.
+const Context = @import("command_registry").Context;
+
 pub const meta = .{
     .description = "Search for users by name",
     .usage = "search <query> [files...] [--limit <n>]",
@@ -156,10 +160,11 @@ pub const Options = struct {
     verbose: bool = false,
 };
 
-pub fn execute(args: Args, options: Options, context: *zcli.Context) !void {
+pub fn execute(args: Args, options: Options, context: *Context) !void {
     // Command implementation
     // Access: args.query, args.files, options.limit, etc.
-    // Context provides: allocator, io (stdout/stderr/stdin), environment, and more
+    // Context provides: allocator, io (stdout/stderr/stdin), environment,
+    //   plugins.<plugin_id> (type-safe plugin data), and more
 }
 ```
 
@@ -684,19 +689,20 @@ pub const global_options = [_]zcli.GlobalOption{
     zcli.option("verbose", bool, .{ .short = 'v', .default = false, .description = "Verbose output" }),
 };
 
-// Lifecycle hooks (all optional)
-pub fn handleGlobalOption(context: *zcli.Context, name: []const u8, value: anytype) !void { }
-pub fn preExecute(context: *zcli.Context, args: zcli.ParsedArgs) !?zcli.ParsedArgs { }
-pub fn postExecute(context: *zcli.Context, result: anytype) !void { }
-pub fn onError(context: *zcli.Context, err: anyerror) !bool { }
+// Lifecycle hooks (all optional). Plugins are compiled independently of the
+// host app, so hooks take `context: anytype` rather than a named Context type.
+pub fn handleGlobalOption(context: anytype, name: []const u8, value: anytype) !void { }
+pub fn preExecute(context: anytype, args: zcli.ParsedArgs) !?zcli.ParsedArgs { }
+pub fn postExecute(context: anytype, result: anytype) !void { }
+pub fn onError(context: anytype, err: anyerror) !bool { }
 
-// Plugin can provide commands
+// Plugin can provide commands (also app-agnostic, so `context: anytype`)
 pub const commands = struct {
     pub const help = struct {
         pub const Args = struct { command: ?[]const u8 = null };
         pub const Options = struct {};
         pub const meta = .{ .description = "Show help for commands" };
-        pub fn execute(args: Args, options: Options, context: *zcli.Context) !void { }
+        pub fn execute(args: Args, options: Options, context: anytype) !void { }
     };
 };
 ```
@@ -768,8 +774,8 @@ pub fn deinitContextData(data: *ContextData, allocator: std.mem.Allocator) void 
     if (data.database) |db| db.close(allocator);
 }
 
-// Access in any hook or command (context is `anytype`):
-pub fn execute(args: Args, options: Options, context: anytype) !void {
+// Access in any hook or command:
+pub fn execute(args: Args, options: Options, context: *Context) !void {
     if (context.plugins.my_plugin.database) |db| {
         // Use db — fully typed, no casts, no lookups
     }
@@ -779,6 +785,34 @@ pub fn execute(args: Args, options: Options, context: anytype) !void {
 `ContextData` structs must be default-constructible; the generated `Context`
 initializes each plugin's field to `.{}`. See `ComputedContextType` in
 `packages/core/src/registry.zig`.
+
+**Typing the `context` parameter:**
+
+The `Context` type is computed per-app from your `config` + plugin set, so each
+app has its own concrete type. A command can name it in two ways — both receive
+the same value (a `*Context`, passed by the dispatcher):
+
+```zig
+// Option A — concrete type (recommended for app-local commands).
+// Full autocomplete, go-to-definition, and errors at the definition site.
+const Context = @import("command_registry").Context;
+
+pub fn execute(args: Args, options: Options, context: *Context) !void { ... }
+```
+
+```zig
+// Option B — generic (for reusable/library commands and plugin hooks).
+// Portable across any app, but no editor hints on `context`.
+pub fn execute(args: Args, options: Options, context: anytype) !void { ... }
+```
+
+Naming the concrete type does **not** create an import cycle: `command_registry`
+imports the command modules, but `Context` depends only on `config` + plugins —
+never on the commands — so the back-reference resolves cleanly. The build wires
+`command_registry` as an available import for every command module (see
+`createDiscoveredModules` in `packages/core/src/build_utils/module_creation.zig`).
+Plugin hooks stay `anytype` because a plugin is compiled independently of the
+app that hosts it.
 
 ## 13. Developer Experience
 

--- a/examples/showcase/src/commands/add.zig
+++ b/examples/showcase/src/commands/add.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
 const store = @import("store");
 const zinput = zcli.zinput;
 const ztheme = zcli.ztheme;
@@ -27,7 +28,7 @@ pub const Options = struct {
     points: ?u32 = null,
 };
 
-pub fn execute(args: Args, options: Options, context: anytype) !void {
+pub fn execute(args: Args, options: Options, context: *Context) !void {
     const allocator = context.allocator;
     var parsed = try store.load(allocator, context.io.io);
     defer parsed.deinit();

--- a/examples/showcase/src/commands/config.zig
+++ b/examples/showcase/src/commands/config.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
 const zinput = zcli.zinput;
 const ztheme = zcli.ztheme;
 
@@ -29,7 +30,7 @@ const Config = struct {
 
 const priorities = [_][]const u8{ "low", "medium", "high", "critical" };
 
-pub fn execute(_: Args, _: Options, context: anytype) !void {
+pub fn execute(_: Args, _: Options, context: *Context) !void {
     const allocator = context.allocator;
         const writer = context.stdout();
         const reader = context.stdin();

--- a/examples/showcase/src/commands/done.zig
+++ b/examples/showcase/src/commands/done.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
 const store = @import("store");
 const ztheme = zcli.ztheme;
 
@@ -12,7 +13,7 @@ pub const meta = .{
 pub const Args = struct { id: u32 };
 pub const Options = struct {};
 
-pub fn execute(args: Args, _: Options, context: anytype) !void {
+pub fn execute(args: Args, _: Options, context: *Context) !void {
     const allocator = context.allocator;
     var parsed = try store.load(allocator, context.io.io);
     defer parsed.deinit();

--- a/examples/showcase/src/commands/edit.zig
+++ b/examples/showcase/src/commands/edit.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
 const store = @import("store");
 const zinput = zcli.zinput;
 const ztheme = zcli.ztheme;
@@ -13,7 +14,7 @@ pub const meta = .{
 pub const Args = struct { id: u32 };
 pub const Options = struct {};
 
-pub fn execute(args: Args, _: Options, context: anytype) !void {
+pub fn execute(args: Args, _: Options, context: *Context) !void {
     const allocator = context.allocator;
     var parsed = try store.load(allocator, context.io.io);
     defer parsed.deinit();

--- a/examples/showcase/src/commands/import.zig
+++ b/examples/showcase/src/commands/import.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
 const store = @import("store");
 const zprogress = zcli.zprogress;
 const ztheme = zcli.ztheme;
@@ -13,7 +14,7 @@ pub const meta = .{
 pub const Args = struct { file: []const u8 };
 pub const Options = struct {};
 
-pub fn execute(args: Args, _: Options, context: anytype) !void {
+pub fn execute(args: Args, _: Options, context: *Context) !void {
     const allocator = context.allocator;
 
     // Read import file

--- a/examples/showcase/src/commands/init.zig
+++ b/examples/showcase/src/commands/init.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
 const store = @import("store");
 const zinput = zcli.zinput;
 const ztheme = zcli.ztheme;
@@ -12,7 +13,7 @@ pub const meta = .{
 pub const Args = struct {};
 pub const Options = struct {};
 
-pub fn execute(_: Args, _: Options, context: anytype) !void {
+pub fn execute(_: Args, _: Options, context: *Context) !void {
     const allocator = context.allocator;
         const writer = context.stdout();
         const reader = context.stdin();

--- a/examples/showcase/src/commands/list.zig
+++ b/examples/showcase/src/commands/list.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
 const store = @import("store");
 const ztheme = zcli.ztheme;
 
@@ -20,7 +21,7 @@ pub const Options = struct {
     all: bool = false,
 };
 
-pub fn execute(_: Args, options: Options, context: anytype) !void {
+pub fn execute(_: Args, options: Options, context: *Context) !void {
     const allocator = context.allocator;
     var parsed = try store.load(allocator, context.io.io);
     defer parsed.deinit();

--- a/examples/showcase/src/commands/remove.zig
+++ b/examples/showcase/src/commands/remove.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
 const store = @import("store");
 const zinput = zcli.zinput;
 const ztheme = zcli.ztheme;
@@ -14,7 +15,7 @@ pub const meta = .{
 pub const Args = struct { id: u32 };
 pub const Options = struct {};
 
-pub fn execute(args: Args, _: Options, context: anytype) !void {
+pub fn execute(args: Args, _: Options, context: *Context) !void {
     const allocator = context.allocator;
     var parsed = try store.load(allocator, context.io.io);
     defer parsed.deinit();

--- a/examples/showcase/src/commands/search.zig
+++ b/examples/showcase/src/commands/search.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
 const store = @import("store");
 const zinput = zcli.zinput;
 const ztheme = zcli.ztheme;
@@ -12,7 +13,7 @@ pub const meta = .{
 pub const Args = struct {};
 pub const Options = struct {};
 
-pub fn execute(_: Args, _: Options, context: anytype) !void {
+pub fn execute(_: Args, _: Options, context: *Context) !void {
     const allocator = context.allocator;
     var parsed = try store.load(allocator, context.io.io);
     defer parsed.deinit();

--- a/examples/showcase/src/commands/show.zig
+++ b/examples/showcase/src/commands/show.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
 const store = @import("store");
 const ztheme = zcli.ztheme;
 
@@ -12,7 +13,7 @@ pub const meta = .{
 pub const Args = struct { id: u32 };
 pub const Options = struct {};
 
-pub fn execute(args: Args, _: Options, context: anytype) !void {
+pub fn execute(args: Args, _: Options, context: *Context) !void {
     const allocator = context.allocator;
     var parsed = try store.load(allocator, context.io.io);
     defer parsed.deinit();

--- a/examples/showcase/src/commands/sprint/close.zig
+++ b/examples/showcase/src/commands/sprint/close.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
 const store = @import("store");
 const zinput = zcli.zinput;
 const ztheme = zcli.ztheme;
@@ -12,7 +13,7 @@ pub const meta = .{
 pub const Args = struct {};
 pub const Options = struct {};
 
-pub fn execute(_: Args, _: Options, context: anytype) !void {
+pub fn execute(_: Args, _: Options, context: *Context) !void {
     const allocator = context.allocator;
     var parsed = try store.load(allocator, context.io.io);
     defer parsed.deinit();

--- a/examples/showcase/src/commands/sprint/create.zig
+++ b/examples/showcase/src/commands/sprint/create.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
 const store = @import("store");
 const zinput = zcli.zinput;
 const ztheme = zcli.ztheme;
@@ -15,7 +16,7 @@ pub const Args = struct {
 };
 pub const Options = struct {};
 
-pub fn execute(args: Args, _: Options, context: anytype) !void {
+pub fn execute(args: Args, _: Options, context: *Context) !void {
     const allocator = context.allocator;
     var parsed = try store.load(allocator, context.io.io);
     defer parsed.deinit();

--- a/examples/showcase/src/commands/sprint/list.zig
+++ b/examples/showcase/src/commands/sprint/list.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
 const store = @import("store");
 const ztheme = zcli.ztheme;
 
@@ -11,7 +12,7 @@ pub const meta = .{
 pub const Args = struct {};
 pub const Options = struct {};
 
-pub fn execute(_: Args, _: Options, context: anytype) !void {
+pub fn execute(_: Args, _: Options, context: *Context) !void {
     const allocator = context.allocator;
     var parsed = try store.load(allocator, context.io.io);
     defer parsed.deinit();

--- a/examples/showcase/src/commands/sync.zig
+++ b/examples/showcase/src/commands/sync.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
 const zprogress = zcli.zprogress;
 
 pub const meta = .{
@@ -10,7 +11,7 @@ pub const meta = .{
 pub const Args = struct {};
 pub const Options = struct {};
 
-pub fn execute(_: Args, _: Options, context: anytype) !void {
+pub fn execute(_: Args, _: Options, context: *Context) !void {
     const io = context.io.io;
     var spinner = zprogress.spinner(io, .{ .style = .dots });
     spinner.start("Connecting to server...");

--- a/packages/core/src/build_utils/module_creation.zig
+++ b/packages/core/src/build_utils/module_creation.zig
@@ -60,6 +60,10 @@ pub fn createDiscoveredModules(
                     .root_source_file = b.path(full_path),
                 });
                 cmd_module.addImport("zcli", zcli_module);
+                // Let commands optionally name the generated Context type via
+                // `@import("command_registry").Context`. The back-reference is
+                // safe: Context depends only on config + plugins, not commands.
+                cmd_module.addImport("command_registry", registry_module);
 
                 // Add shared modules
                 for (shared_modules) |shared_mod| {
@@ -84,6 +88,7 @@ pub fn createDiscoveredModules(
                 .root_source_file = b.path(full_path),
             });
             cmd_module.addImport("zcli", zcli_module);
+            cmd_module.addImport("command_registry", registry_module);
 
             // Add shared modules
             for (shared_modules) |shared_mod| {
@@ -133,6 +138,7 @@ fn createGroupModules(
                     .root_source_file = b.path(full_path),
                 });
                 cmd_module.addImport("zcli", zcli_module);
+                cmd_module.addImport("command_registry", registry_module);
 
                 // Add shared modules
                 for (shared_modules) |shared_mod| {
@@ -167,6 +173,7 @@ fn createGroupModules(
                     .root_source_file = b.path(full_path),
                 });
                 cmd_module.addImport("zcli", zcli_module);
+                cmd_module.addImport("command_registry", registry_module);
 
                 // Add shared modules
                 for (shared_modules) |shared_mod| {

--- a/projects/zcli/src/commands/add/command.zig
+++ b/projects/zcli/src/commands/add/command.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
 
 pub const meta = .{
     .description = "Add a new command to your zcli project",
@@ -24,7 +25,7 @@ pub const Options = struct {
     description: ?[]const u8 = null,
 };
 
-pub fn execute(args: Args, options: Options, context: anytype) !void {
+pub fn execute(args: Args, options: Options, context: *Context) !void {
     const allocator = context.allocator;
     var stdout = context.stdout();
     var stderr = context.stderr();
@@ -105,6 +106,7 @@ pub fn execute(args: Args, options: Options, context: anytype) !void {
     const command_content = try std.fmt.allocPrint(allocator,
         \\const std = @import("std");
         \\const zcli = @import("zcli");
+        \\const Context = @import("command_registry").Context;
         \\
         \\pub const meta = .{{
         \\    .description = "{s}",
@@ -125,8 +127,7 @@ pub fn execute(args: Args, options: Options, context: anytype) !void {
         \\    // verbose: bool = false,
         \\}};
         \\
-        \\pub fn execute(args: Args, options: Options, context: anytype) !void {{
-        \\    comptime zcli.assertValidContext(@TypeOf(context));
+        \\pub fn execute(args: Args, options: Options, context: *Context) !void {{
         \\    _ = args;
         \\    _ = options;
         \\

--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
 
 pub const meta = .{
     .description = "Initialize a new zcli project",
@@ -26,7 +27,7 @@ pub const Options = struct {
     version: ?[]const u8 = null,
 };
 
-pub fn execute(args: Args, options: Options, context: anytype) !void {
+pub fn execute(args: Args, options: Options, context: *Context) !void {
     const allocator = context.allocator;
     var stdout = context.stdout();
     var stderr = context.stderr();
@@ -238,6 +239,7 @@ pub fn execute(args: Args, options: Options, context: anytype) !void {
     const hello_content =
         \\const std = @import("std");
         \\const zcli = @import("zcli");
+        \\const Context = @import("command_registry").Context;
         \\
         \\pub const meta = .{
         \\    .description = "Say hello to someone",
@@ -255,8 +257,7 @@ pub fn execute(args: Args, options: Options, context: anytype) !void {
         \\    loud: bool = false,
         \\};
         \\
-        \\pub fn execute(args: Args, options: Options, context: anytype) !void {
-        \\    comptime zcli.assertValidContext(@TypeOf(context));
+        \\pub fn execute(args: Args, options: Options, context: *Context) !void {
         \\    const greeting = if (options.loud) "HELLO" else "Hello";
         \\    try context.stdout().print("{s}, {s}!\n", .{ greeting, args.name });
         \\}


### PR DESCRIPTION
## Problem

Command `execute` functions had to type the `context` parameter as `anytype`. That gave no autocomplete, no go-to-definition, and no definition-site type checking — you couldn't tell what `context` offered just from the signature.

## Solution

The generated `command_registry` module already exported a concrete `Context` type (computed per-app from your `config` + plugin set, with a typed `plugins.<plugin_id>` field for each plugin). The only missing piece was making that module importable from command modules. Now a command can opt in:

```zig
const Context = @import("command_registry").Context;

pub fn execute(args: Args, options: Options, context: *Context) !void {
    // context.allocator, context.stdout(), context.plugins.<id> — all typed
}
```

`*Context` is the correct annotation (not by value): the dispatcher already passes a `*Context`, which is exactly what `anytype` was silently binding to.

## Fully opt-in, no breakage

- `context: anytype` still works unchanged — keep it for reusable/library commands and plugin hooks (a plugin is compiled independently of its host app).
- **No import cycle.** `command_registry` imports the command modules, but `Context` depends only on `config` + plugins, never on the commands — so the back-reference resolves cleanly. Verified with a standalone two-module spike and the real showcase build.

## Changes

- `module_creation.zig`: wire `command_registry` as an available import for every generated command module (4 spots).
- showcase: convert all 14 example commands to the concrete `*Context`.
- `README.md` / `docs/DESIGN.md`: document the opt-in; fix pre-existing drift where plugin hooks were shown as `*zcli.Context` (they are `anytype` in real plugins).

## Verification

- Showcase builds and runs end-to-end (`add`, `list` — the latter exercises `context.stdout()`, `&context.theme`, `context.allocator` through the concrete pointer).
- `zig build test-core` passes.
- Two pre-existing failures confirmed unrelated (reproduce on a clean tree): `zcli-doc-gen` needs a `docs/` dir, and the full `test` step has a network-dependent release-plugin test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)