### PR TITLE
Scaffold a juicy main() in `zcli init`

### DIFF
--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -215,17 +215,10 @@ pub fn execute(args: Args, options: Options, context: anytype) !void {
         \\const std = @import("std");
         \\const registry = @import("command_registry");
         \\
-        \\pub fn main() !void {
-        \\    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-        \\    defer {
-        \\        const deinit_status = gpa.deinit();
-        \\        if (deinit_status == .leak) {
-        \\            std.log.err("Memory leak detected!", .{});
-        \\        }
-        \\    }
-        \\
+        \\pub fn main(init: std.process.Init) !void {
+        \\    const args = try init.minimal.args.toSlice(init.arena.allocator());
         \\    var app = registry.init();
-        \\    app.run(gpa.allocator()) catch |err| switch (err) {
+        \\    app.run(init.gpa, init.io, init.environ_map, args) catch |err| switch (err) {
         \\        error.CommandNotFound => std.process.exit(1),
         \\        else => return err,
         \\    };


### PR DESCRIPTION
## What

`zcli init` was scaffolding a 0.15-era `src/main.zig`:

```zig
pub fn main() !void {
    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
    defer { ... }
    var app = registry.init();
    app.run(gpa.allocator()) catch |err| switch (err) { ... };
}
```

On 0.16 `run` takes `(allocator, io, environ, args)`, so the generated project **didn't compile**. This emits a [juicy main](https://simonwillison.net/2026/Apr/15/juicy-main/) instead — identical to the framework's own `projects/zcli/src/main.zig`:

```zig
pub fn main(init: std.process.Init) !void {
    const args = try init.minimal.args.toSlice(init.arena.allocator());
    var app = registry.init();
    app.run(init.gpa, init.io, init.environ_map, args) catch |err| switch (err) {
        error.CommandNotFound => std.process.exit(1),
        else => return err,
    };
}
```

> Note: this replaces the earlier approach of moving `main` into `code_generation.zig`. `main` stays in the app author's hands — we only fix the template we generate.

## Verification
- `zcli init myapp` now writes a `src/main.zig` byte-identical to the framework's own (verified by running the built CLI), which compiles and runs.

## Out of scope (flagged for follow-up)
These hand-written **doc** examples still show the old single-arg registry main and would mislead copy-paste users:
- `README.md` (~line 103)
- `docs/ERROR_HANDLING.md` (~line 238)
- `docs/DESIGN.md` (~line 645)

(`packages/core/src/benchmark_runner.zig` and `packages/markdown_fmt/examples/demo.zig` use a plain `main() !void` but are standalone non-registry tools — that's still valid on 0.16 and intentionally left alone.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)