### PR TITLE
feat: add zcli.builtin() shortcut for built-in plugins

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -161,4 +161,6 @@ pub fn build(b: *std.Build) void {
 pub const generate = @import("packages/core/build.zig").generate;
 pub const generateDocs = @import("packages/core/build.zig").generateDocs;
 pub const PluginConfig = @import("packages/core/build.zig").PluginConfig;
+pub const Builtin = @import("packages/core/build.zig").Builtin;
+pub const builtin = @import("packages/core/build.zig").builtin;
 pub const SharedModule = @import("packages/core/build.zig").SharedModule;

--- a/examples/showcase/build.zig
+++ b/examples/showcase/build.zig
@@ -31,13 +31,13 @@ pub fn build(b: *std.Build) void {
 
     const cmd_registry = zcli.generate(b, exe, zcli_dep, zcli_module, .{
         .commands_dir = "src/commands",
-        .plugins = &[_]zcli.PluginConfig{
-            .{ .name = "zcli_help", .path = "packages/core/src/plugins/zcli_help" },
-            .{ .name = "zcli_version", .path = "packages/core/src/plugins/zcli_version" },
-            .{ .name = "zcli_not_found", .path = "packages/core/src/plugins/zcli_not_found" },
-            .{ .name = "zcli_completions", .path = "packages/core/src/plugins/zcli_completions" },
-            .{ .name = "zcli_output", .path = "packages/core/src/plugins/zcli_output" },
-            .{ .name = "zcli_config", .path = "packages/core/src/plugins/zcli_config" },
+        .plugins = &.{
+            zcli.builtin(.help, .{}),
+            zcli.builtin(.version, .{}),
+            zcli.builtin(.not_found, .{}),
+            zcli.builtin(.completions, .{}),
+            zcli.builtin(.output, .{}),
+            zcli.builtin(.config, .{}),
         },
         .shared_modules = &[_]zcli.SharedModule{
             .{ .name = "store", .module = store_module },

--- a/packages/core/build.zig
+++ b/packages/core/build.zig
@@ -242,6 +242,8 @@ pub fn build(b: *std.Build) void {
 // Re-export build utilities for both backwards compatibility and new plugin features
 pub const BuildConfig = types.BuildConfig;
 pub const PluginConfig = types.PluginConfig;
+pub const Builtin = types.Builtin;
+pub const builtin = types.builtin;
 pub const SharedModule = types.SharedModule;
 pub const CommandConfig = types.CommandConfig;
 pub const CommandModule = types.CommandModule;

--- a/packages/core/src/build_utils/main.zig
+++ b/packages/core/src/build_utils/main.zig
@@ -186,8 +186,11 @@ pub fn generate(b: *std.Build, exe: *std.Build.Step.Compile, zcli_dep: *std.Buil
             std.process.exit(1);
         };
 
-        // Check if plugin has config and generate init code
-        const init_code = if (@hasField(@TypeOf(plugin_config), "config"))
+        // Check if plugin has a non-empty config and generate init code.
+        // An empty config (e.g. `builtin(.help, .{})`) means no `.init(...)` call.
+        const has_config = @hasField(@TypeOf(plugin_config), "config") and
+            @typeInfo(@TypeOf(plugin_config.config)).@"struct".fields.len > 0;
+        const init_code = if (has_config)
             configToInitString(b.allocator, plugin_config.config)
         else
             null;

--- a/packages/core/src/build_utils/types.zig
+++ b/packages/core/src/build_utils/types.zig
@@ -157,6 +157,54 @@ pub const PluginConfig = struct {
     init: ?[]const u8 = null,
 };
 
+/// Built-in plugins that ship with zcli. Enable one with `builtin(.help, .{})`
+/// instead of spelling out its name and path by hand.
+pub const Builtin = enum {
+    help,
+    version,
+    not_found,
+    completions,
+    config,
+    output,
+    github_upgrade,
+
+    /// Registration name, e.g. `zcli_help`.
+    pub fn pluginName(comptime self: Builtin) []const u8 {
+        return "zcli_" ++ @tagName(self);
+    }
+
+    /// Path to the plugin's source within the zcli package.
+    pub fn pluginPath(comptime self: Builtin) []const u8 {
+        return "packages/core/src/plugins/zcli_" ++ @tagName(self);
+    }
+};
+
+fn BuiltinPlugin(comptime Config: type) type {
+    return struct {
+        name: []const u8,
+        path: []const u8,
+        config: Config,
+    };
+}
+
+/// Register a built-in plugin in a `generate()` plugins list. Pass `.{}` as the
+/// config for plugins that take none:
+///
+/// ```zig
+/// .plugins = &.{
+///     zcli.builtin(.help, .{}),
+///     zcli.builtin(.github_upgrade, .{ .repo = "user/repo", .command_name = "upgrade" }),
+///     .{ .name = "my_plugin", .path = "src/plugins/my_plugin" }, // handrolled
+/// },
+/// ```
+pub fn builtin(comptime tag: Builtin, comptime config: anytype) BuiltinPlugin(@TypeOf(config)) {
+    return .{
+        .name = tag.pluginName(),
+        .path = tag.pluginPath(),
+        .config = config,
+    };
+}
+
 /// External plugin build configuration
 pub const ExternalPluginBuildConfig = struct {
     commands_dir: []const u8,

--- a/projects/zcli/build.zig
+++ b/projects/zcli/build.zig
@@ -36,27 +36,17 @@ pub fn build(b: *std.Build) void {
 
     const cmd_registry = zcli.generate(b, exe, zcli_dep, zcli_module, .{
         .commands_dir = "src/commands",
-        .plugins = &.{ .{
-            .name = "zcli_help",
-            .path = "packages/core/src/plugins/zcli_help",
-        }, .{
-            .name = "zcli_version",
-            .path = "packages/core/src/plugins/zcli_version",
-        }, .{
-            .name = "zcli_not_found",
-            .path = "packages/core/src/plugins/zcli_not_found",
-        }, .{
-            .name = "zcli_github_upgrade",
-            .path = "packages/core/src/plugins/zcli_github_upgrade",
-            .config = .{
+        .plugins = &.{
+            zcli.builtin(.help, .{}),
+            zcli.builtin(.version, .{}),
+            zcli.builtin(.not_found, .{}),
+            zcli.builtin(.github_upgrade, .{
                 .repo = "ryanhair/zcli",
                 .command_name = "upgrade",
                 .inform_out_of_date = false,
-            },
-        }, .{
-            .name = "zcli_completions",
-            .path = "packages/core/src/plugins/zcli_completions",
-        } },
+            }),
+            zcli.builtin(.completions, .{}),
+        },
         .app_name = "zcli",
         .app_description = "Build beautiful CLIs with zcli - scaffold projects, add commands, and more",
         .shared_modules = &[_]zcli.SharedModule{

--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -172,19 +172,12 @@ pub fn execute(args: Args, options: Options, context: anytype) !void {
         \\    const zcli = @import("zcli");
         \\    const cmd_registry = zcli.generate(b, exe, zcli_dep, zcli_module, .{{
         \\        .commands_dir = "src/commands",
-        \\        .plugins = &.{{ .{{
-        \\            .name = "zcli_help",
-        \\            .path = "src/plugins/zcli_help",
-        \\        }}, .{{
-        \\            .name = "zcli_version",
-        \\            .path = "src/plugins/zcli_version",
-        \\        }}, .{{
-        \\            .name = "zcli_not_found",
-        \\            .path = "src/plugins/zcli_not_found",
-        \\        }}, .{{
-        \\            .name = "zcli_completions",
-        \\            .path = "src/plugins/zcli_completions",
-        \\        }} }},
+        \\        .plugins = &.{{
+        \\            zcli.builtin(.help, .{{}}),
+        \\            zcli.builtin(.version, .{{}}),
+        \\            zcli.builtin(.not_found, .{{}}),
+        \\            zcli.builtin(.completions, .{{}}),
+        \\        }},
         \\        .app_name = "{s}",
         \\        .app_version = "{s}",
         \\        .app_description = "{s}",


### PR DESCRIPTION
## What

Adds a `zcli.builtin(tag, config)` shortcut so built-in plugins enable by tag instead of a redundant name + full path.

**Before:**
```zig
.plugins = &.{
    .{ .name = "zcli_help",    .path = "packages/core/src/plugins/zcli_help" },
    .{ .name = "zcli_version", .path = "packages/core/src/plugins/zcli_version" },
    .{ .name = "zcli_github_upgrade", .path = "packages/core/src/plugins/zcli_github_upgrade",
       .config = .{ .repo = "ryanhair/zcli", .command_name = "upgrade" } },
},
```

**After:**
```zig
.plugins = &.{
    zcli.builtin(.help, .{}),
    zcli.builtin(.version, .{}),
    zcli.builtin(.github_upgrade, .{ .repo = "ryanhair/zcli", .command_name = "upgrade" }),
    .{ .name = "my_plugin", .path = "src/plugins/my_plugin" }, // handrolled, unchanged
},
```

Builtins and handrolled plugins share one ordered list, so pipeline ordering is preserved. Config is **always** passed (`.{}` when none) for uniform, idiomatic call sites — no overloads.

## Why

The name and path for a builtin are 100% redundant (path is always `packages/core/src/plugins/<name>`), and a mistyped path fails only at build time as a confusing "file not found". The tag form is typo-safe and discoverable via the enum.

## Changes

- `build_utils/types.zig` — `Builtin` enum (`help`, `version`, `not_found`, `completions`, `config`, `output`, `github_upgrade`) with `pluginName()`/`pluginPath()`, plus the `builtin()` helper.
- `build_utils/main.zig` — `generate()` treats an **empty** config as no init, so `builtin(.help, .{})` emits a plain import rather than `.init(.{})`.
- `packages/core/build.zig` + `build.zig` — re-export `Builtin` and `builtin`.
- `projects/zcli/build.zig`, `examples/showcase/build.zig`, `init` scaffold template — migrated to `builtin()`.

## Bonus fix

The `init` scaffold emitted `.path = "src/plugins/zcli_help"`, which does **not** resolve to where builtins actually live inside the zcli dependency (`packages/core/src/plugins/...`). `builtin()` centralizes the one correct path, so newly scaffolded projects get working builtins.

## Verification

- `projects/zcli` and `examples/showcase` compile registry + executable cleanly.
- Generated `zcli_generated.zig` confirms correct output: plain imports for empty config, `.init(...)` preserved for `github_upgrade`.
- Core unit tests pass.
- The one failing build step (`zcli-doc-gen` writing to a missing `docs/` dir) is pre-existing — confirmed it fails identically with these changes stashed, and is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)