### PR TITLE
Fix zcli-doc-gen FileNotFound on a clean build

### DIFF
--- a/packages/core/src/doc_gen_main.zig
+++ b/packages/core/src/doc_gen_main.zig
@@ -30,7 +30,8 @@ pub fn main(init: std.process.Init) !void {
             try allocator.dupe(u8, output_dir);
         defer allocator.free(dir);
 
-        // Note: directory creation is handled by the build system step
+        // Ensure the output directory exists before writing into it.
+        try std.Io.Dir.cwd().createDirPath(io, dir);
 
         if (std.mem.eql(u8, format, "man")) {
             try writeManPages(allocator, io, dir, commands, global_opts);


### PR DESCRIPTION
## Problem

On a clean tree, `zig build` fails at the `zcli-doc-gen` run step:

```
error: FileNotFound
... in createFile (zcli-doc-gen)
packages/core/src/doc_gen_main.zig:55  createFile(io, index_path, .{})
```

`generateDocs` wires up `b.addRunArtifact(doc_exe)` with the output dir as an argument, but nothing ever creates that directory. The generator's very first write — the top-level `README.md`/`index.html` — calls `createFile` into a `docs/` dir that doesn't exist yet. Nested command pages already call `createDirPath` for their parents, so only the top-level output dir was missed. A stale comment in the loop even claimed "directory creation is handled by the build system step," which was never true.

## Fix

Create the output directory up front with `createDirPath`, consistent with how nested pages are already handled:

```zig
// Ensure the output directory exists before writing into it.
try std.Io.Dir.cwd().createDirPath(io, dir);
```

## Verification
- `projects/zcli`: `rm -rf docs && zig build` → exit 0, generates `docs/{markdown,man,html}/`.
- `examples/showcase`: `rm -rf docs && zig build` → exit 0; `zig build run` works.

Follow-up to #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)