### PR TITLE
fix(testing): address PTY-harness review findings

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -336,6 +336,7 @@ test "login prompts for credentials" {
 
     var result = try testing.e2e.runInteractive(
         allocator,
+        std.testing.io,
         &.{"./zig-out/bin/myapp", "login"},
         script,
         .{ .allocate_pty = true },
@@ -355,6 +356,7 @@ test "ctrl-c triggers graceful shutdown" {
 
     var result = try testing.e2e.runInteractive(
         allocator,
+        std.testing.io,
         &.{"./zig-out/bin/myapp", "serve"},
         script,
         .{ .forward_signals = true },

--- a/packages/testing/src/e2e.zig
+++ b/packages/testing/src/e2e.zig
@@ -318,12 +318,12 @@ pub const PtyManager = struct {
                     caps.supports_raw_mode = false;
                 }
 
-                caps.supports_echo_control = (self.setEcho(false) catch null) == null;
+                caps.supports_echo_control = if (self.setEcho(false)) |_| true else |_| false;
                 if (caps.supports_echo_control) {
                     _ = self.setEcho(true) catch {};
                 }
 
-                caps.supports_line_buffering = (self.setLineBuffering(false) catch null) == null;
+                caps.supports_line_buffering = if (self.setLineBuffering(false)) |_| true else |_| false;
                 if (caps.supports_line_buffering) {
                     _ = self.setLineBuffering(true) catch {};
                 }
@@ -928,6 +928,18 @@ pub fn runInteractive(
     // Drain any remaining output, then reap.
     drainOutput(allocator, io, read_fd, &output_buffer, 1000) catch {};
 
+    // For a PTY, close the master after draining so a child that reads until
+    // end-of-input gets EOF/SIGHUP and exits — otherwise `child.wait` could block
+    // on it. (The pipe path already closed stdin above for the same reason.)
+    if (using_pty) {
+        if (pty_manager) |*pty| {
+            if (pty.master_fd != -1) {
+                closeFd(pty.master_fd);
+                pty.master_fd = -1;
+            }
+        }
+    }
+
     const term = child.wait(io) catch return InteractiveError.ProcessCrashed;
     const exit_code: u8 = switch (term) {
         .exited => |code| code,
@@ -1064,16 +1076,21 @@ fn drainOutput(
     const start_time = nowMs(io);
     var temp_buffer: [4096]u8 = undefined;
 
+    // Keep reading until the stream has been idle for a few poll windows (~150ms)
+    // or the timeout is hit. Breaking on "buffer already has data" would drop
+    // output that arrives after the script's last matched `expect`.
+    var idle_polls: u8 = 0;
     while (true) {
         const elapsed = nowMs(io) - start_time;
         if (elapsed > timeout_ms) break;
 
         const bytes_read = pollRead(fd, &temp_buffer, 50);
         if (bytes_read == 0) {
-            // Idle for one poll window after we've seen data — assume drained.
-            if (output_buffer.items.len > 0) break;
+            idle_polls += 1;
+            if (idle_polls >= 3) break;
             continue;
         }
+        idle_polls = 0;
         try output_buffer.appendSlice(allocator, temp_buffer[0..bytes_read]);
     }
 }

--- a/packages/testing/src/main.zig
+++ b/packages/testing/src/main.zig
@@ -28,7 +28,7 @@
 //! test "login flow" {
 //!     var script = testing.e2e.InteractiveScript.init(allocator);
 //!     _ = script.expect("Password:").sendHidden("secret");
-//!     const result = try testing.e2e.runInteractive(allocator, &.{"./myapp", "login"}, script, .{});
+//!     const result = try testing.e2e.runInteractive(allocator, std.testing.io, &.{"./myapp", "login"}, script, .{});
 //!     try std.testing.expect(result.success);
 //! }
 //! ```


### PR DESCRIPTION
## What

Follow-up to the external **composer-2.5** review of the libc-free PTY test harness (#22). I re-checked every finding against current `main` (which has moved on: Windows backend, 0.18.0, interactive `add`) and fixed the ones that still exist and are genuine bugs.

## Fixed

- **`drainOutput` dropped trailing output** — it broke on the first idle poll whenever the buffer already had data (always true after a matched `expect`), so bytes emitted after the last `expect` were lost. Now drains until the stream is idle for ~3 poll windows or the timeout.
- **`detectTerminalCapabilities` reported echo / line-buffering support inverted** — `(setEcho(false) catch null) == null` is true only on *failure*. Replaced with `if (setEcho(false)) |_| true else |_| false`. (Pre-existing; masked in tests by the `builtin.is_test` short-circuit.)
- **`runInteractive` PTY hang on success** — the pipe path closed stdin to signal EOF, but the PTY path never closed the master, so a PTY child that reads to EOF could block `child.wait` even on a successful script. Now closes the master after draining (symmetric with the pipe path). The timeout case was already handled by the earlier SIGTERM-on-failure.
- **Stale docs** — `packages/testing/src/main.zig` doc example and `docs/TESTING.md` still showed `runInteractive(allocator, …)` without the `io` parameter added in #22.

## Reviewed and confirmed OK (no change)
ioctl constants (x86_64 + aarch64, both OSes), the `doIoctl` Linux/macOS split, the Linux PTY unlock/number/open sequence and fd ownership, and the `init.zig` fingerprint layout — all correct per the review.

## Accepted / documented (not fixed)
- No controlling-terminal / job-control for spawned children: `std.process.spawn` has no `setsid`/`TIOCSCTTY`, and 0.16 removed the `exec*` family from `std.posix`, so manual fork/exec isn't an option. The child still gets a PTY (so `isatty()` is true).
- The pipe *fallback* when `/dev/ptmx` is unavailable (rare) isn't a full PTY substitute.
- The CLI e2e job runs ubuntu-only; the macOS PTY ioctl path is exercised by the `testing` unit tests (which do run on macos-latest).

## Test plan

- `zig build test` passes natively on macOS (incl. the `cat` interactive test through the fixed drain path).
- `packages/testing` compiles on `x86_64-linux-musl`.
- CI matrix (ubuntu + macos) validates both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)