### PR TITLE
feat(init): select built-in plugins during scaffolding

### DIFF
--- a/packages/terminal/src/backend_posix.zig
+++ b/packages/terminal/src/backend_posix.zig
@@ -62,10 +62,16 @@ pub fn getWindowSize(fd: Handle) !Winsize {
 
 /// A descriptor is a TTY iff its termios can be read — a libc-free isatty
 /// (`std.posix.isatty` was removed in 0.16, and the syscall-free check is
-/// exactly what isatty does under the hood).
+/// exactly what isatty does under the hood). We call the syscall directly
+/// rather than `posix.tcgetattr` so that a non-terminal fd (e.g. /dev/null,
+/// which reports ENODEV on Darwin) simply returns false instead of routing
+/// through `unexpectedErrno`, which dumps a stack trace in debug builds.
 pub fn isTty(fd: Handle) bool {
-    _ = posix.tcgetattr(fd) catch return false;
-    return true;
+    var term: posix.termios = undefined;
+    return switch (posix.errno(posix.system.tcgetattr(fd, &term))) {
+        .SUCCESS => true,
+        else => false,
+    };
 }
 
 pub fn waitReadable(fd: Handle, timeout_ms: i32) bool {

--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -158,8 +158,11 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
 
     // Generate build.zig.zon
     try stdout.print("  Creating build.zig.zon...\n", .{});
-    // Use zcli package from GitHub archive
-    const zcli_version = "0.9.3";
+    // Pin the generated project to the same zcli release as this CLI.
+    // `context.app_version` is read from build.zig.zon at build time, so it
+    // tracks releases automatically (the framework and this CLI are tagged in
+    // lockstep as `zcli-v<version>`).
+    const zcli_version = context.app_version;
     // Package fingerprint: high 32 bits are a checksum of the package name, low
     // 32 bits a random id. Zig rejects a zero fingerprint at build time.
     const fingerprint: u64 = blk: {
@@ -170,18 +173,17 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         if (id == 0) id = 1;
         break :blk (@as(u64, checksum) << 32) | id;
     };
+    // The zcli dependency is added below by `zig fetch --save`, which computes
+    // the real hash. We must NOT pre-write a placeholder entry here: zig parses
+    // the existing manifest before fetching, and an incomplete hash makes that
+    // parse (and therefore the fetch) fail.
     const zon_content = try std.fmt.allocPrint(allocator,
         \\.{{
         \\    .name = .{s},
         \\    .version = "{s}",
         \\    .fingerprint = 0x{x:0>16},
         \\    .minimum_zig_version = "0.16.0",
-        \\    .dependencies = .{{
-        \\        .zcli = .{{
-        \\            .url = "https://github.com/ryanhair/zcli/archive/refs/tags/v{s}.tar.gz",
-        \\            .hash = "1220000000000000000000000000000000000000000000000000000000000000",
-        \\        }},
-        \\    }},
+        \\    .dependencies = .{{}},
         \\    .paths = .{{
         \\        "build.zig",
         \\        "build.zig.zon",
@@ -189,7 +191,7 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         \\    }},
         \\}}
         \\
-    , .{ project_identifier, app_version, fingerprint, zcli_version });
+    , .{ project_identifier, app_version, fingerprint });
     defer allocator.free(zon_content);
 
     var zon_file = try project_dir.createFile(io, "build.zig.zon", .{});
@@ -315,22 +317,28 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
     defer hello_file.close(io);
     try hello_file.writeStreamingAll(io, hello_content);
 
-    // Fetch zcli dependency
-    fetch_deps: {
+    // Fetch the zcli dependency. `zig fetch --save` computes the real hash and
+    // writes the dependency into build.zig.zon; without it the generated project
+    // won't build, so warn with the exact command if it doesn't run.
+    {
         try stdout.print("  Fetching dependencies (this may take a moment)...\n", .{});
-        const zcli_url = try std.fmt.allocPrint(allocator, "https://github.com/ryanhair/zcli/archive/refs/tags/v{s}.tar.gz", .{zcli_version});
+        const zcli_url = try std.fmt.allocPrint(allocator, "https://github.com/ryanhair/zcli/archive/refs/tags/zcli-v{s}.tar.gz", .{zcli_version});
         defer allocator.free(zcli_url);
 
-        var fetch_child = std.process.spawn(io, .{
-            .argv = &.{ "zig", "fetch", "--save", zcli_url },
-            .cwd = .{ .dir = project_dir },
-            .stdout = .pipe,
-            .stderr = .pipe,
-        }) catch {
-            stdout.print("  Note: Run 'zig fetch --save {s}' to add the dependency\n", .{zcli_url}) catch {};
-            break :fetch_deps;
+        const ok = ok: {
+            var fetch_child = std.process.spawn(io, .{
+                .argv = &.{ "zig", "fetch", "--save", zcli_url },
+                .cwd = .{ .dir = project_dir },
+                .stdout = .ignore,
+                .stderr = .inherit,
+            }) catch break :ok false;
+            const term = fetch_child.wait(io) catch break :ok false;
+            break :ok term == .exited and term.exited == 0;
         };
-        _ = fetch_child.wait(io) catch {};
+        if (!ok) {
+            try stderr.print("  Warning: could not add the zcli dependency automatically.\n", .{});
+            try stderr.print("  Run this inside the project to finish setup:\n    zig fetch --save {s}\n", .{zcli_url});
+        }
     }
 
     // Success message

--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -1,6 +1,25 @@
 const std = @import("std");
 const zcli = @import("zcli");
 const Context = @import("command_registry").Context;
+const zinput = zcli.zinput;
+
+/// A built-in plugin the user can opt into during `init`. `tag` is the enum
+/// tag passed to `zcli.builtin(.<tag>, .{})` in the generated build.zig.
+const BuiltinChoice = struct {
+    tag: []const u8,
+    label: []const u8,
+    default: bool,
+};
+
+const builtin_choices = [_]BuiltinChoice{
+    .{ .tag = "help", .label = "zcli_help — --help output for the app and every command", .default = true },
+    .{ .tag = "version", .label = "zcli_version — --version flag", .default = true },
+    .{ .tag = "not_found", .label = "zcli_not_found — \"did you mean?\" suggestions for mistyped commands", .default = true },
+    .{ .tag = "completions", .label = "zcli_completions — shell completion scripts (bash/zsh/fish)", .default = false },
+    .{ .tag = "config", .label = "zcli_config — load option defaults from a config file", .default = false },
+    .{ .tag = "output", .label = "zcli_output — --output flag for json/table/plain output", .default = false },
+    .{ .tag = "github_upgrade", .label = "zcli_github_upgrade — self-update from GitHub releases", .default = false },
+};
 
 pub const meta = .{
     .description = "Initialize a new zcli project",
@@ -66,10 +85,13 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
     const app_description = options.description orelse "A CLI application built with zcli";
     const app_version = options.version orelse "0.1.0";
 
-    // Handle directory creation/validation
-    var project_dir = if (use_current_dir) blk: {
+    // Validate the target directory before prompting or creating anything, so we
+    // never leave a half-created project behind if validation fails or the user
+    // aborts the plugin prompt.
+    if (use_current_dir) {
         // Check if current directory is empty or contains only hidden files
         var dir = try cwd.openDir(io, ".", .{ .iterate = true });
+        defer dir.close(io);
         var iterator = dir.iterate();
 
         var has_visible_files = false;
@@ -88,23 +110,46 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         }
 
         try stdout.print("Initializing zcli project in current directory: {s}\n", .{project_name});
-        break :blk try cwd.openDir(io, ".", .{});
-    } else blk: {
-        // Check if directory already exists
-        cwd.access(io, args.name, .{}) catch |err| switch (err) {
+    } else {
+        // Check if directory already exists (access succeeds => the path exists).
+        if (cwd.access(io, args.name, .{})) |_| {
+            try stderr.print("Error: Directory '{s}' already exists\n", .{args.name});
+            return error.PathAlreadyExists;
+        } else |err| switch (err) {
             error.FileNotFound => {}, // Good, directory doesn't exist
-            else => {
-                try stderr.print("Error: Directory '{s}' already exists\n", .{args.name});
-                return err;
-            },
-        };
+            else => return err,
+        }
 
         try stdout.print("Creating new zcli project: {s}\n", .{project_name});
+    }
 
-        // Create project directory
-        try cwd.createDir(io, args.name, .default_dir);
-        break :blk try cwd.openDir(io, args.name, .{});
-    };
+    // Ask which built-in plugins to include, before touching the filesystem.
+    // Falls back to the preselected defaults when stdin is not a TTY.
+    var choices: [builtin_choices.len][]const u8 = undefined;
+    var defaults: [builtin_choices.len]bool = undefined;
+    for (builtin_choices, 0..) |choice, i| {
+        choices[i] = choice.label;
+        defaults[i] = choice.default;
+    }
+    const selected = try zinput.multiSelect(stdout, context.stdin(), allocator, .{
+        .message = "Select built-in plugins to include:",
+        .choices = &choices,
+        .defaults = &defaults,
+    });
+    defer allocator.free(selected);
+
+    // Build the `zcli.builtin(...)` registration lines for build.zig.
+    var plugins_aw = std.Io.Writer.Allocating.init(allocator);
+    defer plugins_aw.deinit();
+    for (selected) |idx| {
+        try plugins_aw.writer.print("            zcli.builtin(.{s}, .{{}}),\n", .{builtin_choices[idx].tag});
+    }
+    const plugins_block = plugins_aw.written();
+
+    // Now that the destination is validated and plugins are chosen, create and
+    // open the project directory.
+    if (!use_current_dir) try cwd.createDir(io, args.name, .default_dir);
+    var project_dir = try cwd.openDir(io, if (use_current_dir) "." else args.name, .{});
     defer project_dir.close(io);
 
     // Create src and src/commands directories
@@ -184,11 +229,7 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         \\    const cmd_registry = zcli.generate(b, exe, zcli_dep, zcli_module, .{{
         \\        .commands_dir = "src/commands",
         \\        .plugins = &.{{
-        \\            zcli.builtin(.help, .{{}}),
-        \\            zcli.builtin(.version, .{{}}),
-        \\            zcli.builtin(.not_found, .{{}}),
-        \\            zcli.builtin(.completions, .{{}}),
-        \\        }},
+        \\{s}        }},
         \\        .app_name = "{s}",
         \\        .app_version = "{s}",
         \\        .app_description = "{s}",
@@ -206,7 +247,7 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         \\    run_step.dependOn(&run_cmd.step);
         \\}}
         \\
-    , .{ project_name, project_name, app_version, app_description });
+    , .{ project_name, plugins_block, project_name, app_version, app_description });
     defer allocator.free(build_content);
 
     var build_file = try project_dir.createFile(io, "build.zig", .{});

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -47,6 +47,9 @@ fn run(cwd: std.Io.Dir, argv: []const []const u8) !RunResult {
     var child = try std.process.spawn(io, .{
         .argv = argv,
         .cwd = .{ .dir = cwd },
+        // Non-interactive stdin so prompts (e.g. `init`'s plugin selection)
+        // fall back to their defaults instead of blocking on a TTY.
+        .stdin = .ignore,
         .stdout = .pipe,
         .stderr = .pipe,
     });
@@ -138,10 +141,12 @@ test "init scaffolds a project with the expected files and wiring" {
 
     const build_zig = try readFile(proj, a, "build.zig");
     try expectContains(build_zig, "zcli.generate(");
+    // With no TTY, the plugin prompt falls back to its preselected defaults:
+    // help, version, and not_found (but not the opt-in plugins like completions).
     try expectContains(build_zig, "zcli.builtin(.help");
     try expectContains(build_zig, "zcli.builtin(.version");
     try expectContains(build_zig, "zcli.builtin(.not_found");
-    try expectContains(build_zig, "zcli.builtin(.completions");
+    try testing.expect(std.mem.indexOf(u8, build_zig, "zcli.builtin(.completions") == null);
 
     const hello = try readFile(proj, a, "src/commands/hello.zig");
     try expectContains(hello, "pub fn execute(");
@@ -505,4 +510,50 @@ test "interactive: add command drives the wizard and echoes typed input" {
     try testing.expect(result.exit_code == 0);
     try expectContains(result.output, "Created src/commands/deploy.zig");
     try testing.expect(fileExists(tmp.dir, "src/commands/deploy.zig"));
+}
+
+test "interactive: init's plugin multi-select toggles an opt-in plugin" {
+    if (builtin.os.tag == .windows) return;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const proj_abs = try tmpDirAbs(arena.allocator(), tmp);
+
+    // The multi-select enables raw mode once after printing its list, so a single
+    // settle before sending is enough (see the wizard test above for the timing
+    // rationale). The cursor starts on the first choice (help); three Down arrows
+    // move it to `completions` (an opt-in, off by default), Space toggles it on,
+    // and Enter confirms — leaving the three defaults plus completions selected.
+    const settle_ms = 400;
+    var script = harness.InteractiveScript.init(testing.allocator);
+    defer script.deinit();
+    _ = script
+        .expect("Select built-in plugins").delay(settle_ms)
+        .sendRaw("\x1b[B\x1b[B\x1b[B \r");
+
+    var result = harness.runInteractive(
+        testing.allocator,
+        io,
+        &.{ zcli_exe, "init", "myapp" },
+        script,
+        .{ .cwd = proj_abs, .allocate_pty = true, .total_timeout_ms = 30000 },
+    ) catch |err| {
+        // PTY allocation can be denied in some sandboxes; don't fail the suite.
+        std.debug.print("runInteractive unavailable: {any}\n", .{err});
+        return;
+    };
+    defer result.deinit();
+
+    try testing.expect(result.exit_code == 0);
+
+    var proj = try tmp.dir.openDir(io, "myapp", .{});
+    defer proj.close(io);
+    const build_zig = try readFile(proj, arena.allocator(), "build.zig");
+    try expectContains(build_zig, "zcli.builtin(.help");
+    try expectContains(build_zig, "zcli.builtin(.version");
+    try expectContains(build_zig, "zcli.builtin(.not_found");
+    try expectContains(build_zig, "zcli.builtin(.completions");
 }


### PR DESCRIPTION
## What

`zcli init` now lets you choose which built-in plugins to include via an interactive multi-select, with `zcli_help`, `zcli_version`, and `zcli_not_found` preselected. The generated `build.zig`'s `.plugins` list is built from your selection.

```
Creating new zcli project: my-app
? Select built-in plugins to include: (space to toggle, enter to confirm)
    ◉ zcli_help — --help output for the app and every command
    ◉ zcli_version — --version flag
    ◉ zcli_not_found — "did you mean?" suggestions for mistyped commands
    ◯ zcli_completions — shell completion scripts (bash/zsh/fish)
    ◯ zcli_config — load option defaults from a config file
    ◯ zcli_output — --output flag for json/table/plain output
    ◯ zcli_github_upgrade — self-update from GitHub releases
```

## Plugin selection

- **Non-interactive safe:** when stdin isn't a TTY (pipes, CI, `< /dev/null`), the prompt falls back to the three preselected defaults, so scripted `zcli init` keeps working. (Non-TTY also accepts comma-separated numbers for a custom set.)
- **Prompt before any writes:** the prompt runs after the destination directory is *validated* but before anything is created on disk, so aborting the prompt (Ctrl+C) or a validation failure never leaves a half-created project behind.
- **Bug fix (existence check):** the new-dir "already exists" check was inverted — `access()` *succeeds* when the path exists, so the old `catch` never fired and the failure only surfaced later at `createDir`. Now an existing directory fails fast with a clear error *before* prompting.
- **Robustness fix (`terminal.isTty`):** now calls `tcgetattr` directly with an errno switch. A non-terminal fd (e.g. `/dev/null`, which reports `ENODEV` on Darwin) returns `false` cleanly instead of routing through `std.posix.unexpectedErrno`, which dumps a stack trace in debug builds. `init` is the first command to probe the TTY, so this noise would otherwise appear on `zcli init < /dev/null`.

## Scaffolded projects now actually build

Reported separately: a freshly `init`-ed project failed at `zig build` with `invalid hash: incomplete`. Three compounding bugs, all fixed:

- **Placeholder hash broke the fetch.** The template pre-wrote the zcli dependency with a placeholder hash, but `zig fetch --save` parses the existing manifest *before* fetching — the incomplete hash made that parse fail, so the real hash was never written. Now the template emits an empty `.dependencies = .{}` and lets `zig fetch --save` add the complete entry.
- **Wrong tag format.** The dependency URL used `v<version>`, but releases are tagged `zcli-v<version>`; the old URL silently resolved to a stale artifact whose build API predated `zcli.builtin()`. Fixed to `zcli-v<version>`.
- **Stale hardcoded version.** The pin was a hardcoded `"0.9.3"`. Now derived from `context.app_version` (read from `build.zig.zon`), so init always pins the release matching the CLI itself — no drift on future releases.
- **Fetch failures are surfaced:** if `zig fetch` can't run (e.g. offline), init warns with the exact recovery command instead of leaving a silently-broken project.

Verified: `zcli init` → `cd` → `zig build` produces a working binary (`zcli-v0.18.0` dep, real hash, `hello`/`--version`/`--help` all work).

## Tests

- Updated the `init` scaffolding e2e test: asserts the three defaults are present and `completions` is now absent by default; the `run` helper uses `.stdin = .ignore` so the prompt is deterministic in tests.
- Added an interactive PTY e2e test that arrows to `completions`, toggles it with Space, confirms, and asserts all four plugins land in the generated `build.zig`.
- `zig build e2e --summary all`: **11/11 tests pass** (includes the layer-2 test that compiles and runs a scaffolded project). `packages/terminal` and `packages/zinput` unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)