### PR TITLE
Rock-solid line wrapping + live resize for list prompts

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -19,12 +19,16 @@ pub fn build(b: *std.Build) void {
     });
     markdown_fmt_module.addImport("ztheme", ztheme_module);
 
+    // Unicode display-width/grapheme data (used by terminal's wrap.zig).
+    const zg_dep = b.dependency("zg", .{ .target = target, .optimize = optimize });
+
     // Create terminal module
     const terminal_module = b.addModule("terminal", .{
         .root_source_file = b.path("packages/terminal/src/terminal.zig"),
         .target = target,
         .optimize = optimize,
     });
+    terminal_module.addImport("Graphemes", zg_dep.module("Graphemes"));
 
     // Create zprogress module
     const zprogress_module = b.addModule("zprogress", .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -8,6 +8,10 @@
             .url = "https://github.com/OrlovEvgeny/serde.zig/archive/refs/tags/v1.0.3.tar.gz",
             .hash = "serde-1.0.1-1DszT9VLCwAjuQh0WSq-dIfZ-6Gq8edODuhwF9gfsxld",
         },
+        .zg = .{
+            .url = "https://codeberg.org/atman/zg/archive/v0.16.2.tar.gz",
+            .hash = "zg-0.16.2-oGqU3HqftgI6rwFS90ypwfjgToH8Pz829OKuFURlm773",
+        },
     },
     .paths = .{
         "build.zig",

--- a/packages/terminal/build.zig
+++ b/packages/terminal/build.zig
@@ -4,11 +4,14 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    _ = b.addModule("terminal", .{
+    const zg = b.dependency("zg", .{ .target = target, .optimize = optimize });
+
+    const mod = b.addModule("terminal", .{
         .root_source_file = b.path("src/terminal.zig"),
         .target = target,
         .optimize = optimize,
     });
+    mod.addImport("Graphemes", zg.module("Graphemes"));
 
     const test_step = b.step("test", "Run terminal tests");
     const test_mod = b.addModule("test-terminal", .{
@@ -16,6 +19,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    test_mod.addImport("Graphemes", zg.module("Graphemes"));
     const tests = b.addTest(.{ .root_module = test_mod });
     test_step.dependOn(&b.addRunArtifact(tests).step);
 }

--- a/packages/terminal/build.zig.zon
+++ b/packages/terminal/build.zig.zon
@@ -3,7 +3,12 @@
     .version = "0.1.0",
     .fingerprint = 0x8f7b154128ee9476,
     .minimum_zig_version = "0.16.0",
-    .dependencies = .{},
+    .dependencies = .{
+        .zg = .{
+            .url = "https://codeberg.org/atman/zg/archive/v0.16.2.tar.gz",
+            .hash = "zg-0.16.2-oGqU3HqftgI6rwFS90ypwfjgToH8Pz829OKuFURlm773",
+        },
+    },
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/packages/terminal/src/backend.zig
+++ b/packages/terminal/src/backend.zig
@@ -48,3 +48,11 @@ pub const isTty = impl.isTty;
 /// Wait up to `timeout_ms` for `handle` to have input ready to read. Returns
 /// false on timeout or error. A negative timeout blocks indefinitely.
 pub const waitReadable = impl.waitReadable;
+
+/// Watches for terminal-resize events and multiplexes them with stdin
+/// readiness. Construct with `init()` for the duration of an interactive
+/// prompt, `deinit()` when done, and drive it via `wait(handle)`.
+pub const ResizeWatcher = impl.ResizeWatcher;
+
+/// Result of `ResizeWatcher.wait`: either input is ready or a resize occurred.
+pub const InputWait = impl.InputWait;

--- a/packages/terminal/src/backend_posix.zig
+++ b/packages/terminal/src/backend_posix.zig
@@ -73,3 +73,63 @@ pub fn waitReadable(fd: Handle, timeout_ms: i32) bool {
     const n = posix.poll(&fds, timeout_ms) catch return false;
     return n > 0;
 }
+
+/// Whether a `wait` returned because input is ready or the terminal resized.
+pub const InputWait = enum { input, resize };
+
+/// Backstop poll interval. A SIGWINCH interrupts the poll (EINTR) and is caught
+/// immediately; this only bounds the tiny race where the signal lands between
+/// the flag check and the poll entering the kernel — at worst that resize is
+/// noticed one interval later, which is imperceptible.
+const poll_backstop_ms: i32 = 100;
+
+/// Set by the SIGWINCH handler, drained by the watcher. Process-global because
+/// signal handlers can't carry context; only one `ResizeWatcher` is active at a
+/// time (interactive prompts are modal), which this assumes.
+var resize_pending = std.atomic.Value(bool).init(false);
+
+fn handleSigwinch(_: posix.SIG) callconv(.c) void {
+    resize_pending.store(true, .seq_cst);
+}
+
+/// Watches for terminal-resize (SIGWINCH) events and multiplexes them with
+/// stdin readiness. The handler sets an atomic flag and interrupts the poll;
+/// `wait` checks the flag on every wakeup (signal, input, or the backstop
+/// timeout), so a resize is reported promptly whether or not stdin has input.
+pub const ResizeWatcher = struct {
+    old_action: posix.Sigaction,
+
+    pub fn init() ResizeWatcher {
+        resize_pending.store(false, .seq_cst);
+        var act = posix.Sigaction{
+            .handler = .{ .handler = handleSigwinch },
+            .mask = posix.sigemptyset(),
+            .flags = 0,
+        };
+        var old_action: posix.Sigaction = undefined;
+        posix.sigaction(posix.SIG.WINCH, &act, &old_action);
+        return .{ .old_action = old_action };
+    }
+
+    pub fn deinit(self: *ResizeWatcher) void {
+        posix.sigaction(posix.SIG.WINCH, &self.old_action, null);
+    }
+
+    /// Block until stdin (`fd`) has input or the terminal is resized. Uses the
+    /// raw `poll` (not `std.posix.poll`, which retries EINTR internally and
+    /// would hide the SIGWINCH wakeup).
+    pub fn wait(self: *ResizeWatcher, fd: Handle) InputWait {
+        _ = self;
+        while (true) {
+            if (resize_pending.swap(false, .seq_cst)) return .resize;
+
+            var fds = [_]posix.pollfd{.{ .fd = fd, .events = posix.POLL.IN, .revents = 0 }};
+            const rc = posix.system.poll(&fds, 1, poll_backstop_ms);
+            if (resize_pending.swap(false, .seq_cst)) return .resize;
+            switch (posix.errno(rc)) {
+                .SUCCESS => if (rc > 0 and fds[0].revents & posix.POLL.IN != 0) return .input,
+                else => {}, // EINTR / EAGAIN — loop and re-check the flag
+            }
+        }
+    }
+};

--- a/packages/terminal/src/backend_windows.zig
+++ b/packages/terminal/src/backend_windows.zig
@@ -132,3 +132,43 @@ pub fn waitReadable(handle: Handle, timeout_ms: i32) bool {
     const ms: DWORD = if (timeout_ms < 0) INFINITE else @intCast(timeout_ms);
     return WaitForSingleObject(handle, ms) == WAIT_OBJECT_0;
 }
+
+/// Whether a `wait` returned because input is ready or the terminal resized.
+pub const InputWait = enum { input, resize };
+
+/// How often `wait` re-checks the window size while blocked on input. With
+/// `ENABLE_VIRTUAL_TERMINAL_INPUT`, resize events are not delivered through the
+/// byte stream (`ReadFile`), so rather than rewire input reading to consume
+/// console records — which would risk the VT byte path — we poll the size on a
+/// short interval. ~60ms is imperceptible for a resize repaint.
+const resize_poll_ms: i32 = 60;
+
+/// Watches for console-window resizes and multiplexes them with input
+/// readiness. Detects resize by polling `getWindowSize` on the output handle,
+/// which keeps the input-reading path (VT byte stream via `ReadFile`) untouched.
+pub const ResizeWatcher = struct {
+    out: Handle,
+    last: Winsize,
+
+    pub fn init() ResizeWatcher {
+        const out = std.Io.File.stdout().handle;
+        return .{ .out = out, .last = getWindowSize(out) catch .{ .row = 0, .col = 0 } };
+    }
+
+    pub fn deinit(self: *ResizeWatcher) void {
+        _ = self;
+    }
+
+    /// Block until stdin (`handle`) has input or the console window resizes.
+    pub fn wait(self: *ResizeWatcher, handle: Handle) InputWait {
+        while (true) {
+            const ready = WaitForSingleObject(handle, @intCast(resize_poll_ms)) == WAIT_OBJECT_0;
+            const sz = getWindowSize(self.out) catch self.last;
+            if (sz.row != self.last.row or sz.col != self.last.col) {
+                self.last = sz;
+                return .resize;
+            }
+            if (ready) return .input;
+        }
+    }
+};

--- a/packages/terminal/src/event.zig
+++ b/packages/terminal/src/event.zig
@@ -1,0 +1,32 @@
+//! Input event multiplexing.
+//!
+//! `key.zig` turns a byte stream into a `Key`. A terminal resize, by contrast,
+//! isn't a key and doesn't arrive in the byte stream — it comes out-of-band from
+//! a `ResizeWatcher` (a SIGWINCH signal on POSIX, a console-size poll on
+//! Windows). `readEvent` composes those two input sources: it blocks until the
+//! next input of *any* kind and reports it as an `Event`. Future out-of-band
+//! inputs (mouse, focus, bracketed paste) would join `Event` here rather than in
+//! the key parser.
+
+const key = @import("key.zig");
+const backend = @import("backend.zig");
+
+/// An input event: a parsed key press or a terminal resize.
+pub const Event = union(enum) {
+    key: key.Key,
+    resize,
+};
+
+/// Block until a key is read from `reader` or the terminal is resized, reported
+/// via `watcher`. `handle` is the stdin handle — used both for escape-sequence
+/// disambiguation and by the watcher's poll. Bytes already buffered in `reader`
+/// are consumed before polling, so no keypress is missed.
+pub fn readEvent(reader: anytype, handle: backend.Handle, watcher: *backend.ResizeWatcher) !Event {
+    while (true) {
+        if (key.bufferedLen(reader) > 0) return .{ .key = try key.readKeyOpt(reader, handle) };
+        switch (watcher.wait(handle)) {
+            .resize => return .resize,
+            .input => return .{ .key = try key.readKeyOpt(reader, handle) },
+        }
+    }
+}

--- a/packages/terminal/src/key.zig
+++ b/packages/terminal/src/key.zig
@@ -67,11 +67,34 @@ pub fn readByteFn(reader: anytype) !u8 {
     return buf[0];
 }
 
+/// An input event: a key press or a terminal resize. Returned by `readEvent`
+/// for prompts that need to repaint when the terminal is resized.
+pub const Event = union(enum) {
+    key: Key,
+    resize,
+};
+
 /// Read a single key from a reader, parsing ANSI escape sequences.
 /// In raw mode, this reads byte-by-byte and assembles multi-byte
 /// sequences (arrow keys, etc.) into Key values.
 pub fn readKey(reader: anytype) !Key {
     return readKeyImpl(reader, null);
+}
+
+/// Like `readKey`, but also reports terminal-resize events by multiplexing
+/// stdin with the `watcher`. Blocks until a key is read or a resize occurs.
+///
+/// `handle` is the stdin handle (used both for escape-sequence disambiguation
+/// and by the watcher's poll). Buffered input already sitting in `reader` is
+/// consumed before polling, so no keypress is missed.
+pub fn readEvent(reader: anytype, handle: backend.Handle, watcher: *backend.ResizeWatcher) !Event {
+    while (true) {
+        if (bufferedLenOf(reader) > 0) return .{ .key = try readKeyImpl(reader, handle) };
+        switch (watcher.wait(handle)) {
+            .resize => return .resize,
+            .input => return .{ .key = try readKeyImpl(reader, handle) },
+        }
+    }
 }
 
 /// Like `readKey`, but reliably distinguishes a lone Escape from the start of an

--- a/packages/terminal/src/key.zig
+++ b/packages/terminal/src/key.zig
@@ -67,34 +67,11 @@ pub fn readByteFn(reader: anytype) !u8 {
     return buf[0];
 }
 
-/// An input event: a key press or a terminal resize. Returned by `readEvent`
-/// for prompts that need to repaint when the terminal is resized.
-pub const Event = union(enum) {
-    key: Key,
-    resize,
-};
-
 /// Read a single key from a reader, parsing ANSI escape sequences.
 /// In raw mode, this reads byte-by-byte and assembles multi-byte
 /// sequences (arrow keys, etc.) into Key values.
 pub fn readKey(reader: anytype) !Key {
     return readKeyImpl(reader, null);
-}
-
-/// Like `readKey`, but also reports terminal-resize events by multiplexing
-/// stdin with the `watcher`. Blocks until a key is read or a resize occurs.
-///
-/// `handle` is the stdin handle (used both for escape-sequence disambiguation
-/// and by the watcher's poll). Buffered input already sitting in `reader` is
-/// consumed before polling, so no keypress is missed.
-pub fn readEvent(reader: anytype, handle: backend.Handle, watcher: *backend.ResizeWatcher) !Event {
-    while (true) {
-        if (bufferedLenOf(reader) > 0) return .{ .key = try readKeyImpl(reader, handle) };
-        switch (watcher.wait(handle)) {
-            .resize => return .resize,
-            .input => return .{ .key = try readKeyImpl(reader, handle) },
-        }
-    }
 }
 
 /// Like `readKey`, but reliably distinguishes a lone Escape from the start of an
@@ -168,13 +145,15 @@ fn parseEscapeSequence(reader: anytype, esc_handle: ?backend.Handle) !Key {
 /// short poll on `esc_handle` (when provided) catches a sequence split across
 /// reads.
 fn escapeSequenceFollows(reader: anytype, esc_handle: ?backend.Handle) bool {
-    if (bufferedLenOf(reader) > 0) return true;
+    if (bufferedLen(reader) > 0) return true;
     const handle = esc_handle orelse return false;
     return backend.waitReadable(handle, esc_timeout_ms);
 }
 
 /// Buffered byte count for readers that expose it (std.Io.Reader); 0 otherwise.
-fn bufferedLenOf(reader: anytype) usize {
+/// Public so the event multiplexer can avoid blocking on a poll when the reader
+/// already has bytes in hand.
+pub fn bufferedLen(reader: anytype) usize {
     const T = @TypeOf(reader);
     if (@typeInfo(T) == .pointer) {
         const Child = @typeInfo(T).pointer.child;

--- a/packages/terminal/src/terminal.zig
+++ b/packages/terminal/src/terminal.zig
@@ -12,6 +12,20 @@ pub const Key = key.Key;
 pub const readKey = key.readKey;
 pub const readKeyOpt = key.readKeyOpt;
 
+/// An input event (key or terminal resize) and the resize-aware reader.
+pub const Event = key.Event;
+pub const readEvent = key.readEvent;
+
+/// Watches for terminal resizes; construct for the lifetime of a prompt.
+pub const ResizeWatcher = backend.ResizeWatcher;
+
+/// Display-width measurement and word-wrapping (grapheme- and ANSI-aware).
+pub const wrap = @import("wrap.zig");
+pub const displayWidth = wrap.displayWidth;
+pub const wrapToWidth = wrap.wrapToWidth;
+pub const wrapForEach = wrap.wrapForEach;
+pub const wrapCount = wrap.wrapCount;
+
 // ============================================================================
 // Raw mode, echo, window size, TTY detection
 //

--- a/packages/terminal/src/terminal.zig
+++ b/packages/terminal/src/terminal.zig
@@ -12,9 +12,10 @@ pub const Key = key.Key;
 pub const readKey = key.readKey;
 pub const readKeyOpt = key.readKeyOpt;
 
-/// An input event (key or terminal resize) and the resize-aware reader.
-pub const Event = key.Event;
-pub const readEvent = key.readEvent;
+/// Input event multiplexing: a key press or a terminal resize.
+pub const event = @import("event.zig");
+pub const Event = event.Event;
+pub const readEvent = event.readEvent;
 
 /// Watches for terminal resizes; construct for the lifetime of a prompt.
 pub const ResizeWatcher = backend.ResizeWatcher;

--- a/packages/terminal/src/wrap.zig
+++ b/packages/terminal/src/wrap.zig
@@ -1,0 +1,320 @@
+//! Display-width measurement and word-wrapping for terminal rendering.
+//!
+//! Width is grapheme-cluster aware (via zg's Graphemes/DisplayWidth data), so
+//! CJK, emoji (including ZWJ sequences, flags, and skin-tone modifiers), and
+//! combining marks all measure to their true column count. ANSI SGR/CSI/OSC
+//! escape sequences are treated as zero width so colored strings measure by
+//! what's actually painted.
+//!
+//! `wrapToWidth` breaks text at spaces where it can and hard-breaks words with
+//! no break opportunity. It returns slices into the original `text` (the spaces
+//! it breaks at are dropped from the output), so the caller can prepend its own
+//! per-line prefix — this is what lets a prompt hang-indent continuation lines
+//! past the left bullet.
+
+const std = @import("std");
+const Graphemes = @import("Graphemes");
+
+/// Index just past the ANSI escape sequence that starts at `text[i]` (which the
+/// caller has already confirmed is ESC, 0x1b). Handles CSI (`ESC [ … final`),
+/// OSC (`ESC ] … BEL`/`ST`), and the two-byte `ESC x` forms; a truncated
+/// sequence consumes to end of string.
+fn escapeSeqEnd(text: []const u8, i: usize) usize {
+    if (i + 1 >= text.len) return i + 1;
+    switch (text[i + 1]) {
+        '[' => {
+            var j = i + 2;
+            while (j < text.len) : (j += 1) {
+                if (text[j] >= 0x40 and text[j] <= 0x7e) return j + 1;
+            }
+            return text.len;
+        },
+        ']' => {
+            var j = i + 2;
+            while (j < text.len) : (j += 1) {
+                if (text[j] == 0x07) return j + 1; // BEL terminator
+                if (text[j] == 0x1b and j + 1 < text.len and text[j + 1] == '\\') return j + 2; // ST
+            }
+            return text.len;
+        },
+        else => return i + 2,
+    }
+}
+
+/// Display width of a grapheme, clamped to a non-negative column count
+/// (zg returns -1 for BACKSPACE/DEL, 0 for control codes).
+fn graphemeCols(g: Graphemes.Grapheme, text: []const u8) usize {
+    const w = g.displayWidth(text);
+    return if (w > 0) @intCast(w) else 0;
+}
+
+/// Total display width of `text` in terminal cells, grapheme-aware and skipping
+/// ANSI escape sequences.
+pub fn displayWidth(text: []const u8) usize {
+    var total: usize = 0;
+    var skip_until: usize = 0;
+    var it = Graphemes.iterator(text);
+    while (it.next()) |g| {
+        if (g.offset < skip_until) continue;
+        if (text[g.offset] == 0x1b) {
+            skip_until = escapeSeqEnd(text, g.offset);
+            continue;
+        }
+        total += graphemeCols(g, text);
+    }
+    return total;
+}
+
+fn isBreakSpace(text: []const u8, g: Graphemes.Grapheme) bool {
+    return g.len == 1 and (text[g.offset] == ' ' or text[g.offset] == '\t');
+}
+
+/// Streaming greedy word-wrapper. Walks `text` once, with no allocation, and
+/// calls `emitLine(context, line)` for each wrapped line — a slice into `text`.
+/// Words are broken at spaces where possible (the break space is dropped) and
+/// any word longer than `width` is hard-broken at grapheme boundaries. ANSI
+/// escapes are zero width. `width` clamps to at least 1; empty (or all-space)
+/// input emits one empty line. This is the primitive behind `wrapToWidth`,
+/// `wrapCount`, and the prompt renderers.
+pub fn wrapForEach(
+    text: []const u8,
+    width: usize,
+    context: anytype,
+    comptime emitLine: fn (@TypeOf(context), []const u8) anyerror!void,
+) anyerror!void {
+    const W = Wrapper(@TypeOf(context), emitLine);
+    var w = W{ .text = text, .avail = @max(width, 1), .ctx = context };
+
+    var word_start: ?usize = null;
+    var word_end: usize = 0;
+    var word_w: usize = 0;
+    var gap_w: usize = 0;
+
+    var skip_until: usize = 0;
+    var it = Graphemes.iterator(text);
+    while (it.next()) |g| {
+        if (g.offset < skip_until) continue;
+        if (text[g.offset] == 0x1b) {
+            skip_until = escapeSeqEnd(text, g.offset);
+            continue;
+        }
+        const gw = graphemeCols(g, text);
+        if (isBreakSpace(text, g)) {
+            if (word_start) |ws| {
+                try w.place(ws, word_end, word_w, gap_w);
+                word_start = null;
+                word_w = 0;
+                gap_w = 0;
+            }
+            gap_w += gw;
+        } else {
+            if (word_start == null) word_start = g.offset;
+            word_w += gw;
+            word_end = g.offset + g.len;
+        }
+    }
+    if (word_start) |ws| try w.place(ws, word_end, word_w, gap_w);
+
+    if (w.line_w > 0) {
+        try w.emit(text[w.line_start..w.committed_end]);
+    } else if (!w.produced) {
+        try w.emit(text[0..0]);
+    }
+}
+
+fn Wrapper(comptime Ctx: type, comptime emitLine: fn (Ctx, []const u8) anyerror!void) type {
+    return struct {
+        text: []const u8,
+        avail: usize,
+        ctx: Ctx,
+        line_start: usize = 0,
+        line_w: usize = 0,
+        committed_end: usize = 0,
+        produced: bool = false,
+
+        const Self = @This();
+
+        fn emit(self: *Self, line: []const u8) anyerror!void {
+            self.produced = true;
+            try emitLine(self.ctx, line);
+        }
+
+        /// Start a fresh line with a word, hard-breaking it if it alone exceeds
+        /// the width. Full-width chunks are emitted; the trailing chunk becomes
+        /// the current line so a following word can still share it.
+        fn placeFresh(self: *Self, w_start: usize, w_end: usize, w_width: usize) anyerror!void {
+            if (w_width <= self.avail) {
+                self.line_start = w_start;
+                self.line_w = w_width;
+                self.committed_end = w_end;
+                return;
+            }
+            const sub = self.text[w_start..w_end];
+            var seg_start = w_start;
+            var seg_w: usize = 0;
+            var git = Graphemes.iterator(sub);
+            while (git.next()) |g| {
+                const gw = graphemeCols(g, sub);
+                if (seg_w > 0 and seg_w + gw > self.avail) {
+                    try self.emit(self.text[seg_start .. w_start + g.offset]);
+                    seg_start = w_start + g.offset;
+                    seg_w = gw;
+                } else {
+                    seg_w += gw;
+                }
+            }
+            self.line_start = seg_start;
+            self.line_w = seg_w;
+            self.committed_end = w_end;
+        }
+
+        /// Place a completed word (preceded by `gap` columns of spaces) onto the
+        /// current line, wrapping to a new line if it doesn't fit.
+        fn place(self: *Self, w_start: usize, w_end: usize, w_width: usize, gap: usize) anyerror!void {
+            if (self.line_w == 0) {
+                try self.placeFresh(w_start, w_end, w_width);
+            } else if (self.line_w + gap + w_width <= self.avail) {
+                self.line_w += gap + w_width;
+                self.committed_end = w_end;
+            } else {
+                try self.emit(self.text[self.line_start..self.committed_end]);
+                self.line_w = 0;
+                try self.placeFresh(w_start, w_end, w_width);
+            }
+        }
+    };
+}
+
+/// Number of lines `text` wraps to at `width` display columns (no allocation).
+pub fn wrapCount(text: []const u8, width: usize) usize {
+    const Counter = struct {
+        n: usize = 0,
+        fn add(self: *@This(), _: []const u8) anyerror!void {
+            self.n += 1;
+        }
+    };
+    var c = Counter{};
+    wrapForEach(text, width, &c, Counter.add) catch {};
+    return c.n;
+}
+
+/// Break `text` into lines that each fit within `width` display columns,
+/// collecting them into an allocated list. Wraps at spaces where possible and
+/// hard-breaks over-long words; the break spaces are dropped. `width` clamps to
+/// at least 1; empty input yields a single empty segment.
+///
+/// The returned outer slice is owned by the caller (`allocator.free`); the
+/// element slices point into `text` and must not be freed. Prefer `wrapForEach`
+/// or `wrapCount` in hot paths — this exists for callers that want the list.
+pub fn wrapToWidth(allocator: std.mem.Allocator, text: []const u8, width: usize) ![][]const u8 {
+    const Collector = struct {
+        list: *std.ArrayList([]const u8),
+        allocator: std.mem.Allocator,
+        fn add(self: *@This(), line: []const u8) anyerror!void {
+            try self.list.append(self.allocator, line);
+        }
+    };
+    var list = std.ArrayList([]const u8).empty;
+    errdefer list.deinit(allocator);
+    var c = Collector{ .list = &list, .allocator = allocator };
+    try wrapForEach(text, width, &c, Collector.add);
+    return list.toOwnedSlice(allocator);
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+const testing = std.testing;
+
+test "displayWidth: ascii" {
+    try testing.expectEqual(@as(usize, 5), displayWidth("hello"));
+    try testing.expectEqual(@as(usize, 0), displayWidth(""));
+}
+
+test "displayWidth: wide CJK counts 2 cells each" {
+    try testing.expectEqual(@as(usize, 4), displayWidth("你好"));
+}
+
+test "displayWidth: emoji and combining marks" {
+    try testing.expectEqual(@as(usize, 2), displayWidth("😊"));
+    // 'e' + combining acute accent = one grapheme, one column.
+    try testing.expectEqual(@as(usize, 1), displayWidth("\u{0065}\u{0301}"));
+    // Flag = one grapheme, two columns.
+    try testing.expectEqual(@as(usize, 2), displayWidth("🇪🇸"));
+}
+
+test "displayWidth: skips ANSI escapes" {
+    // Without skipping, zg would count the '[36m' bytes → 6.
+    try testing.expectEqual(@as(usize, 2), displayWidth("\x1b[36mhi\x1b[0m"));
+}
+
+fn expectWrap(text: []const u8, width: usize, expected: []const []const u8) !void {
+    const segs = try wrapToWidth(testing.allocator, text, width);
+    defer testing.allocator.free(segs);
+    try testing.expectEqual(expected.len, segs.len);
+    for (expected, segs) |e, s| try testing.expectEqualStrings(e, s);
+}
+
+test "wrapToWidth: fits on one line" {
+    try expectWrap("hello world", 20, &.{"hello world"});
+}
+
+test "wrapToWidth: breaks at word boundary, dropping the break space" {
+    try expectWrap("hello world", 7, &.{ "hello", "world" });
+}
+
+test "wrapToWidth: packs greedily" {
+    try expectWrap("aa bb cc dd", 5, &.{ "aa bb", "cc dd" });
+}
+
+test "wrapToWidth: hard-breaks a word with no break opportunity" {
+    try expectWrap("abcdefghij", 4, &.{ "abcd", "efgh", "ij" });
+}
+
+test "wrapToWidth: hard-break tail can share a line with the next word" {
+    // "abcdef" hard-breaks to "abcd"/"ef"; "gh" then fits after "ef" (ef gh = 5).
+    try expectWrap("abcdef gh", 4, &.{ "abcd", "ef", "gh" });
+}
+
+test "wrapToWidth: empty input yields one empty segment" {
+    try expectWrap("", 10, &.{""});
+    try expectWrap("   ", 10, &.{""});
+}
+
+test "wrapToWidth: width clamps to at least 1" {
+    try expectWrap("ab", 0, &.{ "a", "b" });
+}
+
+test "wrapToWidth: wide grapheme respected across the boundary" {
+    // Each CJH char is 2 cols; width 3 fits one per line (2 + 2 > 3).
+    try expectWrap("你好", 3, &.{ "你", "好" });
+}
+
+test "wrapCount matches wrapToWidth length" {
+    const cases = [_]struct { text: []const u8, width: usize }{
+        .{ .text = "hello world", .width = 20 },
+        .{ .text = "hello world", .width = 7 },
+        .{ .text = "abcdefghij", .width = 4 },
+        .{ .text = "", .width = 10 },
+        .{ .text = "   ", .width = 10 },
+        .{ .text = "你好世界 wide", .width = 5 },
+    };
+    for (cases) |c| {
+        const segs = try wrapToWidth(testing.allocator, c.text, c.width);
+        defer testing.allocator.free(segs);
+        try testing.expectEqual(segs.len, wrapCount(c.text, c.width));
+    }
+}
+
+test "wrapForEach emits slices into the original text" {
+    const Ctx = struct {
+        seen: usize = 0,
+        fn add(self: *@This(), _: []const u8) anyerror!void {
+            self.seen += 1;
+        }
+    };
+    var ctx = Ctx{};
+    try wrapForEach("one two three", 7, &ctx, Ctx.add);
+    try testing.expect(ctx.seen >= 2);
+}

--- a/packages/vterm/build.zig
+++ b/packages/vterm/build.zig
@@ -4,12 +4,15 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    const zg = b.dependency("zg", .{ .target = target, .optimize = optimize });
+
     // Create the vterm module
-    _ = b.addModule("vterm", .{
+    const mod = b.addModule("vterm", .{
         .root_source_file = b.path("src/vterm.zig"),
         .target = target,
         .optimize = optimize,
     });
+    mod.addImport("DisplayWidth", zg.module("DisplayWidth"));
 
     // Tests for the vterm library
     const test_mod = b.addModule("test-vterm", .{
@@ -17,6 +20,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    test_mod.addImport("DisplayWidth", zg.module("DisplayWidth"));
     const vterm_tests = b.addTest(.{
         .root_module = test_mod,
     });

--- a/packages/vterm/build.zig.zon
+++ b/packages/vterm/build.zig.zon
@@ -3,7 +3,12 @@
     .version = "0.1.0",
     .fingerprint = 0x34fbdae36a061113,
     .minimum_zig_version = "0.16.0",
-    .dependencies = .{},
+    .dependencies = .{
+        .zg = .{
+            .url = "https://codeberg.org/atman/zg/archive/v0.16.2.tar.gz",
+            .hash = "zg-0.16.2-oGqU3HqftgI6rwFS90ypwfjgToH8Pz829OKuFURlm773",
+        },
+    },
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/packages/vterm/src/vterm.zig
+++ b/packages/vterm/src/vterm.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
+const DisplayWidth = @import("DisplayWidth");
 
 const CellModule = @import("cell.zig");
 const PositionModule = @import("position.zig");
@@ -50,53 +51,12 @@ pub const TextAttribute = enum {
     underline,
 };
 
-// Character width detection for wide characters (CJK, emojis, etc.)
+// Character width detection for wide characters (CJK, emojis, etc.).
+// vterm uses a fixed one-cell-per-codepoint model, so only the wide/narrow
+// distinction matters here; the underlying Unicode data comes from zg's
+// DisplayWidth table rather than a hand-maintained list of ranges.
 pub fn charWidth(codepoint: u21) u8 {
-    // ASCII and Latin-1 are always 1 column
-    if (codepoint < 0x1100) return 1;
-
-    // Wide characters that take 2 columns
-    // Simplified ranges - covers most common wide characters
-    if ((codepoint >= 0x1100 and codepoint <= 0x115F) or // Hangul Jamo
-        (codepoint >= 0x2E80 and codepoint <= 0x2EFF) or // CJK Radicals
-        (codepoint >= 0x2F00 and codepoint <= 0x2FDF) or // Kangxi Radicals
-        (codepoint >= 0x2FF0 and codepoint <= 0x2FFF) or // CJK Description
-        (codepoint >= 0x3000 and codepoint <= 0x303E) or // CJK Symbols
-        (codepoint >= 0x3041 and codepoint <= 0x3096) or // Hiragana
-        (codepoint >= 0x30A1 and codepoint <= 0x30FA) or // Katakana
-        (codepoint >= 0x3105 and codepoint <= 0x312D) or // Bopomofo
-        (codepoint >= 0x3131 and codepoint <= 0x318E) or // Hangul Compatibility
-        (codepoint >= 0x3190 and codepoint <= 0x31BA) or // Kanbun
-        (codepoint >= 0x31C0 and codepoint <= 0x31E3) or // CJK Strokes
-        (codepoint >= 0x31F0 and codepoint <= 0x31FF) or // Katakana Extension
-        (codepoint >= 0x3200 and codepoint <= 0x32FF) or // Enclosed CJK
-        (codepoint >= 0x3300 and codepoint <= 0x33FF) or // CJK Compatibility
-        (codepoint >= 0x3400 and codepoint <= 0x4DBF) or // CJK Extension A
-        (codepoint >= 0x4E00 and codepoint <= 0x9FFF) or // CJK Unified Ideographs
-        (codepoint >= 0xA960 and codepoint <= 0xA97F) or // Hangul Syllables Extension A
-        (codepoint >= 0xAC00 and codepoint <= 0xD7A3) or // Hangul Syllables
-        (codepoint >= 0xF900 and codepoint <= 0xFAFF) or // CJK Compatibility Ideographs
-        (codepoint >= 0xFE10 and codepoint <= 0xFE19) or // Vertical Forms
-        (codepoint >= 0xFE30 and codepoint <= 0xFE6F) or // CJK Compatibility Forms
-        (codepoint >= 0xFF00 and codepoint <= 0xFF60) or // Fullwidth Forms
-        (codepoint >= 0xFFE0 and codepoint <= 0xFFE6) or // Fullwidth Forms
-        (codepoint >= 0x1F300 and codepoint <= 0x1F5FF) or // Misc Symbols and Pictographs
-        (codepoint >= 0x1F600 and codepoint <= 0x1F64F) or // Emoticons
-        (codepoint >= 0x1F680 and codepoint <= 0x1F6FF) or // Transport and Map
-        (codepoint >= 0x1F700 and codepoint <= 0x1F77F) or // Alchemical Symbols
-        (codepoint >= 0x1F780 and codepoint <= 0x1F7FF) or // Geometric Shapes Extended
-        (codepoint >= 0x1F800 and codepoint <= 0x1F8FF) or // Supplemental Arrows-C
-        (codepoint >= 0x1F900 and codepoint <= 0x1F9FF) or // Supplemental Symbols
-        (codepoint >= 0x1FA00 and codepoint <= 0x1FA6F) or // Chess Symbols
-        (codepoint >= 0x1FA70 and codepoint <= 0x1FAFF) or // Symbols and Pictographs Extended-A
-        (codepoint >= 0x20000 and codepoint <= 0x2FFFD) or // CJK Extension B-F
-        (codepoint >= 0x30000 and codepoint <= 0x3FFFD))
-    { // CJK Extension G
-        return 2;
-    }
-
-    // Default to 1 column for everything else
-    return 1;
+    return if (DisplayWidth.codePointWidth(codepoint) == 2) 2 else 1;
 }
 
 // Parser state for Phase 2

--- a/packages/vterm/src/vterm.zig
+++ b/packages/vterm/src/vterm.zig
@@ -555,10 +555,14 @@ pub const VTerm = struct {
             'A' => { // CUU - Cursor Up
                 const n = self.getParam(0, 1);
                 self.cursor.y = if (n > self.cursor.y) 0 else self.cursor.y - @as(u16, @intCast(n));
+                // Keep the write position (virtual_cursor_y) in sync, as CUP does,
+                // so text written after moving up overwrites the right rows.
+                self.virtual_cursor_y = self.cursor.y;
             },
             'B' => { // CUD - Cursor Down
                 const n = self.getParam(0, 1);
                 self.cursor.y = @min(self.cursor.y + @as(u16, @intCast(n)), self.height - 1);
+                self.virtual_cursor_y = self.cursor.y;
             },
             'C' => { // CUF - Cursor Forward
                 const n = self.getParam(0, 1);

--- a/packages/zinput/build.zig
+++ b/packages/zinput/build.zig
@@ -25,4 +25,19 @@ pub fn build(b: *std.Build) void {
     test_mod.addImport("ztheme", ztheme_dep.module("ztheme"));
     const tests = b.addTest(.{ .root_module = test_mod });
     test_step.dependOn(&b.addRunArtifact(tests).step);
+
+    // Cross-platform render tests: replay prompt output through the vterm
+    // emulator. vterm is a *test-only* dependency — the shipped `zinput` module
+    // above never imports it. Part of `test` so it runs everywhere `test-zinput`
+    // does, including Windows CI (where the POSIX PTY harness can't).
+    const vterm_dep = b.dependency("vterm", .{ .target = target, .optimize = optimize });
+    const render_e2e_mod = b.addModule("render-e2e", .{
+        .root_source_file = b.path("test/render_e2e.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    render_e2e_mod.addImport("zinput", zinput_mod);
+    render_e2e_mod.addImport("vterm", vterm_dep.module("vterm"));
+    const render_e2e_tests = b.addTest(.{ .root_module = render_e2e_mod });
+    test_step.dependOn(&b.addRunArtifact(render_e2e_tests).step);
 }

--- a/packages/zinput/build.zig
+++ b/packages/zinput/build.zig
@@ -40,4 +40,31 @@ pub fn build(b: *std.Build) void {
     render_e2e_mod.addImport("vterm", vterm_dep.module("vterm"));
     const render_e2e_tests = b.addTest(.{ .root_module = render_e2e_mod });
     test_step.dependOn(&b.addRunArtifact(render_e2e_tests).step);
+
+    // Runnable examples — one per input type. `zig build examples` builds them
+    // all; `zig build run-<name>` runs one (they're interactive, so they need a
+    // real terminal). Each is also compiled by `test` so they can't bitrot.
+    const example_names = [_][]const u8{
+        "text",     "confirm", "select", "multi_select",
+        "password", "search",  "number", "editor",
+    };
+    const examples_step = b.step("examples", "Build all interactive prompt examples");
+    for (example_names) |name| {
+        const exe = b.addExecutable(.{
+            .name = b.fmt("zinput-{s}", .{name}),
+            .root_module = b.createModule(.{
+                .root_source_file = b.path(b.fmt("examples/{s}.zig", .{name})),
+                .target = target,
+                .optimize = optimize,
+            }),
+        });
+        exe.root_module.addImport("zinput", zinput_mod);
+
+        examples_step.dependOn(&b.addInstallArtifact(exe, .{}).step);
+        test_step.dependOn(&exe.step); // compile-check in CI without running
+
+        const run = b.addRunArtifact(exe);
+        const run_step = b.step(b.fmt("run-{s}", .{name}), b.fmt("Run the {s} prompt example", .{name}));
+        run_step.dependOn(&run.step);
+    }
 }

--- a/packages/zinput/build.zig.zon
+++ b/packages/zinput/build.zig.zon
@@ -16,5 +16,6 @@
         "build.zig.zon",
         "src/",
         "test/",
+        "examples/",
     },
 }

--- a/packages/zinput/build.zig.zon
+++ b/packages/zinput/build.zig.zon
@@ -6,10 +6,15 @@
     .dependencies = .{
         .terminal = .{ .path = "../terminal" },
         .ztheme = .{ .path = "../ztheme" },
+        // Test-only: the render_e2e tests replay prompt output through the vterm
+        // emulator. Only the test module imports it; the shipped `zinput` module
+        // does not depend on vterm.
+        .vterm = .{ .path = "../vterm" },
     },
     .paths = .{
         "build.zig",
         "build.zig.zon",
         "src/",
+        "test/",
     },
 }

--- a/packages/zinput/examples/README.md
+++ b/packages/zinput/examples/README.md
@@ -1,0 +1,31 @@
+# zinput examples
+
+One runnable example per input type. Each is a self-contained `main` that wires
+a stdin reader / stdout writer (see `common.zig`) and drives a single prompt.
+
+Run one (they're interactive, so use a real terminal):
+
+```sh
+zig build run-select        # or: text, confirm, multi_select,
+                            #     password, search, number, editor
+```
+
+Build all of them at once:
+
+```sh
+zig build examples          # binaries land in zig-out/bin/zinput-<name>
+```
+
+| Example         | Function            | Returns            |
+| --------------- | ------------------- | ------------------ |
+| `text`          | `zinput.text`       | entered string     |
+| `confirm`       | `zinput.confirm`    | `bool`             |
+| `select`        | `zinput.select`     | chosen index       |
+| `multi_select`  | `zinput.multiSelect`| chosen indices     |
+| `password`      | `zinput.password`   | masked string      |
+| `search`        | `zinput.search`     | chosen index       |
+| `number`        | `zinput.number`     | `i64`              |
+| `editor`        | `zinput.editor`     | text from `$EDITOR`|
+
+All prompts fall back to plain line-based input when stdin isn't a TTY, so the
+examples also work when piped (e.g. `printf '2\n' | zig-out/bin/zinput-select`).

--- a/packages/zinput/examples/common.zig
+++ b/packages/zinput/examples/common.zig
@@ -1,0 +1,33 @@
+//! Shared stdin/stdout wiring for the zinput examples.
+//!
+//! The interactive prompts take any writer/reader, so all a real program needs
+//! is a buffered writer over stdout and a reader over stdin, both built from the
+//! process `std.Io`. This keeps each example file focused on the prompt itself.
+
+const std = @import("std");
+
+pub const Io = struct {
+    stdout: std.Io.File.Writer = undefined,
+    stdin: std.Io.File.Reader = undefined,
+    out_buf: [4096]u8 = undefined,
+    in_buf: [4096]u8 = undefined,
+
+    /// Initialise in place. Holds buffers by value, so don't copy an `Io` after
+    /// calling this — take a pointer.
+    pub fn init(self: *Io, io: std.Io) void {
+        self.stdout = std.Io.File.stdout().writer(io, &self.out_buf);
+        self.stdin = std.Io.File.stdin().reader(io, &self.in_buf);
+    }
+
+    pub fn w(self: *Io) *std.Io.Writer {
+        return &self.stdout.interface;
+    }
+
+    pub fn r(self: *Io) *std.Io.Reader {
+        return &self.stdin.interface;
+    }
+
+    pub fn flush(self: *Io) void {
+        self.stdout.interface.flush() catch {};
+    }
+};

--- a/packages/zinput/examples/confirm.zig
+++ b/packages/zinput/examples/confirm.zig
@@ -1,0 +1,21 @@
+//! `zinput.confirm` — a yes/no question with a default (Enter accepts it).
+
+const std = @import("std");
+const zinput = @import("zinput");
+const common = @import("common.zig");
+
+pub fn main(init: std.process.Init) !void {
+    var t: common.Io = .{};
+    t.init(init.io);
+    defer t.flush();
+
+    const ok = zinput.confirm(t.w(), t.r(), .{
+        .message = "Deploy to production?",
+        .default = false,
+    }) catch |err| {
+        try t.w().print("\n({s})\n", .{@errorName(err)});
+        return;
+    };
+
+    try t.w().print("\n{s}\n", .{if (ok) "Deploying." else "Cancelled."});
+}

--- a/packages/zinput/examples/editor.zig
+++ b/packages/zinput/examples/editor.zig
@@ -1,0 +1,27 @@
+//! `zinput.editor` — capture multi-line input by launching an external editor.
+//!
+//! Pressing Enter opens the editor (`editor_cmd`, default `vi`) on a temporary
+//! file seeded with `default`; whatever is saved is returned.
+
+const std = @import("std");
+const zinput = @import("zinput");
+const common = @import("common.zig");
+
+pub fn main(init: std.process.Init) !void {
+    var t: common.Io = .{};
+    t.init(init.io);
+    defer t.flush();
+
+    const message = zinput.editor(t.w(), t.r(), init.gpa, .{
+        .message = "Write a commit message",
+        .default = "Summary line\n\nDetails go here.\n",
+        .extension = ".md",
+        .io = init.io,
+    }) catch |err| {
+        try t.w().print("\n({s})\n", .{@errorName(err)});
+        return;
+    };
+    defer init.gpa.free(message);
+
+    try t.w().print("\n--- captured ({d} bytes) ---\n{s}\n", .{ message.len, message });
+}

--- a/packages/zinput/examples/multi_select.zig
+++ b/packages/zinput/examples/multi_select.zig
@@ -1,0 +1,27 @@
+//! `zinput.multiSelect` — toggle several items with Space, confirm with Enter.
+
+const std = @import("std");
+const zinput = @import("zinput");
+const common = @import("common.zig");
+
+pub fn main(init: std.process.Init) !void {
+    var t: common.Io = .{};
+    t.init(init.io);
+    defer t.flush();
+
+    const toppings = [_][]const u8{ "Cheese", "Pepperoni", "Mushrooms", "Onions", "Pineapple" };
+
+    const picks = zinput.multiSelect(t.w(), t.r(), init.gpa, .{
+        .message = "Choose your toppings:",
+        .choices = &toppings,
+        .defaults = &.{ true, false, false, false, false },
+    }) catch |err| {
+        try t.w().print("\n({s})\n", .{@errorName(err)});
+        return;
+    };
+    defer init.gpa.free(picks);
+
+    try t.w().writeAll("\nYou selected:\n");
+    if (picks.len == 0) try t.w().writeAll("  (nothing)\n");
+    for (picks) |i| try t.w().print("  - {s}\n", .{toppings[i]});
+}

--- a/packages/zinput/examples/number.zig
+++ b/packages/zinput/examples/number.zig
@@ -1,0 +1,23 @@
+//! `zinput.number` — integer input with an optional default and min/max bounds.
+
+const std = @import("std");
+const zinput = @import("zinput");
+const common = @import("common.zig");
+
+pub fn main(init: std.process.Init) !void {
+    var t: common.Io = .{};
+    t.init(init.io);
+    defer t.flush();
+
+    const n = zinput.number(t.w(), t.r(), .{
+        .message = "Pick a number",
+        .default = 42,
+        .min = 1,
+        .max = 100,
+    }) catch |err| {
+        try t.w().print("\n({s})\n", .{@errorName(err)});
+        return;
+    };
+
+    try t.w().print("\nYou entered: {d}\n", .{n});
+}

--- a/packages/zinput/examples/password.zig
+++ b/packages/zinput/examples/password.zig
@@ -1,0 +1,23 @@
+//! `zinput.password` — masked input; the typed characters are never echoed.
+
+const std = @import("std");
+const zinput = @import("zinput");
+const common = @import("common.zig");
+
+pub fn main(init: std.process.Init) !void {
+    var t: common.Io = .{};
+    t.init(init.io);
+    defer t.flush();
+
+    const secret = zinput.password(t.w(), t.r(), init.gpa, .{
+        .message = "Enter a password:",
+        .mask = '*',
+    }) catch |err| {
+        try t.w().print("\n({s})\n", .{@errorName(err)});
+        return;
+    };
+    defer init.gpa.free(secret);
+
+    // Don't print the secret back — just prove we captured it.
+    try t.w().print("\nGot a password of {d} character(s).\n", .{secret.len});
+}

--- a/packages/zinput/examples/search.zig
+++ b/packages/zinput/examples/search.zig
@@ -1,0 +1,26 @@
+//! `zinput.search` — type to fuzzy-filter a list, arrow keys to pick, Enter to select.
+
+const std = @import("std");
+const zinput = @import("zinput");
+const common = @import("common.zig");
+
+pub fn main(init: std.process.Init) !void {
+    var t: common.Io = .{};
+    t.init(init.io);
+    defer t.flush();
+
+    const languages = [_][]const u8{
+        "Zig",    "Rust",       "Go",         "C",       "C++",
+        "Python", "JavaScript", "TypeScript", "Haskell", "OCaml",
+    };
+
+    const idx = zinput.search(t.w(), t.r(), init.gpa, .{
+        .message = "Search languages (type to filter):",
+        .choices = &languages,
+    }) catch |err| {
+        try t.w().print("\n({s})\n", .{@errorName(err)});
+        return;
+    };
+
+    try t.w().print("\nYou chose: {s}\n", .{languages[idx]});
+}

--- a/packages/zinput/examples/select.zig
+++ b/packages/zinput/examples/select.zig
@@ -1,0 +1,23 @@
+//! `zinput.select` — choose one item from a list with the arrow keys and Enter.
+
+const std = @import("std");
+const zinput = @import("zinput");
+const common = @import("common.zig");
+
+pub fn main(init: std.process.Init) !void {
+    var t: common.Io = .{};
+    t.init(init.io);
+    defer t.flush();
+
+    const fruits = [_][]const u8{ "Apple", "Banana", "Cherry", "Dragonfruit", "Elderberry" };
+
+    const idx = zinput.select(t.w(), t.r(), .{
+        .message = "Pick a fruit:",
+        .choices = &fruits,
+    }) catch |err| {
+        try t.w().print("\n({s})\n", .{@errorName(err)});
+        return;
+    };
+
+    try t.w().print("\nYou picked: {s}\n", .{fruits[idx]});
+}

--- a/packages/zinput/examples/text.zig
+++ b/packages/zinput/examples/text.zig
@@ -1,0 +1,22 @@
+//! `zinput.text` — free-form single-line text input with an optional default.
+
+const std = @import("std");
+const zinput = @import("zinput");
+const common = @import("common.zig");
+
+pub fn main(init: std.process.Init) !void {
+    var t: common.Io = .{};
+    t.init(init.io);
+    defer t.flush();
+
+    const name = zinput.text(t.w(), t.r(), init.gpa, .{
+        .message = "What's your name?",
+        .default = "Anonymous",
+    }) catch |err| {
+        try t.w().print("\n({s})\n", .{@errorName(err)});
+        return;
+    };
+    defer init.gpa.free(name);
+
+    try t.w().print("\nHello, {s}!\n", .{name});
+}

--- a/packages/zinput/src/list_render.zig
+++ b/packages/zinput/src/list_render.zig
@@ -1,0 +1,156 @@
+//! Shared rendering machinery for the list-style prompts (select, multi_select,
+//! search): physical-row-accurate wrapping with a hang indent, a viewport that
+//! scrolls to keep the cursor visible, and region erase that survives terminal
+//! resize. Prompts supply their own per-item prefixes/colors via `ItemStyle`
+//! and drive their own key loops; everything about *how many rows* get painted
+//! and *how to wipe them* lives here.
+
+const std = @import("std");
+const terminal = @import("terminal");
+
+/// Current terminal size, defaulting to a sane 24x80 when it can't be queried
+/// (e.g. output isn't a console).
+pub fn windowSize() terminal.Winsize {
+    return terminal.getWindowSize(std.Io.File.stdout().handle) catch .{ .row = 24, .col = 80 };
+}
+
+/// Styling for one rendered item. `first_prefix` is printed on the item's first
+/// physical line (the bullet/marker) and must have a display width equal to
+/// `prefix_w`; continuation lines are padded to `prefix_w` so wrapped text
+/// hang-indents under the label. `line_open`/`line_close` wrap every physical
+/// line, letting a prompt colour the whole row (open) or just the marker
+/// (baked into `first_prefix`) as it prefers.
+pub const ItemStyle = struct {
+    line_open: []const u8 = "",
+    first_prefix: []const u8,
+    prefix_w: usize,
+    line_close: []const u8 = "",
+};
+
+/// Render `label` wrapped to `avail` display columns using `style`, returning
+/// the number of physical rows emitted. `first_line` tracks whether a CRLF
+/// separator is needed; rows are CRLF-*separated*, not terminated, so the
+/// caller's cursor ends at the end of the last row (see `eraseRegion`).
+pub fn renderItem(
+    writer: anytype,
+    first_line: *bool,
+    style: ItemStyle,
+    label: []const u8,
+    avail: usize,
+) !usize {
+    const Ctx = struct {
+        w: @TypeOf(writer),
+        first_line: *bool,
+        style: ItemStyle,
+        seg: usize = 0,
+        rows: usize = 0,
+
+        fn emit(self: *@This(), line: []const u8) anyerror!void {
+            if (!self.first_line.*) try self.w.writeAll("\r\n");
+            self.first_line.* = false;
+            try self.w.writeAll(self.style.line_open);
+            if (self.seg == 0) {
+                try self.w.writeAll(self.style.first_prefix);
+            } else {
+                try writePad(self.w, self.style.prefix_w);
+            }
+            try self.w.writeAll(line);
+            try self.w.writeAll(self.style.line_close);
+            self.seg += 1;
+            self.rows += 1;
+        }
+    };
+    var ctx = Ctx{ .w = writer, .first_line = first_line, .style = style };
+    try terminal.wrapForEach(label, avail, &ctx, Ctx.emit);
+    return ctx.rows;
+}
+
+pub fn writePad(writer: anytype, n: usize) !void {
+    for (0..n) |_| try writer.writeAll(" ");
+}
+
+/// A contiguous window of items to display, chosen so the cursor stays visible
+/// and the total physical rows fit within `budget`.
+pub const Window = struct { start: usize, end: usize };
+
+/// Pick the visible window over `n` items. `rowCount(ctx, i)` returns the
+/// physical (wrapped) row count of item `i` — computed on demand so callers
+/// need no allocated counts array. Grows from the cursor outward (upward first,
+/// matching the existing scroll feel) until `budget` rows are used.
+pub fn viewport(
+    n: usize,
+    cursor: usize,
+    budget: usize,
+    ctx: anytype,
+    comptime rowCount: fn (@TypeOf(ctx), usize) usize,
+) Window {
+    if (n == 0) return .{ .start = 0, .end = 0 };
+    var used = rowCount(ctx, cursor);
+    var start = cursor;
+    while (start > 0) {
+        const c = rowCount(ctx, start - 1);
+        if (used + c > budget) break;
+        used += c;
+        start -= 1;
+    }
+    var end = cursor + 1;
+    while (end < n) {
+        const c = rowCount(ctx, end);
+        if (used + c > budget) break;
+        used += c;
+        end += 1;
+    }
+    return .{ .start = start, .end = end };
+}
+
+/// Erase the previously rendered region. The cursor is at the end of the last
+/// row (rows are CRLF-separated, not terminated), so return to column 0, move up
+/// to the first row, and clear to the end of the display.
+pub fn eraseRegion(writer: anytype, rows: usize) !void {
+    if (rows == 0) return;
+    try writer.writeAll("\r");
+    if (rows > 1) try writer.print("\x1b[{d}A", .{rows - 1});
+    try writer.writeAll("\x1b[0J");
+}
+
+const testing = std.testing;
+
+const CountSlice = struct {
+    counts: []const usize,
+    fn at(self: *const CountSlice, i: usize) usize {
+        return self.counts[i];
+    }
+};
+
+test "viewport keeps cursor visible within budget" {
+    const cs = CountSlice{ .counts = &.{ 1, 1, 1, 1, 1, 1, 1, 1 } };
+    const win = viewport(cs.counts.len, 5, 3, &cs, CountSlice.at);
+    try testing.expect(win.start <= 5 and 5 < win.end);
+    try testing.expect(win.end - win.start <= 3);
+}
+
+test "viewport shows everything when it fits" {
+    const cs = CountSlice{ .counts = &.{ 2, 1, 3 } };
+    const win = viewport(cs.counts.len, 0, 100, &cs, CountSlice.at);
+    try testing.expectEqual(@as(usize, 0), win.start);
+    try testing.expectEqual(@as(usize, 3), win.end);
+}
+
+test "eraseRegion is a no-op for zero rows" {
+    var buf: [64]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&buf);
+    try eraseRegion(&w, 0);
+    try testing.expectEqual(@as(usize, 0), w.buffered().len);
+}
+
+test "renderItem hang-indents continuation lines under the label" {
+    var buf: [512]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&buf);
+    var first = true;
+    // 4-column prefix; a label that must wrap at width 12 (avail 8).
+    const rows = try renderItem(&w, &first, .{ .first_prefix = "  > ", .prefix_w = 4 }, "alpha bravo charlie", 8);
+    try testing.expect(rows >= 2);
+    // First line carries the prefix; a continuation line is padded to 4 spaces.
+    try testing.expect(std.mem.indexOf(u8, w.buffered(), "  > alpha") != null);
+    try testing.expect(std.mem.indexOf(u8, w.buffered(), "\r\n    ") != null);
+}

--- a/packages/zinput/src/multi_select.zig
+++ b/packages/zinput/src/multi_select.zig
@@ -140,7 +140,9 @@ pub fn multiSelect(writer: anytype, reader: anytype, allocator: std.mem.Allocato
 /// Lines are separated by (not terminated with) CRLF: after rendering, the
 /// cursor sits at the end of the last row, which `lr.eraseRegion` relies on to
 /// avoid scrolling the screen when the region reaches the bottom.
-fn renderList(
+///
+/// Public for the cross-platform emulator render tests.
+pub fn renderList(
     writer: anytype,
     config: MultiSelectConfig,
     selected: []const bool,

--- a/packages/zinput/src/multi_select.zig
+++ b/packages/zinput/src/multi_select.zig
@@ -3,6 +3,7 @@
 const std = @import("std");
 const terminal = @import("terminal");
 const zinput = @import("zinput.zig");
+const lr = @import("list_render.zig");
 
 pub const MultiSelectConfig = struct {
     message: []const u8,
@@ -17,10 +18,9 @@ pub fn multiSelect(writer: anytype, reader: anytype, allocator: std.mem.Allocato
     if (config.choices.len == 0) return error.NoChoices;
     const is_tty = terminal.isStdinTty();
 
-    try writer.print("{s}{s} (space to toggle, enter to confirm)\r\n", .{ config.prefix, config.message });
-
     if (!is_tty) {
         // Non-TTY: numbered list, accept comma-separated numbers
+        try writer.print("{s}{s} (space to toggle, enter to confirm)\r\n", .{ config.prefix, config.message });
         for (config.choices, 1..) |choice, i| {
             const is_default = if (config.defaults) |d| (i - 1 < d.len and d[i - 1]) else false;
             const marker: []const u8 = if (is_default) "[x]" else "[ ]";
@@ -51,8 +51,10 @@ pub fn multiSelect(writer: anytype, reader: anytype, allocator: std.mem.Allocato
         return collectDefaults(allocator, config);
     };
     try writer.writeAll(terminal.ansi.hide_cursor);
+    var watcher = terminal.ResizeWatcher.init();
     defer {
         writer.writeAll(terminal.ansi.show_cursor) catch {};
+        watcher.deinit();
         raw.disable();
         zinput.flushWriter(writer);
     }
@@ -67,61 +69,138 @@ pub fn multiSelect(writer: anytype, reader: anytype, allocator: std.mem.Allocato
         @memset(selected, false);
     }
 
+    const stdin = std.Io.File.stdin().handle;
     var cursor: usize = 0;
-
-    try renderMultiSelectList(writer, config.choices, selected, cursor, config.unicode);
+    var rows = try renderList(writer, config, selected, cursor, lr.windowSize());
 
     while (true) {
         zinput.flushWriter(writer);
-        const k = try terminal.readKey(reader);
-        switch (k) {
-            .up => {
-                if (cursor > 0) cursor -= 1;
-                try eraseList(writer, config.choices.len);
-                try renderMultiSelectList(writer, config.choices, selected, cursor, config.unicode);
+        switch (try terminal.readEvent(reader, stdin, &watcher)) {
+            .resize => {
+                try lr.eraseRegion(writer, rows);
+                rows = try renderList(writer, config, selected, cursor, lr.windowSize());
             },
-            .down => {
-                if (cursor < config.choices.len - 1) cursor += 1;
-                try eraseList(writer, config.choices.len);
-                try renderMultiSelectList(writer, config.choices, selected, cursor, config.unicode);
-            },
-            .char => |c| {
-                if (c == ' ') {
-                    selected[cursor] = !selected[cursor];
-                    try eraseList(writer, config.choices.len);
-                    try renderMultiSelectList(writer, config.choices, selected, cursor, config.unicode);
-                }
-            },
-            .enter => {
-                try eraseList(writer, config.choices.len);
-                // Show summary
-                var first = true;
-                try writer.writeAll("  \x1b[36m");
-                for (config.choices, 0..) |choice, i| {
-                    if (selected[i]) {
-                        if (!first) try writer.writeAll(", ");
-                        try writer.writeAll(choice);
-                        first = false;
+            .key => |k| switch (k) {
+                .up => {
+                    if (cursor > 0) cursor -= 1;
+                    try lr.eraseRegion(writer, rows);
+                    rows = try renderList(writer, config, selected, cursor, lr.windowSize());
+                },
+                .down => {
+                    if (cursor < config.choices.len - 1) cursor += 1;
+                    try lr.eraseRegion(writer, rows);
+                    rows = try renderList(writer, config, selected, cursor, lr.windowSize());
+                },
+                .char => |c| {
+                    if (c == ' ') {
+                        selected[cursor] = !selected[cursor];
+                        try lr.eraseRegion(writer, rows);
+                        rows = try renderList(writer, config, selected, cursor, lr.windowSize());
                     }
-                }
-                try writer.writeAll("\x1b[0m\r\n");
+                },
+                .enter => {
+                    try lr.eraseRegion(writer, rows);
+                    // Show summary
+                    var first = true;
+                    try writer.writeAll("  \x1b[36m");
+                    for (config.choices, 0..) |choice, i| {
+                        if (selected[i]) {
+                            if (!first) try writer.writeAll(", ");
+                            try writer.writeAll(choice);
+                            first = false;
+                        }
+                    }
+                    try writer.writeAll("\x1b[0m\r\n");
 
-                // Collect selected indices
-                var result = std.ArrayList(usize).empty;
-                for (0..config.choices.len) |i| {
-                    if (selected[i]) try result.append(allocator, i);
-                }
-                return try result.toOwnedSlice(allocator);
+                    // Collect selected indices
+                    var result = std.ArrayList(usize).empty;
+                    for (0..config.choices.len) |i| {
+                        if (selected[i]) try result.append(allocator, i);
+                    }
+                    return try result.toOwnedSlice(allocator);
+                },
+                .ctrl => |c| {
+                    if (c == 'c') {
+                        try lr.eraseRegion(writer, rows);
+                        return error.UserAborted;
+                    }
+                },
+                else => {},
             },
-            .ctrl => |c| {
-                if (c == 'c') {
-                    try eraseList(writer, config.choices.len);
-                    return error.UserAborted;
-                }
-            },
-            else => {},
         }
     }
+}
+
+/// Render the header and (viewport-limited) choice list at the given terminal
+/// size, returning the number of physical rows emitted. Width is taken as an
+/// explicit parameter (not queried) so this is deterministic and unit-testable.
+/// Uses the shared `list_render` machinery; only the marker/cursor styling is
+/// multi-select-specific.
+///
+/// Lines are separated by (not terminated with) CRLF: after rendering, the
+/// cursor sits at the end of the last row, which `lr.eraseRegion` relies on to
+/// avoid scrolling the screen when the region reaches the bottom.
+fn renderList(
+    writer: anytype,
+    config: MultiSelectConfig,
+    selected: []const bool,
+    cursor: usize,
+    ws: terminal.Winsize,
+) !usize {
+    const width = @max(@as(usize, ws.col), 1);
+    // Leave the last column unused so a full-width line can't trigger the
+    // terminal's deferred auto-wrap (DECAWM) and desync our row count.
+    const usable = @max(width -| 1, 1);
+    const height = @max(@as(usize, ws.row), 2);
+
+    const cursor_sym = terminal.symbols.select_cursor(config.unicode);
+    const sel_sym = terminal.symbols.selected(config.unicode);
+    const unsel_sym = terminal.symbols.unselected(config.unicode);
+    // Cursor row "  <cur> <marker> " and plain row "    <marker> " are both this
+    // wide (assuming a single-column cursor glyph), so wrapped text and the
+    // hang-indent of continuation lines all align.
+    const prefix_w = 5 + terminal.displayWidth(sel_sym);
+    const avail = @max(usable -| prefix_w, 1);
+
+    var rows: usize = 0;
+    var first_line = true;
+
+    // Header (hang-indents any wrap under the message text).
+    const hprefix_w = terminal.displayWidth(config.prefix);
+    var hbuf: [512]u8 = undefined;
+    const header = std.fmt.bufPrint(&hbuf, "{s} (space to toggle, enter to confirm)", .{config.message}) catch config.message;
+    rows += try lr.renderItem(writer, &first_line, .{ .first_prefix = config.prefix, .prefix_w = hprefix_w }, header, @max(usable -| hprefix_w, 1));
+
+    // Viewport over choices; row counts are computed on demand (no allocation).
+    const Counter = struct {
+        choices: []const []const u8,
+        avail: usize,
+        fn at(self: *const @This(), i: usize) usize {
+            return terminal.wrapCount(self.choices[i], self.avail);
+        }
+    };
+    const counter = Counter{ .choices = config.choices, .avail = avail };
+    // Reserve one screen row (below the header) so trailing content never scrolls.
+    const list_budget = @max((height -| 1) -| rows, 1);
+    const win = lr.viewport(config.choices.len, cursor, list_budget, &counter, Counter.at);
+
+    for (win.start..win.end) |i| {
+        const marker = if (selected[i]) sel_sym else unsel_sym;
+        var pbuf: [64]u8 = undefined;
+        const style: lr.ItemStyle = if (i == cursor)
+            .{
+                .first_prefix = std.fmt.bufPrint(&pbuf, "  \x1b[36m{s}\x1b[0m \x1b[32m{s}\x1b[0m ", .{ cursor_sym, marker }) catch "  ",
+                .prefix_w = prefix_w,
+            }
+        else
+            .{
+                .first_prefix = std.fmt.bufPrint(&pbuf, "    {s} ", .{marker}) catch "    ",
+                .prefix_w = prefix_w,
+            };
+        rows += try lr.renderItem(writer, &first_line, style, config.choices[i], avail);
+    }
+
+    return rows;
 }
 
 fn readLine(reader: anytype, allocator: std.mem.Allocator) ![]u8 {
@@ -133,26 +212,6 @@ fn readLine(reader: anytype, allocator: std.mem.Allocator) ![]u8 {
         if (byte != '\r') try buf.append(allocator, byte);
     }
     return try buf.toOwnedSlice(allocator);
-}
-
-fn renderMultiSelectList(writer: anytype, choices: []const []const u8, selected: []const bool, cursor: usize, unicode: bool) !void {
-    const sel_sym = terminal.symbols.selected(unicode);
-    const unsel_sym = terminal.symbols.unselected(unicode);
-    const cursor_sym = terminal.symbols.select_cursor(unicode);
-    for (choices, 0..) |choice, i| {
-        const marker: []const u8 = if (selected[i]) sel_sym else unsel_sym;
-        if (i == cursor) {
-            try writer.print("  \x1b[36m{s}\x1b[0m \x1b[32m{s}\x1b[0m {s}\r\n", .{ cursor_sym, marker, choice });
-        } else {
-            try writer.print("    {s} {s}\r\n", .{ marker, choice });
-        }
-    }
-}
-
-fn eraseList(writer: anytype, count: usize) !void {
-    for (0..count) |_| {
-        try writer.writeAll("\x1b[A\r\x1b[K");
-    }
 }
 
 fn collectDefaults(allocator: std.mem.Allocator, config: MultiSelectConfig) ![]usize {
@@ -222,3 +281,45 @@ test "non-TTY: no defaults returns empty" {
 
     try std.testing.expectEqual(@as(usize, 0), result.len);
 }
+
+// ---------------------------------------------------------------------------
+// Render tests — the regression guard for the erase-count bug: a wrapped option
+// must report the true number of physical rows, and continuation lines must
+// hang-indent under the option text.
+// ---------------------------------------------------------------------------
+
+fn renderToBuf(buf: []u8, config: MultiSelectConfig, selected: []const bool, cursor: usize, ws: terminal.Winsize) !struct { rows: usize, text: []const u8 } {
+    var w: std.Io.Writer = .fixed(buf);
+    const rows = try renderList(&w, config, selected, cursor, ws);
+    return .{ .rows = rows, .text = w.buffered() };
+}
+
+test "renderList: short options are one row each" {
+    var buf: [1024]u8 = undefined;
+    const r = try renderToBuf(&buf, .{ .message = "Pick", .choices = &.{ "a", "b", "c" } }, &.{ false, false, false }, 0, .{ .row = 24, .col = 80 });
+    // 1 header row + 3 option rows.
+    try std.testing.expectEqual(@as(usize, 4), r.rows);
+}
+
+test "renderList: a wrapping option counts as multiple physical rows" {
+    var buf: [4096]u8 = undefined;
+    const long = "this is a fairly long option label that will certainly wrap";
+    // Narrow terminal forces the long option onto several rows.
+    const r = try renderToBuf(&buf, .{ .message = "Pick", .choices = &.{ "short", long } }, &.{ false, false }, 0, .{ .row = 24, .col = 24 });
+    // header(1) + short(1) + long(>=3 at width 24) — the key point is it is not 3.
+    try std.testing.expect(r.rows > 3);
+    // Row count must equal the number of CRLF-separated lines actually emitted.
+    const lines = std.mem.count(u8, r.text, "\r\n") + 1;
+    try std.testing.expectEqual(lines, r.rows);
+}
+
+test "renderList: continuation lines hang-indent under the option text" {
+    var buf: [4096]u8 = undefined;
+    // unicode=false so the prefix is "    [ ] " = 8 columns.
+    const r = try renderToBuf(&buf, .{ .message = "Pick", .choices = &.{"alpha bravo charlie delta"}, .unicode = false }, &.{false}, 0, .{ .row = 24, .col = 20 });
+    _ = r;
+    // The continuation line is preceded by 8 spaces (prefix width), aligning it
+    // under the label text rather than under the bullet.
+    try std.testing.expect(std.mem.indexOf(u8, buf[0..], "\r\n        ") != null);
+}
+

--- a/packages/zinput/src/search.zig
+++ b/packages/zinput/src/search.zig
@@ -3,6 +3,7 @@
 const std = @import("std");
 const terminal = @import("terminal");
 const zinput = @import("zinput.zig");
+const lr = @import("list_render.zig");
 
 pub const SearchConfig = struct {
     message: []const u8,
@@ -31,12 +32,13 @@ pub fn search(writer: anytype, reader: anytype, allocator: std.mem.Allocator, co
     }
 
     // TTY: interactive search
-    try writer.print("{s}{s}\r\n", .{ config.prefix, config.message });
     zinput.flushWriter(writer);
     const raw = terminal.enableRawMode(std.Io.File.stdin().handle) catch return 0;
     try writer.writeAll(terminal.ansi.hide_cursor);
+    var watcher = terminal.ResizeWatcher.init();
     defer {
         writer.writeAll(terminal.ansi.show_cursor) catch {};
+        watcher.deinit();
         raw.disable();
         zinput.flushWriter(writer);
     }
@@ -44,62 +46,64 @@ pub fn search(writer: anytype, reader: anytype, allocator: std.mem.Allocator, co
     var query = std.ArrayList(u8).empty;
     defer query.deinit(allocator);
 
-    // Build initial index mapping (all items)
     var filtered = try buildFiltered(allocator, config.choices, "");
     defer allocator.free(filtered);
+    const stdin = std.Io.File.stdin().handle;
     var cursor: usize = 0;
-    var rendered_lines: usize = 0;
-
-    // Initial render
-    rendered_lines = try renderSearch(writer, config, query.items, filtered, cursor);
+    var rows = try renderSearch(writer, config, query.items, filtered, cursor, lr.windowSize());
 
     while (true) {
         zinput.flushWriter(writer);
-        const k = try terminal.readKey(reader);
-        switch (k) {
-            .up => {
-                if (cursor > 0) cursor -= 1;
-                try eraseRendered(writer, rendered_lines);
-                rendered_lines = try renderSearch(writer, config, query.items, filtered, cursor);
+        switch (try terminal.readEvent(reader, stdin, &watcher)) {
+            .resize => {
+                try lr.eraseRegion(writer, rows);
+                rows = try renderSearch(writer, config, query.items, filtered, cursor, lr.windowSize());
             },
-            .down => {
-                if (cursor < filtered.len -| 1) cursor += 1;
-                try eraseRendered(writer, rendered_lines);
-                rendered_lines = try renderSearch(writer, config, query.items, filtered, cursor);
-            },
-            .enter => {
-                if (filtered.len > 0) {
-                    const selected_idx = filtered[cursor];
-                    try eraseRendered(writer, rendered_lines);
-                    try writer.print("  \x1b[36m{s}\x1b[0m\r\n", .{config.choices[selected_idx]});
-                    return selected_idx;
-                }
-            },
-            .backspace => {
-                if (query.items.len > 0) {
-                    _ = query.pop();
+            .key => |k| switch (k) {
+                .up => {
+                    if (cursor > 0) cursor -= 1;
+                    try lr.eraseRegion(writer, rows);
+                    rows = try renderSearch(writer, config, query.items, filtered, cursor, lr.windowSize());
+                },
+                .down => {
+                    if (cursor < filtered.len -| 1) cursor += 1;
+                    try lr.eraseRegion(writer, rows);
+                    rows = try renderSearch(writer, config, query.items, filtered, cursor, lr.windowSize());
+                },
+                .enter => {
+                    if (filtered.len > 0) {
+                        const selected_idx = filtered[cursor];
+                        try lr.eraseRegion(writer, rows);
+                        try writer.print("  \x1b[36m{s}\x1b[0m\r\n", .{config.choices[selected_idx]});
+                        return selected_idx;
+                    }
+                },
+                .backspace => {
+                    if (query.items.len > 0) {
+                        _ = query.pop();
+                        allocator.free(filtered);
+                        filtered = try buildFiltered(allocator, config.choices, query.items);
+                        cursor = 0;
+                        try lr.eraseRegion(writer, rows);
+                        rows = try renderSearch(writer, config, query.items, filtered, cursor, lr.windowSize());
+                    }
+                },
+                .ctrl => |c| {
+                    if (c == 'c') {
+                        try lr.eraseRegion(writer, rows);
+                        return error.UserAborted;
+                    }
+                },
+                .char => |c| {
+                    try query.append(allocator, c);
                     allocator.free(filtered);
                     filtered = try buildFiltered(allocator, config.choices, query.items);
                     cursor = 0;
-                    try eraseRendered(writer, rendered_lines);
-                    rendered_lines = try renderSearch(writer, config, query.items, filtered, cursor);
-                }
+                    try lr.eraseRegion(writer, rows);
+                    rows = try renderSearch(writer, config, query.items, filtered, cursor, lr.windowSize());
+                },
+                else => {},
             },
-            .ctrl => |c| {
-                if (c == 'c') {
-                    try eraseRendered(writer, rendered_lines);
-                    return error.UserAborted;
-                }
-            },
-            .char => |c| {
-                try query.append(allocator, c);
-                allocator.free(filtered);
-                filtered = try buildFiltered(allocator, config.choices, query.items);
-                cursor = 0;
-                try eraseRendered(writer, rendered_lines);
-                rendered_lines = try renderSearch(writer, config, query.items, filtered, cursor);
-            },
-            else => {},
         }
     }
 }
@@ -133,50 +137,72 @@ fn containsIgnoreCase(haystack: []const u8, needle: []const u8) bool {
     return false;
 }
 
-fn renderSearch(writer: anytype, config: SearchConfig, query: []const u8, filtered: []const usize, cursor: usize) !usize {
-    // Line 1: search input
-    try writer.writeAll("  Search: ");
-    if (query.len > 0) {
-        try writer.writeAll(query);
-    } else {
-        try writer.writeAll("\x1b[2mtype to filter\x1b[0m");
-    }
-    try writer.writeAll("\r\n");
+/// Render the header, search-input line, and viewport-limited results, returning
+/// the number of physical rows emitted. Width is an explicit parameter so this
+/// is deterministic/testable.
+fn renderSearch(
+    writer: anytype,
+    config: SearchConfig,
+    query: []const u8,
+    filtered: []const usize,
+    cursor: usize,
+    ws: terminal.Winsize,
+) !usize {
+    const width = @max(@as(usize, ws.col), 1);
+    const usable = @max(width -| 1, 1);
+    const height = @max(@as(usize, ws.row), 2);
 
-    var lines: usize = 1;
+    const cursor_sym = terminal.symbols.select_cursor(config.unicode);
+    const prefix_w: usize = 4; // "  <cur> " / "    "
+    const avail = @max(usable -| prefix_w, 1);
 
-    // Filtered results (max 7 visible)
-    const max_visible: usize = 7;
-    const visible_count = @min(filtered.len, max_visible);
+    var rows: usize = 0;
+    var first_line = true;
 
-    const marker = terminal.symbols.select_cursor(config.unicode);
+    // Header line.
+    const hprefix_w = terminal.displayWidth(config.prefix);
+    rows += try lr.renderItem(writer, &first_line, .{ .first_prefix = config.prefix, .prefix_w = hprefix_w }, config.message, @max(usable -| hprefix_w, 1));
+
+    // Search-input line: "  Search: <query>".
+    const search_prefix = "  Search: ";
+    const search_prefix_w = terminal.displayWidth(search_prefix);
+    const query_label = if (query.len > 0) query else "\x1b[2mtype to filter\x1b[0m";
+    rows += try lr.renderItem(writer, &first_line, .{ .first_prefix = search_prefix, .prefix_w = search_prefix_w }, query_label, @max(usable -| search_prefix_w, 1));
 
     if (filtered.len == 0) {
-        try writer.writeAll("  \x1b[2mno matches\x1b[0m\r\n");
-        lines += 1;
-    } else {
-        // Calculate scroll window
-        const start = if (cursor >= max_visible) cursor - max_visible + 1 else 0;
-        for (0..visible_count) |i| {
-            const idx = start + i;
-            if (idx >= filtered.len) break;
-            const choice_idx = filtered[idx];
-            if (idx == cursor) {
-                try writer.print("  \x1b[36m{s} {s}\x1b[0m\r\n", .{ marker, config.choices[choice_idx] });
-            } else {
-                try writer.print("    {s}\r\n", .{config.choices[choice_idx]});
-            }
-            lines += 1;
+        rows += try lr.renderItem(writer, &first_line, .{ .first_prefix = "  ", .prefix_w = 2 }, "\x1b[2mno matches\x1b[0m", avail);
+        return rows;
+    }
+
+    // Results viewport (row counts computed on demand).
+    const Counter = struct {
+        choices: []const []const u8,
+        filtered: []const usize,
+        avail: usize,
+        fn at(self: *const @This(), i: usize) usize {
+            return terminal.wrapCount(self.choices[self.filtered[i]], self.avail);
         }
+    };
+    const counter = Counter{ .choices = config.choices, .filtered = filtered, .avail = avail };
+    const list_budget = @max((height -| 1) -| rows, 1);
+    const win = lr.viewport(filtered.len, cursor, list_budget, &counter, Counter.at);
+
+    for (win.start..win.end) |i| {
+        const choice = config.choices[filtered[i]];
+        var pbuf: [32]u8 = undefined;
+        const style: lr.ItemStyle = if (i == cursor)
+            .{
+                .line_open = "\x1b[36m",
+                .first_prefix = std.fmt.bufPrint(&pbuf, "  {s} ", .{cursor_sym}) catch "  ",
+                .prefix_w = prefix_w,
+                .line_close = "\x1b[0m",
+            }
+        else
+            .{ .first_prefix = "    ", .prefix_w = prefix_w };
+        rows += try lr.renderItem(writer, &first_line, style, choice, avail);
     }
 
-    return lines;
-}
-
-fn eraseRendered(writer: anytype, lines: usize) !void {
-    for (0..lines) |_| {
-        try writer.writeAll("\x1b[A\r\x1b[K");
-    }
+    return rows;
 }
 
 fn readLine(reader: anytype, allocator: std.mem.Allocator) ![]u8 {
@@ -218,4 +244,28 @@ test "buildFiltered filters by substring" {
 test "SearchConfig defaults" {
     const cfg = SearchConfig{ .message = "Pick:", .choices = &.{ "a", "b" } };
     try std.testing.expectEqualStrings("? ", cfg.prefix);
+}
+
+fn renderToBuf(buf: []u8, config: SearchConfig, query: []const u8, filtered: []const usize, cursor: usize, ws: terminal.Winsize) !struct { rows: usize, text: []const u8 } {
+    var w: std.Io.Writer = .fixed(buf);
+    const rows = try renderSearch(&w, config, query, filtered, cursor, ws);
+    return .{ .rows = rows, .text = w.buffered() };
+}
+
+test "renderSearch: header + search line + results, row count matches lines" {
+    var buf: [4096]u8 = undefined;
+    const filtered = [_]usize{ 0, 1, 2 };
+    const r = try renderToBuf(&buf, .{ .message = "Pick", .choices = &.{ "alpha", "beta", "gamma" } }, "a", &filtered, 0, .{ .row = 24, .col = 80 });
+    // header(1) + search(1) + 3 results = 5
+    try std.testing.expectEqual(@as(usize, 5), r.rows);
+    const lines = std.mem.count(u8, r.text, "\r\n") + 1;
+    try std.testing.expectEqual(lines, r.rows);
+}
+
+test "renderSearch: no matches renders a message row" {
+    var buf: [1024]u8 = undefined;
+    const empty = [_]usize{};
+    const r = try renderToBuf(&buf, .{ .message = "Pick", .choices = &.{ "a", "b" } }, "zzz", &empty, 0, .{ .row = 24, .col = 80 });
+    try std.testing.expectEqual(@as(usize, 3), r.rows); // header + search + "no matches"
+    try std.testing.expect(std.mem.indexOf(u8, r.text, "no matches") != null);
 }

--- a/packages/zinput/src/search.zig
+++ b/packages/zinput/src/search.zig
@@ -139,8 +139,8 @@ fn containsIgnoreCase(haystack: []const u8, needle: []const u8) bool {
 
 /// Render the header, search-input line, and viewport-limited results, returning
 /// the number of physical rows emitted. Width is an explicit parameter so this
-/// is deterministic/testable.
-fn renderSearch(
+/// is deterministic/testable (used by the cross-platform emulator render tests).
+pub fn renderSearch(
     writer: anytype,
     config: SearchConfig,
     query: []const u8,

--- a/packages/zinput/src/select.zig
+++ b/packages/zinput/src/select.zig
@@ -3,6 +3,7 @@
 const std = @import("std");
 const terminal = @import("terminal");
 const zinput = @import("zinput.zig");
+const lr = @import("list_render.zig");
 
 pub const SelectConfig = struct {
     message: []const u8,
@@ -20,10 +21,9 @@ pub fn select(writer: anytype, reader: anytype, config: SelectConfig) !usize {
     if (config.choices.len == 0) return error.NoChoices;
     const is_tty = terminal.isStdinTty();
 
-    try writer.print("{s}{s}\r\n", .{ config.prefix, config.message });
-
     if (!is_tty) {
         // Non-TTY: numbered list
+        try writer.print("{s}{s}\r\n", .{ config.prefix, config.message });
         for (config.choices, 1..) |choice, i| {
             try writer.print("  {d}) {s}\n", .{ i, choice });
         }
@@ -39,71 +39,103 @@ pub fn select(writer: anytype, reader: anytype, config: SelectConfig) !usize {
     zinput.flushWriter(writer);
     const raw = terminal.enableRawMode(std.Io.File.stdin().handle) catch return 0;
     try writer.writeAll(terminal.ansi.hide_cursor);
+    var watcher = terminal.ResizeWatcher.init();
     defer {
         writer.writeAll(terminal.ansi.show_cursor) catch {};
+        watcher.deinit();
         raw.disable();
         zinput.flushWriter(writer);
     }
 
+    const stdin = std.Io.File.stdin().handle;
     var cursor: usize = 0;
-
-    // Initial render
-    try renderSelectList(writer, config.choices, cursor, config.unicode);
+    var rows = try renderList(writer, config, cursor, lr.windowSize());
 
     while (true) {
         zinput.flushWriter(writer);
-        const k = if (config.interrupt_keys.len > 0)
-            try terminal.readKeyOpt(reader, std.Io.File.stdin().handle)
-        else
-            try terminal.readKey(reader);
-        if (zinput.isInterrupt(k, config.interrupt_keys)) {
-            try eraseList(writer, config.choices.len);
-            try writer.writeAll("\x1b[A\r\x1b[K"); // also clear the prompt line
-            return error.Interrupted;
-        }
-        switch (k) {
-            .up => {
-                if (cursor > 0) cursor -= 1;
-                try eraseList(writer, config.choices.len);
-                try renderSelectList(writer, config.choices, cursor, config.unicode);
+        switch (try terminal.readEvent(reader, stdin, &watcher)) {
+            .resize => {
+                try lr.eraseRegion(writer, rows);
+                rows = try renderList(writer, config, cursor, lr.windowSize());
             },
-            .down => {
-                if (cursor < config.choices.len - 1) cursor += 1;
-                try eraseList(writer, config.choices.len);
-                try renderSelectList(writer, config.choices, cursor, config.unicode);
-            },
-            .enter => {
-                try eraseList(writer, config.choices.len);
-                try writer.print("  \x1b[36m{s}\x1b[0m\r\n", .{config.choices[cursor]});
-                return cursor;
-            },
-            .ctrl => |c| {
-                if (c == 'c') {
-                    try eraseList(writer, config.choices.len);
-                    return error.UserAborted;
+            .key => |k| {
+                if (zinput.isInterrupt(k, config.interrupt_keys)) {
+                    try lr.eraseRegion(writer, rows);
+                    return error.Interrupted;
+                }
+                switch (k) {
+                    .up => {
+                        if (cursor > 0) cursor -= 1;
+                        try lr.eraseRegion(writer, rows);
+                        rows = try renderList(writer, config, cursor, lr.windowSize());
+                    },
+                    .down => {
+                        if (cursor < config.choices.len - 1) cursor += 1;
+                        try lr.eraseRegion(writer, rows);
+                        rows = try renderList(writer, config, cursor, lr.windowSize());
+                    },
+                    .enter => {
+                        try lr.eraseRegion(writer, rows);
+                        try writer.print("  \x1b[36m{s}\x1b[0m\r\n", .{config.choices[cursor]});
+                        return cursor;
+                    },
+                    .ctrl => |c| {
+                        if (c == 'c') {
+                            try lr.eraseRegion(writer, rows);
+                            return error.UserAborted;
+                        }
+                    },
+                    else => {},
                 }
             },
-            else => {},
         }
     }
 }
 
-fn renderSelectList(writer: anytype, choices: []const []const u8, cursor: usize, unicode: bool) !void {
-    const marker = terminal.symbols.select_cursor(unicode);
-    for (choices, 0..) |choice, i| {
-        if (i == cursor) {
-            try writer.print("  \x1b[36m{s} {s}\x1b[0m\r\n", .{ marker, choice });
-        } else {
-            try writer.print("    {s}\r\n", .{choice});
-        }
-    }
-}
+/// Render the header + viewport-limited choice list, returning physical rows
+/// emitted. Width is an explicit parameter so this is deterministic/testable.
+fn renderList(writer: anytype, config: SelectConfig, cursor: usize, ws: terminal.Winsize) !usize {
+    const width = @max(@as(usize, ws.col), 1);
+    const usable = @max(width -| 1, 1);
+    const height = @max(@as(usize, ws.row), 2);
 
-fn eraseList(writer: anytype, count: usize) !void {
-    // Move cursor up `count` lines and clear each
-    for (0..count) |_| {
-        try writer.writeAll("\x1b[A\r\x1b[K");
+    const cursor_sym = terminal.symbols.select_cursor(config.unicode);
+    // "  <cur> " and "    " are both 4 columns (single-column cursor glyph).
+    const prefix_w: usize = 4;
+    const avail = @max(usable -| prefix_w, 1);
+
+    var rows: usize = 0;
+    var first_line = true;
+
+    const hprefix_w = terminal.displayWidth(config.prefix);
+    rows += try lr.renderItem(writer, &first_line, .{ .first_prefix = config.prefix, .prefix_w = hprefix_w }, config.message, @max(usable -| hprefix_w, 1));
+
+    const Counter = struct {
+        choices: []const []const u8,
+        avail: usize,
+        fn at(self: *const @This(), i: usize) usize {
+            return terminal.wrapCount(self.choices[i], self.avail);
+        }
+    };
+    const counter = Counter{ .choices = config.choices, .avail = avail };
+    const list_budget = @max((height -| 1) -| rows, 1);
+    const win = lr.viewport(config.choices.len, cursor, list_budget, &counter, Counter.at);
+
+    for (win.start..win.end) |i| {
+        var pbuf: [32]u8 = undefined;
+        const style: lr.ItemStyle = if (i == cursor)
+            .{
+                .line_open = "\x1b[36m",
+                .first_prefix = std.fmt.bufPrint(&pbuf, "  {s} ", .{cursor_sym}) catch "  ",
+                .prefix_w = prefix_w,
+                .line_close = "\x1b[0m",
+            }
+        else
+            .{ .first_prefix = "    ", .prefix_w = prefix_w };
+        rows += try lr.renderItem(writer, &first_line, style, config.choices[i], avail);
     }
+
+    return rows;
 }
 
 fn readLine(reader: anytype, allocator: std.mem.Allocator) ![]u8 {
@@ -169,4 +201,25 @@ test "non-TTY: shows numbered choices" {
     try std.testing.expect(std.mem.indexOf(u8, written, "2)") != null);
     try std.testing.expect(std.mem.indexOf(u8, written, "first") != null);
     try std.testing.expect(std.mem.indexOf(u8, written, "second") != null);
+}
+
+fn renderToBuf(buf: []u8, config: SelectConfig, cursor: usize, ws: terminal.Winsize) !struct { rows: usize, text: []const u8 } {
+    var w: std.Io.Writer = .fixed(buf);
+    const rows = try renderList(&w, config, cursor, ws);
+    return .{ .rows = rows, .text = w.buffered() };
+}
+
+test "renderList: short options are one row each" {
+    var buf: [1024]u8 = undefined;
+    const r = try renderToBuf(&buf, .{ .message = "Pick", .choices = &.{ "a", "b", "c" } }, 0, .{ .row = 24, .col = 80 });
+    try std.testing.expectEqual(@as(usize, 4), r.rows); // header + 3
+}
+
+test "renderList: wrapped option reports true physical row count" {
+    var buf: [4096]u8 = undefined;
+    const long = "this is a long option label that will certainly wrap at a narrow width";
+    const r = try renderToBuf(&buf, .{ .message = "Pick", .choices = &.{ "short", long } }, 0, .{ .row = 24, .col = 24 });
+    try std.testing.expect(r.rows > 3);
+    const lines = std.mem.count(u8, r.text, "\r\n") + 1;
+    try std.testing.expectEqual(lines, r.rows);
 }

--- a/packages/zinput/src/select.zig
+++ b/packages/zinput/src/select.zig
@@ -93,8 +93,9 @@ pub fn select(writer: anytype, reader: anytype, config: SelectConfig) !usize {
 }
 
 /// Render the header + viewport-limited choice list, returning physical rows
-/// emitted. Width is an explicit parameter so this is deterministic/testable.
-fn renderList(writer: anytype, config: SelectConfig, cursor: usize, ws: terminal.Winsize) !usize {
+/// emitted. Width is an explicit parameter so this is deterministic/testable
+/// (used by the cross-platform emulator render tests).
+pub fn renderList(writer: anytype, config: SelectConfig, cursor: usize, ws: terminal.Winsize) !usize {
     const width = @max(@as(usize, ws.col), 1);
     const usable = @max(width -| 1, 1);
     const height = @max(@as(usize, ws.row), 2);

--- a/packages/zinput/src/zinput.zig
+++ b/packages/zinput/src/zinput.zig
@@ -14,6 +14,10 @@
 const std = @import("std");
 pub const terminal = @import("terminal");
 
+/// Shared rendering machinery for the list-style prompts (wrapping, viewport,
+/// resize-safe erase).
+pub const list_render = @import("list_render.zig");
+
 pub const text_prompt = @import("text.zig");
 pub const confirm_prompt = @import("confirm.zig");
 pub const select_prompt = @import("select.zig");

--- a/packages/zinput/test/render_e2e.zig
+++ b/packages/zinput/test/render_e2e.zig
@@ -1,0 +1,180 @@
+//! Cross-platform rendering end-to-end tests for the list prompts.
+//!
+//! These drive the real render + erase code paths and replay their byte output
+//! through the in-repo `vterm` terminal emulator, then assert on the resulting
+//! screen grid. Because `vterm` is pure logic, these run identically on Linux,
+//! macOS, and Windows (they're part of `zig build test-zinput`, which Windows CI
+//! runs) — unlike the PTY harness, which is POSIX-only.
+//!
+//! The central invariant is the fix for the original bug: navigating a list
+//! whose options wrap must leave **no debris**. We assert that by comparing two
+//! screens that must be identical — a fresh render of the target frame, versus
+//! rendering the first frame, erasing it, then rendering the target frame. Any
+//! leftover character from the wider/taller previous frame makes them differ.
+
+const std = @import("std");
+const zinput = @import("zinput");
+const vterm = @import("vterm");
+
+const Winsize = zinput.terminal.Winsize;
+const testing = std.testing;
+
+/// Replay `bytes` through a fresh `cols`x`rows` emulator and return the visible
+/// grid as text (caller frees).
+fn screenOf(alloc: std.mem.Allocator, cols: u16, rows: u16, bytes: []const u8) ![]u8 {
+    var term = try vterm.VTerm.init(alloc, cols, rows);
+    defer term.deinit();
+    term.write(bytes);
+    return term.getAllText(alloc);
+}
+
+// ---------------------------------------------------------------------------
+// multi_select
+// ---------------------------------------------------------------------------
+
+fn multiFrame(buf: []u8, config: zinput.MultiSelectConfig, selected: []const bool, cursor: usize, ws: Winsize) ![]const u8 {
+    var w: std.Io.Writer = .fixed(buf);
+    _ = try zinput.multi_select_prompt.renderList(&w, config, selected, cursor, ws);
+    return w.buffered();
+}
+
+fn multiNavScreen(alloc: std.mem.Allocator, config: zinput.MultiSelectConfig, selected: []const bool, from: usize, to: usize, ws: Winsize) ![]u8 {
+    var buf: [16384]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&buf);
+    const r0 = try zinput.multi_select_prompt.renderList(&w, config, selected, from, ws);
+    try zinput.list_render.eraseRegion(&w, r0);
+    _ = try zinput.multi_select_prompt.renderList(&w, config, selected, to, ws);
+    return screenOf(alloc, ws.col, ws.row, w.buffered());
+}
+
+test "emulator: multi_select navigation leaves no debris when options wrap" {
+    const alloc = testing.allocator;
+    const ws = Winsize{ .row = 24, .col = 30 };
+    const config = zinput.MultiSelectConfig{ .message = "Pick", .choices = &.{
+        "short",
+        "a genuinely long option label that certainly wraps across several rows",
+        "third choice here",
+    } };
+    const selected = [_]bool{ false, false, false };
+
+    // Fresh render of the target frame (cursor on the long, wrapping option).
+    var cbuf: [16384]u8 = undefined;
+    const clean = try screenOf(alloc, ws.col, ws.row, try multiFrame(&cbuf, config, &selected, 1, ws));
+    defer alloc.free(clean);
+
+    // Same frame reached by rendering frame 0, erasing it, then rendering frame 1.
+    const nav = try multiNavScreen(alloc, config, &selected, 0, 1, ws);
+    defer alloc.free(nav);
+
+    try testing.expectEqualStrings(clean, nav);
+}
+
+test "emulator: multi_select wraps wide CJK options without debris" {
+    const alloc = testing.allocator;
+    const ws = Winsize{ .row = 24, .col = 22 };
+    const config = zinput.MultiSelectConfig{ .message = "Pick", .choices = &.{
+        "ascii option",
+        "你好世界这是一个需要换行显示的很长选项",
+        "另一个选项",
+    } };
+    const selected = [_]bool{ false, true, false };
+
+    var cbuf: [16384]u8 = undefined;
+    const clean = try screenOf(alloc, ws.col, ws.row, try multiFrame(&cbuf, config, &selected, 2, ws));
+    defer alloc.free(clean);
+
+    const nav = try multiNavScreen(alloc, config, &selected, 1, 2, ws);
+    defer alloc.free(nav);
+
+    try testing.expectEqualStrings(clean, nav);
+}
+
+// ---------------------------------------------------------------------------
+// select
+// ---------------------------------------------------------------------------
+
+test "emulator: select navigation leaves no debris when options wrap" {
+    const alloc = testing.allocator;
+    const ws = Winsize{ .row = 24, .col = 24 };
+    const config = zinput.SelectConfig{ .message = "Choose", .choices = &.{
+        "one",
+        "a long choice that will wrap onto multiple lines at this width",
+        "two",
+    } };
+
+    var cbuf: [16384]u8 = undefined;
+    var cw: std.Io.Writer = .fixed(&cbuf);
+    _ = try zinput.select_prompt.renderList(&cw, config, 1, ws);
+    const clean = try screenOf(alloc, ws.col, ws.row, cw.buffered());
+    defer alloc.free(clean);
+
+    var nbuf: [16384]u8 = undefined;
+    var nw: std.Io.Writer = .fixed(&nbuf);
+    const r0 = try zinput.select_prompt.renderList(&nw, config, 0, ws);
+    try zinput.list_render.eraseRegion(&nw, r0);
+    _ = try zinput.select_prompt.renderList(&nw, config, 1, ws);
+    const nav = try screenOf(alloc, ws.col, ws.row, nw.buffered());
+    defer alloc.free(nav);
+
+    try testing.expectEqualStrings(clean, nav);
+}
+
+test "emulator: select hang-indents wrapped continuation lines on screen" {
+    const alloc = testing.allocator;
+    // Short message keeps the header on one row so option rows are predictable.
+    const ws = Winsize{ .row = 24, .col = 20 };
+    const config = zinput.SelectConfig{ .message = "Pick", .choices = &.{
+        "alpha bravo charlie delta echo",
+    } };
+
+    var term = try vterm.VTerm.init(alloc, ws.col, ws.row);
+    defer term.deinit();
+    var buf: [16384]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&buf);
+    _ = try zinput.select_prompt.renderList(&w, config, 0, ws);
+    term.write(w.buffered());
+
+    // Row 0: "? Pick" header. Row 1: first option line (prefix "  > "/"  ❯ ").
+    // Row 2: a wrapped continuation, hang-indented to the 4-column prefix width.
+    const row1 = try term.getLine(alloc, 1);
+    defer alloc.free(row1);
+    const row2 = try term.getLine(alloc, 2);
+    defer alloc.free(row2);
+
+    try testing.expect(std.mem.indexOf(u8, row1, "alpha") != null);
+    // Continuation aligns under the label (4 leading spaces), not the bullet.
+    try testing.expect(std.mem.startsWith(u8, row2, "    "));
+    try testing.expect(std.mem.trim(u8, row2, " ").len > 0);
+}
+
+// ---------------------------------------------------------------------------
+// search
+// ---------------------------------------------------------------------------
+
+test "emulator: search navigation leaves no debris when results wrap" {
+    const alloc = testing.allocator;
+    const ws = Winsize{ .row = 24, .col = 28 };
+    const config = zinput.SearchConfig{ .message = "Find", .choices = &.{
+        "apple",
+        "a very long result entry that will wrap across more than one row",
+        "cherry",
+    } };
+    const filtered = [_]usize{ 0, 1, 2 };
+    const query = "";
+
+    var cbuf: [16384]u8 = undefined;
+    var cw: std.Io.Writer = .fixed(&cbuf);
+    _ = try zinput.search_prompt.renderSearch(&cw, config, query, &filtered, 1, ws);
+    const clean = try screenOf(alloc, ws.col, ws.row, cw.buffered());
+    defer alloc.free(clean);
+
+    var nbuf: [16384]u8 = undefined;
+    var nw: std.Io.Writer = .fixed(&nbuf);
+    const r0 = try zinput.search_prompt.renderSearch(&nw, config, query, &filtered, 0, ws);
+    try zinput.list_render.eraseRegion(&nw, r0);
+    _ = try zinput.search_prompt.renderSearch(&nw, config, query, &filtered, 1, ws);
+    const nav = try screenOf(alloc, ws.col, ws.row, nw.buffered());
+    defer alloc.free(nav);
+
+    try testing.expectEqualStrings(clean, nav);
+}


### PR DESCRIPTION
## Problem

The interactive list prompts assumed **one physical terminal row per option**. Any option wider than the terminal soft-wrapped onto 2+ rows, so the cursor-up erase (which moved up `choices.len` lines) was off, leaving debris on every keypress. Reported as: multiselect options that wrap "totally break rendering — any keyboard nav causes reprints and ugly output."

## Approach

Rework rendering so it's **rock solid**: grapheme- and ANSI-aware width, word-wrap with a **hang indent** (continuation lines align under the label, not the bullet), and **live repaint on terminal resize**.

### Shared layer — `packages/terminal`
- **`wrap.zig`** — `displayWidth` (ANSI/grapheme-aware) plus a **streaming, allocation-free** `wrapForEach`/`wrapCount` and an allocating `wrapToWidth`. Backed by the [`zg`](https://codeberg.org/atman/zg) Unicode library (v0.16.2, MIT, pure Zig — fits the libc-free terminal stack, ~80KB). This gives correct widths for CJK, emoji (incl. ZWJ/flags/skin-tones), and combining marks with no hand-maintained tables.
- **Resize input** — `terminal.readEvent` returns `Event{ key | resize }` via a `ResizeWatcher`, leaving existing `readKey` callers untouched. POSIX uses a SIGWINCH handler + atomic flag with a raw `poll` backstop (note: `ppoll` isn't linkable against Zig 0.16's macOS libc stub). Windows polls the console size, keeping the VT byte reader untouched.

### Prompts — `packages/zinput`
- **`list_render.zig`** — shared viewport (on-demand row counts, no allocation), resize-safe `eraseRegion` (`ESC[0J`), and `renderItem` (hang-indent + per-line styling). `select`, `multi_select`, and `search` all render through it, tracking **true physical rows**, guarding the last column (DECAWM), and scrolling a viewport when content exceeds the screen height. **Public signatures unchanged.**

### `packages/vterm`
- `charWidth` now delegates to `zg` instead of a duplicate hand-maintained width table.

## Verification
- Unit tests across `wrap` / `list_render` / all three prompts (row-count == emitted lines is the regression guard for the erase bug; hang-indent, CJK, ANSI-skip, viewport, no-match).
- Native macOS test suite green; cross-compiles clean for **x86_64-windows** and **aarch64-linux-musl** (libc-free).
- SIGWINCH → `wait()` wakeup runtime-verified; a wrapped frame was visually confirmed (hang-indent aligned under text, CJK wrapped by columns).

## Deferred
- A **permanent PTY e2e resize test** (needs a prompt-demo binary; the PTY harness is POSIX-only). The SIGWINCH→wait mechanism was runtime-verified once and the deterministic render/erase is unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)