### PR TITLE
Deploy site to zcli.sh via Cloudflare Pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -7,15 +7,13 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
-  group: "pages"
+  group: "cloudflare-pages"
   cancel-in-progress: false
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -32,21 +30,12 @@ jobs:
         working-directory: website
         run: ./zine release
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v4
+      - name: Publish install.sh at site root
+        run: cp install.sh website/public/install.sh
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
         with:
-          path: website/public
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy website/public --project-name=zcli --branch=main

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ docs/internal/
 **/docs/html/
 **/docs/markdown/
 **/docs/man/
+.wrangler/

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # zcli installer script
-# Usage: curl -fsSL https://raw.githubusercontent.com/ryanhair/zcli/main/install.sh | sh
+# Usage: curl -fsSL https://zcli.sh/install.sh | sh
 
 set -e
 

--- a/website/layouts/docs.shtml
+++ b/website/layouts/docs.shtml
@@ -80,7 +80,7 @@
           <p>Grab the binary (see the <a href="$site.page('install').link()" style="color:var(--accent)">install page</a> for all options):</p>
           <div class="code">
             <div class="code-head"><span class="fname">terminal</span><span class="lang">sh</span></div>
-<pre><span class="c-prompt">$</span> <span class="c-cmd">curl</span> -fsSL https://raw.githubusercontent.com/ryanhair/zcli/main/install.sh | sh</pre>
+<pre><span class="c-prompt">$</span> <span class="c-cmd">curl</span> -fsSL https://zcli.sh/install.sh | sh</pre>
           </div>
 
           <div class="step"><span class="n">2</span><h2>Scaffold a project</h2></div>

--- a/website/layouts/home.shtml
+++ b/website/layouts/home.shtml
@@ -103,7 +103,7 @@
         <a class="btn ghost" href="https://github.com/ryanhair/zcli" target="_blank" rel="noopener">Star on GitHub</a>
       </div>
       <div class="install-pill">
-        <span><span class="dollar">$</span> curl -fsSL zcli.sh/install.sh | sh</span>
+        <span><span class="dollar">$</span> curl -fsSL https://zcli.sh/install.sh | sh</span>
         <button class="copy" onclick="copyInstall(this)">copy</button>
       </div>
       <div class="chips">
@@ -335,7 +335,7 @@ spinner.<span class="fn">warn</span>(<span class="str">"Warning"</span>);   <spa
 
 <script>
   function copyInstall(btn) {
-    navigator.clipboard.writeText("curl -fsSL https://raw.githubusercontent.com/ryanhair/zcli/main/install.sh | sh").then(function () {
+    navigator.clipboard.writeText("curl -fsSL https://zcli.sh/install.sh | sh").then(function () {
       var old = btn.textContent; btn.textContent = "copied ✓"; btn.style.color = "var(--green)"; btn.style.borderColor = "var(--green)";
       setTimeout(function () { btn.textContent = old; btn.style.color = ""; btn.style.borderColor = ""; }, 1600);
     });

--- a/website/layouts/install.shtml
+++ b/website/layouts/install.shtml
@@ -55,8 +55,8 @@
         <h3>Install script</h3>
         <p>Downloads the latest release binary for your platform and drops it in your install dir.</p>
         <div class="cmdbox">
-          <pre><span class="pr">$</span> curl -fsSL https://raw.githubusercontent.com/ryanhair/zcli/main/install.sh | sh</pre>
-          <button onclick="cp(this,'curl -fsSL https://raw.githubusercontent.com/ryanhair/zcli/main/install.sh | sh')">copy</button>
+          <pre><span class="pr">$</span> curl -fsSL https://zcli.sh/install.sh | sh</pre>
+          <button onclick="cp(this,'curl -fsSL https://zcli.sh/install.sh | sh')">copy</button>
         </div>
         <p style="font-size:13.5px;">Requires <code class="mono" style="color:var(--accent)">curl</code>. The script reads the latest release from GitHub, verifies the checksum when available, and makes the binary executable.</p>
       </div>

--- a/website/zine.ziggy
+++ b/website/zine.ziggy
@@ -1,7 +1,7 @@
 Site {
     .title = "zcli — batteries-included CLI framework for Zig",
-    .host_url = "https://ryanhair.github.io",
-    .url_path_prefix = "zcli",
+    .host_url = "https://zcli.sh",
+    .url_path_prefix = "",
     .content_dir_path = "content",
     .layouts_dir_path = "layouts",
     .assets_dir_path = "assets",


### PR DESCRIPTION
Cut over the docs site from GitHub Pages to **Cloudflare Pages** on the new **zcli.sh** root domain, and serve the installer from `zcli.sh/install.sh`.

## Changes
- **`website/zine.ziggy`** — `host_url` → `https://zcli.sh`, dropped the `/zcli` URL prefix (empty prefix = serve at root).
- **`.github/workflows/deploy-docs.yml`** — replaced the GitHub Pages jobs with a single job that builds via Zine, copies the repo-root `install.sh` into `website/public/install.sh` (single source of truth → served at `zcli.sh/install.sh`), then deploys with `cloudflare/wrangler-action`. `accountId` comes from a repo **variable**, `apiToken` from a secret.
- **`install.sh` / `home.shtml` / `install.shtml` / `docs.shtml`** — point every advertised install command at `https://zcli.sh/install.sh`. Also fixes a latent bug where the hero displayed `zcli.sh/install.sh` but its copy button copied the old `raw.githubusercontent.com` URL.

## Required Cloudflare/GitHub setup (done by owner)
- Pages project named `zcli` (direct upload).
- Secret `CLOUDFLARE_API_TOKEN` (Pages: Edit) + variable `CLOUDFLARE_ACCOUNT_ID`.
- Custom domain `zcli.sh` attached to the Pages project.
- GitHub Pages source set to None.

## Verify after merge
- `https://zcli.sh` loads with root-relative links (no `/zcli`).
- `curl -fsSL https://zcli.sh/install.sh | sh` fetches and runs the installer.

Note: Zine v0.11.3 has no macOS binary, so the config couldn't be built locally on arm64 — the first CI run is the build test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)