### PR TITLE
Arena-per-command allocator for execute()

### DIFF
--- a/docs/adr/0001-arena-per-command-allocator.md
+++ b/docs/adr/0001-arena-per-command-allocator.md
@@ -1,0 +1,16 @@
+# Arena-per-command allocator for `execute()`
+
+Status: proposed
+
+To make AI-authored business logic safe by construction, each command's `execute()` will receive an allocator backed by an arena that is dropped wholesale when the command returns, rather than today's raw pass-through `std.mem.Allocator` (see `packages/core/src/zcli.zig` `Context.allocator`). CLIs are the textbook arena case: a command runs once and exits, so there is essentially no long-lived intra-command state needing fine-grained `free`. The idiom becomes *"never call `free`; the arena reclaims everything at command end,"* which neutralizes the one failure mode of AI-generated Zig that is simultaneously silent, undebuggable by our non-Zig-fluent wedge user, and specific to Zig's manual-memory model: leaks and use-after-free. The other failure modes have owners (compiler for non-compiling code, tests for wrong behavior, shipped context/lint for non-idiomatic code); memory had none until this decision.
+
+## Considered Options
+
+- **Raw pass-through allocator (status quo)** — maximal control, but every `execute()` must manually free; AI-written bodies leak or use-after-free in ways that compile clean and pass happy-path tests. Rejected: pushes the scariest failure onto the user.
+- **Arena-per-command (chosen)** — safe by default, "no frees" idiom.
+
+## Consequences
+
+- Long-running commands (`watch`/`dev`-style loops) would grow the arena unbounded; the idiom must document a child-arena-per-iteration pattern for that advanced case.
+- Does not stop deliberate `free` misuse (covered by idiom/lint) or logic-level pointer bugs (rare in CLI work).
+- Hard to reverse once command authors rely on the "no free" contract — every generated and hand-written command assumes it.

--- a/packages/core/src/registry.zig
+++ b/packages/core/src/registry.zig
@@ -805,9 +805,16 @@ fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const Comma
             zcli_io.finalize();
             defer zcli_io.flush();
 
+            // Arena-per-command allocator: everything the command and framework
+            // bookkeeping allocate during this invocation lives in the arena and is
+            // reclaimed wholesale when execute() returns. Command authors never need
+            // to call free. See docs/adr/0001-arena-per-command-allocator.md.
+            var arena = std.heap.ArenaAllocator.init(allocator);
+            defer arena.deinit();
+
             // Use the computed Context type which includes type-safe plugin data
             var context = Context{
-                .allocator = allocator,
+                .allocator = arena.allocator(),
                 .io = &zcli_io,
                 .environ = environ,
                                 .theme = zcli.ztheme.Theme.init(environ, io),

--- a/packages/testing/src/unit.zig
+++ b/packages/testing/src/unit.zig
@@ -74,10 +74,19 @@ pub fn runCommand(
     io.stdout_override = &stdout_aw.writer;
     io.stderr_override = &stderr_aw.writer;
 
+    // Arena-per-command allocator: mirror the runtime (Registry.execute) so a
+    // command written to never free is leak-free under unit tests too, not just
+    // in production. Command-body allocations are reclaimed when the arena is
+    // dropped; the capture writers and vterm below stay on `allocator` so the
+    // testing allocator still catches harness leaks.
+    // See docs/adr/0001-arena-per-command-allocator.md.
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+
     // Create context with plugins
     const Ctx = zcli.TestContext(plugins);
     var context = Ctx{
-        .allocator = allocator,
+        .allocator = arena.allocator(),
         .io = &io,
     };
     defer context.deinit();
@@ -235,6 +244,34 @@ test "runCommand vterm contains text" {
 
     try std.testing.expect(result.term.containsText("Hello World"));
     try std.testing.expect(!result.term.containsText("Goodbye"));
+}
+
+test "runCommand arena reclaims allocations for a command that never frees" {
+    // The arena-per-command contract: business logic can allocate via
+    // context.allocator and never call free. runCommand uses
+    // std.testing.allocator, which panics on leak, so this test fails if the
+    // arena is removed. See docs/adr/0001-arena-per-command-allocator.md.
+    const TestCommand = struct {
+        pub const Args = struct {};
+        pub const Options = struct {};
+
+        pub fn execute(_: Args, _: Options, context: anytype) !void {
+            // Several allocations of different sizes, none freed.
+            var i: usize = 0;
+            while (i < 8) : (i += 1) {
+                const buf = try context.allocator.alloc(u8, 64 * (i + 1));
+                @memset(buf, 'x');
+            }
+            const dup = try context.allocator.dupe(u8, "leaked-on-purpose");
+            try context.stdout().print("allocated {d} bytes\n", .{dup.len});
+        }
+    };
+
+    var result = try runCommand(TestCommand, &.{}, .{});
+    defer result.deinit();
+
+    try std.testing.expect(result.success);
+    try std.testing.expect(result.term.containsText("allocated 17 bytes"));
 }
 
 test "runCommand vterm detects ANSI formatting" {


### PR DESCRIPTION
## What & why

Give each command's `execute()` an `ArenaAllocator`-backed `context.allocator` that is dropped wholesale when the command returns, replacing the raw pass-through allocator. The idiom becomes **"never call `free`"** — the arena reclaims everything at command end.

This neutralizes leaks and use-after-free: the one failure mode of AI-authored Zig that is simultaneously silent, undebuggable by a non-Zig-fluent user, and specific to manual memory management. CLIs are the textbook arena case — a command runs once and exits, so there is essentially no long-lived intra-command state needing fine-grained `free`.

Full rationale in [`docs/adr/0001-arena-per-command-allocator.md`](docs/adr/0001-arena-per-command-allocator.md) (added in this PR).

## The change

Two entry points invoke a command's `execute()`, and both are scoped:

- **`packages/core/src/registry.zig`** — `Registry.execute()` (production path). Arena created before the `Context`; `defer` order ensures `context.deinit()`'s now-no-op frees run before `arena.deinit()` reclaims.
- **`packages/testing/src/unit.zig`** — `runCommand()` (unit-test tier). This bypasses `Registry.execute()` and previously used the raw testing allocator directly. Without the same arena, a non-freeing command would pass in production but **fail its own generated unit test with a GPA leak**. Applied identical arena scoping; the capture writers and vterm deliberately stay on the raw allocator so genuine harness leaks are still caught. Added a regression test proving a non-freeing command is leak-free through `runCommand`.

`ArenaAllocator.free` is a harmless no-op except for the most-recent allocation, so every existing `.free()` across the framework and plugins becomes a no-op — nothing breaks, memory is reclaimed at `arena.deinit()`.

## Design decision

**Arena-only, no co-equal raw allocator.** Exposing both (`allocator` + `arena`, "prefer arena for short-lived") was rejected: it reintroduces the exact silent-leak failure mode as the default-reachable path and pushes a per-allocation lifetime judgment onto the AI that the user can't audit. The long-running-loop escape hatch (child-arena-per-iteration, which needs a genuinely-freeing backing allocator) is deferred to a future **ADR-0004** as a narrow, explicitly-named advanced API rather than a general raw allocator.

## Verification

| Check | Result |
|---|---|
| `packages/core` `zig build test` | ✅ pass |
| `packages/testing` `zig build test` | ✅ 31/31 |
| `projects/zcli` unit `zig build test` | ✅ pass |
| `projects/zcli` `zig build e2e` | ✅ 11/11 |
| TDD leak-guard: revert arena → test fails with 9 leaks; restore → green | ✅ meaningful |

🤖 Generated with [Claude Code](https://claude.com/claude-code)