### PR TITLE
docs: AI-authored CLI design (CONTEXT + ADRs 0001–0008 + roadmap)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,38 @@
+# zcli
+
+zcli is a batteries-included CLI framework for Zig whose surface is everything derived from your command files. This context covers the vision of AI-authored CLIs — an AI generating zcli command files into a project the human owns.
+
+## Language
+
+**Scaffold**:
+The structural, framework-facing part of a CLI: command layout, `meta`/`Args`/`Options` contracts, plugins, help/completions. Generated and verified by tooling; it is meant to never break at runtime.
+_Avoid_: Boilerplate, skeleton (when precision matters)
+
+**Business logic**:
+The work a command actually does — the body of `execute()`. Unbounded and human-facing. Kept small, localized, and readable enough that a non-Zig-fluent developer can patch it.
+_Avoid_: Handler code, implementation (when distinguishing from Scaffold)
+
+**Wedge user**:
+The polyglot developer who writes CLIs in other languages but does not know Zig. AI removes the language barrier; the generated Zig stays a legitimate, ownable artifact. (Beachhead is the zcli-fluent developer, for whom AI = speed.)
+_Avoid_: End user (ambiguous — could mean the user of the generated CLI)
+
+**Read-back**:
+The AI's "observe" step: reading the current CLI structure out of the command files as stable, ANSI-free text (an enriched `tree`), so it can reconcile against intent. The counterpart to writing via `add`.
+_Avoid_: Dump, export
+
+**Canonical example**:
+A small, complete, CI-compiled example CLI that is a first-class maintained artifact — simultaneously an example, the source of the AI idiom/pattern context, and a drift-detector (a framework change that breaks it forces the context up to date). See ADR-0004.
+_Avoid_: Fixture, sample (when it means throwaway test data)
+
+## Example dialogue
+
+> **Dev:** The AI needs to see what commands exist before it adds one.
+> **Expert:** That's the Read-back — enriched `tree`, plain text, no ANSI. It reads the Scaffold out; it never touches Business logic.
+> **Dev:** Where does the AI learn the idioms so it writes idiomatic bodies?
+> **Expert:** From the Canonical examples via the scaffolded `AGENTS.md`. Not hand-written prose — the examples compile in CI, so the context can't rot.
+> **Dev:** And if the AI's `execute()` body leaks memory?
+> **Expert:** It can't, within the run — the arena reclaims everything at command end. The idiom is "never call `free`."
+
+## Flagged ambiguities
+
+**"AI-powered CLI"** — resolved to mean *build-time codegen* (AI writes zcli source the human owns), NOT runtime (a CLI that embeds an LLM for natural-language dispatch).

--- a/TODOS.md
+++ b/TODOS.md
@@ -3,6 +3,54 @@
 Deferred work and future scope decisions for zcli. Active work happens on branches;
 this file tracks things intentionally postponed with the context to pick them up later.
 
+## Roadmap: AI-authored CLIs
+
+Vision + rationale live in `docs/adr/0001`–`0008` and `CONTEXT.md`. This is the build
+sequence. Each PR references the ADR carrying its rationale. Ordered by dependency.
+
+**Phase 1 — Loop foundations (read + verify + safe execution)**
+- [x] **Arena-per-command allocator** (ADR-0001) — DONE. The keystone: makes freeform AI
+  business logic memory-safe by construction.
+- [ ] **PR: Enriched `tree --show-options`** (ADR-0007) — the AI's read-back. Unified
+  `<>`/`[]`/`:type`/`=default`/`...`/`/-short` grammar; add short flags, defaults,
+  nullable-vs-required, variadic, aliases, hidden; ANSI-free on non-TTY.
+- [ ] **PR: Legible comptime build errors** (grill Q6) — the verify feedback signal; point
+  contract violations at file + field in plain language. Replaces a would-be `zcli check`.
+
+**Phase 2 — Write surface (the scaffolding CLI)**
+- [ ] **PR: `add command` extension** — co-located unit-test stub (Q7); full `meta`
+  coverage (examples/aliases/hidden); hint when it births an undescribed group (ADR-0005/0007).
+- [ ] **PR: `add option`/`add arg` + remove JSON-blob bulk** (ADR-0005) — flag interface
+  (positional name + `--type`/`--multiple`/`--nullable`/`--default`/`--short`/`-d`); AST
+  splice preserving `execute()`; keep the wizard; `add arg` append + `--before`/`--after`.
+  The centerpiece; highest complexity (in-file AST write). Depends on `add command` PR.
+- [ ] **PR: `rm option`/`rm arg`** (ADR-0005) — splice-out; variadic names; error on missing.
+  Shares splice machinery with the previous PR.
+- [ ] **PR: `add group`** (grill Q8) — meta-only `index.zig` by default; `--with-landing`
+  for a custom execute + test.
+- [ ] **PR: `add plugin` + `init` sets `plugins_dir`** (ADR-0006) — convention discovery,
+  no build.zig mutation on the happy path; guided skeleton + commented hook catalog.
+- [ ] **PR: `mv` + `rm`** (grill Q10) — whole-file restructure, carry the co-located test,
+  clean emptied group dirs.
+
+**Phase 3 — Primitives that shrink the freeform surface** (parallelizable with Phase 2)
+- [ ] **PR: HTTP client with safe defaults** (ADR-0002/0003) — core; TLS-verified, timeouts.
+- [ ] **PR: `zcli_secrets` opt-in plugin** (ADR-0003) — credential storage only (not auth
+  flows); keychain-backed with fallback; opt-in to preserve static-musl portability.
+
+**Phase 4 — Context layer (leg 3)** — depends on Phases 2–3 existing
+- [ ] **PR: Canonical example CLIs + CI compile** (ADR-0004) — first-class maintained
+  artifacts; the idiom source and drift-detector. Demonstrate the primitives above.
+- [ ] **PR: `zcli guide`** (ADR-0008) — topic-based; `@embedFile`s the canonical examples
+  from the pinned version. Depends on the examples PR.
+- [ ] **PR: `AGENTS.md` scaffold + `init` append** (ADR-0008) — thin frozen spine (six
+  invariants, speaks commands); marker-delimited, never clobbers. Capstone: it advertises
+  the whole surface, so it lands last.
+
+**Critical path:** `add command` → `add option/arg` → `rm option/arg` (the splice family),
+then the context tail `examples → guide → AGENTS.md`. **Parallelizable early:** enriched
+`tree`, legible build errors, HTTP, secrets.
+
 ## Deferred
 
 ### Un-bundle / evict the TUI libraries from zcli's public surface

--- a/docs/adr/0001-arena-per-command-allocator.md
+++ b/docs/adr/0001-arena-per-command-allocator.md
@@ -1,0 +1,16 @@
+# Arena-per-command allocator for `execute()`
+
+Status: proposed
+
+To make AI-authored business logic safe by construction, each command's `execute()` will receive an allocator backed by an arena that is dropped wholesale when the command returns, rather than today's raw pass-through `std.mem.Allocator` (see `packages/core/src/zcli.zig` `Context.allocator`). CLIs are the textbook arena case: a command runs once and exits, so there is essentially no long-lived intra-command state needing fine-grained `free`. The idiom becomes *"never call `free`; the arena reclaims everything at command end,"* which neutralizes the one failure mode of AI-generated Zig that is simultaneously silent, undebuggable by our non-Zig-fluent wedge user, and specific to Zig's manual-memory model: leaks and use-after-free. The other failure modes have owners (compiler for non-compiling code, tests for wrong behavior, shipped context/lint for non-idiomatic code); memory had none until this decision.
+
+## Considered Options
+
+- **Raw pass-through allocator (status quo)** — maximal control, but every `execute()` must manually free; AI-written bodies leak or use-after-free in ways that compile clean and pass happy-path tests. Rejected: pushes the scariest failure onto the user.
+- **Arena-per-command (chosen)** — safe by default, "no frees" idiom.
+
+## Consequences
+
+- Long-running commands (`watch`/`dev`-style loops) would grow the arena unbounded; the idiom must document a child-arena-per-iteration pattern for that advanced case.
+- Does not stop deliberate `free` misuse (covered by idiom/lint) or logic-level pointer bugs (rare in CLI work).
+- Hard to reverse once command authors rely on the "no free" contract — every generated and hand-written command assumes it.

--- a/docs/adr/0002-ai-authoring-is-additive.md
+++ b/docs/adr/0002-ai-authoring-is-additive.md
@@ -1,0 +1,14 @@
+# AI-authoring is an additive feature, not a reframe
+
+Status: accepted
+
+zcli is gaining the ability for an AI to author CLIs (build-time codegen into a project the human owns), but this must never reframe the framework around AI. Every feature is gated first by the developer building a CLI *without* AI: **"Is this a genuine use-case in a large portion of CLIs?"** A feature that only makes sense because an AI is writing the code does not get built as a feature — instead we capture it as a *pattern/context* handed to the AI. This keeps zcli's identity ("a batteries-included CLI framework whose surface is everything derived from your command files") intact and prevents AI-authoring from bloating scope. Corollary: a primitive's value as an AI constraint (it shrinks the freeform surface) is a welcome *side benefit*, never the primary justification.
+
+## Consequences
+
+- Primitives like an HTTP-with-safe-defaults client qualify because they serve the majority of CLIs directly; the fact that they also stop an AI from hand-rolling something unsafe is a bonus, not the reason.
+- "Danger of freeform AI code" is not, by itself, grounds to add a feature. If a concern is real but niche, it becomes shipped context/idioms, not core surface.
+
+## Corollary: the gate is graduated
+
+The "genuine use-case in a large portion of CLIs" test applies with **full force to the framework** (anything in the shipped binary — runtime surface, plugins, primitives) and with **reduced force to the `zcli` CLI itself** (developer-facing authoring/scaffolding tooling that never ships in the user's artifact). Scaffolding convenience is cheap and self-contained; framework surface is expensive and permanent. So `zcli add option`/`add arg`/`rm option`/`rm arg` are justified as CLI tooling even though a human *could* hand-edit — because the edit is a coordinated multi-site change (struct field + `meta` entry + default + short flag + arg ordering), and the tooling carries no runtime cost.

--- a/docs/adr/0003-secrets-as-opt-in-plugin.md
+++ b/docs/adr/0003-secrets-as-opt-in-plugin.md
@@ -1,0 +1,15 @@
+# Secrets storage is an opt-in plugin, not core
+
+Status: proposed
+
+An HTTP client with safe defaults (TLS verification, timeouts) belongs in core — nearly all CLIs make HTTP calls, so it passes the "genuine use-case in a large portion of CLIs" test universally (ADR-0002). Secrets storage passes that test too, but only for the *service-client* category of CLI (those with a `login`/`auth` step that persists a token), not utility CLIs. More importantly, real OS keychain backends (Linux Secret Service via D-Bus/libsecret, Windows Credential Manager) require dynamic linking and would compromise zcli's static-single-binary (libc-free musl) property for *everyone*, including authors who never store a secret. Therefore secrets ship as an **opt-in `zcli_secrets` plugin** — keychain-backed where available with a documented fallback — so the portability cost is paid only by those who opt in.
+
+## Considered Options
+
+- **Secrets in core** — rejected: forces the keychain/dynamic-linking portability cost on all CLIs.
+- **No secrets support** — rejected: leaves a dominant CLI category to hand-roll credential storage.
+- **Opt-in plugin (chosen)** — pays the cost only on opt-in, matches the existing plugin pattern (config, output, completions, upgrade).
+
+## Scope boundary
+
+The plugin covers *storage/retrieval of an opaque credential* (`get`/`set`/`delete` a named secret). It does **not** cover the auth flow that produces the credential (OAuth, device-code, etc.) — that is service-specific domain logic, left to freeform command code plus shipped patterns.

--- a/docs/adr/0004-ai-context-is-a-projection-of-compiled-examples.md
+++ b/docs/adr/0004-ai-context-is-a-projection-of-compiled-examples.md
@@ -1,0 +1,11 @@
+# AI context ships via AGENTS.md, sourced from CI-compiled canonical examples
+
+Status: accepted
+
+To make any coding agent good at zcli despite LLMs having almost no zcli training data (leg-3 legibility), `zcli init` scaffolds an agent-agnostic `AGENTS.md` into the user's repo that points at the machine-legible tools (`tree`, `add`) and a compact idiom/pattern guide. The idiom and pattern content is **sourced from a small set of canonical example CLIs that CI compiles**, not from hand-maintained prose — so a breaking change to the framework breaks the build and forces the context up to date. This applies the projection philosophy already used for docs/config ("the surface is derived, not hand-kept") to the AI context itself: it is a projection of compiled, tested truth. Stale context is worse than none because it actively steers the model toward APIs that changed, so drift-resistance is the governing requirement.
+
+## Consequences
+
+- The canonical example CLIs become first-class, maintained artifacts — simultaneously the examples, the idiom source, and the drift-detector — not throwaway fixtures.
+- zcli does not build its own agent; it makes existing agents fluent (consistent with ADR-0002, AI-authoring is additive).
+- The patterns for everything deliberately *not* built as a feature (per ADR-0002) live here.

--- a/docs/adr/0005-in-file-scaffolding-edits-preserve-execute.md
+++ b/docs/adr/0005-in-file-scaffolding-edits-preserve-execute.md
@@ -1,0 +1,30 @@
+# Arg/option authoring: one flag-based interface, spliced in-file
+
+Status: accepted
+
+There is exactly one way to describe an arg or option to the `zcli` CLI: a **positional name plus typed flags** — `--type` (element type), `--multiple`, `--nullable`, and, for options, `--default` and `--short`, plus `--description`/`-d`. `type`, `multiple`, and `nullable` stay **decomposed into separate flags** (not encoded into a Zig-type string like `?[]u32`), consistent with the existing deliberate `ArgSpec`/`OptSpec` model. Args and options are added and removed exclusively through the `add option`/`add arg`/`rm option`/`rm arg` verbs; `add command` scaffolds only the command *shell* (path + `-d` description + stubbed `execute` + co-located test) and no longer accepts args/options inline. The prior JSON-blob bulk form (`add command --arg '{…}' --option '{…}'`) is **removed** — flag-based single-item authoring is preferred over blocks of JSON.
+
+Interactive bulk authoring is still served by the **wizard** (`add command` with no flags prompts through args/options in one session), which builds the same `ArgSpec`/`OptSpec` model. So the split is: wizard = human interactive bulk; `add option`/`add arg` = scripted/AI atomic edits. The removed JSON blobs only ever served the awkward non-interactive-bulk middle, now covered better by a shell command followed by atomic `add option`/`add arg` calls (which the AI orchestrates anyway; the transient IR the AI emits is the flag invocations themselves, not JSON).
+
+## Flag semantics
+
+- **Required is implicit**, mirroring the existing `ArgSpec`/`OptSpec` model — there is no `--required` flag. An option with `--nullable` renders `?T = null`; with `--default <expr>` renders `T = <expr>`; with neither it is required (`T`, must be provided). `--default` together with `--nullable` is contradictory and is an **error** (a nullable option already defaults to null; a default_expr is only emitted for non-nullable scalars). Args have no default: `--nullable` makes an arg optional, its absence makes it required.
+- **`add arg` positioning:** appends by default; `--before <name>`/`--after <name>` insert at a chosen point (nearly free given the splice already targets a span); ordering rules (required-before-optional, `multiple` last) are enforced by reusing the existing `validateArg`, erroring clearly on violation. `add option` needs no positioning (options are unordered).
+- **`rm option`/`rm arg` shape:** `rm option <cmd> <name...>` — variadic names allowed (removal needs no per-item spec, so this is the one place bulk reintroduces no DSL); errors if a named field does not exist (never silently succeeds); echoes what was removed. `rm arg` needs no ordering handling — removal only relaxes constraints.
+
+## In-file edits splice via AST, never regenerate
+
+The commands that mutate an existing command file — `add option`/`add arg`/`rm option`/`rm arg` — must edit the file as a **targeted, AST-guided textual splice**: locate the source spans of the `Options`/`Args` struct and the `meta.options`/`meta.args` literals via `std.zig.Ast` (the same read machinery `tree.zig` already uses), and insert or remove the specific field + meta entry while leaving every other byte untouched. They must **not** regenerate the file from the spec model, because regeneration would destroy the file's `execute()` body — the user's/AI's business logic — along with comments and formatting. (Creation-time rendering still uses full-file `generateSource`, since there is no execute body to preserve yet.) Adding an arg appends by default and re-validates ordering (required-before-optional, `multiple` last), erroring clearly on violation.
+
+## Considered Options
+
+- **JSON-blob bulk (status quo)** — removed: a mini-DSL that served neither humans (wizard is better interactively) nor AI (atomic flag calls are more verifiable) well.
+- **Regenerate from spec model on edit** — rejected: destroys `execute()` bodies, comments, formatting.
+- **Flag-based single interface + AST splice (chosen)** — one way to describe an arg/option; surgical in-file edits preserve surrounding code.
+
+## Consequences
+
+- `add option`/`add arg`/`rm option`/`rm arg` are the highest-complexity scaffolding tooling (fine-grained in-file mutation), distinct from `mv`/`rm` which operate at whole-file granularity.
+- The AST read machinery already exists in `tree.zig`; the new work is the write/splice side.
+- Deleting the JSON front-end (`parseArgJson`/`parseOptJson` + the `--arg`/`--option` flags on `add command`) is a net simplification; the shared `ArgSpec`/`OptSpec` model and the wizard front-end stay.
+- Creating a command with several args/options is now N+1 atomic calls instead of one — accepted, and better for AI (each op individually verifiable and echoed).

--- a/docs/adr/0006-add-plugin-via-convention-discovery.md
+++ b/docs/adr/0006-add-plugin-via-convention-discovery.md
@@ -1,0 +1,22 @@
+# `add plugin` scaffolds a file into a convention-discovered `plugins_dir`
+
+Status: accepted
+
+`zcli add plugin <name>` scaffolds a plugin *file* and does **not** mutate `build.zig` on the happy path. The framework already supports convention-based local-plugin discovery via `scanLocalPlugins` over a `plugins_dir` (single-file `plugins/<name>.zig` or multi-file `plugins/<name>/plugin.zig`), exactly parallel to command discovery over `commands_dir`. So `zcli init` will generate `build.zig` with `.plugins_dir = "src/plugins"` (harmless when the dir is absent — discovery returns empty), and `add plugin` simply drops `src/plugins/<name>.zig` plus a co-located test; it is auto-discovered on the next build. This keeps the plugin authoring model consistent with the command model (files-as-source, convention discovery) and eliminates the fragile `build.zig` array-mutation that an explicit-registration approach would require.
+
+Two plugin categories stay distinct: **built-in plugins** (`help`, `version`, `config`, …) remain explicit `zcli.builtin(.tag, .{})` entries chosen via `init`'s multiselect (framework toggles); **user plugins** are convention-discovered. `add plugin` only ever creates the latter.
+
+## Skeleton
+
+The generated file is a guided skeleton, not a bare stub: a header comment, one working pass-through `preExecute` hook (illustrating the real signature and the return-`null`-to-halt pattern), a **commented catalog** of the remaining hooks with exact signatures to uncomment, and `plugin_id` + `ContextData` commented out by default with a note that `plugin_id` is required when `ContextData` is present (minimal-valid plugins need neither — every hook is `@hasDecl`-gated, and `plugin_id` is only required alongside `ContextData`). The CLI surface stays lean: `add plugin <name> [-d <desc>]`, with **no `--hook`/`--with-context` flags** — because naming a hook does not specify its body (unlike an option, which is fully specified by its flags), so the in-file catalog is the better discovery mechanism than CLI flags. Default is single-file `src/plugins/<name>.zig` (consistent with `add command`); the directory form remains available for plugins that grow.
+
+## Considered Options
+
+- **Mutate `build.zig` to add an explicit plugin entry** — rejected for the happy path: fragile array splice; the convention mechanism already exists.
+- **Flag-driven hook scaffolding (`--hook …`)** — rejected: generates empty function bodies the author must fill anyway; adds CLI surface for little gain.
+- **Convention discovery + guided skeleton (chosen).**
+
+## Consequences
+
+- The one residual `build.zig` case: a project whose `build.zig` lacks `plugins_dir` (pre-existing project, or user removed it). There `add plugin` cannot rely on discovery and instead **prints the single line to add** (`.plugins_dir = "src/plugins",`) — a one-line hint, not a multi-site splice. New projects never hit this.
+- `zcli init` must be updated to emit `.plugins_dir = "src/plugins"` in the generated `build.zig`.

--- a/docs/adr/0007-tree-read-back-format.md
+++ b/docs/adr/0007-tree-read-back-format.md
@@ -1,0 +1,35 @@
+# `tree --show-options` is the enriched read-back, with a unified arg/option grammar
+
+Status: accepted
+
+The AI's "observe" step (read-back) is served by enriching the existing `tree --show-options`, not by adding a separate format or `--json`. The default `tree` stays compact and pretty for humans; `--show-options` becomes the complete, machine-legible read-back (ANSI-free when non-TTY via the existing ztheme `no_color` path). The guiding principle is **read/write symmetry**: the read-back surfaces exactly the spec fields the AI writes via `add option`/`add arg`, so it can reconcile current shape against intent and round-trip.
+
+To achieve that, args and options share **one notation** where every glyph maps to one spec field:
+
+- `<…>` required · `[…]` optional
+- `:type` element type · `=x` default · `…` (`...`) multiple/variadic · `/-x` short flag (options only)
+
+Example:
+```
+create  aliases=add  [Create a user]
+  args:    <name:[]const u8>  [count:u32=1]  [files:[]const u8...]
+  options: [--loud/-l]  <--token:[]const u8>  [--repeat/-r:u32]  [--limit:u32=10]  [--tags:[]const u8...]
+```
+
+This extends the grammar `tree` already uses for args (`<>`/`[]`) to options, adding the short/default/multiple markers that were missing.
+
+## Scope boundaries
+
+- **Command-level `aliases` and `hidden` are included** — the AI must see the full authored truth.
+- **Per-field descriptions are excluded.** `tree` is the *map* (shape); the `-d` prose lives in the command file, which the AI reads when editing that command. This is the one place read/write symmetry is intentionally partial.
+- **Scope is authored command files only**, not plugin-provided commands (help/version/completions). The AI reconciles its own work; framework-provided commands are not its to manage.
+
+## Considered Options
+
+- **Separate AI format / `--json`** — rejected: a second dialect and token-heavy; text mirrors the file-layout mental model better (see the earlier read-back decision).
+- **Enrich `--show-options` with a unified grammar (chosen)** — one detailed mode, no new surface, read/write symmetric.
+
+## Consequences
+
+- The gaps to close in the current renderer: short flags, defaults, nullable-vs-required for options, `multiple`/variadic markers, aliases, hidden.
+- Existing arg notation (`<>`/`[]` + `:type`) is retained and extended, not replaced.

--- a/docs/adr/0008-agents-md-three-layer-context.md
+++ b/docs/adr/0008-agents-md-three-layer-context.md
@@ -1,0 +1,41 @@
+# AGENTS.md is a thin frozen spine over a versioned `zcli guide`
+
+Status: accepted
+
+The leg-3 AI context (ADR-0004) is delivered in three layers, each with the stability profile its content needs, resolving the tension that `init` scaffolds `AGENTS.md` *once* (frozen) while the context must be *drift-proof*:
+
+1. **`AGENTS.md`** — scaffolded by `init`, frozen, but safe to freeze because it is thin and **speaks in `zcli` commands, not Zig APIs** (commands are a far more stable contract than code signatures). Contains: project identity, the command loop (read/write/verify), a curated set of invariants, and a pointer to the versioned guide.
+2. **`zcli guide`** (new command) — served from the **pinned** zcli version, so it is drift-proof by construction: it always matches the code the AI writes against. Holds the volatile detail (API signatures, primitive catalog, worked examples).
+3. **Command files + `tree --show-options`** — the live, always-current project state.
+
+Drift-sensitive content lives only in layer 2 (version-matched to the code). `AGENTS.md` never contains a signature.
+
+## Invariants in AGENTS.md
+
+Curation rule: an invariant belongs here only if it is **(a) high-leverage against a common or severe mistake and (b) version-stable**. Principles belong here; signatures go to `zcli guide`. The set (six):
+
+1. Never call `free`/`deinit` on what you allocate in `execute()` — the allocator is a per-command arena, reclaimed automatically (ADR-0001).
+2. Change structure with `zcli add`/`rm`/`mv`, not by hand; write freeform code only in `execute()` bodies.
+3. Output via `context.stdout()`/`context.stderr()` — never `std.debug.print` or direct stdout.
+4. Don't hand-roll terminal I/O — use `zinput` (input), `zprogress` (progress), `ztheme` (color).
+5. Verify with `zig build` + tests; run `zcli guide` for version-matched API detail and examples.
+6. File path = command path (`src/commands/foo/bar.zig` → `app foo bar`; `index.zig` = group landing; plugins in `src/plugins/`).
+
+## `zcli guide` shape
+
+Topic-based, like `go doc`/`git help <topic>`: `zcli guide` prints a one-screen overview + topic list; `zcli guide <topic>` (e.g. `prompts`, `arena`, `output`, `plugins`, `http`) prints a focused reference whose worked example is a **real CI-compiled canonical example** embedded from the pinned zcli (via `@embedFile`), not hand-written prose. Topic granularity keeps token cost down (the AI pulls only what it needs) and the compiled source is the drift-detector (an example that stops compiling fails CI).
+
+## `init` behavior with an existing AGENTS.md
+
+`init` **appends a marker-delimited block** (`<!-- zcli:begin --> … <!-- zcli:end -->`), never clobbering an existing file; if absent it creates the file with that block. The user owns everything outside the markers; the markers let a future upgrade refresh just the zcli section.
+
+## Considered Options
+
+- **Fat self-contained AGENTS.md** — rejected: frozen at init, goes stale on zcli upgrade (the "worse than none" drift failure).
+- **Regenerate AGENTS.md via a command each upgrade** — rejected: requires user action and risks clobbering local edits.
+- **Thin frozen spine + versioned `zcli guide` (chosen).**
+
+## Consequences
+
+- Adds `zcli guide` as a new command (passes the human-first gate — a version-matched reference is useful to any dev, like `rustup doc`).
+- Depends on the canonical examples of ADR-0004 existing and compiling in CI; `guide` is their delivery surface.


### PR DESCRIPTION
## What

Captures the design for zcli's **AI-authored CLI** vision, produced in a `grill-with-docs` session. Scope is **documentation only** — no code changes. It records decisions and rationale so any agent (or future self) can pick up implementation from `TODOS.md`.

**The vision:** build-time codegen — an AI authors zcli command files into a project the human owns. Wedge user is the polyglot developer who doesn't know Zig; the generated Zig stays a legitimate, ownable artifact.

**Governing principle:** AI-authoring is *additive* — every feature must first earn its place for the non-AI developer (graduated: strict for the framework, relaxed for the `zcli` CLI tooling).

## Contents

- **`CONTEXT.md`** — glossary (Scaffold, Business logic, Wedge user, Read-back, Canonical example) + example dialogue.
- **`docs/adr/0001–0008`** — one ADR per decision:
  | ADR | Decision |
  |---|---|
  | 0001 | Arena-per-command allocator (safe freeform Zig) — **already implemented** |
  | 0002 | AI-authoring is additive + graduated gate |
  | 0003 | Secrets as opt-in plugin (portability) |
  | 0004 | AI context from CI-compiled canonical examples (drift-proof) |
  | 0005 | Arg/option authoring: flag interface, AST splice, JSON bulk removed |
  | 0006 | `add plugin` via convention discovery (no build.zig mutation) |
  | 0007 | `tree --show-options` read-back format (unified grammar) |
  | 0008 | AGENTS.md three-layer context + `zcli guide` |
- **`TODOS.md`** — dependency-ordered PR roadmap (4 phases; arena marked done).

## The AI loop this design enables

**read** (`tree --show-options`) → **write** (`add`/`rm`/`mv` + freeform `execute()`) → **verify** (`zig build` + tests), with the arena making freeform business logic memory-safe by construction and `AGENTS.md` + `zcli guide` teaching any agent the idioms despite zero training data on zcli.

## Not in scope

Implementation — tracked as the PR sequence in `TODOS.md`. Arena (ADR-0001) is already done.