### PR TITLE
Enriched `tree --show-options`: unified arg/option read-back grammar (ADR-0007)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -11,8 +11,8 @@ sequence. Each PR references the ADR carrying its rationale. Ordered by dependen
 **Phase 1 — Loop foundations (read + verify + safe execution)**
 - [x] **Arena-per-command allocator** (ADR-0001) — DONE. The keystone: makes freeform AI
   business logic memory-safe by construction.
-- [ ] **PR: Enriched `tree --show-options`** (ADR-0007) — the AI's read-back. Unified
-  `<>`/`[]`/`:type`/`=default`/`...`/`/-short` grammar; add short flags, defaults,
+- [x] **PR: Enriched `tree --show-options`** (ADR-0007) — DONE. The AI's read-back. Unified
+  `<>`/`[]`/`:type`/`=default`/`...`/`/-short` grammar; short flags, defaults,
   nullable-vs-required, variadic, aliases, hidden; ANSI-free on non-TTY.
 - [ ] **PR: Legible comptime build errors** (grill Q6) — the verify feedback signal; point
   contract violations at file + field in plain language. Replaces a would-be `zcli check`.

--- a/projects/zcli/src/commands/tree.zig
+++ b/projects/zcli/src/commands/tree.zig
@@ -75,19 +75,37 @@ pub fn execute(args: Args, options: Options, context: anytype) !void {
 // Tree model
 // ============================================================================
 
+/// One arg or option in the enriched read-back (ADR-0007). Every field maps to
+/// a glyph in the unified grammar: `<>`/`[]` (required/optional), `:type`,
+/// `=default`, `...` (multiple/variadic), `/-short` (options only).
 const Field = struct {
     name: []const u8,
+    /// The value type shown after `:` — the element type for `multiple`
+    /// fields and the inner type for optionals (the `<>`/`[]` bracket already
+    /// carries optionality). Unused for bool options, which render bare.
     type_str: []const u8,
-    /// True when the field has a default value or an optional type.
-    optional: bool,
+    /// `<>` when the argument must be supplied: no default, non-optional,
+    /// non-variadic. Otherwise `[]`.
+    required: bool,
+    /// Default literal rendered as `=x`. Null when absent, `null`-valued, bool,
+    /// or variadic (the latter two carry no meaningful default to surface).
+    default: ?[]const u8 = null,
+    /// Variadic arg / accumulating option → trailing `...`.
+    multiple: bool = false,
+    /// Options only: a short flag rendered as `/-x`.
+    short: ?u8 = null,
+    /// Bool options render as a bare flag (no `:type`, no value placeholder).
+    is_bool: bool = false,
 };
 
 /// A display node: the framework's discovered structure enriched with the
-/// metadata we parse from source (description, args, options).
+/// metadata we parse from source (description, aliases, hidden, args, options).
 const Node = struct {
     name: []const u8,
     command_type: CommandType,
     description: ?[]const u8 = null,
+    aliases: []const []const u8 = &.{},
+    hidden: bool = false,
     args: []const Field = &.{},
     options: []const Field = &.{},
     children: []const Node = &.{},
@@ -122,6 +140,8 @@ fn nodesFromMap(
             .name = info.name,
             .command_type = info.command_type,
             .description = parsed.description,
+            .aliases = parsed.aliases,
+            .hidden = parsed.hidden,
             .args = parsed.args,
             .options = parsed.options,
         };
@@ -143,10 +163,25 @@ fn lessByName(_: void, a: Node, b: Node) bool {
 // Metadata extraction (std.zig.Ast — no build required)
 // ============================================================================
 
+const Ast = std.zig.Ast;
+
 const ParsedMeta = struct {
     description: ?[]const u8 = null,
+    aliases: []const []const u8 = &.{},
+    hidden: bool = false,
     args: []const Field = &.{},
     options: []const Field = &.{},
+};
+
+/// A short flag declared in `meta.options.<name>.short`, matched back onto the
+/// corresponding `Options` field by name.
+const Short = struct { option: []const u8, char: u8 };
+
+const MetaInfo = struct {
+    description: ?[]const u8 = null,
+    aliases: []const []const u8 = &.{},
+    hidden: bool = false,
+    shorts: []const Short = &.{},
 };
 
 /// Read and parse a command file. Files that can't be read or parsed degrade
@@ -158,10 +193,11 @@ fn parseFile(arena: std.mem.Allocator, io: std.Io, dir: std.Io.Dir, sub_path: []
 }
 
 fn parseMeta(arena: std.mem.Allocator, source: [:0]const u8) !ParsedMeta {
-    const Ast = std.zig.Ast;
     var ast = try Ast.parse(arena, source, .zig);
 
-    var result = ParsedMeta{};
+    var meta_info = MetaInfo{};
+    var args: []Field = &.{};
+    var options: []Field = &.{};
     const main_tokens = ast.nodes.items(.main_token);
 
     for (ast.rootDecls()) |decl| {
@@ -170,53 +206,181 @@ fn parseMeta(arena: std.mem.Allocator, source: [:0]const u8) !ParsedMeta {
         const name = ast.tokenSlice(main_tokens[@intFromEnum(decl)] + 1);
 
         if (std.mem.eql(u8, name, "meta")) {
-            result.description = try extractDescription(arena, &ast, init);
+            meta_info = try extractMeta(arena, &ast, init);
         } else if (std.mem.eql(u8, name, "Args")) {
-            result.args = try extractFields(arena, &ast, init);
+            args = try extractFields(arena, &ast, init);
         } else if (std.mem.eql(u8, name, "Options")) {
-            result.options = try extractFields(arena, &ast, init);
+            options = try extractFields(arena, &ast, init);
+        }
+    }
+
+    // Short flags live in `meta`, keyed by the option's field name.
+    applyShorts(options, meta_info.shorts);
+
+    return .{
+        .description = meta_info.description,
+        .aliases = meta_info.aliases,
+        .hidden = meta_info.hidden,
+        .args = args,
+        .options = options,
+    };
+}
+
+/// Overlay the `meta.options.<name>.short` chars onto the parsed Options fields.
+fn applyShorts(options: []Field, shorts: []const Short) void {
+    for (options) |*opt| {
+        for (shorts) |s| {
+            if (std.mem.eql(u8, opt.name, s.option)) {
+                opt.short = s.char;
+                break;
+            }
+        }
+    }
+}
+
+/// Pull `description`, `aliases`, `hidden`, and per-option `short` flags out of
+/// the `meta` struct literal. Only direct fields are inspected; unknown fields
+/// (e.g. `examples`) are ignored.
+fn extractMeta(arena: std.mem.Allocator, ast: *Ast, init: Ast.Node.Index) !MetaInfo {
+    var buf: [2]Ast.Node.Index = undefined;
+    const struct_init = ast.fullStructInit(&buf, init) orelse return .{};
+
+    var result = MetaInfo{};
+    for (struct_init.ast.fields) |field| {
+        const key = fieldName(ast, field);
+        if (std.mem.eql(u8, key, "description")) {
+            if (ast.nodeTag(field) == .string_literal) {
+                result.description = stringValue(arena, ast, field);
+            }
+        } else if (std.mem.eql(u8, key, "aliases")) {
+            result.aliases = try extractAliases(arena, ast, field);
+        } else if (std.mem.eql(u8, key, "hidden")) {
+            result.hidden = std.mem.eql(u8, nodeSource(ast, field), "true");
+        } else if (std.mem.eql(u8, key, "options")) {
+            result.shorts = try extractShorts(arena, ast, field);
         }
     }
     return result;
 }
 
-/// Pull `.description` out of the `meta` struct literal. Only direct fields are
-/// inspected, so nested `.options.<x>.description` entries are ignored.
-fn extractDescription(arena: std.mem.Allocator, ast: *std.zig.Ast, init: std.zig.Ast.Node.Index) !?[]const u8 {
-    var buf: [2]std.zig.Ast.Node.Index = undefined;
-    const struct_init = ast.fullStructInit(&buf, init) orelse return null;
-    const tags = ast.nodes.items(.tag);
+/// `aliases = &.{ "a", "b" }` → the string values. Malformed shapes degrade to
+/// an empty list rather than erroring.
+fn extractAliases(arena: std.mem.Allocator, ast: *Ast, node: Ast.Node.Index) ![]const []const u8 {
+    if (ast.nodeTag(node) != .address_of) return &.{};
+    const array = ast.nodeData(node).node; // unwrap `&`
 
-    for (struct_init.ast.fields) |field| {
-        const name_tok = ast.firstToken(field) - 2; // `.` <name> `=` value
-        if (!std.mem.eql(u8, ast.tokenSlice(name_tok), "description")) continue;
-        if (tags[@intFromEnum(field)] != .string_literal) return null;
-        const raw = ast.tokenSlice(ast.nodes.items(.main_token)[@intFromEnum(field)]);
-        return std.zig.string_literal.parseAlloc(arena, raw) catch null;
+    var buf: [2]Ast.Node.Index = undefined;
+    const array_init = ast.fullArrayInit(&buf, array) orelse return &.{};
+
+    var list = std.ArrayList([]const u8).empty;
+    for (array_init.ast.elements) |el| {
+        if (ast.nodeTag(el) != .string_literal) continue;
+        if (stringValue(arena, ast, el)) |s| try list.append(arena, s);
     }
-    return null;
+    return list.items;
+}
+
+/// `options = .{ .name = .{ .short = 'x', ... }, ... }` → the `short` chars,
+/// keyed by option name.
+fn extractShorts(arena: std.mem.Allocator, ast: *Ast, node: Ast.Node.Index) ![]const Short {
+    var buf: [2]Ast.Node.Index = undefined;
+    const opts = ast.fullStructInit(&buf, node) orelse return &.{};
+
+    var list = std.ArrayList(Short).empty;
+    for (opts.ast.fields) |opt_field| {
+        const opt_name = fieldName(ast, opt_field);
+        var inner_buf: [2]Ast.Node.Index = undefined;
+        const spec = ast.fullStructInit(&inner_buf, opt_field) orelse continue;
+        for (spec.ast.fields) |spec_field| {
+            if (!std.mem.eql(u8, fieldName(ast, spec_field), "short")) continue;
+            if (ast.nodeTag(spec_field) != .char_literal) continue;
+            const parsed = std.zig.parseCharLiteral(ast.tokenSlice(ast.nodeMainToken(spec_field)));
+            if (parsed == .success and parsed.success < 128) {
+                try list.append(arena, .{
+                    .option = try arena.dupe(u8, opt_name),
+                    .char = @intCast(parsed.success),
+                });
+            }
+        }
+    }
+    return list.items;
 }
 
 /// Collect the fields of an `Args` or `Options` struct declaration.
-fn extractFields(arena: std.mem.Allocator, ast: *std.zig.Ast, init: std.zig.Ast.Node.Index) ![]const Field {
-    var buf: [2]std.zig.Ast.Node.Index = undefined;
+fn extractFields(arena: std.mem.Allocator, ast: *Ast, init: Ast.Node.Index) ![]Field {
+    var buf: [2]Ast.Node.Index = undefined;
     const container = ast.fullContainerDecl(&buf, init) orelse return &.{};
-    const tags = ast.nodes.items(.tag);
 
     var fields = std.ArrayList(Field).empty;
     for (container.ast.members) |member| {
         const field = ast.fullContainerField(member) orelse continue;
         const type_node = field.ast.type_expr.unwrap() orelse continue;
         const has_default = field.ast.value_expr != .none;
-        const is_optional_type = tags[@intFromEnum(type_node)] == .optional_type;
+
+        const is_bool = std.mem.eql(u8, nodeSource(ast, type_node), "bool");
+        const shape = analyzeType(ast, type_node);
+        const required = !(has_default or shape.optional or shape.multiple);
+
+        // Surface only meaningful defaults: bool `= false` and optional `= null`
+        // are absence markers already implied by the grammar, and a variadic
+        // field's default carries no useful shape.
+        var default: ?[]const u8 = null;
+        if (has_default and !is_bool and !shape.multiple) {
+            const value = nodeSource(ast, field.ast.value_expr.unwrap().?);
+            if (!std.mem.eql(u8, value, "null")) default = try arena.dupe(u8, value);
+        }
 
         try fields.append(arena, .{
             .name = try arena.dupe(u8, unwrapIdent(ast.tokenSlice(field.ast.main_token))),
-            .type_str = try arena.dupe(u8, nodeSource(ast, type_node)),
-            .optional = has_default or is_optional_type,
+            .type_str = try arena.dupe(u8, shape.element),
+            .required = required,
+            .default = default,
+            .multiple = shape.multiple,
+            .is_bool = is_bool,
         });
     }
     return fields.items;
+}
+
+const TypeShape = struct {
+    /// The value type after stripping optionality and the outer slice of a
+    /// variadic/accumulating field.
+    element: []const u8,
+    optional: bool,
+    multiple: bool,
+};
+
+/// Decompose a field's type into the shape the read-back grammar needs:
+/// `?T` → optional; a `[]…` slice whose element isn't `u8` → multiple (with the
+/// element type surfaced). `[]const u8` stays a whole string, not a multiple.
+fn analyzeType(ast: *Ast, type_node: Ast.Node.Index) TypeShape {
+    var node = type_node;
+    var optional = false;
+    if (ast.nodeTag(node) == .optional_type) {
+        optional = true;
+        node = ast.nodeData(node).node;
+    }
+
+    if (ast.fullPtrType(node)) |ptr| {
+        if (ptr.size == .slice) {
+            const child = nodeSource(ast, ptr.ast.child_type);
+            if (!std.mem.eql(u8, child, "u8")) {
+                return .{ .element = child, .optional = optional, .multiple = true };
+            }
+        }
+    }
+    return .{ .element = nodeSource(ast, node), .optional = optional, .multiple = false };
+}
+
+/// The declared name of a `.name = value` struct-init field (`.` <name> `=`).
+fn fieldName(ast: *Ast, field: Ast.Node.Index) []const u8 {
+    return ast.tokenSlice(ast.firstToken(field) - 2);
+}
+
+/// Parse a `.string_literal` node's value; null on a malformed literal.
+fn stringValue(arena: std.mem.Allocator, ast: *Ast, node: Ast.Node.Index) ?[]const u8 {
+    const raw = ast.tokenSlice(ast.nodeMainToken(node));
+    return std.zig.string_literal.parseAlloc(arena, raw) catch null;
 }
 
 /// Unwrap a `@"quoted"` identifier to its bare name (e.g. `@"dry-run"` -> `dry-run`).
@@ -228,7 +392,7 @@ fn unwrapIdent(token: []const u8) []const u8 {
 }
 
 /// Source text spanned by a node (used to recover a type expression verbatim).
-fn nodeSource(ast: *std.zig.Ast, node: std.zig.Ast.Node.Index) []const u8 {
+fn nodeSource(ast: *Ast, node: Ast.Node.Index) []const u8 {
     const starts = ast.tokens.items(.start);
     const first = ast.firstToken(node);
     const last = ast.lastToken(node);
@@ -274,6 +438,17 @@ fn renderNodes(
         if (node.isGroup()) {
             try paint(writer, theme, " (group)", .marker);
         }
+        // The read-back surfaces the full authored truth (ADR-0007); the
+        // default tree stays compact.
+        if (show_options) {
+            if (node.aliases.len > 0) {
+                const list = try std.mem.join(arena, ",", node.aliases);
+                try paint(writer, theme, try std.fmt.allocPrint(arena, " aliases={s}", .{list}), .marker);
+            }
+            if (node.hidden) {
+                try paint(writer, theme, " (hidden)", .marker);
+            }
+        }
         if (node.description) |d| {
             try paint(writer, theme, " [", .desc);
             try paint(writer, theme, d, .desc);
@@ -303,13 +478,7 @@ fn renderSignature(
         try paint(writer, theme, "args:    ", .marker);
         for (node.args, 0..) |arg, i| {
             if (i > 0) try writer.writeByte(' ');
-            const text = try std.fmt.allocPrint(arena, "{s}{s}:{s}{s}", .{
-                if (arg.optional) "[" else "<",
-                arg.name,
-                arg.type_str,
-                if (arg.optional) "]" else ">",
-            });
-            try paint(writer, theme, text, .flag);
+            try paint(writer, theme, try renderField(arena, arg, false), .flag);
         }
         try writer.writeByte('\n');
     }
@@ -319,16 +488,32 @@ fn renderSignature(
         try paint(writer, theme, "options: ", .marker);
         for (node.options, 0..) |opt, i| {
             if (i > 0) try writer.writeByte(' ');
-            const flag = try toFlagName(arena, opt.name);
-            // bool flags need no value placeholder.
-            const text = if (std.mem.eql(u8, opt.type_str, "bool"))
-                try std.fmt.allocPrint(arena, "--{s}", .{flag})
-            else
-                try std.fmt.allocPrint(arena, "--{s} <{s}>", .{ flag, opt.type_str });
-            try paint(writer, theme, text, .flag);
+            try paint(writer, theme, try renderField(arena, opt, true), .flag);
         }
         try writer.writeByte('\n');
     }
+}
+
+/// Render one field in the unified grammar (ADR-0007):
+/// `<name:type=default...>` with `<>`/`[]` for required/optional, and options
+/// carrying a `--` prefix plus an optional `/-short`. Bool options render bare.
+fn renderField(arena: std.mem.Allocator, field: Field, is_option: bool) ![]const u8 {
+    var aw: std.Io.Writer.Allocating = .init(arena);
+    const w = &aw.writer;
+
+    try w.writeByte(if (field.required) '<' else '[');
+    if (is_option) {
+        try w.print("--{s}", .{try toFlagName(arena, field.name)});
+        if (field.short) |s| try w.print("/-{c}", .{s});
+    } else {
+        try w.writeAll(field.name);
+    }
+    if (!field.is_bool) try w.print(":{s}", .{field.type_str});
+    if (field.default) |d| try w.print("={s}", .{d});
+    if (field.multiple) try w.writeAll("...");
+    try w.writeByte(if (field.required) '>' else ']');
+
+    return aw.written();
 }
 
 /// Option field names are snake_case; CLI flags are kebab-case.
@@ -361,7 +546,7 @@ test "parseMeta extracts top-level description, ignoring nested ones" {
     const source =
         \\pub const meta = .{
         \\    .description = "Say hello",
-        \\    .options = .{ .loud = .{ .description = "shout it" } },
+        \\    .options = .{ .loud = .{ .short = 'l', .description = "shout it" } },
         \\};
         \\pub const Args = struct { name: []const u8, count: u32 = 1 };
         \\pub const Options = struct { loud: bool = false, repeat: ?u32 = null };
@@ -373,15 +558,64 @@ test "parseMeta extracts top-level description, ignoring nested ones" {
     try testing.expectEqual(@as(usize, 2), parsed.args.len);
     try testing.expectEqualStrings("name", parsed.args[0].name);
     try testing.expectEqualStrings("[]const u8", parsed.args[0].type_str);
-    try testing.expect(!parsed.args[0].optional);
+    try testing.expect(parsed.args[0].required);
     try testing.expectEqualStrings("count", parsed.args[1].name);
-    try testing.expect(parsed.args[1].optional); // has default
+    try testing.expect(!parsed.args[1].required); // has default
+    try testing.expectEqualStrings("1", parsed.args[1].default.?);
 
     try testing.expectEqual(@as(usize, 2), parsed.options.len);
     try testing.expectEqualStrings("loud", parsed.options[0].name);
-    try testing.expectEqualStrings("bool", parsed.options[0].type_str);
+    try testing.expect(parsed.options[0].is_bool);
+    try testing.expectEqual(@as(u8, 'l'), parsed.options[0].short.?);
     try testing.expectEqualStrings("repeat", parsed.options[1].name);
-    try testing.expectEqualStrings("?u32", parsed.options[1].type_str);
+    try testing.expectEqualStrings("u32", parsed.options[1].type_str); // optional stripped
+    try testing.expect(!parsed.options[1].required);
+    try testing.expect(parsed.options[1].default == null); // `= null` suppressed
+}
+
+test "parseMeta captures aliases, hidden, defaults, and variadic shape" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const source =
+        \\pub const meta = .{
+        \\    .description = "Create a user",
+        \\    .aliases = &.{ "add", "new" },
+        \\    .hidden = true,
+        \\    .options = .{ .repeat = .{ .short = 'r' } },
+        \\};
+        \\pub const Args = struct { name: []const u8, files: [][]const u8 };
+        \\pub const Options = struct {
+        \\    token: []const u8,
+        \\    repeat: ?u32 = null,
+        \\    limit: u32 = 10,
+        \\    tags: []const []const u8 = &.{},
+        \\};
+    ;
+    const parsed = try parseMeta(arena, source);
+
+    try testing.expectEqual(@as(usize, 2), parsed.aliases.len);
+    try testing.expectEqualStrings("add", parsed.aliases[0]);
+    try testing.expectEqualStrings("new", parsed.aliases[1]);
+    try testing.expect(parsed.hidden);
+
+    // files: variadic arg → element type surfaced, multiple set, not required.
+    try testing.expectEqualStrings("files", parsed.args[1].name);
+    try testing.expectEqualStrings("[]const u8", parsed.args[1].type_str);
+    try testing.expect(parsed.args[1].multiple);
+    try testing.expect(!parsed.args[1].required);
+
+    // token: required (no default, non-optional, non-variadic).
+    try testing.expect(parsed.options[0].required);
+    // repeat: short applied from meta.
+    try testing.expectEqual(@as(u8, 'r'), parsed.options[1].short.?);
+    // limit: meaningful default surfaced.
+    try testing.expectEqualStrings("10", parsed.options[2].default.?);
+    // tags: accumulating option → multiple, default suppressed.
+    try testing.expect(parsed.options[3].multiple);
+    try testing.expect(parsed.options[3].default == null);
+    try testing.expectEqualStrings("[]const u8", parsed.options[3].type_str);
 }
 
 test "parseMeta unwraps @\"quoted\" option field names" {
@@ -440,22 +674,43 @@ test "renderNodes with show_options lists args and options" {
 
     const nodes = [_]Node{
         .{
-            .name = "add",
+            .name = "create",
             .command_type = .leaf,
-            .args = &.{.{ .name = "title", .type_str = "[]const u8", .optional = false }},
+            .aliases = &.{"add"},
+            .args = &.{
+                .{ .name = "name", .type_str = "[]const u8", .required = true },
+                .{ .name = "count", .type_str = "u32", .required = false, .default = "1" },
+                .{ .name = "files", .type_str = "[]const u8", .required = false, .multiple = true },
+            },
             .options = &.{
-                .{ .name = "loud", .type_str = "bool", .optional = true },
-                .{ .name = "max_count", .type_str = "?u32", .optional = true },
+                .{ .name = "loud", .type_str = "", .required = false, .short = 'l', .is_bool = true },
+                .{ .name = "token", .type_str = "[]const u8", .required = true },
+                .{ .name = "repeat", .type_str = "u32", .required = false, .short = 'r' },
+                .{ .name = "limit", .type_str = "u32", .required = false, .default = "10" },
+                .{ .name = "max_tags", .type_str = "[]const u8", .required = false, .multiple = true },
             },
         },
     };
 
     const out = try renderToString(arena, &nodes, true);
     const expected =
-        "└── add\n" ++
-        "    args:    <title:[]const u8>\n" ++
-        "    options: --loud --max-count <?u32>\n";
+        "└── create aliases=add\n" ++
+        "    args:    <name:[]const u8> [count:u32=1] [files:[]const u8...]\n" ++
+        "    options: [--loud/-l] <--token:[]const u8> [--repeat/-r:u32] [--limit:u32=10] [--max-tags:[]const u8...]\n";
     try testing.expectEqualStrings(expected, out);
+}
+
+test "renderNodes hides aliases and hidden marker without show_options" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const nodes = [_]Node{
+        .{ .name = "create", .command_type = .leaf, .aliases = &.{"add"}, .hidden = true },
+    };
+
+    const out = try renderToString(arena, &nodes, false);
+    try testing.expectEqualStrings("└── create\n", out);
 }
 
 test "nodesFromMap sorts, maps kinds, and enriches with metadata" {

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -246,7 +246,7 @@ test "tree lists the discovered commands" {
     try expectContains(r.stdout, "create");
 }
 
-test "tree --show-options surfaces args and options" {
+test "tree --show-options surfaces the unified arg/option grammar" {
     var sample = try openSampleFixture();
     defer sample.close(io);
 
@@ -254,8 +254,25 @@ test "tree --show-options surfaces args and options" {
     defer r.deinit();
     try expectOk(r);
 
-    try expectContains(r.stdout, "name"); // hello's positional arg
-    try expectContains(r.stdout, "loud"); // hello's option
+    // Command-level aliases (ADR-0007): surfaced only under --show-options.
+    try expectContains(r.stdout, "aliases=hi");
+    // Args: required <>, defaulted [=], variadic [...].
+    try expectContains(r.stdout, "<name:[]const u8> [times:u32=1] [extra:[]const u8...]");
+    // Options: bool renders bare with its short flag; optional keeps its type.
+    try expectContains(r.stdout, "[--loud/-l] [--repeat:u32]");
+}
+
+test "tree stays compact without --show-options" {
+    var sample = try openSampleFixture();
+    defer sample.close(io);
+
+    var r = try run(sample, &.{ zcli_exe, "tree" });
+    defer r.deinit();
+    try expectOk(r);
+
+    // Descriptions stay; the read-back-only aliases marker does not.
+    try expectContains(r.stdout, "Say hello to someone");
+    try std.testing.expect(std.mem.indexOf(u8, r.stdout, "aliases=") == null);
 }
 
 // ============================================================================

--- a/projects/zcli/test/fixtures/sample/src/commands/hello.zig
+++ b/projects/zcli/test/fixtures/sample/src/commands/hello.zig
@@ -4,18 +4,25 @@ const Context = @import("command_registry").Context;
 
 pub const meta = .{
     .description = "Say hello to someone",
+    .aliases = &.{"hi"},
     .examples = &.{
         "hello World",
         "hello Alice --loud",
+    },
+    .options = .{
+        .loud = .{ .short = 'l', .description = "Shout the greeting" },
     },
 };
 
 pub const Args = struct {
     name: []const u8,
+    times: u32 = 1,
+    extra: [][]const u8,
 };
 
 pub const Options = struct {
     loud: bool = false,
+    repeat: ?u32 = null,
 };
 
 pub fn execute(args: Args, options: Options, context: *Context) !void {


### PR DESCRIPTION
## Summary

Enriches `tree --show-options` into the AI's complete, machine-legible **read-back** (ADR-0007). Args and options now share one notation where every glyph maps to a spec field, giving read/write symmetry with what `add option`/`add arg` will write:

| Glyph | Meaning |
|---|---|
| `<>` / `[]` | required / optional |
| `:type` | element type (optional `?T` and outer variadic slice stripped) |
| `=x` | default (suppressed for bool `= false`, `= null`, and variadics) |
| `...` | variadic arg / accumulating option |
| `/-x` | short flag (options only) |

Command-level `aliases` and `hidden` are surfaced too — but **only under `--show-options`**; the default `tree` stays compact and pretty. Scope is authored command files only (not plugin-provided commands), and output is ANSI-free on non-TTY via the existing ztheme `no_color` path.

Everything is derived from the command source via `std.zig.Ast` (no build required): short flags from `meta.options.<name>.short`, aliases/hidden from `meta`, and the variadic/optional shape from each field's type node.

### Example (piped → ANSI-free)

```
├── add (group) [Add commands and plugins to your zcli project]
│   └── command [Add a new command to your zcli project]
│       args:    [path:[]const u8]
│       options: [--description/-d:[]const u8] [--arg:[]const u8...] [--option:[]const u8...]
├── list aliases=ls [List all tasks]
│   options: [--status/-s:[]const u8] [--all/-a]
```

## Tests

- **19/19 unit** (`zig build test`) — rewrote the tree tests around the new `Field` model; added coverage for aliases/hidden/variadic capture and the compact-vs-read-back split.
- **12/12 e2e** (`zig build e2e`) — enriched the `hello` fixture (short flag, alias, `?u32`, defaulted + variadic args — parse-only for `tree`, never compiled) and tightened the assertion to the exact grammar line.

Every 0.16 `std.zig.Ast` access (`fullPtrType.size`, `optional_type` unwrap, `parseCharLiteral`, `address_of`→`fullArrayInit`) was verified against lib source and a throwaway probe before writing.

Closes the Phase-1 "Enriched `tree --show-options`" item in `TODOS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)