### PR TITLE
Legible comptime build errors: name the command in contract violations (grill Q6)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -14,8 +14,10 @@ sequence. Each PR references the ADR carrying its rationale. Ordered by dependen
 - [x] **PR: Enriched `tree --show-options`** (ADR-0007) — DONE. The AI's read-back. Unified
   `<>`/`[]`/`:type`/`=default`/`...`/`/-short` grammar; short flags, defaults,
   nullable-vs-required, variadic, aliases, hidden; ANSI-free on non-TTY.
-- [ ] **PR: Legible comptime build errors** (grill Q6) — the verify feedback signal; point
-  contract violations at file + field in plain language. Replaces a would-be `zcli check`.
+- [x] **PR: Legible comptime build errors** (grill Q6) — DONE. The verify feedback signal;
+  `validateCommand` names every meta/Args/Options contract violation by command path in
+  plain language. (execute-shape check omitted: `@TypeOf(execute)` → Context → registry is a
+  comptime dependency loop; a bad signature still fails at the framework call site.)
 
 **Phase 2 — Write surface (the scaffolding CLI)**
 - [ ] **PR: `add command` extension** — co-located unit-test stub (Q7); full `meta`

--- a/packages/core/src/registry.zig
+++ b/packages/core/src/registry.zig
@@ -119,12 +119,9 @@ fn RegistryBuilder(comptime config: Config, comptime commands: []const CommandEn
         ) {
             _ = self;
 
-            // Validate command metadata at compile time if meta is present
-            if (@hasDecl(Module, "meta")) {
-                const ArgsType = if (@hasDecl(Module, "Args")) Module.Args else struct {};
-                const OptionsType = if (@hasDecl(Module, "Options")) Module.Options else struct {};
-                zcli.validateMeta(Module.meta, ArgsType, OptionsType);
-            }
+            // Validate the whole command contract at compile time, with errors
+            // that name this command by its path.
+            comptime zcli.validateCommand(path, Module);
 
             return RegistryBuilder(
                 config,
@@ -192,12 +189,14 @@ fn discoverPluginCommands(comptime CommandsStruct: type, comptime path_prefix: [
         // Build the path for this command
         const current_path = path_prefix ++ .{decl.name};
 
-        // Validate command metadata at compile time if meta is present
-        if (@hasDecl(CommandType, "meta")) {
-            const ArgsType = if (@hasDecl(CommandType, "Args")) CommandType.Args else struct {};
-            const OptionsType = if (@hasDecl(CommandType, "Options")) CommandType.Options else struct {};
-            zcli.validateMeta(CommandType.meta, ArgsType, OptionsType);
+        // Validate the whole command contract at compile time, naming the
+        // command by its space-joined path.
+        comptime var path_str: []const u8 = "";
+        inline for (current_path, 0..) |component, idx| {
+            if (idx > 0) path_str = path_str ++ " ";
+            path_str = path_str ++ component;
         }
+        comptime zcli.validateCommand(path_str, CommandType);
 
         // Add this command/group to entries
         entries = entries ++ .{CommandEntry{

--- a/packages/core/src/zcli.zig
+++ b/packages/core/src/zcli.zig
@@ -418,8 +418,49 @@ pub const parseCommandLine = command_parser.parseCommandLine;
 pub const CommandParseResult = command_parser.CommandParseResult;
 
 // ============================================================================
-// Metadata Validation - Compile-time validation for command metadata
+// Command Validation - Compile-time validation of the command contract
 // ============================================================================
+
+/// The prefix every command contract error carries. `path` is the command's
+/// registered path (e.g. "add command"), which maps directly to the file under
+/// src/commands/ — so the author, or an AI agent, can jump straight to it.
+fn commandContext(comptime path: []const u8) []const u8 {
+    return "command '" ++ path ++ "': ";
+}
+
+/// Validate a command module's contract at compile time, with every error
+/// naming the command by its path in plain language. This is the "verify" signal
+/// of the authoring loop: a malformed command fails the build with a message an
+/// author (or an AI agent) can act on, not a template error buried deep in the
+/// framework.
+///
+/// Checks that `Args`/`Options` are structs and the `meta` block is well-formed
+/// (delegated to `validateMeta`). The `execute` signature is intentionally *not*
+/// asserted here: a command's `execute` typically takes `context: *Context`,
+/// and `Context` is a projection of the very registry being built — reaching for
+/// `@TypeOf(execute)` at registration time forms a comptime dependency loop.
+/// A wrong `execute` shape still fails the build at the framework's own call
+/// site, pointing at the author's file.
+pub fn validateCommand(comptime path: []const u8, comptime Module: type) void {
+    @setEvalBranchQuota(10000);
+    const loc = commandContext(path);
+
+    const ArgsType = if (@hasDecl(Module, "Args")) Module.Args else struct {};
+    const OptionsType = if (@hasDecl(Module, "Options")) Module.Options else struct {};
+
+    if (@hasDecl(Module, "Args") and @typeInfo(ArgsType) != .@"struct") {
+        @compileError(loc ++ "`Args` must be a struct, found `" ++ @typeName(ArgsType) ++
+            "`. Example: `pub const Args = struct { name: []const u8 };`");
+    }
+    if (@hasDecl(Module, "Options") and @typeInfo(OptionsType) != .@"struct") {
+        @compileError(loc ++ "`Options` must be a struct, found `" ++ @typeName(OptionsType) ++
+            "`. Example: `pub const Options = struct { verbose: bool = false };`");
+    }
+
+    if (@hasDecl(Module, "meta")) {
+        validateMeta(path, Module.meta, ArgsType, OptionsType);
+    }
+}
 
 /// Validate command metadata at compile time to catch typos and invalid fields.
 /// This function checks:
@@ -427,20 +468,22 @@ pub const CommandParseResult = command_parser.CommandParseResult;
 /// - Options metadata fields (description, short, name)
 /// - That option/arg meta field names match actual struct fields
 ///
-/// Call this in the registry when processing commands to get compile-time errors
-/// for invalid metadata.
+/// `path` names the owning command so every error points back at its file.
+/// Prefer `validateCommand`, which calls this as part of the full contract.
 pub fn validateMeta(
+    comptime path: []const u8,
     comptime meta: anytype,
     comptime ArgsType: type,
     comptime OptionsType: type,
 ) void {
     @setEvalBranchQuota(10000);
+    const loc = commandContext(path);
 
     const MetaType = @TypeOf(meta);
     const meta_info = @typeInfo(MetaType);
 
     if (meta_info != .@"struct") {
-        @compileError("meta must be a struct");
+        @compileError(loc ++ "`meta` must be a struct");
     }
 
     // Valid top-level meta fields
@@ -457,7 +500,7 @@ pub fn validateMeta(
             break :blk false;
         };
         if (!is_valid) {
-            @compileError("Unknown meta field: '" ++ field.name ++ "'. Valid fields are: description, examples, args, options, hidden, aliases");
+            @compileError(loc ++ "unknown meta field '" ++ field.name ++ "'. Valid fields are: description, examples, args, options, hidden, aliases");
         }
     }
 
@@ -467,7 +510,7 @@ pub fn validateMeta(
         const options_meta_info = @typeInfo(@TypeOf(options_meta));
 
         if (options_meta_info != .@"struct") {
-            @compileError("meta.options must be a struct");
+            @compileError(loc ++ "`meta.options` must be a struct");
         }
 
         const options_fields = @typeInfo(OptionsType).@"struct".fields;
@@ -484,7 +527,7 @@ pub fn validateMeta(
             }
 
             if (!field_exists) {
-                @compileError("Option metadata field '" ++ field.name ++ "' does not exist in Options struct");
+                @compileError(loc ++ "meta.options describes '" ++ field.name ++ "', which is not a field in the Options struct");
             }
 
             // Validate the metadata for this option
@@ -504,7 +547,7 @@ pub fn validateMeta(
                         break :blk false;
                     };
                     if (!opt_is_valid) {
-                        @compileError("Unknown option metadata field: '" ++ opt_field.name ++ "' in option '" ++ field.name ++ "'. Valid fields are: description, short, name, env");
+                        @compileError(loc ++ "unknown option metadata field '" ++ opt_field.name ++ "' in option '" ++ field.name ++ "'. Valid fields are: description, short, name, env");
                     }
                 }
             }
@@ -517,7 +560,7 @@ pub fn validateMeta(
         const args_meta_info = @typeInfo(@TypeOf(args_meta));
 
         if (args_meta_info != .@"struct") {
-            @compileError("meta.args must be a struct");
+            @compileError(loc ++ "`meta.args` must be a struct");
         }
 
         const args_fields = @typeInfo(ArgsType).@"struct".fields;
@@ -534,7 +577,7 @@ pub fn validateMeta(
             }
 
             if (!field_exists) {
-                @compileError("Args metadata field '" ++ field.name ++ "' does not exist in Args struct");
+                @compileError(loc ++ "meta.args describes '" ++ field.name ++ "', which is not a field in the Args struct");
             }
 
             // Args metadata should be simple strings (descriptions)
@@ -562,12 +605,48 @@ pub fn validateMeta(
             };
 
             if (!is_valid_type) {
-                @compileError("Args metadata for field '" ++ field.name ++ "' must be a string description");
+                @compileError(loc ++ "meta.args for '" ++ field.name ++ "' must be a string description");
             }
         }
     }
 }
 
+test "validateCommand accepts a well-formed command" {
+    // A full, valid command: reaching the assertion means it compiled without
+    // tripping a contract error.
+    const Cmd = struct {
+        pub const meta = .{
+            .description = "Greet someone",
+            .aliases = &.{"hi"},
+            .options = .{ .loud = .{ .short = 'l', .description = "Shout it" } },
+        };
+        pub const Args = struct { name: []const u8 };
+        pub const Options = struct { loud: bool = false };
+        pub fn execute(_: Args, _: Options, _: anytype) !void {}
+    };
+    comptime validateCommand("greet", Cmd);
+
+    // A metadata-only command group (no execute) is valid too.
+    const Group = struct {
+        pub const meta = .{ .description = "A group" };
+    };
+    comptime validateCommand("group", Group);
+
+    try testing.expect(true);
+}
+
+// The negative cases below are compile errors by design, so they cannot be run
+// as tests. Each is verified by hand; uncomment one to see the message it emits.
+//
+//   command 'broken': unknown meta field 'desciption'. Valid fields are: ...
+//     pub const meta = .{ .desciption = "typo" };
+//
+//   command 'broken': `Args` must be a struct, found `u32`. ...
+//     pub const Args = u32;
+//
+//   command 'broken': meta.options describes 'nope', which is not a field in the Options struct
+//     pub const meta = .{ .options = .{ .nope = .{ .short = 'x' } } };
+//     pub const Options = struct { real: bool = false };
 
 test "Context creation" {
     const allocator = testing.allocator;


### PR DESCRIPTION
## Summary

The **verify** signal of the AI authoring loop (grill Q6): when a command file violates zcli's contract, the build should fail in language the author — or an AI agent — can act on, not a template error buried deep in the framework.

Adds `validateCommand(path, Module)`, called from both registration paths (`register` and `discoverPluginCommands`) with the command's registered path (e.g. `sprint create`), which maps straight to the file under `src/commands/`. Every contract error now carries a `command '<path>': ` prefix.

### Before → after

A typo'd meta field previously surfaced as a generic `@compileError` with no command context. Now:

```
command 'brokentest': unknown meta field 'desciption'. Valid fields are: description, examples, args, options, hidden, aliases
command 'brokentest': `Args` must be a struct, found `u32`. Example: `pub const Args = struct { name: []const u8 };`
command 'sprint broken': meta.options describes 'nonexistent', which is not a field in the Options struct
```

(All three captured from real builds against the showcase.)

## What changed

- **`validateCommand`** (new, `zcli.zig`): checks `Args`/`Options` are structs and delegates `meta` to `validateMeta`, prefixing every message with the command path.
- **`validateMeta`** now takes `path` and threads it through all eight of its messages.
- **`registry.zig`**: both call sites replaced with `comptime zcli.validateCommand(path, Module)` (the plugin path joins its `[]const []const u8` path with spaces).

## Scope note: why `execute` shape isn't asserted here

A command's `execute` takes `context: *Context`, and `Context` is a projection of the very registry being built — so reaching for `@TypeOf(Module.execute)` at registration time forms a **comptime dependency loop** (verified: "dependency loop with length 5"). A wrong `execute` signature still fails the build at the framework's own call site, which points at the author's file. Args/Options/meta don't reference `Context`, so they validate cleanly.

## Tests

- **core 769/769**, **meta-CLI 19/19**, **e2e 12/12**.
- Added a positive `validateCommand` test (well-formed command + metadata-only group) and documented the compile-error-by-design negatives inline.

Closes the Phase-1 "Legible comptime build errors" item in `TODOS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)