### PR TITLE
add command: hint undescribed new groups; scaffold full meta surface

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -20,8 +20,14 @@ sequence. Each PR references the ADR carrying its rationale. Ordered by dependen
   comptime dependency loop; a bad signature still fails at the framework call site.)
 
 **Phase 2 — Write surface (the scaffolding CLI)**
-- [ ] **PR: `add command` extension** — co-located unit-test stub (Q7); full `meta`
-  coverage (examples/aliases/hidden); hint when it births an undescribed group (ADR-0005/0007).
+- [x] **PR: `add command` extension** — DONE (partial). Full `meta` coverage (commented
+  `aliases`/`hidden` scaffolded alongside `examples`); hint when it births an undescribed
+  group (ADR-0005/0007). The co-located unit-test stub (Q7) was split out below — it needs a
+  `test` step wired into `init`'s generated build.zig to actually run, so it earns its own PR.
+- [ ] **PR: generated-project testing story (Q7)** — co-located unit-test stub from
+  `add command`, PLUS a `test` step in `init`'s generated build.zig that discovers command
+  files and compiles each as a test module (mirrors the meta-CLI's `command_test_files` loop +
+  a `command_registry` Context stub). Without the build wiring the stub never runs.
 - [ ] **PR: `add option`/`add arg` + remove JSON-blob bulk** (ADR-0005) — flag interface
   (positional name + `--type`/`--multiple`/`--nullable`/`--default`/`--short`/`-d`); AST
   splice preserving `execute()`; keep the wizard; `add arg` append + `--before`/`--after`.

--- a/projects/zcli/src/commands/add/command.zig
+++ b/projects/zcli/src/commands/add/command.zig
@@ -185,8 +185,8 @@ fn runWizardOnce(
         switch (action) {
             0 => {
                 const content = try generateSource(arena, path.parts, description, args_list.items, opts_list.items);
-                try writeCommandFile(arena, io, path.parts, file_path, content);
-                try finish(w, theme, path.parts, file_path);
+                const new_groups = try writeCommandFile(arena, io, path.parts, file_path, content);
+                try finish(w, theme, path.parts, file_path, new_groups);
                 return .created;
             },
             1 => try gatherArgs(arena, w, r, theme, &args_list),
@@ -229,8 +229,8 @@ fn skeleton(arena: std.mem.Allocator, context: *Context, args: Args, options: Op
 
     const description = options.description orelse "TODO: Add description";
     const content = try generateSource(arena, parts, description, &.{}, &.{});
-    try writeCommandFile(arena, io, parts, file_path, content);
-    try finish(context.stdout(), &context.theme, parts, file_path);
+    const new_groups = try writeCommandFile(arena, io, parts, file_path, content);
+    try finish(context.stdout(), &context.theme, parts, file_path, new_groups);
 }
 
 // ---------------------------------------------------------------------------
@@ -280,8 +280,8 @@ fn declarative(arena: std.mem.Allocator, context: *Context, args: Args, options:
 
     const description = options.description orelse "TODO: Add description";
     const content = try generateSource(arena, parts, description, args_list.items, opts_list.items);
-    try writeCommandFile(arena, io, parts, file_path, content);
-    try finish(context.stdout(), &context.theme, parts, file_path);
+    const new_groups = try writeCommandFile(arena, io, parts, file_path, content);
+    try finish(context.stdout(), &context.theme, parts, file_path, new_groups);
 }
 
 fn parseArgJson(arena: std.mem.Allocator, json: []const u8) !ArgSpec {
@@ -958,13 +958,30 @@ fn review(
     try w.writeAll("\r\n");
 }
 
-fn finish(w: *std.Io.Writer, theme: *const Theme, parts: []const []const u8, file_path: []const u8) !void {
+fn finish(
+    w: *std.Io.Writer,
+    theme: *const Theme,
+    parts: []const []const u8,
+    file_path: []const u8,
+    new_groups: []const NewGroup,
+) !void {
     try w.writeAll("\n  ");
     {
         var buf: [512]u8 = undefined;
         const line = std.fmt.bufPrint(&buf, "\u{2714} Created {s}", .{file_path}) catch "\u{2714} Created command";
         try ztheme.theme(line).success().render(w, theme);
     }
+
+    // A nested path can bring new group directories into being; a fresh group
+    // has no index.zig, so it has no description in help or `tree`.
+    for (new_groups) |g| {
+        try w.writeAll("\n  ");
+        var buf: [512]u8 = undefined;
+        const line = std.fmt.bufPrint(&buf, "Note: new group '{s}' has no description.", .{g.name}) catch "Note: new group has no description.";
+        try ztheme.theme(line).warning().render(w, theme);
+        try w.print("\n    Add {s} with `pub const meta = .{{ .description = \"...\" }};` to describe it.\n", .{g.index_path});
+    }
+
     try w.writeAll("\n\n  Next steps\n");
     try w.print("    1. Implement execute() in {s}\n", .{file_path});
     try w.writeAll("    2. zig build\n");
@@ -1025,7 +1042,13 @@ fn generateSource(
 
     try w.writeAll("    .examples = &.{\n        \"");
     try writeExample(w, parts, args_list);
-    try w.writeAll("\",\n    },\n};\n\n");
+    try w.writeAll("\",\n    },\n");
+    // Surface the rest of the authored meta so the shell shows the full
+    // surface `tree --show-options` reads back (commented until the author
+    // wants them).
+    try w.writeAll("    // .aliases = &.{\"alias\"}, // alternate names this command answers to\n");
+    try w.writeAll("    // .hidden = true,          // omit from help and tree listings\n");
+    try w.writeAll("};\n\n");
 
     // Args struct.
     try w.writeAll("pub const Args = struct {");
@@ -1182,31 +1205,51 @@ fn fileExists(io: std.Io, path: []const u8) bool {
     return true;
 }
 
+/// A command group directory this invocation created from scratch. Because a
+/// fresh directory has no `index.zig`, it has no description — the caller hints
+/// how to give it one (ADR-0007: a group's description comes from index meta).
+const NewGroup = struct {
+    /// The group's command path, space-joined (e.g. "users" or "gh add").
+    name: []const u8,
+    /// Where a describing `index.zig` would live.
+    index_path: []const u8,
+};
+
+/// Write the command file, creating any missing parent group directories.
+/// Returns the groups that were newly created (and are therefore undescribed).
 fn writeCommandFile(
     arena: std.mem.Allocator,
     io: std.Io,
     parts: []const []const u8,
     file_path: []const u8,
     content: []const u8,
-) !void {
+) ![]const NewGroup {
     const cwd = std.Io.Dir.cwd();
+    var new_groups = std.ArrayList(NewGroup).empty;
 
     if (parts.len > 1) {
         var dir = std.ArrayList(u8).empty;
         try dir.appendSlice(arena, "src/commands");
-        for (parts[0 .. parts.len - 1]) |segment| {
+        for (parts[0 .. parts.len - 1], 0..) |segment, i| {
             try dir.append(arena, '/');
             try dir.appendSlice(arena, segment);
             cwd.createDir(io, dir.items, .default_dir) catch |err| switch (err) {
-                error.PathAlreadyExists => {},
+                error.PathAlreadyExists => continue,
                 else => return err,
             };
+            // createDir succeeded, so this group is brand new and undescribed.
+            try new_groups.append(arena, .{
+                .name = try std.mem.join(arena, " ", parts[0 .. i + 1]),
+                .index_path = try std.fmt.allocPrint(arena, "{s}/index.zig", .{dir.items}),
+            });
         }
     }
 
     var file = try cwd.createFile(io, file_path, .{});
     defer file.close(io);
     try file.writeStreamingAll(io, content);
+
+    return new_groups.items;
 }
 
 // ---------------------------------------------------------------------------

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -173,16 +173,29 @@ test "add command creates stubs at the right paths" {
         var r = try run(tmp.dir, &.{ zcli_exe, "add", "command", "deploy" });
         defer r.deinit();
         try expectOk(r);
+        // A flat command births no group, so no group hint.
+        try testing.expect(std.mem.indexOf(u8, r.stdout, "new group") == null);
     }
     try testing.expect(fileExists(tmp.dir, "src/commands/deploy.zig"));
 
-    // Nested path creates intermediate directories.
+    // Nested path creates intermediate directories, and the new 'users' group
+    // has no index.zig yet — the command hints how to describe it.
     {
         var r = try run(tmp.dir, &.{ zcli_exe, "add", "command", "users/create", "--description", "Create a user" });
         defer r.deinit();
         try expectOk(r);
+        try expectContains(r.stdout, "new group 'users' has no description");
+        try expectContains(r.stdout, "src/commands/users/index.zig");
     }
     try testing.expect(fileExists(tmp.dir, "src/commands/users/create.zig"));
+
+    // A second command under an existing group births nothing, so no hint.
+    {
+        var r = try run(tmp.dir, &.{ zcli_exe, "add", "command", "users/list" });
+        defer r.deinit();
+        try expectOk(r);
+        try testing.expect(std.mem.indexOf(u8, r.stdout, "new group") == null);
+    }
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -191,6 +204,10 @@ test "add command creates stubs at the right paths" {
     const created = try readFile(tmp.dir, a, "src/commands/users/create.zig");
     try expectContains(created, ".description = \"Create a user\"");
     try expectContains(created, "pub fn execute(");
+    // Full meta surface is scaffolded as commented fields (read/write symmetry
+    // with `tree --show-options`).
+    try expectContains(created, "// .aliases =");
+    try expectContains(created, "// .hidden =");
 }
 
 test "add command outside a project fails clearly" {


### PR DESCRIPTION
## Summary

Two extensions to `add command`, both serving read/write symmetry with the enriched `tree --show-options` (ADR-0007):

### 1. Undescribed-group hint
A nested path like `add command users/create` can bring new group directories into being. A fresh directory has no `index.zig`, so the group has **no description** in help or `tree`. `writeCommandFile` now reports which group dirs it actually *created* (`createDir` succeeded, not `PathAlreadyExists`), and `finish` hints how to describe each:

```
Note: new group 'users' has no description.
  Add src/commands/users/index.zig with `pub const meta = .{ .description = "..." };` to describe it.
```

Fires **only on birth** — a second command under an existing group hints nothing; a flat command hints nothing; a nested `gh/pr/open` hints for both new `gh` and `gh pr`.

### 2. Full meta surface
Generated command files now scaffold commented `.aliases`/`.hidden` next to `.examples`, so every shell shows the whole authored surface the read-back reports:

```zig
pub const meta = .{
    .description = "Create a user",
    .examples = &.{ "users create" },
    // .aliases = &.{"alias"}, // alternate names this command answers to
    // .hidden = true,          // omit from help and tree listings
};
```

## Scope note: the test stub is deliberately deferred

Grill Q7's "co-located unit-test stub" is **not** in this PR. `zcli init` generates a project build.zig with **no `test` step at all**, so a stub would never run. Wiring command-file test discovery into the generated build (mirroring the meta-CLI's `command_test_files` loop + a `command_registry` Context stub) is a real chunk that earns its own PR — split out in `TODOS.md`. (Decision confirmed with the maintainer.)

## Tests
- **meta-CLI 19/19**, **e2e 12/12**.
- Extended the `add command` e2e to assert the group hint fires on birth and *only* on birth (flat command → none; second command under an existing group → none), and that the commented meta fields are scaffolded. Verified live against a temp project (flat / new-group / nested / pre-existing-group cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)