### PR TITLE
add arg + remove the JSON-blob front-end (ADR-0005, centerpiece part 2)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -35,10 +35,12 @@ sequence. Each PR references the ADR carrying its rationale. Ordered by dependen
   `execute()`/comments/formatting). `add option <cmd> <name> --type/--multiple/--nullable/
   --default/--short/-d`. (Note: zcli auto-derives shorts from field first-letters — `default`
   would claim `-d`, so the command's own Options declares `description` before `default`.)
-- [ ] **PR: `add arg` + remove JSON-blob bulk** (ADR-0005) — the second half. `add arg` append
-  + `--before`/`--after` (splice engine's `Anchor` already supports both), ordering rules via
-  `validateArg`; then delete the JSON front-end (`parseArgJson`/`parseOptJson` + `--arg`/
-  `--option` on `add command`) now that flag-based authoring replaces it. Keep the wizard.
+- [x] **PR: `add arg` + remove JSON-blob bulk** (ADR-0005) — DONE. The centerpiece's second
+  half. `add arg <cmd> <name> --type/--multiple/--nullable/--before/--after/-d`, reusing the
+  splice `Anchor`; ordering (required-before-optional, `multiple` last) validated against the
+  real file via a new `splice.fieldShapes` reader, erroring clearly before any write. Deleted
+  the JSON front-end (`declarative`/`parseArgJson`/`parseOptJson` + `--arg`/`--option` on
+  `add command`) and the now-dead `validateArg`/`validateOpt`; the wizard + shared spec stay.
 - [ ] **PR: `rm option`/`rm arg`** (ADR-0005) — splice-out; variadic names; error on missing.
   Shares splice machinery with the previous PR.
 - [ ] **PR: `add group`** (grill Q8) — meta-only `index.zig` by default; `--with-landing`

--- a/projects/zcli/build.zig
+++ b/projects/zcli/build.zig
@@ -110,6 +110,7 @@ pub fn build(b: *std.Build) void {
         "src/commands/dev.zig",
         "src/commands/add/command.zig",
         "src/commands/add/option.zig",
+        "src/commands/add/arg.zig",
     };
     for (command_test_files) |path| {
         const mod = b.addModule(b.fmt("test-{s}", .{path}), .{

--- a/projects/zcli/src/commands/add/arg.zig
+++ b/projects/zcli/src/commands/add/arg.zig
@@ -1,0 +1,293 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
+const ztheme = zcli.ztheme;
+
+const scaffold = @import("scaffold");
+const spec = scaffold.spec;
+const splice = scaffold.splice;
+
+pub const meta = .{
+    .description = "Add a positional argument to an existing command",
+    .examples = &.{
+        "add arg users/create name --type []const u8",
+        "add arg deploy target --type []const u8 --before env",
+        "add arg run rest --type []const u8 --multiple",
+    },
+    .args = .{
+        .command = "Target command path (e.g. 'users/create')",
+        .name = "Argument name (snake_case or kebab-case)",
+    },
+    .options = .{
+        .type = .{ .description = "Element/scalar Zig type (e.g. u32, []const u8)", .short = 't' },
+        .multiple = .{ .description = "Variadic: captures all remaining positionals ([]const u8 only)" },
+        .nullable = .{ .description = "Optional: renders as ?T = null" },
+        .before = .{ .description = "Insert before this existing argument" },
+        .after = .{ .description = "Insert after this existing argument" },
+        .description = .{ .description = "Argument description", .short = 'd' },
+    },
+};
+
+pub const Args = struct {
+    command: []const u8,
+    name: []const u8,
+};
+
+pub const Options = struct {
+    type: []const u8,
+    // See option.zig: `description` precedes any other d-word so `-d` stays its
+    // short. (No collision here, but kept for consistency with `add option`.)
+    description: ?[]const u8 = null,
+    multiple: bool = false,
+    nullable: bool = false,
+    before: ?[]const u8 = null,
+    after: ?[]const u8 = null,
+};
+
+/// Maximum bytes read from a command source file before splicing.
+const max_source_bytes = 1024 * 1024;
+
+pub fn execute(args: Args, options: Options, context: *Context) !void {
+    var arena_state = std.heap.ArenaAllocator.init(context.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const io = context.io.io;
+    const stderr = context.stderr();
+
+    // Preflight: must be inside a zcli project.
+    std.Io.Dir.cwd().access(io, "src/commands", .{}) catch {
+        try stderr.print("Error: Not in a zcli project directory\n", .{});
+        try stderr.print("Run this command from the root of your zcli project (where build.zig is)\n", .{});
+        return error.NotInZcliProject;
+    };
+
+    const parts = spec.parsePath(arena, args.command) catch {
+        try stderr.print("Error: Invalid command path: '{s}'\n", .{args.command});
+        return error.InvalidCommandPath;
+    };
+    const file_path = try spec.buildFilePath(arena, parts);
+
+    const name = spec.normalizeName(arena, args.name) catch |err| {
+        try stderr.print("Error: Invalid argument name '{s}': {s}\n", .{ args.name, @errorName(err) });
+        return err;
+    };
+
+    const arg = try buildSpec(arena, stderr, name, options);
+    const anchor = try resolveAnchor(arena, stderr, options);
+
+    // Read the target command's source (NUL-terminated for the AST parser).
+    const raw = std.Io.Dir.cwd().readFileAlloc(io, file_path, arena, .limited(max_source_bytes)) catch {
+        try stderr.print("Error: Command not found: {s}\n", .{file_path});
+        try stderr.print("Create it first with `zcli add command {s}`\n", .{args.command});
+        return error.CommandNotFound;
+    };
+    const source = try arena.dupeZ(u8, raw);
+
+    // Validate placement against the real file before touching it: duplicate
+    // name, unknown anchor, and the ordering rules (required-before-optional,
+    // `multiple` last).
+    const existing = try splice.fieldShapes(arena, source, "Args");
+    try validateOrder(arena, stderr, file_path, existing, arg, anchor);
+
+    const updated = splice.insertArg(arena, source, arg, anchor) catch |err| switch (err) {
+        splice.SpliceError.DuplicateField => {
+            try stderr.print("Error: {s} already has an argument named '{s}'\n", .{ file_path, name });
+            return err;
+        },
+        else => {
+            try stderr.print("Error: could not edit {s}: {s}\n", .{ file_path, @errorName(err) });
+            return err;
+        },
+    };
+
+    var file = try std.Io.Dir.cwd().createFile(io, file_path, .{});
+    defer file.close(io);
+    try file.writeStreamingAll(io, updated);
+
+    try finish(context.stdout(), &context.theme, file_path, arg);
+}
+
+/// Assemble the ArgSpec from the flags. Positionals have no default and no short
+/// flag: `--nullable` makes an arg optional, its absence makes it required. A
+/// `--multiple` positional is the varargs tail, which zcli only supports as
+/// `[]const u8`, and it can't also be `--nullable` (a variadic already captures
+/// zero or more).
+fn buildSpec(arena: std.mem.Allocator, stderr: *std.Io.Writer, name: []const u8, options: Options) !spec.ArgSpec {
+    const elem_type = std.mem.trim(u8, options.type, " \t");
+    if (elem_type.len == 0) {
+        try stderr.print("Error: --type is required\n", .{});
+        return error.MissingType;
+    }
+
+    if (options.multiple) {
+        if (options.nullable) {
+            try stderr.print("Error: --multiple and --nullable are contradictory (a variadic already captures zero or more)\n", .{});
+            return error.ContradictoryFlags;
+        }
+        if (!std.mem.eql(u8, elem_type, "[]const u8")) {
+            try stderr.print("Error: a --multiple positional must be []const u8 (it captures the remaining arguments)\n", .{});
+            return error.PositionalMultipleMustBeString;
+        }
+    }
+
+    return .{
+        .name = name,
+        .elem_type = try arena.dupe(u8, elem_type),
+        .multiple = options.multiple,
+        .nullable = options.nullable,
+        .description = try arena.dupe(u8, options.description orelse ""),
+    };
+}
+
+/// `--before`/`--after` are mutually exclusive; their targets are field names,
+/// so they are normalized the same way the stored field names were.
+fn resolveAnchor(arena: std.mem.Allocator, stderr: *std.Io.Writer, options: Options) !splice.Anchor {
+    if (options.before != null and options.after != null) {
+        try stderr.print("Error: pass only one of --before/--after\n", .{});
+        return error.ContradictoryFlags;
+    }
+    if (options.before) |b| return .{ .before = try spec.toFieldName(arena, b) };
+    if (options.after) |a| return .{ .after = try spec.toFieldName(arena, a) };
+    return .append;
+}
+
+/// Enforce the ADR-0005 ordering rules against the file's real arguments, with
+/// the new arg placed at `anchor`: a `multiple` argument must be last, and a
+/// required argument may not follow an optional one.
+fn validateOrder(
+    arena: std.mem.Allocator,
+    stderr: *std.Io.Writer,
+    file_path: []const u8,
+    existing: []const splice.FieldShape,
+    arg: spec.ArgSpec,
+    anchor: splice.Anchor,
+) !void {
+    for (existing) |e| {
+        if (std.mem.eql(u8, e.name, arg.name)) {
+            try stderr.print("Error: {s} already has an argument named '{s}'\n", .{ file_path, arg.name });
+            return splice.SpliceError.DuplicateField;
+        }
+    }
+
+    const idx = switch (anchor) {
+        .append => existing.len,
+        .before => |t| indexOfName(existing, t) orelse return anchorNotFound(stderr, file_path, t),
+        .after => |t| (indexOfName(existing, t) orelse return anchorNotFound(stderr, file_path, t)) + 1,
+    };
+
+    // The resulting order, with the new arg spliced in at idx.
+    var order = std.ArrayList(splice.FieldShape).empty;
+    try order.appendSlice(arena, existing[0..idx]);
+    try order.append(arena, .{ .name = arg.name, .optional = arg.nullable, .multiple = arg.multiple });
+    try order.appendSlice(arena, existing[idx..]);
+
+    var last_multiple: ?[]const u8 = null;
+    var last_optional: ?[]const u8 = null;
+    for (order.items) |s| {
+        if (last_multiple) |m| {
+            try stderr.print("Error: a multiple argument must be last, but '{s}' would follow '{s}'\n", .{ s.name, m });
+            return error.MultipleNotLast;
+        }
+        if (!s.optional and !s.multiple) {
+            if (last_optional) |o| {
+                try stderr.print("Error: required argument '{s}' cannot follow optional argument '{s}'\n", .{ s.name, o });
+                return error.BadArgOrder;
+            }
+        }
+        if (s.optional) last_optional = s.name;
+        if (s.multiple) last_multiple = s.name;
+    }
+}
+
+fn indexOfName(list: []const splice.FieldShape, name: []const u8) ?usize {
+    for (list, 0..) |s, i| {
+        if (std.mem.eql(u8, s.name, name)) return i;
+    }
+    return null;
+}
+
+fn anchorNotFound(stderr: *std.Io.Writer, file_path: []const u8, name: []const u8) anyerror {
+    stderr.print("Error: {s} has no argument named '{s}' to anchor against\n", .{ file_path, name }) catch {};
+    return splice.SpliceError.AnchorNotFound;
+}
+
+fn finish(w: *std.Io.Writer, theme: *const ztheme.Theme, file_path: []const u8, arg: spec.ArgSpec) !void {
+    try w.writeAll("\n  ");
+    var buf: [512]u8 = undefined;
+    const line = std.fmt.bufPrint(&buf, "\u{2714} Added argument '{s}' to {s}", .{ arg.name, file_path }) catch "\u{2714} Added argument";
+    try ztheme.theme(line).success().render(w, theme);
+    try w.writeAll("\n\n  Next steps\n");
+    try w.print("    1. Read the argument back with `zcli tree --show-options`\n", .{});
+    try w.writeAll("    2. zig build\n");
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const testing = std.testing;
+
+fn shapes(arena: std.mem.Allocator, comptime pairs: anytype) ![]const splice.FieldShape {
+    var list = std.ArrayList(splice.FieldShape).empty;
+    inline for (pairs) |p| {
+        try list.append(arena, .{ .name = p[0], .optional = p[1], .multiple = p[2] });
+    }
+    return list.items;
+}
+
+fn requiredArg(name: []const u8) spec.ArgSpec {
+    return .{ .name = name, .elem_type = "[]const u8", .multiple = false, .nullable = false, .description = "" };
+}
+
+test "buildSpec: multiple must be a string" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var aw = std.Io.Writer.Allocating.init(arena.allocator());
+    try testing.expectError(error.PositionalMultipleMustBeString, buildSpec(arena.allocator(), &aw.writer, "nums", .{ .type = "u32", .multiple = true }));
+}
+
+test "buildSpec: multiple and nullable are contradictory" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var aw = std.Io.Writer.Allocating.init(arena.allocator());
+    try testing.expectError(error.ContradictoryFlags, buildSpec(arena.allocator(), &aw.writer, "rest", .{ .type = "[]const u8", .multiple = true, .nullable = true }));
+}
+
+test "validateOrder: required cannot append after an optional" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    var aw = std.Io.Writer.Allocating.init(a);
+    const existing = try shapes(a, .{.{ "first", true, false }}); // one optional arg
+    try testing.expectError(error.BadArgOrder, validateOrder(a, &aw.writer, "x.zig", existing, requiredArg("second"), .append));
+}
+
+test "validateOrder: nothing may follow a variadic" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    var aw = std.Io.Writer.Allocating.init(a);
+    const existing = try shapes(a, .{.{ "rest", false, true }}); // existing variadic (last)
+    // Appending after it is illegal.
+    try testing.expectError(error.MultipleNotLast, validateOrder(a, &aw.writer, "x.zig", existing, requiredArg("late"), .append));
+}
+
+test "validateOrder: unknown anchor is reported" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    var aw = std.Io.Writer.Allocating.init(a);
+    const existing = try shapes(a, .{.{ "name", false, false }});
+    try testing.expectError(splice.SpliceError.AnchorNotFound, validateOrder(a, &aw.writer, "x.zig", existing, requiredArg("x"), .{ .after = "missing" }));
+}
+
+test "validateOrder: required before an optional is accepted" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    var aw = std.Io.Writer.Allocating.init(a);
+    const existing = try shapes(a, .{.{ "opt", true, false }});
+    // Inserting a required arg *before* the optional keeps the order valid.
+    try validateOrder(a, &aw.writer, "x.zig", existing, requiredArg("req"), .{ .before = "opt" });
+}

--- a/projects/zcli/src/commands/add/command.zig
+++ b/projects/zcli/src/commands/add/command.zig
@@ -11,8 +11,6 @@ const Theme = ztheme.Theme;
 const scaffold = @import("scaffold");
 const ArgSpec = scaffold.spec.ArgSpec;
 const OptSpec = scaffold.spec.OptSpec;
-const isSupportedArrayElem = scaffold.spec.isSupportedArrayElem;
-const enumHasMember = scaffold.spec.enumHasMember;
 const buildEnumType = scaffold.spec.buildEnumType;
 const writeEscaped = scaffold.spec.writeEscaped;
 const quoteString = scaffold.spec.quoteString;
@@ -32,15 +30,12 @@ pub const meta = .{
         "add command",
         "add command deploy",
         "add command users/create --description \"Create a user\"",
-        "add command search --arg '{\"name\":\"query\",\"type\":\"[]const u8\"}' --option '{\"name\":\"limit\",\"type\":\"u32\",\"nullable\":true}'",
     },
     .args = .{
         .path = "Command path (e.g., 'deploy' or 'users/create'). Omit to be prompted.",
     },
     .options = .{
         .description = .{ .description = "Description of the command", .short = 'd' },
-        .arg = .{ .description = "Declarative positional arg as JSON {name,type,multiple?,nullable?,description?}. Repeatable." },
-        .option = .{ .description = "Declarative option as JSON {name,type,multiple?,nullable?,default?,short?,description?}. Repeatable." },
     },
 };
 
@@ -50,8 +45,6 @@ pub const Args = struct {
 
 pub const Options = struct {
     description: ?[]const u8 = null,
-    arg: [][]const u8 = &.{},
-    option: [][]const u8 = &.{},
 };
 
 // Wizard prompts pass `.interrupt_keys = back_keys` so Escape aborts with
@@ -78,12 +71,9 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         return error.NotInZcliProject;
     };
 
-    // Declarative mode: any --arg/--option fully specifies the command up front.
-    if (options.arg.len > 0 or options.option.len > 0) {
-        return declarative(arena, context, args, options);
-    }
-
-    // Otherwise: interactive on a TTY, classic skeleton when piped.
+    // Interactive on a TTY, classic skeleton when piped. Args and options are
+    // added afterward with `add arg`/`add option` (ADR-0005) or, interactively,
+    // through the wizard's own prompts.
     if (!zinput.terminal.isStdinTty()) {
         return skeleton(arena, context, args, options);
     }
@@ -217,223 +207,6 @@ fn skeleton(arena: std.mem.Allocator, context: *Context, args: Args, options: Op
 }
 
 // ---------------------------------------------------------------------------
-// Declarative mode (--arg / --option JSON)
-// ---------------------------------------------------------------------------
-
-fn declarative(arena: std.mem.Allocator, context: *Context, args: Args, options: Options) !void {
-    const stderr = context.stderr();
-    const io = context.io.io;
-
-    const raw_path = args.path orelse {
-        try stderr.print("Error: A command path is required\n", .{});
-        try stderr.print("Usage: zcli add command <path> --arg '{{...}}' --option '{{...}}'\n", .{});
-        return error.MissingCommandPath;
-    };
-
-    const parts = parsePath(arena, raw_path) catch {
-        try stderr.print("Error: Invalid command path: '{s}'\n", .{raw_path});
-        return error.InvalidCommandPath;
-    };
-
-    const file_path = try buildFilePath(arena, parts);
-    if (fileExists(io, file_path)) {
-        try stderr.print("Error: Command already exists: {s}\n", .{file_path});
-        return error.CommandAlreadyExists;
-    }
-
-    var args_list = std.ArrayList(ArgSpec).empty;
-    for (options.arg, 0..) |json, i| {
-        const spec = parseArgJson(arena, json) catch |err| {
-            try stderr.print("Error: --arg #{d} {s}: {s}\n", .{ i + 1, @errorName(err), json });
-            return err;
-        };
-        try validateArg(stderr, &args_list, spec, i);
-        try args_list.append(arena, spec);
-    }
-
-    var opts_list = std.ArrayList(OptSpec).empty;
-    for (options.option, 0..) |json, i| {
-        const spec = parseOptJson(arena, json) catch |err| {
-            try stderr.print("Error: --option #{d} {s}: {s}\n", .{ i + 1, @errorName(err), json });
-            return err;
-        };
-        try validateOpt(stderr, &opts_list, spec, i);
-        try opts_list.append(arena, spec);
-    }
-
-    const description = options.description orelse "TODO: Add description";
-    const content = try generateSource(arena, parts, description, args_list.items, opts_list.items);
-    const new_groups = try writeCommandFile(arena, io, parts, file_path, content);
-    try finish(context.stdout(), &context.theme, parts, file_path, new_groups);
-}
-
-fn parseArgJson(arena: std.mem.Allocator, json: []const u8) !ArgSpec {
-    const parsed = try std.json.parseFromSlice(std.json.Value, arena, json, .{});
-    defer parsed.deinit();
-    const obj = switch (parsed.value) {
-        .object => |o| o,
-        else => return error.NotAnObject,
-    };
-
-    const name = try normalizeName(arena, try jsonString(obj, "name", error.MissingName));
-    const elem_type = try arena.dupe(u8, try jsonString(obj, "type", error.MissingType));
-    if (elem_type.len == 0) return error.EmptyType;
-    const multiple = jsonBool(obj, "multiple", false);
-    // Positional varargs are []const u8 slices only.
-    if (multiple and !std.mem.eql(u8, elem_type, "[]const u8")) return error.PositionalMultipleMustBeString;
-    const nullable = jsonBool(obj, "nullable", false);
-    const description = try arena.dupe(u8, jsonStringOr(obj, "description", ""));
-
-    return .{
-        .name = name,
-        .elem_type = elem_type,
-        .multiple = multiple,
-        .nullable = nullable,
-        .description = description,
-    };
-}
-
-fn parseOptJson(arena: std.mem.Allocator, json: []const u8) !OptSpec {
-    const parsed = try std.json.parseFromSlice(std.json.Value, arena, json, .{});
-    defer parsed.deinit();
-    const obj = switch (parsed.value) {
-        .object => |o| o,
-        else => return error.NotAnObject,
-    };
-
-    const name = try normalizeName(arena, try jsonString(obj, "name", error.MissingName));
-    const elem_type = try arena.dupe(u8, try jsonString(obj, "type", error.MissingType));
-    if (elem_type.len == 0) return error.EmptyType;
-    const multiple = jsonBool(obj, "multiple", false);
-    if (multiple and !isSupportedArrayElem(elem_type)) return error.UnsupportedArrayElement;
-    const nullable = jsonBool(obj, "nullable", false);
-    const description = try arena.dupe(u8, jsonStringOr(obj, "description", ""));
-
-    var short: ?u8 = null;
-    if (obj.get("short")) |v| switch (v) {
-        .string => |s| {
-            if (s.len != 1 or !std.ascii.isAlphabetic(s[0])) return error.BadShort;
-            short = s[0];
-        },
-        else => return error.BadShort,
-    };
-
-    var default_expr: ?[]const u8 = null;
-    if (multiple) {
-        // List option: non-nullable defaults to an empty slice; no scalar default.
-        if (!nullable) default_expr = "&.{}";
-    } else if (!nullable) {
-        const v = obj.get("default") orelse return error.MissingDefault; // non-nullable scalar requires a default
-        default_expr = try renderDefault(arena, elem_type, v);
-    }
-
-    return .{
-        .name = name,
-        .elem_type = elem_type,
-        .multiple = multiple,
-        .nullable = nullable,
-        .default_expr = default_expr,
-        .short = short,
-        .description = description,
-    };
-}
-
-/// Render a JSON default value as a Zig expression, using light type awareness.
-/// Whether `name` is a member of an `enum { a, b = 1, ... }` type string.
-fn renderDefault(arena: std.mem.Allocator, elem_type: []const u8, v: std.json.Value) ![]const u8 {
-    if (std.mem.eql(u8, elem_type, "[]const u8")) {
-        const s = switch (v) {
-            .string => |x| x,
-            else => return error.BadDefault,
-        };
-        return quoteString(arena, s);
-    }
-    if (std.mem.startsWith(u8, elem_type, "enum")) {
-        const s = switch (v) {
-            .string => |x| x,
-            else => return error.BadDefault,
-        };
-        // The default must name one of the enum's members, or the generated
-        // `= .<default>` won't compile.
-        if (!enumHasMember(elem_type, s)) return error.BadDefault;
-        return std.fmt.allocPrint(arena, ".{s}", .{s});
-    }
-    if (std.mem.eql(u8, elem_type, "bool")) {
-        return switch (v) {
-            .bool => |b| if (b) "true" else "false",
-            else => error.BadDefault,
-        };
-    }
-    // Numeric or custom type: emit the JSON scalar verbatim.
-    return switch (v) {
-        .integer => |x| std.fmt.allocPrint(arena, "{d}", .{x}),
-        .float => |x| std.fmt.allocPrint(arena, "{d}", .{x}),
-        .number_string => |x| arena.dupe(u8, x),
-        .string => |x| arena.dupe(u8, x), // custom type → raw Zig expression
-        .bool => |x| if (x) "true" else "false",
-        else => error.BadDefault,
-    };
-}
-
-fn jsonString(obj: std.json.ObjectMap, key: []const u8, miss: anyerror) ![]const u8 {
-    const v = obj.get(key) orelse return miss;
-    return switch (v) {
-        .string => |s| s,
-        else => error.NotAString,
-    };
-}
-
-fn jsonStringOr(obj: std.json.ObjectMap, key: []const u8, fallback: []const u8) []const u8 {
-    const v = obj.get(key) orelse return fallback;
-    return switch (v) {
-        .string => |s| s,
-        else => fallback,
-    };
-}
-
-fn jsonBool(obj: std.json.ObjectMap, key: []const u8, fallback: bool) bool {
-    const v = obj.get(key) orelse return fallback;
-    return switch (v) {
-        .bool => |b| b,
-        else => fallback,
-    };
-}
-
-fn validateArg(stderr: *std.Io.Writer, list: *std.ArrayList(ArgSpec), spec: ArgSpec, index: usize) !void {
-    for (list.items) |e| {
-        if (std.mem.eql(u8, e.name, spec.name)) {
-            try stderr.print("Error: --arg #{d}: duplicate name '{s}'\n", .{ index + 1, spec.name });
-            return error.DuplicateArg;
-        }
-        if (e.multiple) {
-            try stderr.print("Error: --arg #{d}: a multiple argument must be last\n", .{index + 1});
-            return error.MultipleNotLast;
-        }
-    }
-    if (!spec.nullable and !spec.multiple) {
-        for (list.items) |e| {
-            if (e.nullable and !e.multiple) {
-                try stderr.print("Error: --arg #{d}: required '{s}' cannot follow an optional argument\n", .{ index + 1, spec.name });
-                return error.BadArgOrder;
-            }
-        }
-    }
-}
-
-fn validateOpt(stderr: *std.Io.Writer, list: *std.ArrayList(OptSpec), spec: OptSpec, index: usize) !void {
-    for (list.items) |e| {
-        if (std.mem.eql(u8, e.name, spec.name)) {
-            try stderr.print("Error: --option #{d}: duplicate name '{s}'\n", .{ index + 1, spec.name });
-            return error.DuplicateOption;
-        }
-        if (spec.short) |c| if (e.short == c) {
-            try stderr.print("Error: --option #{d}: duplicate short flag '-{c}'\n", .{ index + 1, c });
-            return error.DuplicateShort;
-        };
-    }
-}
-
-// ---------------------------------------------------------------------------
 // Step 1: command path (with live preview)
 // ---------------------------------------------------------------------------
 
@@ -490,7 +263,6 @@ fn resolveCommandPath(
         return .{ .parts = parts, .prompted = prompted };
     }
 }
-
 
 // ---------------------------------------------------------------------------
 // Step 3: positional arguments
@@ -1443,54 +1215,6 @@ test "generateSource: multiple is independent of element type" {
     try expectContains(src, "tags: [][]const u8 = &.{},"); // multiple string option
     try expectContains(src, "\"users create <email> [age] names...\"");
 }
-
-test "parseOptJson: multiple is a separate flag, not a type" {
-    var arena = std.heap.ArenaAllocator.init(testing.allocator);
-    defer arena.deinit();
-    const a = arena.allocator();
-
-    const ints = try parseOptJson(a, "{\"name\":\"ports\",\"type\":\"u32\",\"multiple\":true}");
-    try testing.expect(ints.multiple);
-    try testing.expectEqualStrings("u32", ints.elem_type);
-    try testing.expectEqualStrings("&.{}", ints.default_expr.?);
-
-    const nullable_list = try parseOptJson(a, "{\"name\":\"ports\",\"type\":\"i64\",\"multiple\":true,\"nullable\":true}");
-    try testing.expect(nullable_list.default_expr == null);
-
-    const scalar = try parseOptJson(a, "{\"name\":\"retries\",\"type\":\"u32\",\"default\":3}");
-    try testing.expectEqualStrings("3", scalar.default_expr.?);
-    try testing.expectError(error.UnsupportedArrayElement, parseOptJson(a, "{\"name\":\"x\",\"type\":\"bool\",\"multiple\":true}"));
-    try testing.expectError(error.MissingDefault, parseOptJson(a, "{\"name\":\"x\",\"type\":\"u32\"}"));
-}
-
-test "parseOptJson: enum default must name a member" {
-    var arena = std.heap.ArenaAllocator.init(testing.allocator);
-    defer arena.deinit();
-    const a = arena.allocator();
-
-    const ok = try parseOptJson(a, "{\"name\":\"format\",\"type\":\"enum { json, yaml }\",\"default\":\"yaml\"}");
-    try testing.expectEqualStrings(".yaml", ok.default_expr.?);
-    // A default that isn't a member would generate `= .xml`, which won't compile.
-    try testing.expectError(error.BadDefault, parseOptJson(a, "{\"name\":\"format\",\"type\":\"enum { json, yaml }\",\"default\":\"xml\"}"));
-}
-
-test "enumHasMember handles explicit values and spacing" {
-    try testing.expect(enumHasMember("enum { json, yaml }", "json"));
-    try testing.expect(enumHasMember("enum { a = 1, b = 2 }", "b"));
-    try testing.expect(!enumHasMember("enum { json, yaml }", "xml"));
-    try testing.expect(!enumHasMember("enum {}", "x"));
-}
-
-test "parseArgJson: positional multiple must be a string" {
-    var arena = std.heap.ArenaAllocator.init(testing.allocator);
-    defer arena.deinit();
-    const a = arena.allocator();
-
-    const ok = try parseArgJson(a, "{\"name\":\"names\",\"type\":\"[]const u8\",\"multiple\":true}");
-    try testing.expect(ok.multiple);
-    try testing.expectError(error.PositionalMultipleMustBeString, parseArgJson(a, "{\"name\":\"nums\",\"type\":\"u8\",\"multiple\":true}"));
-}
-
 fn expectContains(haystack: []const u8, needle: []const u8) !void {
     if (std.mem.indexOf(u8, haystack, needle) == null) {
         std.debug.print("\nexpected to find:\n  {s}\nin:\n{s}\n", .{ needle, haystack });

--- a/projects/zcli/src/scaffold/spec.zig
+++ b/projects/zcli/src/scaffold/spec.zig
@@ -323,3 +323,16 @@ test "parsePath accepts slash and space separators" {
     try testing.expectError(error.InvalidCommandPath, parsePath(a, "  "));
     try testing.expectEqualStrings("src/commands/users/create.zig", try buildFilePath(a, p));
 }
+
+test "enumHasMember handles explicit values and spacing" {
+    try testing.expect(enumHasMember("enum { json, yaml }", "json"));
+    try testing.expect(enumHasMember("enum { a = 1, b = 2 }", "b"));
+    try testing.expect(!enumHasMember("enum { json, yaml }", "xml"));
+    try testing.expect(!enumHasMember("enum {}", "x"));
+}
+
+test "isSupportedArrayElem accepts numeric and string element types" {
+    try testing.expect(isSupportedArrayElem("[]const u8"));
+    try testing.expect(isSupportedArrayElem("u32"));
+    try testing.expect(!isSupportedArrayElem("bool"));
+}

--- a/projects/zcli/src/scaffold/splice.zig
+++ b/projects/zcli/src/scaffold/splice.zig
@@ -69,6 +69,50 @@ fn ensureNoField(arena: std.mem.Allocator, source: [:0]const u8, container: []co
     }
 }
 
+/// The ordering-relevant shape of an existing `Args`/`Options` field.
+pub const FieldShape = struct {
+    name: []const u8,
+    /// Nullable (`?T`) or defaulted — optional to supply.
+    optional: bool,
+    /// Variadic/accumulating slice (element type is not `u8`).
+    multiple: bool,
+};
+
+/// Each field of `container`'s struct as its ordering shape, in source order.
+/// Mirrors the type analysis tree.zig uses for read-back; used to validate arg
+/// ordering (required-before-optional, `multiple` last) against the real file.
+pub fn fieldShapes(arena: std.mem.Allocator, source: [:0]const u8, container: []const u8) ![]const FieldShape {
+    var ast = try Ast.parse(arena, source, .zig);
+    const init = findDeclInit(&ast, container) orelse return &.{};
+    var buf: [2]Ast.Node.Index = undefined;
+    const cd = ast.fullContainerDecl(&buf, init) orelse return SpliceError.NotAStruct;
+
+    var out = std.ArrayList(FieldShape).empty;
+    for (cd.ast.members) |m| {
+        const cf = ast.fullContainerField(m) orelse continue;
+        const type_node = cf.ast.type_expr.unwrap() orelse continue;
+
+        var node = type_node;
+        var optional = cf.ast.value_expr != .none; // has a default
+        if (ast.nodeTag(node) == .optional_type) {
+            optional = true;
+            node = ast.nodeData(node).node;
+        }
+        var multiple = false;
+        if (ast.fullPtrType(node)) |ptr| {
+            if (ptr.size == .slice and !std.mem.eql(u8, nodeSource(&ast, ptr.ast.child_type), "u8")) {
+                multiple = true;
+            }
+        }
+        try out.append(arena, .{
+            .name = try arena.dupe(u8, ast.tokenSlice(cf.ast.main_token)),
+            .optional = optional,
+            .multiple = multiple,
+        });
+    }
+    return out.items;
+}
+
 // ---------------------------------------------------------------------------
 // Struct-field splice
 // ---------------------------------------------------------------------------
@@ -212,6 +256,10 @@ fn findDeclInit(ast: *Ast, name: []const u8) ?Ast.Node.Index {
     return null;
 }
 
+fn nodeSource(ast: *Ast, node: Ast.Node.Index) []const u8 {
+    return ast.source[tokStart(ast, ast.firstToken(node))..tokEnd(ast, ast.lastToken(node))];
+}
+
 fn memberName(ast: *Ast, member: Ast.Node.Index) []const u8 {
     const cf = ast.fullContainerField(member) orelse return "";
     return ast.tokenSlice(cf.ast.main_token);
@@ -257,8 +305,13 @@ test "insertOption creates block, appends field, preserves execute" {
     const a = arena.allocator();
 
     const out = try insertOption(a, shell, .{
-        .name = "limit", .elem_type = "u32", .multiple = false, .nullable = false,
-        .default_expr = "10", .short = 'l', .description = "Max results",
+        .name = "limit",
+        .elem_type = "u32",
+        .multiple = false,
+        .nullable = false,
+        .default_expr = "10",
+        .short = 'l',
+        .description = "Max results",
     });
     try expectParses(a, out);
     try testing.expect(std.mem.indexOf(u8, out, "limit: u32 = 10,") != null);
@@ -267,7 +320,12 @@ test "insertOption creates block, appends field, preserves execute" {
 
     // Chain a second option into the now-existing block.
     const out2 = try insertOption(a, try a.dupeZ(u8, out), .{
-        .name = "verbose", .elem_type = "bool", .multiple = false, .nullable = false, .default_expr = "false", .description = "Loud",
+        .name = "verbose",
+        .elem_type = "bool",
+        .multiple = false,
+        .nullable = false,
+        .default_expr = "false",
+        .description = "Loud",
     });
     try expectParses(a, out2);
     try testing.expect(std.mem.indexOf(u8, out2, "verbose: bool = false,") != null);
@@ -279,14 +337,22 @@ test "insertArg appends and positions with before/after" {
     const a = arena.allocator();
 
     const one = try insertArg(a, shell, .{
-        .name = "name", .elem_type = "[]const u8", .multiple = false, .nullable = false, .description = "Who",
+        .name = "name",
+        .elem_type = "[]const u8",
+        .multiple = false,
+        .nullable = false,
+        .description = "Who",
     }, .append);
     try expectParses(a, one);
     try testing.expect(std.mem.indexOf(u8, one, "name: []const u8,") != null);
     try testing.expect(std.mem.indexOf(u8, one, ".name = \"Who\",") != null);
 
     const before = try insertArg(a, try a.dupeZ(u8, one), .{
-        .name = "count", .elem_type = "u32", .multiple = false, .nullable = true, .description = "",
+        .name = "count",
+        .elem_type = "u32",
+        .multiple = false,
+        .nullable = true,
+        .description = "",
     }, .{ .before = "name" });
     try expectParses(a, before);
     const ci = std.mem.indexOf(u8, before, "count: ?u32 = null").?;
@@ -300,10 +366,20 @@ test "duplicate field is rejected" {
     const a = arena.allocator();
 
     const one = try insertOption(a, shell, .{
-        .name = "limit", .elem_type = "u32", .multiple = false, .nullable = false, .default_expr = "10", .description = "",
+        .name = "limit",
+        .elem_type = "u32",
+        .multiple = false,
+        .nullable = false,
+        .default_expr = "10",
+        .description = "",
     });
     try testing.expectError(SpliceError.DuplicateField, insertOption(a, try a.dupeZ(u8, one), .{
-        .name = "limit", .elem_type = "u32", .multiple = false, .nullable = false, .default_expr = "1", .description = "",
+        .name = "limit",
+        .elem_type = "u32",
+        .multiple = false,
+        .nullable = false,
+        .default_expr = "1",
+        .description = "",
     }));
 }
 
@@ -319,4 +395,29 @@ test "fieldNames reads Args in source order" {
     try testing.expectEqual(@as(usize, 2), names.len);
     try testing.expectEqualStrings("first", names[0]);
     try testing.expectEqualStrings("second", names[1]);
+}
+
+test "fieldShapes classifies required, optional, and variadic" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const src =
+        \\pub const Args = struct {
+        \\    name: []const u8,
+        \\    count: u32 = 1,
+        \\    tag: ?[]const u8 = null,
+        \\    rest: [][]const u8,
+        \\};
+        \\
+    ;
+    const shapes = try fieldShapes(a, src, "Args");
+    try testing.expectEqual(@as(usize, 4), shapes.len);
+    // name: required string (not optional, not multiple).
+    try testing.expect(!shapes[0].optional and !shapes[0].multiple);
+    // count: defaulted → optional.
+    try testing.expect(shapes[1].optional and !shapes[1].multiple);
+    // tag: nullable → optional.
+    try testing.expect(shapes[2].optional);
+    // rest: [][]const u8 → variadic.
+    try testing.expect(shapes[3].multiple);
 }

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -479,32 +479,57 @@ test "scaffolded project builds, runs, and round-trips add command" {
         try expectContains(r.stdout, "TODO: Implement ping");
     }
 
-    // Declarative mode (`--arg`/`--option` JSON) generates a fully-typed command
-    // through the real binary. `multiple` is its own flag, independent of the
-    // element type — covering a multiple string positional, a multiple integer
-    // option, plus enum/numeric/nullable options and a short flag — and the
-    // result must compile and parse under real zcli.
+    // A second command assembled entirely from atomic `add arg`/`add option`
+    // edits — the flag interface that replaced the JSON blob (ADR-0005). This
+    // exercises the full arg shape set (required, optional, variadic) with
+    // `--before` positioning, plus enum/numeric/nullable/multiple options and a
+    // short flag; the result must compile and parse under the real binary.
     {
-        var r = try run(proj, &.{
-            zcli_exe,        "add",                                                                  "command", "users/create",
-            "--description", "Create a user",
-            "--arg",         "{\"name\":\"email\",\"type\":\"[]const u8\"}",
-            "--arg",         "{\"name\":\"names\",\"type\":\"[]const u8\",\"multiple\":true}",
-            "--option",      "{\"name\":\"verbose\",\"type\":\"bool\",\"default\":false,\"short\":\"v\"}",
-            "--option",      "{\"name\":\"format\",\"type\":\"enum { json, yaml }\",\"default\":\"yaml\"}",
-            "--option",      "{\"name\":\"ports\",\"type\":\"u32\",\"multiple\":true}",
-            "--option",      "{\"name\":\"note\",\"type\":\"[]const u8\",\"nullable\":true}",
-        });
+        var r = try run(proj, &.{ zcli_exe, "add", "command", "users/create", "--description", "Create a user" });
         defer r.deinit();
         try expectOk(r);
     }
-    // Optional positionals (`?T = null`) are a distinct generated shape.
     {
-        var r = try run(proj, &.{
-            zcli_exe, "add",                                         "command", "lookup",
-            "--arg",  "{\"name\":\"id\",\"type\":\"[]const u8\"}",
-            "--arg",  "{\"name\":\"revision\",\"type\":\"i64\",\"nullable\":true}",
-        });
+        var r = try run(proj, &.{ zcli_exe, "add", "arg", "users/create", "email", "--type", "[]const u8" });
+        defer r.deinit();
+        try expectOk(r);
+    }
+    {
+        var r = try run(proj, &.{ zcli_exe, "add", "arg", "users/create", "names", "--type", "[]const u8", "--multiple" });
+        defer r.deinit();
+        try expectOk(r);
+    }
+    // An optional positional inserted *before* the variadic (kept valid by
+    // --before: required email, optional age, variadic names).
+    {
+        var r = try run(proj, &.{ zcli_exe, "add", "arg", "users/create", "age", "--type", "u8", "--nullable", "--before", "names" });
+        defer r.deinit();
+        try expectOk(r);
+    }
+    // The ordering rule is enforced live: nothing may follow a variadic.
+    {
+        var r = try run(proj, &.{ zcli_exe, "add", "arg", "users/create", "late", "--type", "[]const u8" });
+        defer r.deinit();
+        try testing.expect(r.exit_code != 0);
+        try expectContains(r.stderr, "must be last");
+    }
+    {
+        var r = try run(proj, &.{ zcli_exe, "add", "option", "users/create", "verbose", "--type", "bool", "--default", "false", "--short", "v" });
+        defer r.deinit();
+        try expectOk(r);
+    }
+    {
+        var r = try run(proj, &.{ zcli_exe, "add", "option", "users/create", "format", "--type", "enum { json, yaml }", "--default", ".yaml" });
+        defer r.deinit();
+        try expectOk(r);
+    }
+    {
+        var r = try run(proj, &.{ zcli_exe, "add", "option", "users/create", "ports", "--type", "u32", "--multiple" });
+        defer r.deinit();
+        try expectOk(r);
+    }
+    {
+        var r = try run(proj, &.{ zcli_exe, "add", "option", "users/create", "note", "--type", "[]const u8", "--nullable" });
         defer r.deinit();
         try expectOk(r);
     }
@@ -514,8 +539,8 @@ test "scaffolded project builds, runs, and round-trips add command" {
         try expectOk(r);
     }
     {
-        // Multiple-string positional, multiple-integer option, short flag, enum.
-        var r = try run(proj, &.{ "./zig-out/bin/demo", "users", "create", "alice@example.com", "x", "y", "-v", "--format", "json", "--ports", "8080", "--ports", "9090" });
+        // required + optional + variadic positionals, short flag, enum, multiple option.
+        var r = try run(proj, &.{ "./zig-out/bin/demo", "users", "create", "alice@example.com", "5", "x", "y", "-v", "--format", "json", "--ports", "8080", "--ports", "9090" });
         defer r.deinit();
         try expectOk(r);
         try expectContains(r.stdout, "TODO: Implement users create");


### PR DESCRIPTION
## Summary

Completes the scaffolding centerpiece (ADR-0005): positional arguments are now authored with the **same in-file splice engine** as options (shipped in #35), and the old JSON-blob bulk interface is **gone**.

### New command

```
add arg <cmd> <name> --type <T> [--multiple] [--nullable] [--before <name>] [--after <name>] [-d <desc>]
```

Positionals have no default and no short flag: `--nullable` makes one optional, its absence makes it required, and `--multiple` is the `[]const u8` varargs tail. Placement reuses the splice engine's `Anchor` — append by default, `--before`/`--after <name>` to position.

### Ordering validated against the real file, before any write

A new `splice.fieldShapes` reader classifies each existing field (name + optional + variadic) straight from the AST — the same analysis `tree.zig` uses for read-back. `add arg` builds the *resulting* order with the new arg spliced in at its anchor and enforces the ADR-0005 rules, erroring clearly and naming both fields:

```
Error: required argument 'extra' cannot follow optional argument 'count'
Error: a multiple argument must be last, but 'late' would follow 'names'
```

### Removed the JSON front-end

Per ADR-0005: `declarative()`, `parseArgJson`/`parseOptJson` + their JSON helpers, the `--arg`/`--option` flags and their meta/examples on `add command`, and the now-dead `validateArg`/`validateOpt`. `add command` scaffolds the *shell*; args/options are added afterward with `add arg`/`add option` (scripted/AI) or the interactive **wizard** (kept unchanged). The shared `ArgSpec`/`OptSpec` model and all rendering helpers stay in `scaffold`; the `enumHasMember`/`isSupportedArrayElem` tests moved to `spec.zig` alongside their code.

`add command foo --arg '{}'` now returns `OptionUnknown`, confirming the blob is gone.

## Tests

- **39/39 unit** — arg `buildSpec` rules (multiple-must-be-string, multiple+nullable contradiction), ordering validation (required-after-optional, nothing-after-variadic, unknown-anchor, valid `--before`), and `fieldShapes` classification.
- **12/12 e2e** — the round-trip now assembles a `users/create` command **entirely from atomic `add arg`/`add option` calls** (required + optional-via-`--before` + variadic positionals; enum/multiple/nullable options; short flag), asserts the **live ordering rejection**, then rebuilds and runs the binary.

Net: `command.zig` −282 lines (JSON removal), `arg.zig` +293, splice/spec grow by the `fieldShapes` reader + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)