### PR TITLE
rm option / rm arg — the splice-out inverse (ADR-0005)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -41,8 +41,10 @@ sequence. Each PR references the ADR carrying its rationale. Ordered by dependen
   real file via a new `splice.fieldShapes` reader, erroring clearly before any write. Deleted
   the JSON front-end (`declarative`/`parseArgJson`/`parseOptJson` + `--arg`/`--option` on
   `add command`) and the now-dead `validateArg`/`validateOpt`; the wizard + shared spec stay.
-- [ ] **PR: `rm option`/`rm arg`** (ADR-0005) — splice-out; variadic names; error on missing.
-  Shares splice machinery with the previous PR.
+- [x] **PR: `rm option`/`rm arg`** (ADR-0005) — DONE. New `rm` group with `option`/`arg`
+  subcommands. Splice-out (`splice.removeOption`/`removeArg`) computes each field's span +
+  trailing comma/whitespace and cuts it, dropping the emptied `meta.<sub>` block; variadic
+  `names`; batch is atomic — a missing name (`splice.missingFields`) rejects the whole edit.
 - [ ] **PR: `add group`** (grill Q8) — meta-only `index.zig` by default; `--with-landing`
   for a custom execute + test.
 - [ ] **PR: `add plugin` + `init` sets `plugins_dir`** (ADR-0006) — convention discovery,

--- a/projects/zcli/build.zig
+++ b/projects/zcli/build.zig
@@ -111,6 +111,8 @@ pub fn build(b: *std.Build) void {
         "src/commands/add/command.zig",
         "src/commands/add/option.zig",
         "src/commands/add/arg.zig",
+        "src/commands/rm/option.zig",
+        "src/commands/rm/arg.zig",
     };
     for (command_test_files) |path| {
         const mod = b.addModule(b.fmt("test-{s}", .{path}), .{

--- a/projects/zcli/src/commands/rm/arg.zig
+++ b/projects/zcli/src/commands/rm/arg.zig
@@ -1,0 +1,104 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
+const ztheme = zcli.ztheme;
+
+const scaffold = @import("scaffold");
+const spec = scaffold.spec;
+const splice = scaffold.splice;
+
+pub const meta = .{
+    .description = "Remove one or more positional arguments from an existing command",
+    .examples = &.{
+        "rm arg users/create age",
+        "rm arg deploy target env",
+    },
+    .args = .{
+        .command = "Target command path (e.g. 'users/create')",
+        .names = "One or more argument names to remove",
+    },
+};
+
+pub const Args = struct {
+    command: []const u8,
+    names: [][]const u8,
+};
+
+pub const Options = struct {};
+
+/// Maximum bytes read from a command source file before splicing.
+const max_source_bytes = 1024 * 1024;
+
+pub fn execute(args: Args, _: Options, context: *Context) !void {
+    var arena_state = std.heap.ArenaAllocator.init(context.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const io = context.io.io;
+    const stderr = context.stderr();
+
+    std.Io.Dir.cwd().access(io, "src/commands", .{}) catch {
+        try stderr.print("Error: Not in a zcli project directory\n", .{});
+        try stderr.print("Run this command from the root of your zcli project (where build.zig is)\n", .{});
+        return error.NotInZcliProject;
+    };
+
+    if (args.names.len == 0) {
+        try stderr.print("Error: name at least one argument to remove\n", .{});
+        return error.MissingName;
+    }
+
+    const parts = spec.parsePath(arena, args.command) catch {
+        try stderr.print("Error: Invalid command path: '{s}'\n", .{args.command});
+        return error.InvalidCommandPath;
+    };
+    const file_path = try spec.buildFilePath(arena, parts);
+
+    // Normalize names the same way the fields were stored (kebab → snake).
+    const names = try arena.alloc([]const u8, args.names.len);
+    for (args.names, 0..) |raw, i| {
+        names[i] = spec.normalizeName(arena, raw) catch |err| {
+            try stderr.print("Error: Invalid argument name '{s}': {s}\n", .{ raw, @errorName(err) });
+            return err;
+        };
+    }
+
+    const raw = std.Io.Dir.cwd().readFileAlloc(io, file_path, arena, .limited(max_source_bytes)) catch {
+        try stderr.print("Error: Command not found: {s}\n", .{file_path});
+        return error.CommandNotFound;
+    };
+    var source = try arena.dupeZ(u8, raw);
+
+    // Reject the whole batch if any name is absent — never partially edit.
+    // (Removal only relaxes ordering constraints, so no re-validation is needed.)
+    const missing = try splice.missingFields(arena, source, "Args", names);
+    if (missing.len > 0) {
+        try stderr.print("Error: {s} has no argument named ", .{file_path});
+        for (missing, 0..) |m, i| {
+            if (i > 0) try stderr.print(", ", .{});
+            try stderr.print("'{s}'", .{m});
+        }
+        try stderr.print("\n", .{});
+        return error.FieldNotFound;
+    }
+
+    for (names) |name| {
+        const updated = try splice.removeArg(arena, source, name);
+        source = try arena.dupeZ(u8, updated);
+    }
+
+    var file = try std.Io.Dir.cwd().createFile(io, file_path, .{});
+    defer file.close(io);
+    try file.writeStreamingAll(io, source);
+
+    try finish(context.stdout(), &context.theme, file_path, names.len);
+}
+
+fn finish(w: *std.Io.Writer, theme: *const ztheme.Theme, file_path: []const u8, count: usize) !void {
+    try w.writeAll("\n  ");
+    var buf: [512]u8 = undefined;
+    const plural: []const u8 = if (count == 1) "" else "s";
+    const line = std.fmt.bufPrint(&buf, "\u{2714} Removed {d} argument{s} from {s}", .{ count, plural, file_path }) catch "\u{2714} Removed";
+    try ztheme.theme(line).success().render(w, theme);
+    try w.writeAll("\n");
+}

--- a/projects/zcli/src/commands/rm/index.zig
+++ b/projects/zcli/src/commands/rm/index.zig
@@ -1,0 +1,3 @@
+pub const meta = .{
+    .description = "Remove args and options from an existing command",
+};

--- a/projects/zcli/src/commands/rm/option.zig
+++ b/projects/zcli/src/commands/rm/option.zig
@@ -1,0 +1,103 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
+const ztheme = zcli.ztheme;
+
+const scaffold = @import("scaffold");
+const spec = scaffold.spec;
+const splice = scaffold.splice;
+
+pub const meta = .{
+    .description = "Remove one or more options from an existing command",
+    .examples = &.{
+        "rm option users/create verbose",
+        "rm option deploy region retries",
+    },
+    .args = .{
+        .command = "Target command path (e.g. 'users/create')",
+        .names = "One or more option names to remove",
+    },
+};
+
+pub const Args = struct {
+    command: []const u8,
+    names: [][]const u8,
+};
+
+pub const Options = struct {};
+
+/// Maximum bytes read from a command source file before splicing.
+const max_source_bytes = 1024 * 1024;
+
+pub fn execute(args: Args, _: Options, context: *Context) !void {
+    var arena_state = std.heap.ArenaAllocator.init(context.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const io = context.io.io;
+    const stderr = context.stderr();
+
+    std.Io.Dir.cwd().access(io, "src/commands", .{}) catch {
+        try stderr.print("Error: Not in a zcli project directory\n", .{});
+        try stderr.print("Run this command from the root of your zcli project (where build.zig is)\n", .{});
+        return error.NotInZcliProject;
+    };
+
+    if (args.names.len == 0) {
+        try stderr.print("Error: name at least one option to remove\n", .{});
+        return error.MissingName;
+    }
+
+    const parts = spec.parsePath(arena, args.command) catch {
+        try stderr.print("Error: Invalid command path: '{s}'\n", .{args.command});
+        return error.InvalidCommandPath;
+    };
+    const file_path = try spec.buildFilePath(arena, parts);
+
+    // Normalize names the same way the fields were stored (kebab → snake).
+    const names = try arena.alloc([]const u8, args.names.len);
+    for (args.names, 0..) |raw, i| {
+        names[i] = spec.normalizeName(arena, raw) catch |err| {
+            try stderr.print("Error: Invalid option name '{s}': {s}\n", .{ raw, @errorName(err) });
+            return err;
+        };
+    }
+
+    const raw = std.Io.Dir.cwd().readFileAlloc(io, file_path, arena, .limited(max_source_bytes)) catch {
+        try stderr.print("Error: Command not found: {s}\n", .{file_path});
+        return error.CommandNotFound;
+    };
+    var source = try arena.dupeZ(u8, raw);
+
+    // Reject the whole batch if any name is absent — never partially edit.
+    const missing = try splice.missingFields(arena, source, "Options", names);
+    if (missing.len > 0) {
+        try stderr.print("Error: {s} has no option named ", .{file_path});
+        for (missing, 0..) |m, i| {
+            if (i > 0) try stderr.print(", ", .{});
+            try stderr.print("'{s}'", .{m});
+        }
+        try stderr.print("\n", .{});
+        return error.FieldNotFound;
+    }
+
+    for (names) |name| {
+        const updated = try splice.removeOption(arena, source, name);
+        source = try arena.dupeZ(u8, updated);
+    }
+
+    var file = try std.Io.Dir.cwd().createFile(io, file_path, .{});
+    defer file.close(io);
+    try file.writeStreamingAll(io, source);
+
+    try finish(context.stdout(), &context.theme, file_path, names.len);
+}
+
+fn finish(w: *std.Io.Writer, theme: *const ztheme.Theme, file_path: []const u8, count: usize) !void {
+    try w.writeAll("\n  ");
+    var buf: [512]u8 = undefined;
+    const plural: []const u8 = if (count == 1) "" else "s";
+    const line = std.fmt.bufPrint(&buf, "\u{2714} Removed {d} option{s} from {s}", .{ count, plural, file_path }) catch "\u{2714} Removed";
+    try ztheme.theme(line).success().render(w, theme);
+    try w.writeAll("\n");
+}

--- a/projects/zcli/src/scaffold/splice.zig
+++ b/projects/zcli/src/scaffold/splice.zig
@@ -17,6 +17,7 @@ pub const SpliceError = error{
     SubNotStruct,
     AnchorNotFound,
     DuplicateField,
+    FieldNotFound,
 };
 
 /// Where to place a new field among existing ones.
@@ -67,6 +68,24 @@ fn ensureNoField(arena: std.mem.Allocator, source: [:0]const u8, container: []co
     for (try fieldNames(arena, source, container)) |existing| {
         if (std.mem.eql(u8, existing, name)) return SpliceError.DuplicateField;
     }
+}
+
+/// The `targets` that are not fields of `container`, in the given order. Empty
+/// slice → all present. Lets a bulk `rm` reject the whole batch before editing.
+pub fn missingFields(arena: std.mem.Allocator, source: [:0]const u8, container: []const u8, targets: []const []const u8) ![]const []const u8 {
+    const existing = try fieldNames(arena, source, container);
+    var missing = std.ArrayList([]const u8).empty;
+    for (targets) |t| {
+        var found = false;
+        for (existing) |e| {
+            if (std.mem.eql(u8, e, t)) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) try missing.append(arena, t);
+    }
+    return missing.items;
 }
 
 /// The ordering-relevant shape of an existing `Args`/`Options` field.
@@ -155,6 +174,97 @@ pub fn insertMetaEntry(arena: std.mem.Allocator, source: [:0]const u8, sub: []co
     // Absent → append `.sub = .{ entry }` as a new meta field.
     const block = try std.fmt.allocPrint(arena, ".{s} = .{{\n        {s},\n    }}", .{ sub, entry_text });
     return spliceMembers(arena, &ast, source, si.ast.fields, ast.lastToken(init), block, "    ", .append, initFieldName);
+}
+
+// ---------------------------------------------------------------------------
+// Removal (the splice-out inverse of insert*)
+// ---------------------------------------------------------------------------
+
+/// Remove an option from a command's source: its field in `Options` and its
+/// entry in `meta.options`. Errors if the field does not exist; a missing meta
+/// entry is tolerated (the struct field is the source of truth).
+pub fn removeOption(arena: std.mem.Allocator, source: [:0]const u8, name: []const u8) ![]u8 {
+    const without_field = try removeStructField(arena, source, "Options", name);
+    return removeMetaEntry(arena, try arena.dupeZ(u8, without_field), "options", name);
+}
+
+/// Remove an argument from a command's source: its field in `Args` and its entry
+/// in `meta.args`. Errors if the field does not exist.
+pub fn removeArg(arena: std.mem.Allocator, source: [:0]const u8, name: []const u8) ![]u8 {
+    const without_field = try removeStructField(arena, source, "Args", name);
+    return removeMetaEntry(arena, try arena.dupeZ(u8, without_field), "args", name);
+}
+
+/// Remove the `name` field from `pub const <container> = struct {...}`.
+fn removeStructField(arena: std.mem.Allocator, source: [:0]const u8, container: []const u8, name: []const u8) ![]u8 {
+    var ast = try Ast.parse(arena, source, .zig);
+    const init = findDeclInit(&ast, container) orelse return SpliceError.ContainerNotFound;
+    var buf: [2]Ast.Node.Index = undefined;
+    const cd = ast.fullContainerDecl(&buf, init) orelse return SpliceError.NotAStruct;
+
+    for (cd.ast.members) |m| {
+        if (std.mem.eql(u8, memberName(&ast, m), name)) {
+            return cutSpan(arena, source, memberSpan(&ast, source, ast.firstToken(m), ast.lastToken(m)));
+        }
+    }
+    return SpliceError.FieldNotFound;
+}
+
+/// Remove the `.name` entry from `meta.<sub> = .{...}`. If it was the only entry,
+/// the whole `.<sub> = .{...}` meta field is removed. A missing block or entry is
+/// tolerated (no-op) — the struct field, not the meta, defines the field.
+fn removeMetaEntry(arena: std.mem.Allocator, source: [:0]const u8, sub: []const u8, name: []const u8) ![]u8 {
+    var ast = try Ast.parse(arena, source, .zig);
+    const init = findDeclInit(&ast, "meta") orelse return SpliceError.NoMeta;
+    var buf: [2]Ast.Node.Index = undefined;
+    const si = ast.fullStructInit(&buf, init) orelse return SpliceError.MetaNotStruct;
+
+    for (si.ast.fields) |field| {
+        if (!std.mem.eql(u8, initFieldName(&ast, field), sub)) continue;
+
+        var b2: [2]Ast.Node.Index = undefined;
+        const inner = ast.fullStructInit(&b2, field) orelse return SpliceError.SubNotStruct;
+
+        // Last entry → drop the whole `.sub = .{...}` meta field.
+        if (inner.ast.fields.len == 1 and std.mem.eql(u8, initFieldName(&ast, inner.ast.fields[0]), name)) {
+            return cutSpan(arena, source, metaFieldSpan(&ast, source, field));
+        }
+        for (inner.ast.fields) |entry| {
+            if (std.mem.eql(u8, initFieldName(&ast, entry), name)) {
+                return cutSpan(arena, source, metaFieldSpan(&ast, source, entry));
+            }
+        }
+        break; // block found, entry absent → tolerate
+    }
+    return arena.dupe(u8, source); // block/entry absent → unchanged
+}
+
+/// The byte range to cut for a struct field: from its first token through its
+/// trailing comma, extended over the surrounding same-line whitespace and the
+/// trailing newline so the whole line is removed cleanly.
+fn memberSpan(ast: *Ast, source: [:0]const u8, first: Ast.TokenIndex, last: Ast.TokenIndex) [2]usize {
+    var lo = tokStart(ast, first);
+    while (lo > 0 and (source[lo - 1] == ' ' or source[lo - 1] == '\t')) lo -= 1;
+
+    var hi = tokEnd(ast, last);
+    if (ast.tokens.items(.tag)[last + 1] == .comma) hi = tokEnd(ast, last + 1);
+    while (hi < source.len and (source[hi] == ' ' or source[hi] == '\t')) hi += 1;
+    if (hi < source.len and source[hi] == '\n') hi += 1;
+
+    return .{ lo, hi };
+}
+
+/// Like `memberSpan` but for a `meta` struct-init field, whose logical start is
+/// the leading `.` (three tokens before the value: `.` `name` `=`).
+fn metaFieldSpan(ast: *Ast, source: [:0]const u8, field: Ast.Node.Index) [2]usize {
+    return memberSpan(ast, source, ast.firstToken(field) - 3, ast.lastToken(field));
+}
+
+fn cutSpan(arena: std.mem.Allocator, source: [:0]const u8, span: [2]usize) ![]u8 {
+    var out = std.ArrayList(u8).empty;
+    try out.appendSlice(arena, source[0..span[0]]);
+    try out.appendSlice(arena, source[span[1]..]);
+    return out.items;
 }
 
 // ---------------------------------------------------------------------------
@@ -358,6 +468,76 @@ test "insertArg appends and positions with before/after" {
     const ci = std.mem.indexOf(u8, before, "count: ?u32 = null").?;
     const ni = std.mem.indexOf(u8, before, "name: []const u8").?;
     try testing.expect(ci < ni); // count spliced before name
+}
+
+test "removeOption strips the field and its meta entry, preserving execute" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // Build a command with two options, then remove one.
+    const one = try insertOption(a, shell, .{
+        .name = "limit",
+        .elem_type = "u32",
+        .multiple = false,
+        .nullable = false,
+        .default_expr = "10",
+        .description = "Max",
+    });
+    const two = try insertOption(a, try a.dupeZ(u8, one), .{
+        .name = "verbose",
+        .elem_type = "bool",
+        .multiple = false,
+        .nullable = false,
+        .default_expr = "false",
+        .description = "Loud",
+    });
+
+    const out = try removeOption(a, try a.dupeZ(u8, two), "limit");
+    try expectParses(a, out);
+    try testing.expect(std.mem.indexOf(u8, out, "limit") == null); // field + meta entry gone
+    try testing.expect(std.mem.indexOf(u8, out, "verbose: bool = false,") != null); // sibling kept
+    try testing.expect(std.mem.indexOf(u8, out, "author's business logic") != null);
+}
+
+test "removing the only option drops the emptied meta.options block" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const one = try insertOption(a, shell, .{
+        .name = "limit",
+        .elem_type = "u32",
+        .multiple = false,
+        .nullable = false,
+        .default_expr = "10",
+        .description = "Max",
+    });
+    const out = try removeOption(a, try a.dupeZ(u8, one), "limit");
+    try expectParses(a, out);
+    try testing.expect(std.mem.indexOf(u8, out, ".options") == null); // whole meta block removed
+    try testing.expect(std.mem.indexOf(u8, out, "limit") == null); // field gone; Options now empty
+}
+
+test "removeArg strips the field and keeps ordering of the rest" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const one = try insertArg(a, shell, .{ .name = "name", .elem_type = "[]const u8", .multiple = false, .nullable = false, .description = "Who" }, .append);
+    const two = try insertArg(a, try a.dupeZ(u8, one), .{ .name = "count", .elem_type = "u32", .multiple = false, .nullable = true, .description = "" }, .append);
+
+    const out = try removeArg(a, try a.dupeZ(u8, two), "name");
+    try expectParses(a, out);
+    try testing.expect(std.mem.indexOf(u8, out, "name:") == null);
+    try testing.expect(std.mem.indexOf(u8, out, "count: ?u32 = null,") != null);
+}
+
+test "removing an absent field errors" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    try testing.expectError(SpliceError.FieldNotFound, removeOption(a, shell, "ghost"));
 }
 
 test "duplicate field is rejected" {

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -324,9 +324,9 @@ test "release --dry-run previews without creating a tag" {
     }
 
     var r = try run(tmp.dir, &.{
-        zcli_exe,        "release", "patch",
-        "--dry-run",     "--skip-checks", "--skip-tests",
-        "--message",     "test notes",
+        zcli_exe,    "release",       "patch",
+        "--dry-run", "--skip-checks", "--skip-tests",
+        "--message", "test notes",
     });
     defer r.deinit();
     try expectOk(r);
@@ -541,6 +541,41 @@ test "scaffolded project builds, runs, and round-trips add command" {
     {
         // required + optional + variadic positionals, short flag, enum, multiple option.
         var r = try run(proj, &.{ "./zig-out/bin/demo", "users", "create", "alice@example.com", "5", "x", "y", "-v", "--format", "json", "--ports", "8080", "--ports", "9090" });
+        defer r.deinit();
+        try expectOk(r);
+        try expectContains(r.stdout, "TODO: Implement users create");
+    }
+
+    // `rm option`/`rm arg` splice fields back out (the inverse editor). A bulk
+    // removal that names a missing field rejects the whole batch and edits
+    // nothing; the valid removals then splice out cleanly and the result must
+    // still compile and run under the real binary.
+    {
+        var r = try run(proj, &.{ zcli_exe, "rm", "option", "users/create", "note", "ghost" });
+        defer r.deinit();
+        try testing.expect(r.exit_code != 0);
+        try expectContains(r.stderr, "has no option named 'ghost'");
+    }
+    {
+        var r = try run(proj, &.{ zcli_exe, "rm", "option", "users/create", "note", "ports" });
+        defer r.deinit();
+        try expectOk(r);
+        try expectContains(r.stdout, "Removed 2 options");
+    }
+    {
+        // Remove the optional positional; email + variadic names remain valid.
+        var r = try run(proj, &.{ zcli_exe, "rm", "arg", "users/create", "age" });
+        defer r.deinit();
+        try expectOk(r);
+    }
+    {
+        var r = try run(proj, &.{ "zig", "build" });
+        defer r.deinit();
+        try expectOk(r);
+    }
+    {
+        // The removed --ports/--note flags are gone; the trimmed command still runs.
+        var r = try run(proj, &.{ "./zig-out/bin/demo", "users", "create", "alice@example.com", "x", "y", "-v", "--format", "json" });
         defer r.deinit();
         try expectOk(r);
         try expectContains(r.stdout, "TODO: Implement users create");


### PR DESCRIPTION
## Summary

Completes the arg/option authoring family (ADR-0005): a new **`rm`** group whose `option`/`arg` subcommands remove fields from an existing command via the **same** AST-guided, in-file editor — the inverse of `add option`/`add arg` (#35, #37).

### Splice engine gains removal (`scaffold/splice.zig`)

- **`removeOption`/`removeArg`** strip a field from the `Options`/`Args` struct *and* its entry from `meta.options`/`meta.args`. A field's cut span is its first token through its trailing comma, extended over the surrounding same-line whitespace and newline — so the whole line goes and **nothing else moves** (`execute()`, comments, formatting untouched). Removing the last meta entry drops the emptied `.<sub> = .{...}` block entirely. Every removal test asserts the result **re-parses**.
- **`missingFields(source, container, targets)`** reports absent names so a bulk removal can reject the whole batch before editing anything.

### Commands

```
rm option <cmd> <name...>
rm arg    <cmd> <name...>
```

Variadic names (bulk removal). The struct field is the source of truth — a missing meta entry is tolerated, an absent field errors and names it. The batch is **atomic**: one unknown name edits nothing. `rm arg` needs no ordering re-check (removal only relaxes constraints).

Live behavior, read back through `tree`:

```
# before:  options: [--region:[]const u8] [--retries/-r:u32=3] [--verbose]
$ zcli rm option deploy region verbose      →  ✔ Removed 2 options
# after:   options: [--retries/-r:u32=3]

$ zcli rm option deploy region ghost        →  Error: … has no option named 'ghost'   (region untouched)
```

## Tests

- **43/43 unit** — removal re-parse across strip / last-entry-drops-block / absent-field cases, sibling-preservation, and `missingFields`.
- **12/12 e2e** — the round-trip now removes options (including a **rejected partial batch**) and the optional positional, **rebuilds, and reruns** the trimmed command under the real binary.

Design note: `rm/option.zig` and `rm/arg.zig` are self-contained parallels (matching the `add/option`+`add/arg` precedent); the shared *logic* — span cutting, `missingFields`, the block-collapse — lives in `scaffold`, not duplicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)