### PR TITLE
add group — scaffold a command group's index.zig (grill Q8)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -45,8 +45,11 @@ sequence. Each PR references the ADR carrying its rationale. Ordered by dependen
   subcommands. Splice-out (`splice.removeOption`/`removeArg`) computes each field's span +
   trailing comma/whitespace and cuts it, dropping the emptied `meta.<sub>` block; variadic
   `names`; batch is atomic — a missing name (`splice.missingFields`) rejects the whole edit.
-- [ ] **PR: `add group`** (grill Q8) — meta-only `index.zig` by default; `--with-landing`
-  for a custom execute + test.
+- [x] **PR: `add group`** (grill Q8) — DONE. `add group <path> [-d] [--with-landing]` writes a
+  meta-only `index.zig` (pure group) by default; `--with-landing` adds an empty-`Args` `execute`
+  (optional group — positionals would clash with subcommand names). Describes an existing
+  undescribed group; refuses an already-described one. The `add command` group-hint now points
+  at `zcli add group <path>/... -d`. (The co-located test rides the deferred Q7 testing PR.)
 - [ ] **PR: `add plugin` + `init` sets `plugins_dir`** (ADR-0006) — convention discovery,
   no build.zig mutation on the happy path; guided skeleton + commented hook catalog.
 - [ ] **PR: `mv` + `rm`** (grill Q10) — whole-file restructure, carry the co-located test,

--- a/projects/zcli/build.zig
+++ b/projects/zcli/build.zig
@@ -111,6 +111,7 @@ pub fn build(b: *std.Build) void {
         "src/commands/add/command.zig",
         "src/commands/add/option.zig",
         "src/commands/add/arg.zig",
+        "src/commands/add/group.zig",
         "src/commands/rm/option.zig",
         "src/commands/rm/arg.zig",
     };

--- a/projects/zcli/src/commands/add/command.zig
+++ b/projects/zcli/src/commands/add/command.zig
@@ -703,7 +703,7 @@ fn finish(
         var buf: [512]u8 = undefined;
         const line = std.fmt.bufPrint(&buf, "Note: new group '{s}' has no description.", .{g.name}) catch "Note: new group has no description.";
         try ztheme.theme(line).warning().render(w, theme);
-        try w.print("\n    Add {s} with `pub const meta = .{{ .description = \"...\" }};` to describe it.\n", .{g.index_path});
+        try w.print("\n    Describe it with `zcli add group {s} -d \"...\"`.\n", .{g.name});
     }
 
     try w.writeAll("\n\n  Next steps\n");
@@ -864,10 +864,9 @@ fn fileExists(io: std.Io, path: []const u8) bool {
 /// fresh directory has no `index.zig`, it has no description — the caller hints
 /// how to give it one (ADR-0007: a group's description comes from index meta).
 const NewGroup = struct {
-    /// The group's command path, space-joined (e.g. "users" or "gh add").
+    /// The group's path, slash-joined (e.g. "users" or "gh/pr") — the form
+    /// `zcli add group` accepts as a single argument.
     name: []const u8,
-    /// Where a describing `index.zig` would live.
-    index_path: []const u8,
 };
 
 /// Write the command file, creating any missing parent group directories.
@@ -894,8 +893,7 @@ fn writeCommandFile(
             };
             // createDir succeeded, so this group is brand new and undescribed.
             try new_groups.append(arena, .{
-                .name = try std.mem.join(arena, " ", parts[0 .. i + 1]),
-                .index_path = try std.fmt.allocPrint(arena, "{s}/index.zig", .{dir.items}),
+                .name = try std.mem.join(arena, "/", parts[0 .. i + 1]),
             });
         }
     }

--- a/projects/zcli/src/commands/add/group.zig
+++ b/projects/zcli/src/commands/add/group.zig
@@ -1,0 +1,206 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
+const ztheme = zcli.ztheme;
+
+const scaffold = @import("scaffold");
+const spec = scaffold.spec;
+
+pub const meta = .{
+    .description = "Add a command group (a directory of subcommands) to your project",
+    .examples = &.{
+        "add group users --description \"Manage users\"",
+        "add group gh/pr -d \"Work with pull requests\"",
+        "add group server --with-landing -d \"Run and manage the server\"",
+    },
+    .args = .{
+        .path = "Group path (e.g. 'users' or 'gh/pr')",
+    },
+    .options = .{
+        .description = .{ .description = "Description of the group (shown in help and tree)", .short = 'd' },
+        .with_landing = .{ .description = "Also scaffold a runnable landing command (execute) for the group itself" },
+    },
+};
+
+pub const Args = struct {
+    path: []const u8,
+};
+
+pub const Options = struct {
+    description: ?[]const u8 = null,
+    with_landing: bool = false,
+};
+
+pub fn execute(args: Args, options: Options, context: *Context) !void {
+    var arena_state = std.heap.ArenaAllocator.init(context.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const io = context.io.io;
+    const stderr = context.stderr();
+
+    std.Io.Dir.cwd().access(io, "src/commands", .{}) catch {
+        try stderr.print("Error: Not in a zcli project directory\n", .{});
+        try stderr.print("Run this command from the root of your zcli project (where build.zig is)\n", .{});
+        return error.NotInZcliProject;
+    };
+
+    const parts = spec.parsePath(arena, args.path) catch {
+        try stderr.print("Error: Invalid group path: '{s}'\n", .{args.path});
+        return error.InvalidCommandPath;
+    };
+
+    // A group is a directory of subcommands, described by its index.zig.
+    const dir = try std.fmt.allocPrint(arena, "src/commands/{s}", .{try join(arena, parts, "/")});
+    const index_path = try std.fmt.allocPrint(arena, "{s}/index.zig", .{dir});
+
+    const cwd = std.Io.Dir.cwd();
+    if (fileExists(io, index_path)) {
+        try stderr.print("Error: group already described: {s}\n", .{index_path});
+        return error.GroupAlreadyExists;
+    }
+
+    // Create the group directory (and any missing parents).
+    var acc = std.ArrayList(u8).empty;
+    try acc.appendSlice(arena, "src/commands");
+    for (parts) |segment| {
+        try acc.append(arena, '/');
+        try acc.appendSlice(arena, segment);
+        cwd.createDir(io, acc.items, .default_dir) catch |err| switch (err) {
+            error.PathAlreadyExists => {},
+            else => return err,
+        };
+    }
+
+    const description = options.description orelse "TODO: Add description";
+    const content = try generateIndex(arena, parts, description, options.with_landing);
+
+    var file = try cwd.createFile(io, index_path, .{});
+    defer file.close(io);
+    try file.writeStreamingAll(io, content);
+
+    try finish(context.stdout(), &context.theme, parts, index_path, options.with_landing);
+}
+
+/// The `index.zig` source for a group. Meta-only by default (a pure group, no
+/// execute); with `--with-landing` it also gets an empty `Options` and an
+/// `execute` so the group runs on its own. A landing group must have no `Args`
+/// fields (positionals would clash with subcommand names), so `Args` is empty.
+fn generateIndex(arena: std.mem.Allocator, parts: []const []const u8, description: []const u8, with_landing: bool) ![]u8 {
+    var aw = std.Io.Writer.Allocating.init(arena);
+    const w = &aw.writer;
+
+    if (with_landing) {
+        try w.writeAll(
+            \\const std = @import("std");
+            \\const zcli = @import("zcli");
+            \\const Context = @import("command_registry").Context;
+            \\
+            \\
+        );
+    }
+
+    try w.writeAll("pub const meta = .{\n    .description = \"");
+    try spec.writeEscaped(w, description);
+    try w.writeAll("\",\n};\n");
+
+    if (with_landing) {
+        try w.writeAll(
+            \\
+            \\// A command group with subcommands must have an empty Args struct;
+            \\// positional arguments would be ambiguous with subcommand names.
+            \\pub const Args = struct {};
+            \\
+            \\pub const Options = struct {};
+            \\
+            \\pub fn execute(args: Args, options: Options, context: *Context) !void {
+            \\    _ = args;
+            \\    _ = options;
+            \\
+            \\    const stdout = context.stdout();
+            \\    try stdout.print("TODO: Implement
+        );
+        try w.writeByte(' ');
+        try writePath(w, parts);
+        try w.writeAll(" (run with a subcommand for more)\\n\", .{});\n}\n");
+    }
+
+    return aw.written();
+}
+
+fn finish(w: *std.Io.Writer, theme: *const ztheme.Theme, parts: []const []const u8, index_path: []const u8, with_landing: bool) !void {
+    try w.writeAll("\n  ");
+    var buf: [512]u8 = undefined;
+    const line = std.fmt.bufPrint(&buf, "\u{2714} Created group {s}", .{index_path}) catch "\u{2714} Created group";
+    try ztheme.theme(line).success().render(w, theme);
+
+    try w.writeAll("\n\n  Next steps\n");
+    try w.writeAll("    1. Add a subcommand: zcli add command ");
+    try writePath(w, parts);
+    try w.writeAll("/<name>\n");
+    if (with_landing) {
+        try w.writeAll("    2. Implement the landing execute() in ");
+        try w.writeAll(index_path);
+        try w.writeAll("\n");
+    }
+}
+
+fn writePath(w: *std.Io.Writer, parts: []const []const u8) !void {
+    for (parts, 0..) |p, i| {
+        if (i > 0) try w.writeByte(' ');
+        try w.writeAll(p);
+    }
+}
+
+fn join(arena: std.mem.Allocator, parts: []const []const u8, sep: []const u8) ![]const u8 {
+    return std.mem.join(arena, sep, parts);
+}
+
+fn fileExists(io: std.Io, path: []const u8) bool {
+    std.Io.Dir.cwd().access(io, path, .{}) catch return false;
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const testing = std.testing;
+
+test "generateIndex: meta-only by default" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const src = try generateIndex(a, &.{"users"}, "Manage users", false);
+    try testing.expect(std.mem.indexOf(u8, src, ".description = \"Manage users\"") != null);
+    try testing.expect(std.mem.indexOf(u8, src, "pub fn execute") == null); // pure group
+    try expectParses(a, src);
+}
+
+test "generateIndex: with-landing adds an empty-Args execute" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const src = try generateIndex(a, &.{ "gh", "pr" }, "Pull requests", true);
+    try testing.expect(std.mem.indexOf(u8, src, "pub const Args = struct {};") != null); // no positionals
+    try testing.expect(std.mem.indexOf(u8, src, "pub fn execute(args: Args, options: Options") != null);
+    try testing.expect(std.mem.indexOf(u8, src, "TODO: Implement gh pr") != null);
+    try expectParses(a, src);
+}
+
+test "generateIndex: description is escaped" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const src = try generateIndex(a, &.{"x"}, "has \"quotes\"", false);
+    try testing.expect(std.mem.indexOf(u8, src, "\\\"quotes\\\"") != null);
+    try expectParses(a, src);
+}
+
+fn expectParses(arena: std.mem.Allocator, source: []const u8) !void {
+    const ast = try std.zig.Ast.parse(arena, try arena.dupeZ(u8, source), .zig);
+    try testing.expectEqual(@as(usize, 0), ast.errors.len);
+}

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -185,7 +185,7 @@ test "add command creates stubs at the right paths" {
         defer r.deinit();
         try expectOk(r);
         try expectContains(r.stdout, "new group 'users' has no description");
-        try expectContains(r.stdout, "src/commands/users/index.zig");
+        try expectContains(r.stdout, "zcli add group users");
     }
     try testing.expect(fileExists(tmp.dir, "src/commands/users/create.zig"));
 
@@ -208,6 +208,45 @@ test "add command creates stubs at the right paths" {
     // with `tree --show-options`).
     try expectContains(created, "// .aliases =");
     try expectContains(created, "// .hidden =");
+}
+
+test "add group scaffolds meta-only and landing index files" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try makeProjectDirs(tmp.dir);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // Meta-only group (a pure group: index.zig with just a description).
+    {
+        var r = try run(tmp.dir, &.{ zcli_exe, "add", "group", "users", "--description", "Manage users" });
+        defer r.deinit();
+        try expectOk(r);
+    }
+    const idx = try readFile(tmp.dir, a, "src/commands/users/index.zig");
+    try expectContains(idx, ".description = \"Manage users\"");
+    try testing.expect(std.mem.indexOf(u8, idx, "pub fn execute") == null); // pure group
+
+    // Describing an already-described group is refused.
+    {
+        var r = try run(tmp.dir, &.{ zcli_exe, "add", "group", "users", "-d", "again" });
+        defer r.deinit();
+        try testing.expect(r.exit_code != 0);
+        try expectContains(r.stderr, "already described");
+    }
+
+    // A landing group (nested path) gets an empty-Args execute.
+    {
+        var r = try run(tmp.dir, &.{ zcli_exe, "add", "group", "gh/pr", "--with-landing", "-d", "Pull requests" });
+        defer r.deinit();
+        try expectOk(r);
+    }
+    const landing = try readFile(tmp.dir, a, "src/commands/gh/pr/index.zig");
+    try expectContains(landing, "pub const Args = struct {};"); // no positionals
+    try expectContains(landing, "pub fn execute(args: Args, options: Options");
+    try expectContains(landing, "TODO: Implement gh pr");
 }
 
 test "add command outside a project fails clearly" {
@@ -579,6 +618,38 @@ test "scaffolded project builds, runs, and round-trips add command" {
         defer r.deinit();
         try expectOk(r);
         try expectContains(r.stdout, "TODO: Implement users create");
+    }
+
+    // `add group --with-landing` scaffolds a runnable group; with a subcommand
+    // under it, both the group landing and the subcommand must compile and run.
+    {
+        var r = try run(proj, &.{ zcli_exe, "add", "group", "server", "--with-landing", "-d", "Manage the server" });
+        defer r.deinit();
+        try expectOk(r);
+    }
+    {
+        var r = try run(proj, &.{ zcli_exe, "add", "command", "server/status", "-d", "Show status" });
+        defer r.deinit();
+        try expectOk(r);
+    }
+    {
+        var r = try run(proj, &.{ "zig", "build" });
+        defer r.deinit();
+        try expectOk(r);
+    }
+    {
+        // The group runs on its own (landing execute)...
+        var r = try run(proj, &.{ "./zig-out/bin/demo", "server" });
+        defer r.deinit();
+        try expectOk(r);
+        try expectContains(r.stdout, "TODO: Implement server");
+    }
+    {
+        // ...and dispatches to its subcommand.
+        var r = try run(proj, &.{ "./zig-out/bin/demo", "server", "status" });
+        defer r.deinit();
+        try expectOk(r);
+        try expectContains(r.stdout, "TODO: Implement server status");
     }
 }
 


### PR DESCRIPTION
## Summary

New **`add group <path> [--description] [--with-landing]`** — the command the #34 group-hint has been pointing at.

- **Default (meta-only):** writes `src/commands/<path>/index.zig` with just `pub const meta = .{ .description = "…" }` — a *pure group*. Also **describes an existing undescribed group** directory (the primary use case the hint surfaces), and **refuses** a group that already has an `index.zig`.
- **`--with-landing`:** additionally scaffolds an empty-`Args` `execute` so the group runs on its own (an *optional group*). `Args` must be empty — positionals would be ambiguous with subcommand names, which the framework enforces at comptime — so the shell declares `pub const Args = struct {};` explicitly.

### Closing the loop with `add command`

The `add command` group-hint now points straight at the new command instead of describing the file by hand, and its `NewGroup` path is **slash-joined** so the suggestion is copy-pasteable as a single argument:

```
Note: new group 'gh/pr' has no description.
    Describe it with `zcli add group gh/pr -d "..."`.
```

(Dropped the now-unused `index_path` field from `NewGroup`.)

## Live behavior

```
$ zcli add group gh -d "GitHub commands"        →  ✔ Created group src/commands/gh/index.zig
$ zcli add group server --with-landing -d "…"    →  ✔ (index.zig with a runnable execute)
$ zcli add group gh -d "…"                        →  Error: group already described: …/gh/index.zig
```

```
# tree read-back
├── gh (group) [GitHub commands]
├── server (group) [Run the server]
```

## Tests

- **46/46 unit** — `generateIndex` meta-only vs landing shape, description escaping, both re-parse.
- **13/13 e2e** — a fast file-shape test (pure vs landing, already-described refusal) **plus** the slow round-trip now scaffolds a `--with-landing` group with a subcommand, **rebuilds, and runs both** the group landing (`demo server`) and the subcommand (`demo server status`).

Scope note: grill Q8 mentioned "custom execute + test" for `--with-landing`; the co-located **test** rides the deferred Q7 generated-project-testing PR (there's still no `test` step in generated builds), so this ships the execute only — consistent with `add command`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)