### PR TITLE
add plugin + init sets plugins_dir (ADR-0006)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -50,8 +50,12 @@ sequence. Each PR references the ADR carrying its rationale. Ordered by dependen
   (optional group — positionals would clash with subcommand names). Describes an existing
   undescribed group; refuses an already-described one. The `add command` group-hint now points
   at `zcli add group <path>/... -d`. (The co-located test rides the deferred Q7 testing PR.)
-- [ ] **PR: `add plugin` + `init` sets `plugins_dir`** (ADR-0006) — convention discovery,
-  no build.zig mutation on the happy path; guided skeleton + commented hook catalog.
+- [x] **PR: `add plugin` + `init` sets `plugins_dir`** (ADR-0006) — DONE. `init` now emits
+  `.plugins_dir = "src/plugins"` in the generated build.zig, so `add plugin <name> [-d]` just
+  drops `src/plugins/<name>.zig` (auto-discovered by `scanLocalPlugins`, no build.zig mutation).
+  Guided skeleton: one working pass-through `preExecute` + a commented catalog of every other
+  hook with exact signatures; `plugin_id`/`ContextData` commented out. Residual case: on a
+  build.zig lacking `plugins_dir`, it prints the one-line fix (never splices).
 - [ ] **PR: `mv` + `rm`** (grill Q10) — whole-file restructure, carry the co-located test,
   clean emptied group dirs.
 

--- a/projects/zcli/build.zig
+++ b/projects/zcli/build.zig
@@ -112,6 +112,7 @@ pub fn build(b: *std.Build) void {
         "src/commands/add/option.zig",
         "src/commands/add/arg.zig",
         "src/commands/add/group.zig",
+        "src/commands/add/plugin.zig",
         "src/commands/rm/option.zig",
         "src/commands/rm/arg.zig",
     };

--- a/projects/zcli/src/commands/add/plugin.zig
+++ b/projects/zcli/src/commands/add/plugin.zig
@@ -1,0 +1,237 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
+const ztheme = zcli.ztheme;
+
+const scaffold = @import("scaffold");
+const spec = scaffold.spec;
+
+pub const meta = .{
+    .description = "Add a local plugin to your zcli project",
+    .examples = &.{
+        "add plugin telemetry",
+        "add plugin auth -d \"Attach an auth token to every request\"",
+    },
+    .args = .{
+        .name = "Plugin name (snake_case or kebab-case)",
+    },
+    .options = .{
+        .description = .{ .description = "One-line description (used in the file header)", .short = 'd' },
+    },
+};
+
+pub const Args = struct {
+    name: []const u8,
+};
+
+pub const Options = struct {
+    description: ?[]const u8 = null,
+};
+
+/// Maximum bytes read from build.zig when checking for `plugins_dir`.
+const max_source_bytes = 1024 * 1024;
+
+pub fn execute(args: Args, options: Options, context: *Context) !void {
+    var arena_state = std.heap.ArenaAllocator.init(context.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const io = context.io.io;
+    const stderr = context.stderr();
+    const cwd = std.Io.Dir.cwd();
+
+    cwd.access(io, "src/commands", .{}) catch {
+        try stderr.print("Error: Not in a zcli project directory\n", .{});
+        try stderr.print("Run this command from the root of your zcli project (where build.zig is)\n", .{});
+        return error.NotInZcliProject;
+    };
+
+    const name = spec.normalizeName(arena, args.name) catch |err| {
+        try stderr.print("Error: Invalid plugin name '{s}': {s}\n", .{ args.name, @errorName(err) });
+        return err;
+    };
+
+    // Single-file plugin, matching `add command`'s default (the directory form
+    // `plugins/<name>/plugin.zig` remains available for plugins that grow).
+    const file_path = try std.fmt.allocPrint(arena, "src/plugins/{s}.zig", .{name});
+    if (fileExists(io, file_path)) {
+        try stderr.print("Error: plugin already exists: {s}\n", .{file_path});
+        return error.PluginAlreadyExists;
+    }
+
+    cwd.createDir(io, "src/plugins", .default_dir) catch |err| switch (err) {
+        error.PathAlreadyExists => {},
+        else => return err,
+    };
+
+    const description = options.description orelse "TODO: describe this plugin";
+    const content = try generatePlugin(arena, name, description);
+
+    var file = try cwd.createFile(io, file_path, .{});
+    defer file.close(io);
+    try file.writeStreamingAll(io, content);
+
+    try finish(context.stdout(), &context.theme, file_path, hasPluginsDir(arena, io));
+}
+
+/// A guided plugin skeleton (ADR-0006): a header, one working pass-through
+/// `preExecute` hook, and a commented catalog of the remaining hooks with exact
+/// signatures. `plugin_id`/`ContextData` are commented out — a minimal plugin
+/// needs neither (hooks are `@hasDecl`-gated; `plugin_id` is only required
+/// alongside `ContextData`).
+fn generatePlugin(arena: std.mem.Allocator, name: []const u8, description: []const u8) ![]u8 {
+    var aw = std.Io.Writer.Allocating.init(arena);
+    const w = &aw.writer;
+
+    try w.print(
+        \\const std = @import("std");
+        \\const zcli = @import("zcli");
+        \\
+        \\/// The `{s}` plugin — {s}
+        \\///
+        \\/// Plugins shape command execution through optional hooks, each discovered
+        \\/// by name (@hasDecl-gated) — declare only the ones you need. This skeleton
+        \\/// wires a pass-through `preExecute`; uncomment others from the catalog below.
+        \\
+        \\/// Runs before a command's execute(). Return `args` to continue, or `null`
+        \\/// to halt the pipeline (e.g. after handling a global flag yourself).
+        \\pub fn preExecute(context: anytype, args: zcli.ParsedArgs) !?zcli.ParsedArgs {{
+        \\    _ = context;
+        \\    return args;
+        \\}}
+        \\
+    , .{ name, description });
+
+    // The commented catalog is static (no interpolation) except the plugin_id
+    // line at the end, so it is written verbatim.
+    try w.writeAll(
+        \\
+        \\// ===========================================================================
+        \\// Hook catalog — uncomment and implement the ones you need.
+        \\// ===========================================================================
+        \\
+        \\// Rewrite raw argv before global options are parsed (e.g. expand an alias).
+        \\// pub fn preParse(context: anytype, args: []const []const u8) ![]const []const u8 {
+        \\//     _ = context;
+        \\//     return args;
+        \\// }
+        \\
+        \\// Transform args after global options are stripped. Set
+        \\// `continue_processing = false` to stop the pipeline.
+        \\// pub fn transformArgs(context: anytype, args: []const []const u8) !zcli.TransformResult {
+        \\//     _ = context;
+        \\//     return .{ .args = args };
+        \\// }
+        \\
+        \\// Inspect or replace parsed positionals. Return `null` to leave them as-is.
+        \\// pub fn postParse(context: anytype, args: zcli.ParsedArgs) !?zcli.ParsedArgs {
+        \\//     _ = context;
+        \\//     _ = args;
+        \\//     return null;
+        \\// }
+        \\
+        \\// Runs after a command's execute(); `success` is false if it errored.
+        \\// pub fn postExecute(context: anytype, success: bool) !void {
+        \\//     _ = context;
+        \\//     _ = success;
+        \\// }
+        \\
+        \\// Handle an error raised during execution. Return `true` if you handled it
+        \\// (which suppresses the framework's default handling).
+        \\// pub fn onError(context: anytype, err: anyerror) !bool {
+        \\//     _ = context;
+        \\//     _ = err;
+        \\//     return false;
+        \\// }
+        \\
+        \\// Provide and handle global options (available on every command).
+        \\// pub const global_options = [_]zcli.GlobalOption{
+        \\//     zcli.option("verbose", bool, .{ .short = 'v', .default = false, .description = "Verbose output" }),
+        \\// };
+        \\// pub fn handleGlobalOption(context: anytype, name: []const u8, value: anytype) !void {
+        \\//     _ = context;
+        \\//     _ = name;
+        \\//     _ = value;
+        \\// }
+        \\
+        \\// Per-plugin state, reachable as `context.plugins.<plugin_id>`. `plugin_id`
+        \\// is REQUIRED whenever `ContextData` is present (and only then).
+        \\
+    );
+    try w.print("// pub const plugin_id = \"{s}\";\n", .{name});
+    try w.writeAll("// pub const ContextData = struct {};\n");
+
+    return aw.written();
+}
+
+/// Whether build.zig already sets `plugins_dir` (best-effort; on any read error
+/// we assume it does, to avoid a misleading hint).
+fn hasPluginsDir(arena: std.mem.Allocator, io: std.Io) bool {
+    const raw = std.Io.Dir.cwd().readFileAlloc(io, "build.zig", arena, .limited(max_source_bytes)) catch return true;
+    return std.mem.indexOf(u8, raw, "plugins_dir") != null;
+}
+
+fn finish(w: *std.Io.Writer, theme: *const ztheme.Theme, file_path: []const u8, plugins_dir_wired: bool) !void {
+    try w.writeAll("\n  ");
+    var buf: [512]u8 = undefined;
+    const line = std.fmt.bufPrint(&buf, "\u{2714} Created plugin {s}", .{file_path}) catch "\u{2714} Created plugin";
+    try ztheme.theme(line).success().render(w, theme);
+
+    if (!plugins_dir_wired) {
+        // The one residual build.zig case (ADR-0006): no plugins_dir to discover
+        // through. Print the single line to add — not a multi-site splice.
+        try w.writeAll("\n\n  ");
+        try ztheme.theme("Note: your build.zig has no plugins_dir, so this plugin won't be discovered.").warning().render(w, theme);
+        try w.writeAll("\n    Add `.plugins_dir = \"src/plugins\",` to the zcli.generate(...) call.\n");
+    }
+
+    try w.writeAll("\n\n  Next steps\n");
+    try w.print("    1. Implement the preExecute hook (or uncomment others) in {s}\n", .{file_path});
+    try w.writeAll("    2. zig build\n");
+}
+
+fn fileExists(io: std.Io, path: []const u8) bool {
+    std.Io.Dir.cwd().access(io, path, .{}) catch return false;
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const testing = std.testing;
+
+test "generatePlugin: wires a pass-through preExecute and a commented catalog" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const src = try generatePlugin(a, "telemetry", "Track usage");
+    try testing.expect(std.mem.indexOf(u8, src, "The `telemetry` plugin — Track usage") != null);
+    try testing.expect(std.mem.indexOf(u8, src, "pub fn preExecute(context: anytype, args: zcli.ParsedArgs) !?zcli.ParsedArgs") != null);
+    // Catalog hooks are present but commented out.
+    try testing.expect(std.mem.indexOf(u8, src, "// pub fn onError(context: anytype, err: anyerror) !bool") != null);
+    try testing.expect(std.mem.indexOf(u8, src, "// pub const plugin_id = \"telemetry\";") != null);
+    try expectParses(a, src);
+}
+
+test "generatePlugin: only the working hook is uncommented" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const src = try generatePlugin(a, "auth", "x");
+    // Exactly one uncommented `pub fn` (preExecute); the rest are `// pub fn`.
+    var count: usize = 0;
+    var it = std.mem.splitScalar(u8, src, '\n');
+    while (it.next()) |ln| {
+        const t = std.mem.trim(u8, ln, " ");
+        if (std.mem.startsWith(u8, t, "pub fn ")) count += 1;
+    }
+    try testing.expectEqual(@as(usize, 1), count);
+}
+
+fn expectParses(arena: std.mem.Allocator, source: []const u8) !void {
+    const ast = try std.zig.Ast.parse(arena, try arena.dupeZ(u8, source), .zig);
+    try testing.expectEqual(@as(usize, 0), ast.errors.len);
+}

--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -230,6 +230,9 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         \\    const zcli = @import("zcli");
         \\    const cmd_registry = zcli.generate(b, exe, zcli_dep, zcli_module, .{{
         \\        .commands_dir = "src/commands",
+        \\        // Local plugins in src/plugins/ are auto-discovered (add with
+        \\        // `zcli add plugin <name>`). Harmless when the directory is absent.
+        \\        .plugins_dir = "src/plugins",
         \\        .plugins = &.{{
         \\{s}        }},
         \\        .app_name = "{s}",

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -141,6 +141,8 @@ test "init scaffolds a project with the expected files and wiring" {
 
     const build_zig = try readFile(proj, a, "build.zig");
     try expectContains(build_zig, "zcli.generate(");
+    // Local-plugin discovery is wired so `add plugin` needs no build.zig edit.
+    try expectContains(build_zig, ".plugins_dir = \"src/plugins\"");
     // With no TTY, the plugin prompt falls back to its preselected defaults:
     // help, version, and not_found (but not the opt-in plugins like completions).
     try expectContains(build_zig, "zcli.builtin(.help");
@@ -247,6 +249,41 @@ test "add group scaffolds meta-only and landing index files" {
     try expectContains(landing, "pub const Args = struct {};"); // no positionals
     try expectContains(landing, "pub fn execute(args: Args, options: Options");
     try expectContains(landing, "TODO: Implement gh pr");
+}
+
+test "add plugin scaffolds a skeleton and hints when plugins_dir is missing" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try makeProjectDirs(tmp.dir);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // A build.zig that does NOT wire plugins_dir → the command prints the
+    // one-line fix rather than editing build.zig.
+    try tmp.dir.writeFile(io, .{ .sub_path = "build.zig", .data = "pub fn build(b: *std.Build) void { _ = b; }\n" });
+    {
+        var r = try run(tmp.dir, &.{ zcli_exe, "add", "plugin", "telemetry", "-d", "Track usage" });
+        defer r.deinit();
+        try expectOk(r);
+        try expectContains(r.stdout, "won't be discovered");
+        try expectContains(r.stdout, ".plugins_dir = \"src/plugins\",");
+    }
+
+    const src = try readFile(tmp.dir, a, "src/plugins/telemetry.zig");
+    try expectContains(src, "The `telemetry` plugin — Track usage");
+    try expectContains(src, "pub fn preExecute(context: anytype, args: zcli.ParsedArgs)");
+    try expectContains(src, "// pub fn onError(context: anytype, err: anyerror) !bool"); // catalog, commented
+    try expectContains(src, "// pub const plugin_id = \"telemetry\";");
+
+    // A duplicate is refused.
+    {
+        var r = try run(tmp.dir, &.{ zcli_exe, "add", "plugin", "telemetry" });
+        defer r.deinit();
+        try testing.expect(r.exit_code != 0);
+        try expectContains(r.stderr, "already exists");
+    }
 }
 
 test "add command outside a project fails clearly" {
@@ -650,6 +687,30 @@ test "scaffolded project builds, runs, and round-trips add command" {
         defer r.deinit();
         try expectOk(r);
         try expectContains(r.stdout, "TODO: Implement server status");
+    }
+
+    // `add plugin` drops a file into the convention-discovered src/plugins/ dir
+    // (init wired `.plugins_dir`). The generated skeleton must compile and be
+    // auto-discovered on the next build — no build.zig edit — and its
+    // pass-through preExecute must not disturb command output.
+    {
+        var r = try run(proj, &.{ zcli_exe, "add", "plugin", "telemetry", "-d", "Track usage" });
+        defer r.deinit();
+        try expectOk(r);
+        // plugins_dir is wired by init, so no "won't be discovered" hint.
+        try testing.expect(std.mem.indexOf(u8, r.stdout, "won't be discovered") == null);
+    }
+    try testing.expect(fileExists(proj, "src/plugins/telemetry.zig"));
+    {
+        var r = try run(proj, &.{ "zig", "build" });
+        defer r.deinit();
+        try expectOk(r);
+    }
+    {
+        var r = try run(proj, &.{ "./zig-out/bin/demo", "hello", "World" });
+        defer r.deinit();
+        try expectOk(r);
+        try expectContains(r.stdout, "Hello, World!"); // preExecute is pass-through
     }
 }
 


### PR DESCRIPTION
## Summary

Local plugins now follow the same **files-as-source + convention-discovery** model as commands (ADR-0006).

- **`init` emits `.plugins_dir = "src/plugins"`** in the generated `build.zig`, so `add plugin` never mutates `build.zig` on the happy path — it just drops a file that `scanLocalPlugins` auto-discovers on the next build.
- **`add plugin <name> [-d <desc>]`** writes `src/plugins/<name>.zig`: a **guided skeleton**, not a bare stub —
  - one **working** pass-through `preExecute` hook (real signature, return-`null`-to-halt),
  - a **commented catalog** of every other hook (`preParse`, `transformArgs`, `postParse`, `postExecute`, `onError`, `global_options`/`handleGlobalOption`) with exact signatures to uncomment,
  - `plugin_id`/`ContextData` commented out with a note that `plugin_id` is required *only* alongside `ContextData` — a minimal plugin needs neither (hooks are `@hasDecl`-gated).
- **No `--hook`/`--with-context` flags:** naming a hook doesn't specify its body (unlike an option, which its flags fully specify), so the in-file catalog is the better discovery surface (ADR-0006).

### Residual `build.zig` case
On a pre-existing project whose `build.zig` lacks `plugins_dir`, the command prints the **single line to add** rather than splicing:

```
Note: your build.zig has no plugins_dir, so this plugin won't be discovered.
  Add `.plugins_dir = "src/plugins",` to the zcli.generate(...) call.
```

New projects (init) never hit this.

## Tests

- **48/48 unit** — skeleton shape (header/preExecute/commented catalog/`plugin_id`), *exactly one* uncommented `pub fn`, and re-parse.
- **14/14 e2e** — a fast file-shape/hint/duplicate test, **plus** the round-trip now adds a plugin to the init-scaffolded project, **rebuilds** (proving convention discovery compiles the skeleton with **no `build.zig` edit**), and reruns a command through the plugin's pass-through `preExecute`.

Scope note: ADR-0006 mentions a co-located test alongside the plugin; like `add command`/`add group`, that rides the deferred Q7 generated-project-testing PR (generated builds still have no `test` step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)