### PR TITLE
mv + rm command — whole-file restructure (grill Q10)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -56,8 +56,11 @@ sequence. Each PR references the ADR carrying its rationale. Ordered by dependen
   Guided skeleton: one working pass-through `preExecute` + a commented catalog of every other
   hook with exact signatures; `plugin_id`/`ContextData` commented out. Residual case: on a
   build.zig lacking `plugins_dir`, it prints the one-line fix (never splices).
-- [ ] **PR: `mv` + `rm`** (grill Q10) — whole-file restructure, carry the co-located test,
-  clean emptied group dirs.
+- [x] **PR: `mv` + `rm command`** (grill Q10) — DONE. Whole-file restructure. `mv <from> <to>`
+  renames/moves a leaf command file (creating destination group dirs); `rm command <path>`
+  deletes one. Both clean group dirs the move/removal leaves empty (`scaffold.fs.removeEmptyParents`,
+  cascading up but preserving a group that still holds an `index.zig` or siblings). In-file
+  tests/`execute` travel with the file. Leaf-only: moving/removing a whole group errors clearly.
 
 **Phase 3 — Primitives that shrink the freeform surface** (parallelizable with Phase 2)
 - [ ] **PR: HTTP client with safe defaults** (ADR-0002/0003) — core; TLS-verified, timeouts.

--- a/projects/zcli/src/commands/mv.zig
+++ b/projects/zcli/src/commands/mv.zig
@@ -1,0 +1,107 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
+const ztheme = zcli.ztheme;
+
+const scaffold = @import("scaffold");
+const spec = scaffold.spec;
+const fs = scaffold.fs;
+
+pub const meta = .{
+    .description = "Move or rename a command file, tidying up empty groups",
+    .examples = &.{
+        "mv deploy release",
+        "mv users/create users/register",
+        "mv users/create admin/create",
+    },
+    .args = .{
+        .from = "Existing command path",
+        .to = "New command path",
+    },
+};
+
+pub const Args = struct {
+    from: []const u8,
+    to: []const u8,
+};
+
+pub const Options = struct {};
+
+pub fn execute(args: Args, _: Options, context: *Context) !void {
+    var arena_state = std.heap.ArenaAllocator.init(context.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const io = context.io.io;
+    const stderr = context.stderr();
+    const cwd = std.Io.Dir.cwd();
+
+    cwd.access(io, "src/commands", .{}) catch {
+        try stderr.print("Error: Not in a zcli project directory\n", .{});
+        try stderr.print("Run this command from the root of your zcli project (where build.zig is)\n", .{});
+        return error.NotInZcliProject;
+    };
+
+    const from_parts = spec.parsePath(arena, args.from) catch {
+        try stderr.print("Error: Invalid command path: '{s}'\n", .{args.from});
+        return error.InvalidCommandPath;
+    };
+    const to_parts = spec.parsePath(arena, args.to) catch {
+        try stderr.print("Error: Invalid command path: '{s}'\n", .{args.to});
+        return error.InvalidCommandPath;
+    };
+
+    const from_file = try spec.buildFilePath(arena, from_parts);
+    if (!exists(io, from_file)) {
+        if (exists(io, try fs.groupPath(arena, from_parts))) {
+            try stderr.print("Error: '{s}' is a command group; move its subcommands individually\n", .{args.from});
+            return error.IsAGroup;
+        }
+        try stderr.print("Error: Command not found: {s}\n", .{from_file});
+        return error.CommandNotFound;
+    }
+
+    const to_file = try spec.buildFilePath(arena, to_parts);
+    if (exists(io, to_file)) {
+        try stderr.print("Error: Destination already exists: {s}\n", .{to_file});
+        return error.CommandAlreadyExists;
+    }
+    if (exists(io, try fs.groupPath(arena, to_parts))) {
+        try stderr.print("Error: Destination is a command group: {s}\n", .{args.to});
+        return error.CommandAlreadyExists;
+    }
+
+    // Create any parent group directories the destination needs.
+    if (to_parts.len > 1) {
+        var dir = std.ArrayList(u8).empty;
+        try dir.appendSlice(arena, "src/commands");
+        for (to_parts[0 .. to_parts.len - 1]) |segment| {
+            try dir.append(arena, '/');
+            try dir.appendSlice(arena, segment);
+            cwd.createDir(io, dir.items, .default_dir) catch |err| switch (err) {
+                error.PathAlreadyExists => {},
+                else => return err,
+            };
+        }
+    }
+
+    try cwd.rename(from_file, cwd, to_file, io);
+    // Tidy up any group the source left empty (its co-located `execute` and
+    // any in-file tests travel with the file).
+    try fs.removeEmptyParents(cwd, io, arena, from_parts);
+
+    try finish(context.stdout(), &context.theme, from_file, to_file);
+}
+
+fn finish(w: *std.Io.Writer, theme: *const ztheme.Theme, from_file: []const u8, to_file: []const u8) !void {
+    try w.writeAll("\n  ");
+    var buf: [512]u8 = undefined;
+    const line = std.fmt.bufPrint(&buf, "\u{2714} Moved {s} \u{2192} {s}", .{ from_file, to_file }) catch "\u{2714} Moved command";
+    try ztheme.theme(line).success().render(w, theme);
+    try w.writeAll("\n\n  Note: update the command's `meta.examples` if they name the old path.\n");
+}
+
+fn exists(io: std.Io, path: []const u8) bool {
+    std.Io.Dir.cwd().access(io, path, .{}) catch return false;
+    return true;
+}

--- a/projects/zcli/src/commands/rm/command.zig
+++ b/projects/zcli/src/commands/rm/command.zig
@@ -1,0 +1,76 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
+const ztheme = zcli.ztheme;
+
+const scaffold = @import("scaffold");
+const spec = scaffold.spec;
+const fs = scaffold.fs;
+
+pub const meta = .{
+    .description = "Remove a whole command file from your project",
+    .examples = &.{
+        "rm command deploy",
+        "rm command users/create",
+    },
+    .args = .{
+        .path = "Command path to remove (e.g. 'users/create')",
+    },
+};
+
+pub const Args = struct {
+    path: []const u8,
+};
+
+pub const Options = struct {};
+
+pub fn execute(args: Args, _: Options, context: *Context) !void {
+    var arena_state = std.heap.ArenaAllocator.init(context.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const io = context.io.io;
+    const stderr = context.stderr();
+    const cwd = std.Io.Dir.cwd();
+
+    cwd.access(io, "src/commands", .{}) catch {
+        try stderr.print("Error: Not in a zcli project directory\n", .{});
+        try stderr.print("Run this command from the root of your zcli project (where build.zig is)\n", .{});
+        return error.NotInZcliProject;
+    };
+
+    const parts = spec.parsePath(arena, args.path) catch {
+        try stderr.print("Error: Invalid command path: '{s}'\n", .{args.path});
+        return error.InvalidCommandPath;
+    };
+
+    const file_path = try spec.buildFilePath(arena, parts);
+    if (!exists(io, file_path)) {
+        // A group directory is not removed here — that would delete its
+        // subcommands (and any index.zig) wholesale. Ask for the leaf files.
+        if (exists(io, try fs.groupPath(arena, parts))) {
+            try stderr.print("Error: '{s}' is a command group; remove its subcommands first\n", .{args.path});
+            return error.IsAGroup;
+        }
+        try stderr.print("Error: Command not found: {s}\n", .{file_path});
+        return error.CommandNotFound;
+    }
+
+    try cwd.deleteFile(io, file_path);
+    try fs.removeEmptyParents(cwd, io, arena, parts);
+
+    try finish(context.stdout(), &context.theme, file_path);
+}
+
+fn finish(w: *std.Io.Writer, theme: *const ztheme.Theme, file_path: []const u8) !void {
+    try w.writeAll("\n  ");
+    var buf: [512]u8 = undefined;
+    const line = std.fmt.bufPrint(&buf, "\u{2714} Removed {s}", .{file_path}) catch "\u{2714} Removed command";
+    try ztheme.theme(line).success().render(w, theme);
+    try w.writeAll("\n");
+}
+
+fn exists(io: std.Io, path: []const u8) bool {
+    std.Io.Dir.cwd().access(io, path, .{}) catch return false;
+    return true;
+}

--- a/projects/zcli/src/scaffold.zig
+++ b/projects/zcli/src/scaffold.zig
@@ -1,13 +1,16 @@
-//! Shared scaffolding library for the `add` command family. `spec` is the
-//! arg/option model plus its rendering/validation helpers; `splice` is the
-//! in-file AST-guided editor that adds fields to existing command files without
-//! disturbing their `execute()` bodies (ADR-0005). Wired to command modules as
-//! the `scaffold` shared module in build.zig.
+//! Shared scaffolding library for the `add`/`rm`/`mv` command family. `spec` is
+//! the arg/option model plus its rendering/validation helpers; `splice` is the
+//! in-file AST-guided editor that edits existing command files without
+//! disturbing their `execute()` bodies (ADR-0005); `fs` holds the whole-file
+//! filesystem helpers (empty-group cleanup). Wired to command modules as the
+//! `scaffold` shared module in build.zig.
 
 pub const spec = @import("scaffold/spec.zig");
 pub const splice = @import("scaffold/splice.zig");
+pub const fs = @import("scaffold/fs.zig");
 
 test {
     _ = spec;
     _ = splice;
+    _ = fs;
 }

--- a/projects/zcli/src/scaffold/fs.zig
+++ b/projects/zcli/src/scaffold/fs.zig
@@ -1,0 +1,86 @@
+//! Filesystem helpers for the whole-file scaffolding commands (`mv`,
+//! `rm command`). Pure of any Context — just std IO — so it lives beside `spec`
+//! and `splice` in the scaffold toolkit. Operations are relative to a caller-
+//! supplied `base` directory (the project root, or a tmp dir in tests).
+
+const std = @import("std");
+
+/// After the command file at `parts` is removed or moved away, delete any group
+/// directories it leaves empty — walking up from its immediate parent and
+/// stopping at the first non-empty directory. Never touches `src/commands`
+/// itself, and never removes a group that still holds an `index.zig` (a
+/// described/landing group) or other subcommands.
+pub fn removeEmptyParents(base: std.Io.Dir, io: std.Io, arena: std.mem.Allocator, parts: []const []const u8) !void {
+    if (parts.len < 2) return; // a top-level command has no group parent
+
+    var depth = parts.len - 1;
+    while (depth >= 1) : (depth -= 1) {
+        const dir = try groupPath(arena, parts[0..depth]);
+        if (!isEmptyDir(base, io, dir)) break; // stop at the first non-empty parent
+        base.deleteDir(io, dir) catch break;
+    }
+}
+
+/// `src/commands/<seg>/<seg>...` for a group's path segments.
+pub fn groupPath(arena: std.mem.Allocator, segments: []const []const u8) ![]const u8 {
+    var buf = std.ArrayList(u8).empty;
+    try buf.appendSlice(arena, "src/commands");
+    for (segments) |s| {
+        try buf.append(arena, '/');
+        try buf.appendSlice(arena, s);
+    }
+    return buf.items;
+}
+
+fn isEmptyDir(base: std.Io.Dir, io: std.Io, path: []const u8) bool {
+    var dir = base.openDir(io, path, .{ .iterate = true }) catch return false;
+    defer dir.close(io);
+    var it = dir.iterate();
+    const first = it.next(io) catch return false;
+    return first == null;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const testing = std.testing;
+
+test "groupPath joins segments under src/commands" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    try testing.expectEqualStrings("src/commands/gh/pr", try groupPath(arena.allocator(), &.{ "gh", "pr" }));
+    try testing.expectEqualStrings("src/commands", try groupPath(arena.allocator(), &.{}));
+}
+
+test "removeEmptyParents cascades up but stops at a non-empty group" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const io = testing.io;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // Layout: src/commands/a/b/c.zig (just removed) with a sibling described
+    // group src/commands/a/kept/ holding an index.zig.
+    try tmp.dir.createDir(io, "src", .default_dir);
+    try tmp.dir.createDir(io, "src/commands", .default_dir);
+    try tmp.dir.createDir(io, "src/commands/a", .default_dir);
+    try tmp.dir.createDir(io, "src/commands/a/b", .default_dir); // now empty (c.zig gone)
+    try tmp.dir.createDir(io, "src/commands/a/kept", .default_dir);
+    try tmp.dir.writeFile(io, .{ .sub_path = "src/commands/a/kept/index.zig", .data = "pub const meta = .{};" });
+
+    try removeEmptyParents(tmp.dir, io, a, &.{ "a", "b", "c" });
+
+    // a/b was empty → removed. a still holds kept/ → preserved (cascade stops).
+    try testing.expect(!dirExists(tmp.dir, io, "src/commands/a/b"));
+    try testing.expect(dirExists(tmp.dir, io, "src/commands/a"));
+    try testing.expect(dirExists(tmp.dir, io, "src/commands/a/kept"));
+}
+
+fn dirExists(base: std.Io.Dir, io: std.Io, path: []const u8) bool {
+    var d = base.openDir(io, path, .{}) catch return false;
+    d.close(io);
+    return true;
+}

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -712,6 +712,53 @@ test "scaffolded project builds, runs, and round-trips add command" {
         try expectOk(r);
         try expectContains(r.stdout, "Hello, World!"); // preExecute is pass-through
     }
+
+    // `mv` + `rm command`: whole-file restructure. Move a command into a new
+    // group, rebuild, and run it at its new path; then remove it, rebuild, and
+    // confirm both the command and its now-empty group directory are gone.
+    {
+        var r = try run(proj, &.{ zcli_exe, "add", "command", "scratch", "-d", "Scratch" });
+        defer r.deinit();
+        try expectOk(r);
+    }
+    {
+        var r = try run(proj, &.{ zcli_exe, "mv", "scratch", "tools/scratch" });
+        defer r.deinit();
+        try expectOk(r);
+    }
+    try testing.expect(!fileExists(proj, "src/commands/scratch.zig"));
+    try testing.expect(fileExists(proj, "src/commands/tools/scratch.zig"));
+    {
+        var r = try run(proj, &.{ "zig", "build" });
+        defer r.deinit();
+        try expectOk(r);
+    }
+    {
+        // The moved command runs at its new path (its execute() travelled intact).
+        var r = try run(proj, &.{ "./zig-out/bin/demo", "tools", "scratch" });
+        defer r.deinit();
+        try expectOk(r);
+        try expectContains(r.stdout, "TODO: Implement scratch");
+    }
+    {
+        var r = try run(proj, &.{ zcli_exe, "rm", "command", "tools/scratch" });
+        defer r.deinit();
+        try expectOk(r);
+    }
+    // The command file is gone and its sole-occupant group dir was cleaned up.
+    try testing.expect(!fileExists(proj, "src/commands/tools/scratch.zig"));
+    try testing.expect(!fileExists(proj, "src/commands/tools"));
+    {
+        var r = try run(proj, &.{ "zig", "build" });
+        defer r.deinit();
+        try expectOk(r);
+    }
+    {
+        // The removed command no longer resolves.
+        var r = try run(proj, &.{ "./zig-out/bin/demo", "tools", "scratch" });
+        defer r.deinit();
+        try testing.expect(r.exit_code != 0);
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

The whole-file counterparts to the field-level `add`/`rm` family (ADR-0005 calls these out as *whole-file granularity*): move/rename a command, or delete one, tidying up the directory tree.

- **`mv <from> <to>`** renames or relocates a leaf command file, creating any destination group directories first. It's a `rename`, so the `execute()` body and any in-file tests travel with the file untouched.
- **`rm command <path>`** deletes a leaf command file — joining the `rm` group beside `rm option`/`rm arg`, symmetric with `add command`.

### Cleanup: `scaffold.fs.removeEmptyParents`

Both commands clean up afterward via a new shared helper that walks up from the affected command's parent and deletes each **now-empty** group directory — cascading, but **stopping at the first group that still holds an `index.zig`** (a described/landing group) or other subcommands, so nothing with user content is ever removed. Refactored to take a base `Dir` (not a hidden `cwd()`) so it's unit-testable against a tmp tree.

### Safety

Both are **leaf-only**: moving or removing a whole group (which would take its subcommands and `index.zig` with it) errors clearly rather than doing something destructive. Plus the standard guards — source-not-found, destination-exists.

Live:
```
$ zcli mv users/create admin/register   →  ✔ Moved …/users/create.zig → …/admin/register.zig
$ zcli rm command users/list            →  ✔ Removed …/users/list.zig   (empty users/ dir cleaned)
$ zcli rm command admin                 →  Error: 'admin' is a command group; remove its subcommands first
```

## Tests

- **50/50 unit** — `removeEmptyParents` cascade-and-stop (preserves a sibling described group), `groupPath`.
- **14/14 e2e** — the round-trip now **moves** a command into a new group, **rebuilds**, runs it at its new path (proving the moved `execute()` compiles and works), then **removes** it, rebuilds, and confirms both the command and its emptied group directory are gone.

Note: `mv` prints a reminder to update the command's `meta.examples` if they name the old path (examples are prose the tool doesn't rewrite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)