### PR TITLE
zig fmt the tree + enforce in CI (grade fix 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,23 @@ on:
     branches: [main]
 
 jobs:
+  fmt:
+    name: zig fmt check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+
+      # Explicit paths rather than "." — scripts/ and website/ contain no Zig
+      # source, and this keeps cache/output dirs out of scope.
+      - name: Check formatting
+        run: zig fmt --check packages projects examples build.zig
+
   test:
     name: unit tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/GRADE_TODO.md
+++ b/GRADE_TODO.md
@@ -8,7 +8,7 @@ Grades at audit time: Architecture A-, Docs/DX A-, Testing B+, Security B, Zig p
 ## Priority items
 
 - [x] 1. **CI test wiring** — ztheme's 44 tests are missing from the root test aggregator (`build.zig` `test_projects`), and projects/zcli's 81 unit tests never run in CI (only `e2e` runs). Add both to the root `zig build test` aggregation.
-- [ ] 2. **zig fmt** — 22 files fail `zig fmt --check` (incl. `packages/core/src/registry.zig`, `projects/zcli/src/commands/release.zig`). Run `zig fmt`, add a `fmt --check` step to CI.
+- [x] 2. **zig fmt** — 22 files fail `zig fmt --check` (incl. `packages/core/src/registry.zig`, `projects/zcli/src/commands/release.zig`). Run `zig fmt`, add a `fmt --check` step to CI.
 - [ ] 3. **HTTP redirect header leak** — the safe wrapper forwards caller headers (incl. `Authorization`) across cross-origin redirects for GETs (`packages/core/src/http.zig:115`, `:250-256`). Strip sensitive headers on cross-origin hops; add a loopback test (redirect to a second listener, assert auth header absent on hop 2).
 - [ ] 4. **install.sh fails open** — checksum verification silently skipped when `shasum` is missing (`install.sh:86-103`); failed `checksums.txt` download warns-and-continues. Fail closed: fall back to `sha256sum`, abort if neither exists or checksums can't be fetched.
 - [ ] 5. **Upgrade plugin temp-file TOCTOU** — downloads to predictable `.upgrade-<name>-0` in CWD (`packages/core/src/plugins/zcli_github_upgrade/plugin.zig:430-478`); symlink clobber risk. Download to a private per-invocation temp dir (same filesystem as the executable so the final rename stays atomic).

--- a/GRADE_TODO.md
+++ b/GRADE_TODO.md
@@ -1,0 +1,66 @@
+# Repo Grade — Fix Tracker
+
+Findings from the full-repo audit (2026-07-02): security, architecture, structure, Zig patterns, testing/CI, docs.
+Working through these one PR at a time, in order. Each item is scoped to be one reviewable PR.
+
+Grades at audit time: Architecture A-, Docs/DX A-, Testing B+, Security B, Zig patterns B-, Structure C+.
+
+## Priority items
+
+- [x] 1. **CI test wiring** — ztheme's 44 tests are missing from the root test aggregator (`build.zig` `test_projects`), and projects/zcli's 81 unit tests never run in CI (only `e2e` runs). Add both to the root `zig build test` aggregation.
+- [ ] 2. **zig fmt** — 22 files fail `zig fmt --check` (incl. `packages/core/src/registry.zig`, `projects/zcli/src/commands/release.zig`). Run `zig fmt`, add a `fmt --check` step to CI.
+- [ ] 3. **HTTP redirect header leak** — the safe wrapper forwards caller headers (incl. `Authorization`) across cross-origin redirects for GETs (`packages/core/src/http.zig:115`, `:250-256`). Strip sensitive headers on cross-origin hops; add a loopback test (redirect to a second listener, assert auth header absent on hop 2).
+- [ ] 4. **install.sh fails open** — checksum verification silently skipped when `shasum` is missing (`install.sh:86-103`); failed `checksums.txt` download warns-and-continues. Fail closed: fall back to `sha256sum`, abort if neither exists or checksums can't be fetched.
+- [ ] 5. **Upgrade plugin temp-file TOCTOU** — downloads to predictable `.upgrade-<name>-0` in CWD (`packages/core/src/plugins/zcli_github_upgrade/plugin.zig:430-478`); symlink clobber risk. Download to a private per-invocation temp dir (same filesystem as the executable so the final rename stays atomic).
+- [ ] 6. **Upgrade plugin bypasses safe HTTP wrapper** — raw `std.http.Client` at `plugin.zig:238`, `:435`, `:489`; no timeout, so `onStartup` version check (`inform_out_of_date`) can hang the CLI indefinitely. Route through `zcli`'s `http.Client` or add explicit short timeouts; time-box the startup check.
+- [ ] 7. **Dormant compile bombs in core** — (a) `.Slice` should be `.slice` (`registry.zig:1350`, `:1390`); (b) broken `std.mem.join(&[_]u8{}, ...)` in duplicate-path `@compileError` branches (`registry.zig:421`, `:489`, `:505`); (c) comptime underflow for a zero-command registry (`registry.zig:1045-1062`, missing empty guard the plugin sort has); (d) `std.posix.getenv` (gone in 0.16) in the unused option-`env` feature (`options/parser.zig:200`) — remove or reimplement via threaded environ.
+- [ ] 8. **snapshot.zig is un-migrated 0.15 code exported as pub API** — `packages/testing/src/snapshot.zig` uses `std.fs.cwd()` / `getEnvVarOwned`; first downstream caller of `expectSnapshot` gets a compile error. Migrate to 0.16 IO.
+- [ ] 9. **vterm resize out-of-bounds** — `resize` reallocates `new_width × new_height` but never updates `scrollback_lines` (`packages/vterm/src/vterm.zig:362-386`), so post-resize scrolling indexes out of bounds; `buffer_start` never advances (circular buffer half-implemented). Also `eraseFromCursor`/`eraseToCursor` mix viewport vs buffer coordinates (`:683-698`).
+- [ ] 10. **Required options read `undefined`** — non-bool, non-optional, non-defaulted Options fields are initialized to `undefined` and read if the flag is absent (`options/parser.zig:174-177`, `command_parser.zig:240-243`). Enforce defaults/optionality at comptime in `validateMeta`, or implement required-option errors.
+- [ ] 11. **`context.exit()` drops buffered output** — `registry.zig:392-394`, `zcli.zig:170-172` discard `self` and call `std.process.exit` without flushing the framework-owned writers. Flush `self.io` before exiting.
+
+## Security — remaining
+
+- [ ] 12. **testBinary is a no-op** — prints "Testing new binary…" but never executes it (`plugin.zig:583-590`). Actually spawn the temp binary with `--version` and check exit code, or remove the step and message.
+- [ ] 13. **Checksum line matching is a loose substring** — `parseExpectedChecksum` uses `indexOf` on the whole line (`plugin.zig:550-560`), so `myapp-x86_64-linux-debug` can match before `myapp-x86_64-linux`. Split into digest/filename columns and compare exactly.
+- [ ] 14. **`sh -c` in release.zig** — `getReleaseNotes` interpolates tag names into a shell string (`projects/zcli/src/commands/release.zig:633-640`); every other call uses argv arrays. Drop the shell, pass the tag range as one argv element.
+- [ ] 15. **Resource limits partially enforced** — only `checkOptionCount`/`checkOptionNameLength` are wired; `checkArraySize`, `max_argument_count`, `checkCommandDepth` unused (`packages/core/src/resource_limits.zig` vs `options/parser.zig`, `args.zig`). Wire them in or delete the unused fields; tighten `security_test.zig` to assert the caps that are enforced.
+- [ ] 16. **serde hash label mismatch** — `build.zig.zon` pins v1.0.3 URL but the hash string says `serde-1.0.1`; re-run `zig fetch --save` so label and artifact agree.
+- [ ] 17. **No release signing (documented decision)** — integrity anchors solely on GitHub (checksums.txt from the same release). Consider minisign/cosign signing of checksums.txt; at minimum document the trust model in ADR-0002/0003.
+- [ ] 18. **Startup version check behavior** — document the outbound network call at `Config.inform_out_of_date`, and cache the last check with a min interval so it doesn't fire on every invocation.
+
+## Zig patterns / correctness — remaining
+
+- [ ] 19. **Dead diagnostic system** — `ZcliDiagnostic`/`formatDiagnostic` (`diagnostic_errors.zig`) never constructed or consumed; real error context goes through a test-suppressed `std.log` side channel invisible to `onError` plugins. Wire diagnostics through the pipeline (so help plugin can name the unknown option) or delete. Also fix `convertLongOptionError`/`convertShortOptionError` `anyerror` catch-alls (`options/parser.zig:286-305`).
+- [ ] 20. **Option-parsing heuristics disagree** — three different "does this flag take a value" heuristics: `command_parser.zig:75-115`, `options/parser.zig`, `args.zig:findNextPositional` (`:240-257`). Unify on one source of truth (the comptime Options type).
+- [ ] 21. **Global options half-implemented** — short options "assume boolean for now" (`registry.zig:916-917`); `convertValue` supports only bool/u16/u32/[]const u8 while `plugin_types.option()` accepts more (`registry.zig:951-960`). Support the full type set or reject unsupported types at declaration.
+- [ ] 22. **`IO` two-phase init pointer-stability trap** — `finalize()` wires writers to in-struct buffers; any copy after finalize dangles (`zcli.zig:344-391`). Restructure to prevent misuse (heap/pin, or factory that returns a pointer).
+- [ ] 23. **parseCommandLine leak on error path** — frees only the slice, not parsed option arrays, when `parseArgs` fails outside an arena (`command_parser.zig:128-132`); plus muddled belt-and-suspenders frees of arena memory in `Context.deinit`.
+- [ ] 24. **errors.zig fossils** — discarded `allocator` params kept "for API compatibility" (`errors.zig:11`, `:33`, `:97`) contrary to the no-backward-compat rule; doc references a nonexistent "zcli-suggestions plugin"; `editDistance` silently caps at 62 chars with a 32KB stack matrix.
+- [ ] 25. **zinput text input is byte-oriented** — `char: u8` echo/backspace per byte breaks multibyte UTF-8 (`packages/zinput/src/text.zig`), inconsistent with the grapheme-aware wrapping elsewhere in the stack.
+
+## Structure / dead code
+
+- [ ] 26. **Split `executeCommand`** — single ~584-line function (`registry.zig:962-1545`); regular-command and plugin-command paths are ~230 near-identical lines each (6 copies of the onError inline-for). Extract shared helpers.
+- [ ] 27. **Context triplication** — the Context interface is defined three times (`registry.zig:278-396`, `zcli.zig:107-203`, `zcli.zig:264-341`); `getCommandDescription` copy-pasted verbatim in all three. Single source of truth.
+- [ ] 28. **Split `add/command.zig`** (1,221 lines) — wizard prompt IO, declarative scaffold, source rendering, and ANSI paint helpers in one file. (Split plan already sketched: generate/declarative/wizard/command.)
+- [ ] 29. **Legacy `build_utils.zig` cleanup** — 772-line doc-header + stale test grab-bag incl. a no-op `expect(true)` test (`:25-36`). Also `build_utils/main.zig` contains never-run tests asserting a generator signature that no longer exists (`:465`, `:547` vs `code_generation.zig:180-190`) — fix and wire them, or delete.
+- [ ] 30. **plugin_system.zig dead apparatus** — ~850 of 1,014 lines are mocks/tests including a sandbox/capabilities concept that doesn't exist in the runtime (`build_utils/plugin_system.zig:659`). Trim to the ~160 lines of real build logic.
+- [ ] 31. **`scanLocalPlugins` unreachable / ADR-0006 dead** — `generate()` hardcodes `.plugins_dir = null` (`build_utils/main.zig:215`), so convention plugin discovery is dead code while ADR-0006 says "accepted". Either implement (roadmap: `zcli add plugin`) or mark the ADR deferred and remove the dead path.
+- [ ] 32. **Stale `terminal` dep in core's zon** — `packages/core/build.zig.zon` declares `.terminal` but core never uses it.
+- [ ] 33. **Dead parser code** — `parseShortOptions` has zero callers (dead un-meta duplicate of `parseShortOptionsWithMeta`, `options/parser.zig:655+`); `expected_char` comptime block copy-pasted three times in one function (`:511`, `:546`, `:582`).
+- [ ] 34. **core/build.zig test-wiring duplication** — same five `addImport` lines copy-pasted across four test loops with mis-indentation (`packages/core/build.zig:84-198`), plus a leftover "debug hanging" step (`:200-210`). Extract a helper.
+
+## Build / CI / test — remaining
+
+- [ ] 35. **Re-enable `build_integration_test.zig`** — disabled at `packages/core/build.zig:74` ("needs rework for 0.16 *Build-based discoverCommands").
+- [ ] 36. **Orphaned example tests** — `packages/vterm/example/tests/cli_test.zig` (20 tests) and showcase command tests have test steps but root only builds examples (`build.zig:129-142`).
+- [ ] 37. **e2e on macOS in CI** — the PTY harness works on macOS but the e2e job is ubuntu-only (`ci.yml:64-80`).
+- [ ] 38. **release.yml uses deprecated setup-zig action** — `goto-bus-stop/setup-zig@v2` vs ci.yml's `mlugg/setup-zig@v2`.
+- [ ] 39. **Root build shells out per package** — `addSystemCommand(&.{"zig"})` + `setCwd` forfeits shared cache/flag propagation; module wiring duplicated between root `build.zig:65-74` and `packages/core/build.zig:32-41`. Consider `b.dependency`-based aggregation.
+- [ ] 40. **`generate()` config is `anytype`** — hand-rolled `@hasField` checks (`build_utils/main.zig:164-167`); use a typed config struct. Also `readVersionFromZon` string-scans the zon and build errors call `std.process.exit(1)` mid-build.
+
+## Docs — remaining
+
+- [ ] 41. **Stale docs** — README.md:487 lists the removed "interactive" package; TODOS.md:59 leaves shipped HTTP client unchecked; `projects/zcli/build.zig:138` + `test/e2e.zig:8` reference gitignored `.context/e2e-test-plan.md`; ADR-0001 status still "proposed" though shipped.
+- [ ] 42. **Missing per-package READMEs / CONTRIBUTING.md** — core, terminal, testing, zinput, zprogress have no README despite the root claiming all packages work standalone.

--- a/build.zig
+++ b/build.zig
@@ -87,6 +87,8 @@ pub fn build(b: *std.Build) void {
         .{ .name = "zprogress", .path = "packages/zprogress" },
         .{ .name = "terminal", .path = "packages/terminal" },
         .{ .name = "zinput", .path = "packages/zinput" },
+        .{ .name = "ztheme", .path = "packages/ztheme" },
+        .{ .name = "zcli", .path = "projects/zcli" },
     };
 
     const example_projects = [_]ProjectInfo{

--- a/examples/showcase/src/commands/add.zig
+++ b/examples/showcase/src/commands/add.zig
@@ -46,8 +46,8 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         priority = store.priorityFromString(options.priority) orelse .medium;
     } else {
         // Interactive mode
-                const writer = context.stdout();
-                const reader = context.stdin();
+        const writer = context.stdout();
+        const reader = context.stdin();
 
         title_owned = try zinput.text(writer, reader, allocator, .{
             .message = "Task title:",

--- a/examples/showcase/src/commands/config.zig
+++ b/examples/showcase/src/commands/config.zig
@@ -32,8 +32,8 @@ const priorities = [_][]const u8{ "low", "medium", "high", "critical" };
 
 pub fn execute(_: Args, _: Options, context: *Context) !void {
     const allocator = context.allocator;
-        const writer = context.stdout();
-        const reader = context.stdin();
+    const writer = context.stdout();
+    const reader = context.stdin();
 
     // Load the current config so prompts can show existing values as defaults.
     // Keep `parsed` alive until after we write, so its strings stay valid.

--- a/examples/showcase/src/commands/init.zig
+++ b/examples/showcase/src/commands/init.zig
@@ -15,8 +15,8 @@ pub const Options = struct {};
 
 pub fn execute(_: Args, _: Options, context: *Context) !void {
     const allocator = context.allocator;
-        const writer = context.stdout();
-        const reader = context.stdin();
+    const writer = context.stdout();
+    const reader = context.stdin();
 
     // Check if already initialized
     if (std.Io.Dir.cwd().access(context.io.io, "tasks.json", .{})) |_| {

--- a/examples/showcase/src/commands/remove.zig
+++ b/examples/showcase/src/commands/remove.zig
@@ -26,8 +26,8 @@ pub fn execute(args: Args, _: Options, context: *Context) !void {
         return;
     };
 
-        const writer = context.stdout();
-        const reader = context.stdin();
+    const writer = context.stdout();
+    const reader = context.stdin();
 
     const msg = try std.fmt.allocPrint(allocator, "Remove task #{d}: {s}?", .{ task.id, task.title });
     defer allocator.free(msg);

--- a/examples/showcase/src/commands/search.zig
+++ b/examples/showcase/src/commands/search.zig
@@ -33,8 +33,8 @@ pub fn execute(_: Args, _: Options, context: *Context) !void {
     }
     defer for (titles.items) |t| allocator.free(t);
 
-        const writer = context.stdout();
-        const reader = context.stdin();
+    const writer = context.stdout();
+    const reader = context.stdin();
 
     const idx = try zinput.search(writer, reader, allocator, .{
         .message = "Search tasks:",

--- a/examples/showcase/src/commands/sprint/close.zig
+++ b/examples/showcase/src/commands/sprint/close.zig
@@ -24,8 +24,8 @@ pub fn execute(_: Args, _: Options, context: *Context) !void {
         return;
     }
 
-        const writer = context.stdout();
-        const reader = context.stdin();
+    const writer = context.stdout();
+    const reader = context.stdin();
 
     const idx = try zinput.select(writer, reader, .{
         .message = "Close which sprint?",

--- a/examples/showcase/src/commands/sprint/create.zig
+++ b/examples/showcase/src/commands/sprint/create.zig
@@ -23,8 +23,8 @@ pub fn execute(args: Args, _: Options, context: *Context) !void {
     var data = parsed.value;
 
     const name = if (args.name) |n| n else blk: {
-                const writer = context.stdout();
-                const reader = context.stdin();
+        const writer = context.stdout();
+        const reader = context.stdin();
         break :blk try zinput.text(writer, reader, allocator, .{
             .message = "Sprint name:",
             .default = try std.fmt.allocPrint(allocator, "Sprint {d}", .{data.sprints.len + 1}),

--- a/packages/core/build.zig
+++ b/packages/core/build.zig
@@ -91,7 +91,7 @@ pub fn build(b: *std.Build) void {
         test_mod.addImport("markdown_fmt", markdown_fmt_dep.module("markdown_fmt"));
         test_mod.addImport("zprogress", zprogress_dep.module("zprogress"));
         test_mod.addImport("zinput", zinput_dep.module("zinput"));
-                test_mod.addImport("serde", serde_dep.module("serde"));
+        test_mod.addImport("serde", serde_dep.module("serde"));
         const tests = b.addTest(.{
             .root_module = test_mod,
         });
@@ -111,7 +111,7 @@ pub fn build(b: *std.Build) void {
         test_mod.addImport("markdown_fmt", markdown_fmt_dep.module("markdown_fmt"));
         test_mod.addImport("zprogress", zprogress_dep.module("zprogress"));
         test_mod.addImport("zinput", zinput_dep.module("zinput"));
-                test_mod.addImport("serde", serde_dep.module("serde"));
+        test_mod.addImport("serde", serde_dep.module("serde"));
         const tests = b.addTest(.{
             .root_module = test_mod,
         });
@@ -130,7 +130,7 @@ pub fn build(b: *std.Build) void {
         test_mod.addImport("markdown_fmt", markdown_fmt_dep.module("markdown_fmt"));
         test_mod.addImport("zprogress", zprogress_dep.module("zprogress"));
         test_mod.addImport("zinput", zinput_dep.module("zinput"));
-                test_mod.addImport("serde", serde_dep.module("serde"));
+        test_mod.addImport("serde", serde_dep.module("serde"));
         const tests = b.addTest(.{
             .root_module = test_mod,
         });
@@ -181,7 +181,7 @@ pub fn build(b: *std.Build) void {
         test_mod.addImport("markdown_fmt", markdown_fmt_dep.module("markdown_fmt"));
         test_mod.addImport("zprogress", zprogress_dep.module("zprogress"));
         test_mod.addImport("zinput", zinput_dep.module("zinput"));
-                test_mod.addImport("serde", serde_dep.module("serde"));
+        test_mod.addImport("serde", serde_dep.module("serde"));
         const sequential_tests = b.addTest(.{
             .root_module = test_mod,
         });

--- a/packages/core/src/build_utils.zig
+++ b/packages/core/src/build_utils.zig
@@ -380,7 +380,6 @@ test "empty plugin list handling" {
     try std.testing.expect(std.mem.indexOf(u8, source, ".build();") != null);
 }
 
-
 /// Comprehensive integration tests for the plugin system
 /// These tests verify that plugins work correctly in realistic scenarios
 
@@ -450,7 +449,6 @@ const TestData = struct {
     help_transform_called: bool = false,
     plugin_command_executed: bool = false,
 };
-
 
 test "context data defaults" {
     // ContextData is a plain, default-constructible struct. The generated

--- a/packages/core/src/plugins/zcli_completions/bash.zig
+++ b/packages/core/src/plugins/zcli_completions/bash.zig
@@ -201,5 +201,6 @@ pub fn generate(
     // Register completion
     try writer.print("complete -F _{s}_completions {s}\n", .{ app_name, app_name });
 
-    var al = aw.toArrayList(); return al.toOwnedSlice(allocator);
+    var al = aw.toArrayList();
+    return al.toOwnedSlice(allocator);
 }

--- a/packages/core/src/plugins/zcli_completions/fish.zig
+++ b/packages/core/src/plugins/zcli_completions/fish.zig
@@ -248,5 +248,6 @@ pub fn generate(
         try writer.writeAll("\n");
     }
 
-    var al = aw.toArrayList(); return al.toOwnedSlice(allocator);
+    var al = aw.toArrayList();
+    return al.toOwnedSlice(allocator);
 }

--- a/packages/core/src/plugins/zcli_completions/plugin.zig
+++ b/packages/core/src/plugins/zcli_completions/plugin.zig
@@ -231,7 +231,7 @@ fn getShellType(shell: []const u8) ?ShellType {
 
 fn detectShell(_: std.mem.Allocator, environ: *const std.process.Environ.Map) ?ShellType {
     const shell_path = environ.get("SHELL") orelse return null;
-    
+
     // Extract shell name from path (e.g., "/bin/bash" -> "bash")
     const shell_name = std.fs.path.basename(shell_path);
 
@@ -240,7 +240,7 @@ fn detectShell(_: std.mem.Allocator, environ: *const std.process.Environ.Map) ?S
 
 fn getInstallPath(allocator: std.mem.Allocator, environ: *const std.process.Environ.Map, shell_type: ShellType, app_name: []const u8) ![]const u8 {
     const home = environ.get("HOME") orelse return error.HomeNotFound;
-    
+
     return switch (shell_type) {
         .bash => try std.fmt.allocPrint(
             allocator,

--- a/packages/core/src/plugins/zcli_completions/zsh.zig
+++ b/packages/core/src/plugins/zcli_completions/zsh.zig
@@ -464,5 +464,6 @@ pub fn generate(
     // Call the function
     try writer.print("_{s} \"$@\"\n", .{app_name});
 
-    var al = aw.toArrayList(); return al.toOwnedSlice(allocator);
+    var al = aw.toArrayList();
+    return al.toOwnedSlice(allocator);
 }

--- a/packages/core/src/plugins/zcli_config/plugin.zig
+++ b/packages/core/src/plugins/zcli_config/plugin.zig
@@ -11,7 +11,6 @@ const zcli = @import("zcli");
 ///   1. --config <path>
 ///   2. ./{app_name}.config.json / .toml / .yaml / .yml
 ///   3. $XDG_CONFIG_HOME/{app_name}/config.json / .toml / .yaml / .yml
-
 pub const plugin_id = "zcli_config";
 
 pub const Format = enum { json, toml, yaml };

--- a/packages/core/src/plugins/zcli_not_found/levenshtein.zig
+++ b/packages/core/src/plugins/zcli_not_found/levenshtein.zig
@@ -47,8 +47,8 @@ pub fn editDistance(a: []const u8, b: []const u8) usize {
 
             curr_row[j] = @min(@min(prev_row[j] + 1, // deletion
                 curr_row[j - 1] + 1 // insertion
-                ), prev_row[j - 1] + cost // substitution
-                );
+            ), prev_row[j - 1] + cost // substitution
+            );
         }
 
         // Swap rows

--- a/packages/core/src/registry.zig
+++ b/packages/core/src/registry.zig
@@ -311,7 +311,7 @@ fn ComputedContextType(comptime config: Config, comptime plugins: []const type) 
                 .allocator = allocator,
                 .io = io_struct,
                 .environ = env,
-                                .theme = zcli.ztheme.Theme.init(env, io_struct.io),
+                .theme = zcli.ztheme.Theme.init(env, io_struct.io),
             };
         }
 
@@ -342,8 +342,6 @@ fn ComputedContextType(comptime config: Config, comptime plugins: []const type) 
                     Plugin.deinitContextData(&@field(self.plugins, field_name), self.allocator);
                 }
             }
-
-            
         }
 
         // I/O convenience methods
@@ -816,7 +814,7 @@ fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const Comma
                 .allocator = arena.allocator(),
                 .io = &zcli_io,
                 .environ = environ,
-                                .theme = zcli.ztheme.Theme.init(environ, io),
+                .theme = zcli.ztheme.Theme.init(environ, io),
                 .available_commands = available_commands,
                 .command_path = &.{},
                 .plugin_command_info = plugin_command_info_list,

--- a/packages/markdown_fmt/src/main.zig
+++ b/packages/markdown_fmt/src/main.zig
@@ -395,7 +395,6 @@ test "parse markdown inside semantic tags" {
 test "write with semantic tags and runtime values" {
     var buf: [256]u8 = undefined;
     var writer: std.Io.Writer = .fixed(&buf);
-    
 
     try write(&writer, "<success>Processed **{d}** items</success>", .{42});
 

--- a/packages/zinput/src/multi_select.zig
+++ b/packages/zinput/src/multi_select.zig
@@ -324,4 +324,3 @@ test "renderList: continuation lines hang-indent under the option text" {
     // under the label text rather than under the bullet.
     try std.testing.expect(std.mem.indexOf(u8, buf[0..], "\r\n        ") != null);
 }
-

--- a/packages/ztheme/src/api/fluent.zig
+++ b/packages/ztheme/src/api/fluent.zig
@@ -417,7 +417,8 @@ pub fn Themed(comptime T: type) type {
         /// Get the styled content as a string (requires allocator)
         pub fn toString(self: Self, allocator: std.mem.Allocator, theme_ctx: *const Theme) ![]u8 {
             var list: std.ArrayList(u8) = .empty;
-            var aw_render: std.Io.Writer.Allocating = .init(allocator); try self.render(&aw_render.writer, theme_ctx);
+            var aw_render: std.Io.Writer.Allocating = .init(allocator);
+            try self.render(&aw_render.writer, theme_ctx);
             return list.toOwnedSlice(allocator);
         }
 

--- a/projects/zcli/src/commands/add/option.zig
+++ b/projects/zcli/src/commands/add/option.zig
@@ -19,7 +19,7 @@ pub const meta = .{
         .name = "Option name (snake_case or kebab-case)",
     },
     .options = .{
-        .@"type" = .{ .description = "Element/scalar Zig type (e.g. u32, bool, []const u8)", .short = 't' },
+        .type = .{ .description = "Element/scalar Zig type (e.g. u32, bool, []const u8)", .short = 't' },
         .multiple = .{ .description = "Accumulate repeated flags into a slice" },
         .nullable = .{ .description = "Optional: renders as ?T = null" },
         .default = .{ .description = "Default value, a Zig expression (required for a non-nullable scalar)" },
@@ -34,7 +34,7 @@ pub const Args = struct {
 };
 
 pub const Options = struct {
-    @"type": []const u8,
+    type: []const u8,
     // `description` MUST precede `default`: zcli auto-derives a short flag from
     // each field's first letter, so `default` would otherwise claim `-d`. Short
     // flags resolve to the first matching field, so declaring `description`
@@ -108,7 +108,7 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
 /// `--default` and `--nullable` are contradictory; a non-nullable scalar needs
 /// a `--default`; a `--multiple` element type must be one the parser accumulates.
 fn buildSpec(arena: std.mem.Allocator, stderr: *std.Io.Writer, name: []const u8, options: Options) !spec.OptSpec {
-    const elem_type = std.mem.trim(u8, options.@"type", " \t");
+    const elem_type = std.mem.trim(u8, options.type, " \t");
     if (elem_type.len == 0) {
         try stderr.print("Error: --type is required\n", .{});
         return error.MissingType;
@@ -181,20 +181,22 @@ fn expectBuildError(err: anyerror, name: []const u8, options: Options) !void {
 
 test "buildSpec: nullable + default is contradictory" {
     try expectBuildError(error.ContradictoryFlags, "region", .{
-        .@"type" = "[]const u8", .nullable = true, .default = "\"us\"",
+        .type = "[]const u8",
+        .nullable = true,
+        .default = "\"us\"",
     });
 }
 
 test "buildSpec: non-nullable scalar requires a default" {
-    try expectBuildError(error.MissingDefault, "count", .{ .@"type" = "u32" });
+    try expectBuildError(error.MissingDefault, "count", .{ .type = "u32" });
 }
 
 test "buildSpec: multiple rejects unsupported element types" {
-    try expectBuildError(error.UnsupportedArrayElement, "flags", .{ .@"type" = "bool", .multiple = true });
+    try expectBuildError(error.UnsupportedArrayElement, "flags", .{ .type = "bool", .multiple = true });
 }
 
 test "buildSpec: bad short flag" {
-    try expectBuildError(error.BadShort, "loud", .{ .@"type" = "bool", .default = "false", .short = "loud" });
+    try expectBuildError(error.BadShort, "loud", .{ .type = "bool", .default = "false", .short = "loud" });
 }
 
 test "buildSpec: well-formed scalar" {
@@ -202,7 +204,10 @@ test "buildSpec: well-formed scalar" {
     defer arena.deinit();
     var aw = std.Io.Writer.Allocating.init(arena.allocator());
     const s = try buildSpec(arena.allocator(), &aw.writer, "limit", .{
-        .@"type" = "u32", .default = "10", .short = "l", .description = "Max",
+        .type = "u32",
+        .default = "10",
+        .short = "l",
+        .description = "Max",
     });
     try testing.expectEqualStrings("limit", s.name);
     try testing.expectEqualStrings("u32", s.elem_type);
@@ -214,6 +219,6 @@ test "buildSpec: non-nullable multiple defaults to empty slice" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
     var aw = std.Io.Writer.Allocating.init(arena.allocator());
-    const s = try buildSpec(arena.allocator(), &aw.writer, "tags", .{ .@"type" = "[]const u8", .multiple = true });
+    const s = try buildSpec(arena.allocator(), &aw.writer, "tags", .{ .type = "[]const u8", .multiple = true });
     try testing.expectEqualStrings("&.{}", s.default_expr.?);
 }

--- a/projects/zcli/src/commands/release.zig
+++ b/projects/zcli/src/commands/release.zig
@@ -535,7 +535,11 @@ fn updateBuildZonVersion(allocator: std.mem.Allocator, io: std.Io, new_version: 
                 while (i < line.len and (line[i] == ' ' or line[i] == '\t')) : (i += 1) {}
                 break :blk line[0..i];
             };
-            { const s = try std.fmt.allocPrint(allocator, "{s}.version = \"{s}\",\n", .{ indent, new_version }); defer allocator.free(s); try new_content.appendSlice(allocator, s); }
+            {
+                const s = try std.fmt.allocPrint(allocator, "{s}.version = \"{s}\",\n", .{ indent, new_version });
+                defer allocator.free(s);
+                try new_content.appendSlice(allocator, s);
+            }
         } else {
             try new_content.appendSlice(allocator, line);
             try new_content.append(allocator, '\n');

--- a/projects/zcli/src/scaffold/spec.zig
+++ b/projects/zcli/src/scaffold/spec.zig
@@ -272,13 +272,23 @@ test "renderOptField covers scalar, nullable, multiple" {
     const a = arena.allocator();
 
     try testing.expectEqualStrings("limit: u32 = 10", try renderOptField(a, .{
-        .name = "limit", .elem_type = "u32", .multiple = false, .nullable = false, .default_expr = "10",
+        .name = "limit",
+        .elem_type = "u32",
+        .multiple = false,
+        .nullable = false,
+        .default_expr = "10",
     }));
     try testing.expectEqualStrings("repeat: ?u32 = null", try renderOptField(a, .{
-        .name = "repeat", .elem_type = "u32", .multiple = false, .nullable = true,
+        .name = "repeat",
+        .elem_type = "u32",
+        .multiple = false,
+        .nullable = true,
     }));
     try testing.expectEqualStrings("tags: [][]const u8 = &.{}", try renderOptField(a, .{
-        .name = "tags", .elem_type = "[]const u8", .multiple = true, .nullable = false,
+        .name = "tags",
+        .elem_type = "[]const u8",
+        .multiple = true,
+        .nullable = false,
     }));
 }
 
@@ -288,13 +298,25 @@ test "renderArgField covers required, optional, variadic" {
     const a = arena.allocator();
 
     try testing.expectEqualStrings("name: []const u8", try renderArgField(a, .{
-        .name = "name", .elem_type = "[]const u8", .multiple = false, .nullable = false, .description = "",
+        .name = "name",
+        .elem_type = "[]const u8",
+        .multiple = false,
+        .nullable = false,
+        .description = "",
     }));
     try testing.expectEqualStrings("count: ?u32 = null", try renderArgField(a, .{
-        .name = "count", .elem_type = "u32", .multiple = false, .nullable = true, .description = "",
+        .name = "count",
+        .elem_type = "u32",
+        .multiple = false,
+        .nullable = true,
+        .description = "",
     }));
     try testing.expectEqualStrings("files: [][]const u8", try renderArgField(a, .{
-        .name = "files", .elem_type = "[]const u8", .multiple = true, .nullable = false, .description = "",
+        .name = "files",
+        .elem_type = "[]const u8",
+        .multiple = true,
+        .nullable = false,
+        .description = "",
     }));
 }
 
@@ -304,10 +326,21 @@ test "renderOptMetaEntry includes short only when present" {
     const a = arena.allocator();
 
     try testing.expectEqualStrings(".loud = .{ .description = \"Shout it\", .short = 'l' }", try renderOptMetaEntry(a, .{
-        .name = "loud", .elem_type = "bool", .multiple = false, .nullable = false, .default_expr = "false", .short = 'l', .description = "Shout it",
+        .name = "loud",
+        .elem_type = "bool",
+        .multiple = false,
+        .nullable = false,
+        .default_expr = "false",
+        .short = 'l',
+        .description = "Shout it",
     }));
     try testing.expectEqualStrings(".limit = .{ .description = \"Max\" }", try renderOptMetaEntry(a, .{
-        .name = "limit", .elem_type = "u32", .multiple = false, .nullable = false, .default_expr = "1", .description = "Max",
+        .name = "limit",
+        .elem_type = "u32",
+        .multiple = false,
+        .nullable = false,
+        .default_expr = "1",
+        .description = "Max",
     }));
 }
 


### PR DESCRIPTION
## Summary

Grade tracker item 2 (stacked on #43 — will retarget to main automatically when that merges).

- Ran `zig fmt` on the 22 files that failed `--check` (incl. `packages/core/src/registry.zig`, `projects/zcli/src/commands/release.zig`, the completions plugins, showcase commands). Whitespace-only.
- Added a `fmt` job to CI: `zig fmt --check packages projects examples build.zig`. Explicit paths because scripts/ and website/ contain no Zig source.

## Verification

- `zig fmt --check` now clean
- Full root `zig build test` green after formatting (macOS, zig 0.16.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)