### PR TITLE
Make local plugin discovery actually work (fixes #41's add plugin)

### DIFF
--- a/packages/core/src/build_utils/main.zig
+++ b/packages/core/src/build_utils/main.zig
@@ -212,7 +212,9 @@ pub fn generate(b: *std.Build, exe: *std.Build.Step.Compile, zcli_dep: *std.Buil
     // Create BuildConfig
     const build_config = BuildConfig{
         .commands_dir = config.commands_dir,
-        .plugins_dir = null,
+        // Honor a caller-provided plugins_dir so local plugins under it are
+        // convention-discovered (ADR-0006). Optional: absent → no local scan.
+        .plugins_dir = if (@hasField(@TypeOf(config), "plugins_dir")) config.plugins_dir else null,
         .plugins = plugins.items,
         .shared_modules = if (@hasField(@TypeOf(config), "shared_modules")) config.shared_modules else null,
         .command_configs = if (@hasField(@TypeOf(config), "command_configs")) config.command_configs else null,

--- a/packages/core/src/build_utils/module_creation.zig
+++ b/packages/core/src/build_utils/module_creation.zig
@@ -193,14 +193,19 @@ fn createGroupModules(
 pub fn addPluginModulesToRegistry(b: *std.Build, registry_module: *std.Build.Module, zcli_dep: *std.Build.Dependency, zcli_module: *std.Build.Module, plugins: []const PluginInfo) void {
     for (plugins) |plugin_info| {
         if (plugin_info.is_local) {
-            // import_name is like "src/plugins/zcli_help/plugin"
-            // zcli_dep path handling:
-            // - If using .path dependency, it points directly to packages/core
-            // - If using .url dependency, it points to the repo root
-            // We'll try both paths for compatibility
-            const plugin_path = b.fmt("{s}.zig", .{plugin_info.import_name});
+            // Two kinds of "local" plugin resolve against different roots:
+            //   - project_path set → a plugin in the *consuming project*
+            //     (discovered under plugins_dir); resolve with b.path.
+            //   - otherwise → a framework built-in living in the zcli package;
+            //     import_name is like "src/plugins/zcli_help/plugin", resolved
+            //     against the zcli dependency.
+            const root_source_file = if (plugin_info.project_path) |project_path|
+                b.path(project_path)
+            else
+                zcli_dep.path(b.fmt("{s}.zig", .{plugin_info.import_name}));
+
             const plugin_module = b.addModule(plugin_info.import_name, .{
-                .root_source_file = zcli_dep.path(plugin_path),
+                .root_source_file = root_source_file,
             });
             plugin_module.addImport("zcli", zcli_module);
 

--- a/packages/core/src/build_utils/plugin_system.zig
+++ b/packages/core/src/build_utils/plugin_system.zig
@@ -45,12 +45,17 @@ pub fn scanLocalPlugins(b: *std.Build, plugins_dir: []const u8) ![]PluginInfo {
                     }
 
                     const import_name = try std.fmt.allocPrint(b.allocator, "plugins/{s}", .{plugin_name});
+                    // `entry.name` aliases the iterator's buffer, reused on the
+                    // next `next()`, so `plugin_name` must be duped to outlive the
+                    // scan (import_name/project_path already copy via allocPrint).
+                    const project_path = try std.fmt.allocPrint(b.allocator, "{s}/{s}", .{ plugins_dir, entry.name });
 
                     try plugins.append(b.allocator, PluginInfo{
-                        .name = plugin_name,
+                        .name = try b.allocator.dupe(u8, plugin_name),
                         .import_name = import_name,
                         .is_local = true,
                         .dependency = null,
+                        .project_path = project_path,
                     });
                 }
             },
@@ -70,12 +75,15 @@ pub fn scanLocalPlugins(b: *std.Build, plugins_dir: []const u8) ![]PluginInfo {
                 _ = subdir.statFile(b.graph.io, "plugin.zig", .{}) catch continue; // Skip if no plugin.zig
 
                 const import_name = try std.fmt.allocPrint(b.allocator, "plugins/{s}/plugin", .{entry.name});
+                // Dupe entry.name — it aliases the iterator's reused buffer.
+                const project_path = try std.fmt.allocPrint(b.allocator, "{s}/{s}/plugin.zig", .{ plugins_dir, entry.name });
 
                 try plugins.append(b.allocator, PluginInfo{
-                    .name = entry.name,
+                    .name = try b.allocator.dupe(u8, entry.name),
                     .import_name = import_name,
                     .is_local = true,
                     .dependency = null,
+                    .project_path = project_path,
                 });
             },
             else => continue,

--- a/packages/core/src/build_utils/types.zig
+++ b/packages/core/src/build_utils/types.zig
@@ -12,6 +12,10 @@ pub const PluginInfo = struct {
     dependency: ?*std.Build.Dependency,
     /// Optional initialization code (from PluginConfig)
     init: ?[]const u8 = null,
+    /// For plugins discovered in the *consuming project* (via `plugins_dir`):
+    /// the project-relative source path, resolved with `b.path`. Null for
+    /// framework built-ins, which live in the zcli package (`zcli_dep.path`).
+    project_path: ?[]const u8 = null,
 };
 
 /// Command type classification

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -691,8 +691,7 @@ test "scaffolded project builds, runs, and round-trips add command" {
 
     // `add plugin` drops a file into the convention-discovered src/plugins/ dir
     // (init wired `.plugins_dir`). The generated skeleton must compile and be
-    // auto-discovered on the next build — no build.zig edit — and its
-    // pass-through preExecute must not disturb command output.
+    // auto-discovered on the next build — no build.zig edit.
     {
         var r = try run(proj, &.{ zcli_exe, "add", "plugin", "telemetry", "-d", "Track usage" });
         defer r.deinit();
@@ -701,6 +700,23 @@ test "scaffolded project builds, runs, and round-trips add command" {
         try testing.expect(std.mem.indexOf(u8, r.stdout, "won't be discovered") == null);
     }
     try testing.expect(fileExists(proj, "src/plugins/telemetry.zig"));
+
+    // Replace the pass-through skeleton with a plugin whose preExecute has a
+    // *visible* effect, so the rebuild proves the plugin is genuinely discovered
+    // and its hook runs — not merely that the file compiles. (A pass-through
+    // hook is indistinguishable from one that never ran.)
+    try proj.writeFile(io, .{
+        .sub_path = "src/plugins/telemetry.zig",
+        .data =
+        \\const std = @import("std");
+        \\const zcli = @import("zcli");
+        \\pub fn preExecute(context: anytype, args: zcli.ParsedArgs) !?zcli.ParsedArgs {
+        \\    try context.stderr().print("[telemetry] hook ran\n", .{});
+        \\    return args;
+        \\}
+        \\
+        ,
+    });
     {
         var r = try run(proj, &.{ "zig", "build" });
         defer r.deinit();
@@ -710,7 +726,10 @@ test "scaffolded project builds, runs, and round-trips add command" {
         var r = try run(proj, &.{ "./zig-out/bin/demo", "hello", "World" });
         defer r.deinit();
         try expectOk(r);
-        try expectContains(r.stdout, "Hello, World!"); // preExecute is pass-through
+        try expectContains(r.stdout, "Hello, World!");
+        // The discovered plugin's preExecute ran (proves .plugins_dir is honored
+        // and the local-plugin module resolves to the project's src/plugins/).
+        try expectContains(r.stderr, "[telemetry] hook ran");
     }
 
     // `mv` + `rm command`: whole-file restructure. Move a command into a new


### PR DESCRIPTION
## Summary

`add plugin` (#41) scaffolds a file into `src/plugins/` and relies on convention discovery to wire it into the build — but discovery **never actually worked**. Three bugs, none caught because the generated skeleton's `preExecute` is a pass-through, indistinguishable from a hook that never ran.

### The three bugs

1. **`plugins_dir` dropped.** The public `generate()` built its `BuildConfig` with `.plugins_dir = null` hardcoded, ignoring the caller's `config.plugins_dir`. `scanLocalPlugins` was therefore never invoked — a project setting `.plugins_dir = "src/plugins"` (as `init` emits) had zero effect.

2. **Wrong module root.** Once discovered, a local plugin resolved against the **zcli package** (`zcli_dep.path`) just like a built-in → `<zcli>/plugins/telemetry.zig` (wrong root, missing `src/`). Added `PluginInfo.project_path` for plugins that live in the *consuming project*; those resolve with `b.path(<plugins_dir>/<name>.zig)`. Built-ins (`project_path == null`) still resolve via `zcli_dep.path`.

3. **Use-after-free on the plugin name.** `scanLocalPlugins` stored `PluginInfo.name = entry.name` without duping, but `std.Io.Dir`'s iterator reuses its entry-name buffer on each `next()`. By codegen time the name aliased overwritten memory, so the generated `const <name> = @import(...)` binding came out as garbage bytes:
   ```
   zcli_generated.zig:12:7: error: expected 'an identifier', found invalid bytes
   ```
   (`import_name`/`project_path` were fine — `allocPrint` copies; only `name` aliased the volatile buffer.) Fixed by duping.

### Why it wasn't caught

The #41 e2e asserted the plugin file *compiled*, but its pass-through `preExecute` produced identical output whether or not it ran. This PR replaces the skeleton with a plugin whose `preExecute` writes a visible marker, rebuilds, and asserts the marker appears — proving the plugin is genuinely discovered **and its hook executes**. That assertion is the regression guard all three bugs slipped past.

## Tests
- **core 797/797**, **meta-CLI 50/50**, **e2e 14/14**.
- The strengthened round-trip e2e now fails on any of the three regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)