### PR TITLE
context.exit() flushes buffered output (grade fix 11)

### DIFF
--- a/GRADE_TODO.md
+++ b/GRADE_TODO.md
@@ -17,7 +17,7 @@ Grades at audit time: Architecture A-, Docs/DX A-, Testing B+, Security B, Zig p
 - [ ] 8. **snapshot.zig is un-migrated 0.15 code exported as pub API** — `packages/testing/src/snapshot.zig` uses `std.fs.cwd()` / `getEnvVarOwned`; first downstream caller of `expectSnapshot` gets a compile error. Migrate to 0.16 IO.
 - [ ] 9. **vterm resize out-of-bounds** — `resize` reallocates `new_width × new_height` but never updates `scrollback_lines` (`packages/vterm/src/vterm.zig:362-386`), so post-resize scrolling indexes out of bounds; `buffer_start` never advances (circular buffer half-implemented). Also `eraseFromCursor`/`eraseToCursor` mix viewport vs buffer coordinates (`:683-698`).
 - [ ] 10. **Required options read `undefined`** — non-bool, non-optional, non-defaulted Options fields are initialized to `undefined` and read if the flag is absent (`options/parser.zig:174-177`, `command_parser.zig:240-243`). Enforce defaults/optionality at comptime in `validateMeta`, or implement required-option errors.
-- [ ] 11. **`context.exit()` drops buffered output** — `registry.zig:392-394`, `zcli.zig:170-172` discard `self` and call `std.process.exit` without flushing the framework-owned writers. Flush `self.io` before exiting.
+- [x] 11. **`context.exit()` drops buffered output** — `registry.zig:392-394`, `zcli.zig:170-172` discard `self` and call `std.process.exit` without flushing the framework-owned writers. Flush `self.io` before exiting.
 
 ## Security — remaining
 

--- a/packages/core/src/registry.zig
+++ b/packages/core/src/registry.zig
@@ -386,8 +386,11 @@ fn ComputedContextType(comptime config: Config, comptime plugins: []const type) 
             return self.global_options;
         }
 
-        /// Exit the process with the given code
-        pub fn exit(_: *Self, code: u8) void {
+        /// Exit the process with the given code, flushing buffered output
+        /// first — std.process.exit alone silently drops anything printed
+        /// just before the call.
+        pub fn exit(self: *Self, code: u8) noreturn {
+            self.io.flush();
             std.process.exit(code);
         }
     };

--- a/packages/core/src/zcli.zig
+++ b/packages/core/src/zcli.zig
@@ -167,7 +167,10 @@ pub const Context = struct {
         return self.io.stdin();
     }
 
-    pub fn exit(_: *Self, code: u8) void {
+    pub fn exit(self: *Self, code: u8) noreturn {
+        // std.process.exit does not flush buffered writers — without this,
+        // anything printed just before exit() is silently dropped.
+        self.io.flush();
         std.process.exit(code);
     }
 

--- a/projects/zcli/src/commands/dev.zig
+++ b/projects/zcli/src/commands/dev.zig
@@ -41,9 +41,7 @@ pub fn execute(args: Args, options: Options, context: anytype) !void {
     var probe = std.Io.Dir.cwd().openDir(io, "src", .{}) catch |err| switch (err) {
         error.FileNotFound => {
             try status.writeAll("No 'src' directory found. Run this from a zcli project root.\n");
-            try status.flush();
             context.exit(1);
-            return;
         },
         else => return err,
     };

--- a/projects/zcli/src/commands/tree.zig
+++ b/projects/zcli/src/commands/tree.zig
@@ -43,9 +43,7 @@ pub fn execute(args: Args, options: Options, context: anytype) !void {
         error.FileNotFound => {
             const stderr = context.stderr();
             try stderr.print("No '{s}' directory found. Run this from a zcli project root.\n", .{commands_dir});
-            try stderr.flush(); // process.exit won't flush the buffered writer
-            context.exit(1);
-            return;
+            context.exit(1); // flushes buffered output before exiting
         },
         else => return err,
     };

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -296,6 +296,18 @@ test "add command outside a project fails clearly" {
     try expectContains(r.stderr, "Not in a zcli project");
 }
 
+test "tree outside a project exits nonzero and its message survives the exit" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var r = try run(tmp.dir, &.{ zcli_exe, "tree" });
+    defer r.deinit();
+    try testing.expect(r.exit_code != 0);
+    // The message goes to a buffered writer immediately before context.exit —
+    // it only reaches us because exit() flushes the framework IO.
+    try expectContains(r.stderr, "No 'src/commands' directory found");
+}
+
 test "gh add workflow release writes the workflow file" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();


### PR DESCRIPTION
## Summary

Grade tracker item 11: `context.exit()` discarded `self` and called `std.process.exit` directly — dropping whatever sat in the buffered writers. The project memory even documents this as a known trap ("try writer.flush() before exiting on an early-return path"), and both in-tree call sites (dev.zig, tree.zig) carried manual-flush workarounds with comments.

- Both `exit` implementations (base `Context` in zcli.zig, registry's computed Context) now call `self.io.flush()` first, and are typed `noreturn`.
- The manual workarounds in dev.zig/tree.zig are removed — the framework guarantee replaces them.

## Verification

- New e2e test: `zcli tree` outside a project exits nonzero **and** its buffered stderr message reaches the parent — with the manual flush deleted, that only passes because `exit()` flushes (verified: the message arrives).
- Full e2e suite green (15 tests), core suite green, `zig fmt --check` clean.

Note: while verifying this I hit (and diagnosed) an unrelated pre-existing PTY-harness deadlock that intermittently hangs the e2e suite — fix in the next PR; both this branch's e2e runs were verified with that fix applied locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)