### PR TITLE
ADR-0009: release-integrity trust model, signing deferred with triggers (grade fix 17)

### DIFF
--- a/GRADE_TODO.md
+++ b/GRADE_TODO.md
@@ -26,7 +26,7 @@ Grades at audit time: Architecture A-, Docs/DX A-, Testing B+, Security B, Zig p
 - [x] 14. **`sh -c` in release.zig** — `getReleaseNotes` interpolates tag names into a shell string (`projects/zcli/src/commands/release.zig:633-640`); every other call uses argv arrays. Drop the shell, pass the tag range as one argv element.
 - [x] 15. **Resource limits partially enforced** — only `checkOptionCount`/`checkOptionNameLength` are wired; `checkArraySize`, `max_argument_count`, `checkCommandDepth` unused (`packages/core/src/resource_limits.zig` vs `options/parser.zig`, `args.zig`). Wire them in or delete the unused fields; tighten `security_test.zig` to assert the caps that are enforced.
 - [x] 16. **serde hash label mismatch** — *false alarm*: upstream v1.0.3 tag ships a zon still declaring version 1.0.1, so the `serde-1.0.1-…` hash IS correct for the v1.0.3 tarball. Explanatory comment (already in core's zon) copied to the root zon so it isn't "fixed" into a broken build.
-- [ ] 17. **No release signing (documented decision)** — integrity anchors solely on GitHub (checksums.txt from the same release). Consider minisign/cosign signing of checksums.txt; at minimum document the trust model in ADR-0002/0003.
+- [x] 17. **No release signing (documented decision)** — integrity anchors solely on GitHub (checksums.txt from the same release). Consider minisign/cosign signing of checksums.txt; at minimum document the trust model in ADR-0002/0003.
 - [ ] 18. **Startup version check behavior** — document the outbound network call at `Config.inform_out_of_date`, and cache the last check with a min interval so it doesn't fire on every invocation.
 
 ## Zig patterns / correctness — remaining

--- a/TODOS.md
+++ b/TODOS.md
@@ -122,3 +122,21 @@ then the context tail `examples → guide → AGENTS.md`. **Parallelizable early
 - **Effort:** S–M (module split within `packages/testing`, or a new `zcli-testing-unit` package).
 - **Context:** `packages/testing/build.zig.zon` (the new `zcli_core` + `vterm` deps);
   `packages/testing/src/unit.zig` is the only tier needing core.
+
+### Sign releases (checksums.txt) with a pinned client key
+
+- **What:** Sign `checksums.txt` with a detached-signature scheme (minisign/signify style) in the
+  release workflow, verify in both `install.sh` and the `zcli_github_upgrade` plugin against a
+  public key pinned in the client. Removes GitHub account/token security as the sole integrity
+  anchor for distributed binaries.
+- **Why deferred:** ADR-0009 records the current model: fail-closed checksums from the same
+  release defend transit integrity and asset mix-ups, not a malicious publisher. A signing key
+  only adds security once it lives somewhere the release credentials do not — pre-adoption,
+  it's key-management ceremony with no one downstream to protect.
+- **Trigger to revisit:** Third-party install base emerges; releases move to CI with long-lived
+  credentials; or a packaging ecosystem (Homebrew tap, distro) wants a verifiable artifact.
+- **Effort:** M (keygen + secret in release workflow, ~30-line verify in installer and plugin,
+  key-rotation story documented).
+- **Context:** `docs/adr/0009-release-integrity-trust-model.md`; enforcement landed in the
+  audit-fix series (#46 installer fail-closed, #47 scratch dir, #57 exec smoke test, #58 exact
+  checksum matching).

--- a/docs/adr/0009-release-integrity-trust-model.md
+++ b/docs/adr/0009-release-integrity-trust-model.md
@@ -1,0 +1,66 @@
+# Release integrity anchors on the GitHub release, unsigned (for now)
+
+Status: accepted
+
+zcli has two trust-establishing distribution paths: the `curl | sh` installer
+(`install.sh`) and the self-upgrade plugin (`zcli_github_upgrade`). Both fetch
+a binary **and** a `checksums.txt` from the same GitHub release over HTTPS,
+verify the binary's SHA-256 against the checksum file, and fail **closed**:
+the installer aborts if checksum tooling is unavailable or the checksum file
+cannot be fetched; the plugin errors on a missing or mismatched digest, with
+the checksum line matched by exact filename. The upgrade additionally
+downloads into a private randomly-named scratch directory, smoke-tests that
+the staged binary actually execs, and swaps it in atomically with a backup.
+
+This ADR records what that design does and does not defend against, because
+the security audit found the trust model implemented but nowhere written down
+— and an unlegible trust model invites both false confidence and false alarms.
+
+## What the checksum defends against
+
+- Corruption or truncation in transit (including through proxies and mirrors).
+- Asset mix-ups: downloading the wrong platform's binary, or a stale/partial
+  asset, fails verification instead of getting installed. The exec smoke test
+  then catches the residual case a digest cannot (a correctly-published asset
+  that is simply the wrong architecture under this platform's name).
+
+## What it does not defend against
+
+`checksums.txt` ships in the **same release** as the binaries, so anyone who
+can publish a release can publish matching checksums. Integrity therefore
+reduces to the security of:
+
+1. the maintainer's GitHub account and any tokens with release permission, and
+2. GitHub itself (release storage and the HTTPS endpoints).
+
+This is trust-on-first-use anchored on GitHub. A compromised maintainer token
+or a malicious release pipeline defeats checksum verification by construction
+— only a signature under a key the *client already holds* would catch it.
+
+## Considered Options
+
+- **Detached signature over `checksums.txt` (minisign/OpenBSD signify style),
+  public key pinned in the client** — the right eventual answer: one small
+  signature check in the installer and upgrade plugin, and release integrity
+  stops depending solely on GitHub account security. Deferred, not rejected:
+  it introduces a real signing key to generate, protect, back up, and rotate,
+  and a compromised signing key stored *next to* the release credentials adds
+  ceremony without adding security. The value arrives when the key lives
+  somewhere the release token does not.
+- **Sigstore/cosign keyless signing** — avoids long-lived keys, but pulls a
+  substantial verification dependency into a libc-free static binary and ties
+  verification to an external transparency-log ecosystem. Disproportionate
+  for zcli's current audience.
+- **Document the model, defer signing (chosen)** — the enforcement that
+  exists (fail-closed checksums, exact matching, scratch-dir download, atomic
+  swap, exec smoke test) is real and tested; what was missing was a written
+  statement of where its guarantees end. This ADR is that statement.
+
+## Trigger to revisit
+
+Add release signing when any of these becomes true: zcli binaries are
+distributed beyond the maintainer's own projects (meaningful third-party
+install base); releases start being published by CI with long-lived
+credentials rather than an interactive maintainer session; or a package
+ecosystem (Homebrew tap, distro packaging) wants a verifiable upstream
+artifact. The deferred-work entry in `TODOS.md` carries the effort estimate.


### PR DESCRIPTION
## Summary

Grade tracker item 17 — docs-only. The audit noted release integrity anchors solely on GitHub (checksums.txt ships in the same release it verifies) and recommended either signing or, at minimum, writing the trust model down. This does the latter, as an ADR in the house style:

- **What the current pipeline guarantees**: fail-closed checksum verification in both installer and upgrade plugin (exact filename matching), private scratch-dir downloads, atomic swap with backup, exec smoke test — defends transit corruption and asset mix-ups.
- **Where the guarantee ends**: anyone who can publish a release publishes matching checksums; integrity reduces to maintainer account/token security and GitHub itself. Only a key the client already holds would catch a malicious publisher.
- **Decision**: defer signing (minisign-style pinned key is the right eventual answer; sigstore is disproportionate for a libc-free static binary), with concrete revisit triggers — third-party install base, CI-published releases with long-lived credentials, or packaging-ecosystem demand.
- **TODOS.md** gets the matching deferred entry (why-deferred / trigger / effort M / context), per the repo's debt-register convention.

No code changes. If you'd rather do real signing now instead, say the word and I'll set up the minisign flow — the ADR's "considered options" section already sketches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)