### PR TITLE
Phase 4: canonical examples become CI-compiled + first HTTP example (ADR-0004)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,25 @@ jobs:
             zig build test-secrets-live
           '
 
+  examples:
+    name: canonical examples compile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+
+      # The canonical example CLIs are the idiom source AND the drift-detector
+      # (ADR-0004): compiling them here means a framework change that breaks the
+      # documented idioms fails CI, rather than silently rotting the examples
+      # (and the AI context sourced from them).
+      - name: Build all example CLIs
+        run: zig build build-examples
+
   e2e:
     name: zcli end-to-end tests
     runs-on: ubuntu-latest

--- a/build.zig
+++ b/build.zig
@@ -109,8 +109,13 @@ pub fn build(b: *std.Build) void {
         .{ .name = "zcli", .path = "projects/zcli" },
     };
 
+    // Canonical example CLIs (ADR-0004): first-class, CI-compiled artifacts that
+    // are simultaneously the examples, the idiom source, and the drift-detector —
+    // a breaking framework change breaks `zig build build-examples` (run in CI),
+    // forcing the examples (and the context derived from them) back up to date.
     const example_projects = [_]ProjectInfo{
         .{ .name = "showcase", .path = "examples/showcase" },
+        .{ .name = "repostat", .path = "examples/repostat" },
         .{ .name = "vterm_example", .path = "packages/vterm/example" },
     };
 

--- a/examples/repostat/README.md
+++ b/examples/repostat/README.md
@@ -1,0 +1,33 @@
+# repostat — a `zcli.http` example
+
+A tiny CLI that prints stats for a public GitHub repository:
+
+```
+$ repostat repo ziglang/zig
+ziglang/zig
+  General-purpose programming language and toolchain...
+  ★ 35000 stars  ·  Zig
+  https://github.com/ziglang/zig
+```
+
+It's a **canonical example** (ADR-0004): a compiled, CI-checked teaching artifact
+for one idiom — calling an HTTP API from a command with `zcli.http`. See
+[`src/commands/repo.zig`](src/commands/repo.zig).
+
+What it demonstrates:
+
+- **`zcli.http.Client`** with safe defaults (TLS verification, a request timeout,
+  a bounded response body) — no boilerplate to get them.
+- **Request headers** via `client.request(.GET, url, .{ .headers = ... })`.
+- **Typed JSON** with `Response.json(T, ...)` — the `Repo` struct models only the
+  fields it renders; unknown fields are ignored.
+- **The arena-per-command allocator** (ADR-0001): nothing here frees memory by
+  hand; it's all reclaimed when the command returns.
+- **Plain-language errors** to stderr for the failure paths (bad slug, non-200,
+  unparseable body).
+
+Run it:
+
+```
+zig build run -- repo ryanhair/zcli
+```

--- a/examples/repostat/build.zig
+++ b/examples/repostat/build.zig
@@ -1,0 +1,40 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const zcli_dep = b.dependency("zcli", .{ .target = target, .optimize = optimize });
+    const zcli_module = zcli_dep.module("zcli");
+
+    const exe = b.addExecutable(.{
+        .name = "repostat",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    exe.root_module.addImport("zcli", zcli_module);
+
+    const zcli = @import("zcli");
+    const cmd_registry = zcli.generate(b, exe, zcli_dep, zcli_module, .{
+        .commands_dir = "src/commands",
+        .plugins = &.{
+            zcli.builtin(.help, .{}),
+            zcli.builtin(.version, .{}),
+            zcli.builtin(.not_found, .{}),
+        },
+        .app_name = "repostat",
+        .app_description = "Show stats for public GitHub repositories (a zcli.http example)",
+    });
+    exe.root_module.addImport("command_registry", cmd_registry);
+
+    b.installArtifact(exe);
+
+    const run_cmd = b.addRunArtifact(exe);
+    run_cmd.step.dependOn(b.getInstallStep());
+    if (b.args) |args| run_cmd.addArgs(args);
+    const run_step = b.step("run", "Run the application");
+    run_step.dependOn(&run_cmd.step);
+}

--- a/examples/repostat/build.zig.zon
+++ b/examples/repostat/build.zig.zon
@@ -1,0 +1,19 @@
+.{
+    .name = .repostat,
+    .version = "0.1.0",
+    .fingerprint = 0x4365e7a6833ce10b,
+    .minimum_zig_version = "0.16.0",
+    .dependencies = .{
+        // This example lives inside the zcli repo, so it builds against the
+        // local tree (that's what lets CI compile it against unreleased changes
+        // as a drift-detector). In your OWN project you don't hand-write this —
+        // `zcli init` fetches a released zcli for you, which looks like:
+        //   .zcli = .{ .url = "git+https://github.com/ryanhair/zcli#<tag>", .hash = "..." },
+        .zcli = .{ .path = "../.." },
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}

--- a/examples/repostat/src/commands/repo.zig
+++ b/examples/repostat/src/commands/repo.zig
@@ -1,0 +1,78 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
+
+pub const meta = .{
+    .description = "Show stats for a public GitHub repository",
+    .examples = &.{
+        "repo ziglang/zig",
+        "repo ryanhair/zcli",
+    },
+    .args = .{
+        .slug = "Repository as owner/name (e.g. ziglang/zig)",
+    },
+};
+
+pub const Args = struct {
+    slug: []const u8,
+};
+
+pub const Options = struct {};
+
+/// Only the fields we render. `Response.json` ignores unknown fields, so this
+/// struct can model just the slice of GitHub's payload we care about.
+const Repo = struct {
+    full_name: []const u8,
+    description: ?[]const u8 = null,
+    stargazers_count: u64 = 0,
+    language: ?[]const u8 = null,
+    html_url: []const u8,
+};
+
+pub fn execute(args: Args, _: Options, context: *Context) !void {
+    // The arena-per-command allocator: everything here is freed at once when the
+    // command returns, so nothing below needs an explicit `free`/`deinit` for
+    // memory (network handles still get `deinit`).
+    const arena = context.allocator;
+    const io = context.io;
+    const stderr = context.stderr();
+
+    const url = try std.fmt.allocPrint(arena, "https://api.github.com/repos/{s}", .{args.slug});
+
+    // Safe defaults come for free: TLS verification on, a 30s timeout, and a
+    // bounded response body. `arena` owns the response body.
+    var client = zcli.http.Client.init(arena, io, .{});
+    defer client.deinit();
+
+    var response = client.request(.GET, url, .{
+        .headers = &.{
+            .{ .name = "User-Agent", .value = "zcli-repostat" }, // GitHub requires one
+            .{ .name = "Accept", .value = "application/vnd.github+json" },
+        },
+    }) catch |err| {
+        try stderr.print("Error: request to GitHub failed: {s}\n", .{@errorName(err)});
+        return err;
+    };
+    defer response.deinit();
+
+    if (response.status != .ok) {
+        try stderr.print(
+            "Error: GitHub returned {d} for '{s}' (is the repo public and spelled owner/name?)\n",
+            .{ @intFromEnum(response.status), args.slug },
+        );
+        return error.RequestFailed;
+    }
+
+    const parsed = response.json(Repo, arena) catch {
+        try stderr.print("Error: could not parse GitHub's response\n", .{});
+        return error.BadResponse;
+    };
+    const repo = parsed.value;
+
+    const stdout = context.stdout();
+    try stdout.print("{s}\n", .{repo.full_name});
+    if (repo.description) |d| try stdout.print("  {s}\n", .{d});
+    try stdout.print("  \u{2605} {d} stars", .{repo.stargazers_count});
+    if (repo.language) |l| try stdout.print("  \u{00b7}  {s}", .{l});
+    try stdout.print("\n  {s}\n", .{repo.html_url});
+}

--- a/examples/repostat/src/main.zig
+++ b/examples/repostat/src/main.zig
@@ -1,0 +1,15 @@
+const std = @import("std");
+const registry = @import("command_registry");
+
+pub const std_options: std.Options = .{
+    .log_level = .warn,
+};
+
+pub fn main(init: std.process.Init) !void {
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
+    var app = registry.init();
+    app.run(init.gpa, init.io, init.environ_map, args) catch |err| switch (err) {
+        error.CommandNotFound => std.process.exit(1),
+        else => return err,
+    };
+}


### PR DESCRIPTION
First PR of **Phase 4** (the context layer). Establishes the mechanism ADR-0004 is built on: **canonical example CLIs that CI compiles**, so they're simultaneously the examples, the idiom source, and the drift-detector.

## The gap
`build-examples` existed in the root `build.zig`, but **no CI job ran it** — examples could rot silently, taking the future AI context (guide / AGENTS.md, sourced from these examples) with them.

## What this does
1. **CI compiles the examples** — a new `examples` job runs `zig build build-examples` on every PR/push. A framework change that breaks a documented idiom now fails CI instead of rotting the example.
2. **Adds `examples/repostat`** — a tiny GitHub repo-stats CLI, the canonical teaching artifact for one idiom: calling an HTTP API from a command with `zcli.http`.

```
$ repostat repo ziglang/zig
ziglang/zig
  General-purpose programming language and toolchain...
  ★ 35000 stars  ·  Zig
  https://github.com/ziglang/zig
```

`src/commands/repo.zig` (~50 lines) exercises:
- `zcli.http.Client` **safe defaults** (TLS verification, request timeout, bounded body) — no boilerplate;
- request **headers** via `client.request(.GET, url, .{ .headers = ... })`;
- **typed JSON** with `Response.json(T, ...)` — the `Repo` struct models only the fields it renders (unknown ignored);
- the **arena-per-command allocator** (ADR-0001) — nothing frees memory by hand;
- **plain-language errors** to stderr for bad slug / non-200 / unparseable body.

It uses only std-linkable deps, so it compiles on the Linux CI runner with nothing extra installed.

## Scope
First increment of the canonical set. `showcase` already covers structure/config/output/completions. The **auth/secrets service-client** example (which pulls the OS-keychain link deps into the examples job) is a focused follow-up before the `zcli guide` PR draws on the set.

## Verified
- `zig build build-examples` compiles showcase + repostat + vterm_example;
- `repostat --help` / `repo --help` dispatch correctly;
- `zig fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)