### PR TITLE
options: one source of truth for flag/value classification (grade fix 20)

### DIFF
--- a/GRADE_TODO.md
+++ b/GRADE_TODO.md
@@ -32,7 +32,7 @@ Grades at audit time: Architecture A-, Docs/DX A-, Testing B+, Security B, Zig p
 ## Zig patterns / correctness — remaining
 
 - [x] 19. **Dead diagnostic system** — `ZcliDiagnostic`/`formatDiagnostic` (`diagnostic_errors.zig`) never constructed or consumed; real error context goes through a test-suppressed `std.log` side channel invisible to `onError` plugins. Wire diagnostics through the pipeline (so help plugin can name the unknown option) or delete. Also fix `convertLongOptionError`/`convertShortOptionError` `anyerror` catch-alls (`options/parser.zig:286-305`).
-- [ ] 20. **Option-parsing heuristics disagree** — three different "does this flag take a value" heuristics: `command_parser.zig:75-115`, `options/parser.zig`, `args.zig:findNextPositional` (`:240-257`). Unify on one source of truth (the comptime Options type).
+- [x] 20. **Option-parsing heuristics disagree** — three different "does this flag take a value" heuristics: `command_parser.zig:75-115`, `options/parser.zig`, `args.zig:findNextPositional` (`:240-257`). Unify on one source of truth (the comptime Options type).
 - [ ] 21. **Global options half-implemented** — short options "assume boolean for now" (`registry.zig:916-917`); `convertValue` supports only bool/u16/u32/[]const u8 while `plugin_types.option()` accepts more (`registry.zig:951-960`). Support the full type set or reject unsupported types at declaration.
 - [ ] 22. **`IO` two-phase init pointer-stability trap** — `finalize()` wires writers to in-struct buffers; any copy after finalize dangles (`zcli.zig:344-391`). Restructure to prevent misuse (heap/pin, or factory that returns a pointer).
 - [ ] 23. **parseCommandLine leak on error path** — frees only the slice, not parsed option arrays, when `parseArgs` fails outside an arena (`command_parser.zig:128-132`); plus muddled belt-and-suspenders frees of arena memory in `Context.deinit`.
@@ -48,7 +48,7 @@ Grades at audit time: Architecture A-, Docs/DX A-, Testing B+, Security B, Zig p
 - [ ] 30. **plugin_system.zig dead apparatus** — ~850 of 1,014 lines are mocks/tests including a sandbox/capabilities concept that doesn't exist in the runtime (`build_utils/plugin_system.zig:659`). Trim to the ~160 lines of real build logic.
 - [x] 31. **`scanLocalPlugins` unreachable / ADR-0006 dead** *(resolved by #41/#51: `generate()` honors `plugins_dir`, init wires it, discovery fixed)* — `generate()` hardcodes `.plugins_dir = null` (`build_utils/main.zig:215`), so convention plugin discovery is dead code while ADR-0006 says "accepted". Either implement (roadmap: `zcli add plugin`) or mark the ADR deferred and remove the dead path.
 - [ ] 32. **Stale `terminal` dep in core's zon** — `packages/core/build.zig.zon` declares `.terminal` but core never uses it.
-- [ ] 33. **Dead parser code** — `parseShortOptions` has zero callers (dead un-meta duplicate of `parseShortOptionsWithMeta`, `options/parser.zig:655+`); `expected_char` comptime block copy-pasted three times in one function (`:511`, `:546`, `:582`).
+- [ ] 33. **Dead parser code** — `parseShortOptions` has zero callers (dead un-meta duplicate of `parseShortOptionsWithMeta`, `options/parser.zig:655+`). *(The triple-pasted `expected_char` block was consolidated into `shortCharForField` by item 20.)*
 - [ ] 34. **core/build.zig test-wiring duplication** — same five `addImport` lines copy-pasted across four test loops with mis-indentation (`packages/core/build.zig:84-198`), plus a leftover "debug hanging" step (`:200-210`). Extract a helper.
 
 ## Build / CI / test — remaining

--- a/packages/core/src/args.zig
+++ b/packages/core/src/args.zig
@@ -57,6 +57,15 @@ pub const ZcliDiagnostic = diagnostic_errors.ZcliDiagnostic;
 /// // parsed.name = "Alice", parsed.age = 25, parsed.verbose = true
 /// ```
 ///
+/// ## Contract: positionals only
+/// `args` must contain positional arguments only — every token is consumed
+/// in order, exactly as given. parseArgs does NOT detect or skip `--flags`:
+/// it cannot know the command's Options type, so any guess about whether a
+/// flag consumes the next token would be wrong for someone (a boolean flag
+/// followed by a real positional used to lose that positional). Splitting a
+/// mixed command line is `parseCommandLine`'s job — it classifies with the
+/// actual Options type, then hands the positionals here.
+///
 /// ## Returns
 /// Returns ArgsType on success or ZcliError on failure.
 /// Common errors include:
@@ -113,8 +122,8 @@ fn parseArgsInternal(comptime ArgsType: type, args: []const []const u8, diag: ?*
             }
             break;
         } else if (comptime @typeInfo(field_type) == .optional) {
-            // Optional field - find next positional argument
-            const next_positional = findNextPositional(args, arg_index);
+            // Optional field - consume the next argument if present
+            const next_positional: ?usize = if (arg_index < args.len) arg_index else null;
             if (next_positional) |pos| {
                 @field(result, field.name) = parseValue(field_type, args[pos]) catch |err| {
                     if (err == ZcliError.ArgumentInvalidValue) {
@@ -134,7 +143,7 @@ fn parseArgsInternal(comptime ArgsType: type, args: []const []const u8, diag: ?*
             }
         } else if (comptime type_utils.hasDefaultValue(ArgsType, field.name)) {
             // Field with default value - optional in parsing
-            const next_positional = findNextPositional(args, arg_index);
+            const next_positional: ?usize = if (arg_index < args.len) arg_index else null;
             if (next_positional) |pos| {
                 @field(result, field.name) = parseValue(field_type, args[pos]) catch |err| {
                     if (err == ZcliError.ArgumentInvalidValue) {
@@ -151,8 +160,8 @@ fn parseArgsInternal(comptime ArgsType: type, args: []const []const u8, diag: ?*
             }
             // If no argument provided, default value is already set by struct initialization
         } else {
-            // Required field - find next positional argument
-            const next_positional = findNextPositional(args, arg_index);
+            // Required field - consume the next argument
+            const next_positional: ?usize = if (arg_index < args.len) arg_index else null;
             if (next_positional == null) {
                 if (diag) |d| d.* = .{ .ArgumentMissingRequired = .{
                     .field_name = field.name,
@@ -262,33 +271,6 @@ fn hasVarArgs(comptime T: type) bool {
         if (isVarArgs(field.type)) return true;
     }
     return false;
-}
-
-/// Check if a string looks like a negative number
-fn isNegativeNumber(str: []const u8) bool {
-    if (str.len < 2 or str[0] != '-') return false;
-    // Check if the character after '-' is a digit
-    return str[1] >= '0' and str[1] <= '9';
-}
-
-/// Find the next positional argument starting from the given index, skipping options
-fn findNextPositional(args: []const []const u8, start_index: usize) ?usize {
-    var i = start_index;
-    while (i < args.len) {
-        const arg = args[i];
-        if (std.mem.startsWith(u8, arg, "-") and !isNegativeNumber(arg)) {
-            // Skip option (but not negative numbers)
-            i += 1;
-            // Skip option value if it doesn't start with -
-            if (i < args.len and !std.mem.startsWith(u8, args[i], "-")) {
-                i += 1;
-            }
-        } else {
-            // Found positional argument (including negative numbers)
-            return i;
-        }
-    }
-    return null;
 }
 
 /// Count the number of required arguments (non-optional, non-varargs)
@@ -613,24 +595,32 @@ test "parseArgs all supported float types" {
     try std.testing.expectApproxEqAbs(@as(f128, 789.012), parsed.f128_val, 0.001);
 }
 
-test "parseArgs skip options" {
-    // Test that options are properly skipped during argument parsing
+test "parseArgs consumes tokens in order, no option guessing" {
+    // parseArgs' contract is positionals-only: it must NOT try to detect and
+    // skip flags. (The old heuristic assumed every flag consumed the next
+    // token, so a boolean flag followed by a real positional lost the
+    // positional. Classification belongs to parseCommandLine, which knows
+    // the Options type.)
     const TestArgs = struct {
         image: []const u8,
         command: ?[]const u8,
         args: [][]const u8,
     };
 
-    // Mix options with positional arguments
-    const args = [_][]const u8{ "--name", "mycontainer", "ubuntu", "-v", "/tmp:/tmp", "bash", "arg1", "arg2" };
+    const args = [_][]const u8{ "ubuntu", "bash", "arg1", "arg2" };
     const parsed = try parseArgs(TestArgs, &args, null);
 
-    // Should extract positional args correctly, skipping options
     try std.testing.expectEqualStrings("ubuntu", parsed.image);
     try std.testing.expectEqualStrings("bash", parsed.command.?);
     try std.testing.expectEqual(@as(usize, 2), parsed.args.len);
     try std.testing.expectEqualStrings("arg1", parsed.args[0]);
     try std.testing.expectEqualStrings("arg2", parsed.args[1]);
+
+    // A dash token is data, not a flag to skip.
+    const DashArgs = struct { first: []const u8, rest: [][]const u8 };
+    const dash_args = [_][]const u8{ "--literal", "x" };
+    const dashed = try parseArgs(DashArgs, &dash_args, null);
+    try std.testing.expectEqualStrings("--literal", dashed.first);
 }
 
 test "parseArgs varargs empty" {

--- a/packages/core/src/command_parser.zig
+++ b/packages/core/src/command_parser.zig
@@ -87,13 +87,17 @@ pub fn parseCommandLine(
                     i += 1;
                     continue;
                 } else {
-                    // --option format, might need next arg as value
+                    // --option format, might need next arg as value. Uses the
+                    // same resolution the options parser uses (incl. custom
+                    // meta names) and the same "next token is a value, not
+                    // another flag" condition, so split and parse agree.
                     const option_name = arg[2..]; // Remove "--"
-                    if (needsValue(OptionsType, option_name) and i + 1 < args.len) {
+                    const takes_value = option_utils.longOptionTakesValue(OptionsType, meta, option_name) orelse false;
+                    if (takes_value and i + 1 < args.len and
+                        (!std.mem.startsWith(u8, args[i + 1], "-") or isNegativeNumber(args[i + 1])))
+                    {
                         i += 1;
-                        if (i < args.len) {
-                            option_args.append(allocator, args[i]) catch return ZcliError.SystemOutOfMemory;
-                        }
+                        option_args.append(allocator, args[i]) catch return ZcliError.SystemOutOfMemory;
                     }
                 }
             } else {
@@ -102,11 +106,10 @@ pub fn parseCommandLine(
                 if (option_chars.len == 1) {
                     // Single short option, might need value
                     const option_char = option_chars[0];
-                    if (needsValueShort(OptionsType, meta, option_char) and i + 1 < args.len) {
+                    const takes_value = option_utils.shortOptionTakesValue(OptionsType, meta, option_char) orelse false;
+                    if (takes_value and i + 1 < args.len) {
                         i += 1;
-                        if (i < args.len) {
-                            option_args.append(allocator, args[i]) catch return ZcliError.SystemOutOfMemory;
-                        }
+                        option_args.append(allocator, args[i]) catch return ZcliError.SystemOutOfMemory;
                     }
                 }
                 // For bundled short options (-xyz), assume they're all boolean
@@ -154,68 +157,6 @@ fn isNegativeNumber(arg: []const u8) bool {
 
     // Check if the character after '-' is a digit
     return std.ascii.isDigit(arg[1]);
-}
-
-/// Check if an option field needs a value (i.e., is not a boolean)
-fn needsValue(comptime OptionsType: type, option_name: []const u8) bool {
-    const type_info = @typeInfo(OptionsType);
-    if (type_info != .@"struct") return false;
-
-    inline for (type_info.@"struct".fields) |field| {
-        if (std.mem.eql(u8, field.name, option_name)) {
-            return field.type != bool;
-        }
-
-        // Also check with dash conversion (field_name -> field-name)
-        var dash_name_buf: [64]u8 = undefined;
-        const dash_name = convertUnderscoresToDashes(field.name, &dash_name_buf);
-        if (std.mem.eql(u8, dash_name, option_name)) {
-            return field.type != bool;
-        }
-    }
-
-    return false;
-}
-
-/// Check if a short option needs a value
-fn needsValueShort(comptime OptionsType: type, comptime meta: anytype, option_char: u8) bool {
-    const type_info = @typeInfo(OptionsType);
-    if (type_info != .@"struct") return false;
-
-    inline for (type_info.@"struct".fields) |field| {
-        // Get the expected short option character for this field
-        const expected_char = comptime blk: {
-            // Check if meta provides a custom short option
-            if (@TypeOf(meta) != @TypeOf(null) and @hasField(@TypeOf(meta), "options")) {
-                const options_meta = meta.options;
-                if (@hasField(@TypeOf(options_meta), field.name)) {
-                    const field_meta = @field(options_meta, field.name);
-                    if (@TypeOf(field_meta) != []const u8 and @hasField(@TypeOf(field_meta), "short")) {
-                        break :blk field_meta.short;
-                    }
-                }
-            }
-            // Fall back to first character of field name
-            break :blk if (field.name.len > 0) field.name[0] else 0;
-        };
-
-        if (expected_char == option_char) {
-            // Return true if the field is not a boolean (needs a value)
-            return field.type != bool;
-        }
-    }
-
-    return false;
-}
-
-/// Convert underscores to dashes for option names
-fn convertUnderscoresToDashes(name: []const u8, buffer: []u8) []const u8 {
-    var i: usize = 0;
-    for (name) |c| {
-        buffer[i] = if (c == '_') '-' else c;
-        i += 1;
-    }
-    return buffer[0..name.len];
 }
 
 /// Parse options from a list of option arguments
@@ -839,4 +780,55 @@ test "parseCommandLine applies env fallbacks even with no flags on the command l
     const r2 = try parseCommandLine(Args, Options, meta, allocator, &env, &.{ "input.txt", "--region", "ap-south-1" }, null);
     defer r2.deinit();
     try std.testing.expectEqualStrings("ap-south-1", r2.options.region);
+}
+
+test "pre-split honors custom meta names when classifying values" {
+    // --out is a custom name for output_file, which takes a value. The old
+    // pre-split heuristic only looked at field names, so "result.txt" was
+    // classified as a positional and parsing then failed with
+    // MissingOptionValue — split and parse disagreed about the same token.
+    const allocator = std.testing.allocator;
+    const Args = struct { file: []const u8 };
+    const Options = struct { output_file: ?[]const u8 = null };
+    const meta = .{ .options = .{ .output_file = .{ .name = "out" } } };
+
+    const result = try parseCommandLine(Args, Options, meta, allocator, null, &.{ "--out", "result.txt", "input.zig" }, null);
+    defer result.deinit();
+    try std.testing.expectEqualStrings("result.txt", result.options.output_file.?);
+    try std.testing.expectEqualStrings("input.zig", result.args.file);
+}
+
+test "boolean flag followed by a bare word keeps the word as a positional" {
+    const allocator = std.testing.allocator;
+    const Args = struct { file: []const u8 };
+    const Options = struct { verbose: bool = false };
+
+    const result = try parseCommandLine(Args, Options, null, allocator, null, &.{ "--verbose", "input.txt" }, null);
+    defer result.deinit();
+    try std.testing.expect(result.options.verbose);
+    try std.testing.expectEqualStrings("input.txt", result.args.file);
+}
+
+test "a flag is never classified as another flag's value" {
+    // --tag wants a value but the next token is itself a flag: the split
+    // applies the same next-token rule the parser does, so the parser
+    // reports the missing value for the right option.
+    const allocator = std.testing.allocator;
+    const Options = struct { tag: ?[]const u8 = null, verbose: bool = false };
+
+    var diag: ?ZcliDiagnostic = null;
+    const result = parseCommandLine(struct {}, Options, null, allocator, null, &.{ "--tag", "--verbose" }, &diag);
+    try std.testing.expectError(ZcliError.OptionMissingValue, result);
+    try std.testing.expectEqualStrings("tag", diag.?.OptionMissingValue.option_name);
+}
+
+test "negative numbers classify as values and positionals, not flags" {
+    const allocator = std.testing.allocator;
+    const Args = struct { delta: i32 };
+    const Options = struct { offset: i32 = 0 };
+
+    const result = try parseCommandLine(Args, Options, null, allocator, null, &.{ "--offset", "-5", "-10" }, null);
+    defer result.deinit();
+    try std.testing.expectEqual(@as(i32, -5), result.options.offset);
+    try std.testing.expectEqual(@as(i32, -10), result.args.delta);
 }

--- a/packages/core/src/options/parser.zig
+++ b/packages/core/src/options/parser.zig
@@ -412,34 +412,11 @@ fn parseLongOptions(
         option_name = option_part;
     }
 
-    // Convert dashes to underscores for field name
-    const option_field_name_buf = try allocator.alloc(u8, option_name.len);
-    defer allocator.free(option_field_name_buf);
-    const option_field_name = utils.dashesToUnderscores(option_field_name_buf, option_name) catch |err| {
-        return err;
-    };
-
-    // Generate field matching code at comptime
+    // Generate field matching code at comptime, via the shared resolution
+    // rules (options/utils.zig) that the pre-split classifier also uses.
     var found = false;
     inline for (@typeInfo(OptionsType).@"struct".fields, 0..) |field, i| {
-        // Check if this field matches the option name, either by field name or custom name
-        const matches = blk: {
-            // Check if this field has a custom name in metadata
-            if (comptime @TypeOf(meta) != @TypeOf(null)) {
-                if (comptime @hasField(@TypeOf(meta), "options")) {
-                    const options_meta = meta.options;
-                    if (comptime @hasField(@TypeOf(options_meta), field.name)) {
-                        const field_meta = @field(options_meta, field.name);
-                        if (comptime @hasField(@TypeOf(field_meta), "name")) {
-                            // Custom name is specified - only match on custom name, not field name
-                            break :blk std.mem.eql(u8, field_meta.name, option_name);
-                        }
-                    }
-                }
-            }
-            // No custom name specified - fall back to standard field name matching
-            break :blk std.mem.eql(u8, field.name, option_field_name) or std.mem.eql(u8, field.name, option_name);
-        };
+        const matches = utils.longNameMatchesField(meta, field.name, option_name);
 
         if (matches) {
             found = true;
@@ -547,20 +524,7 @@ fn parseShortOptionsWithMeta(
         var char_is_boolean = false;
         inline for (@typeInfo(OptionsType).@"struct".fields) |field| {
             // Get the expected short option character for this field (comptime)
-            const expected_char = comptime blk: {
-                if (@TypeOf(meta) != @TypeOf(null) and @hasField(@TypeOf(meta), "options")) {
-                    const options_meta = meta.options;
-                    if (@hasField(@TypeOf(options_meta), field.name)) {
-                        const field_meta = @field(options_meta, field.name);
-                        if (@TypeOf(field_meta) != []const u8 and @hasField(@TypeOf(field_meta), "short")) {
-                            // Custom short option is specified
-                            break :blk field_meta.short;
-                        }
-                    }
-                }
-                // Fall back to first character of field name
-                break :blk if (field.name.len > 0) field.name[0] else 0;
-            };
+            const expected_char = comptime utils.shortCharForField(meta, field.name);
 
             const matches = expected_char == char;
 
@@ -581,21 +545,7 @@ fn parseShortOptionsWithMeta(
         for (options_part) |char| {
             inline for (@typeInfo(OptionsType).@"struct".fields, 0..) |field, i| {
                 _ = i; // Unused for boolean flags
-                // Get the expected short option character for this field (comptime)
-                const expected_char = comptime blk: {
-                    if (@TypeOf(meta) != @TypeOf(null) and @hasField(@TypeOf(meta), "options")) {
-                        const options_meta = meta.options;
-                        if (@hasField(@TypeOf(options_meta), field.name)) {
-                            const field_meta = @field(options_meta, field.name);
-                            if (@TypeOf(field_meta) != []const u8 and @hasField(@TypeOf(field_meta), "short")) {
-                                // Custom short option is specified
-                                break :blk field_meta.short;
-                            }
-                        }
-                    }
-                    // Fall back to first character of field name
-                    break :blk if (field.name.len > 0) field.name[0] else 0;
-                };
+                const expected_char = comptime utils.shortCharForField(meta, field.name);
 
                 const matches = expected_char == char;
 
@@ -618,20 +568,7 @@ fn parseShortOptionsWithMeta(
         var char_found = false;
         inline for (@typeInfo(OptionsType).@"struct".fields, 0..) |field, i| {
             // Get the expected short option character for this field (comptime)
-            const expected_char = comptime blk: {
-                if (@TypeOf(meta) != @TypeOf(null) and @hasField(@TypeOf(meta), "options")) {
-                    const options_meta = meta.options;
-                    if (@hasField(@TypeOf(options_meta), field.name)) {
-                        const field_meta = @field(options_meta, field.name);
-                        if (@TypeOf(field_meta) != []const u8 and @hasField(@TypeOf(field_meta), "short")) {
-                            // Custom short option is specified
-                            break :blk field_meta.short;
-                        }
-                    }
-                }
-                // Fall back to first character of field name
-                break :blk if (field.name.len > 0) field.name[0] else 0;
-            };
+            const expected_char = comptime utils.shortCharForField(meta, field.name);
 
             const matches = expected_char == char;
 

--- a/packages/core/src/options/utils.zig
+++ b/packages/core/src/options/utils.zig
@@ -524,3 +524,123 @@ test "isArrayType function" {
     try std.testing.expect(!isArrayType(u32));
     try std.testing.expect(!isArrayType(bool));
 }
+
+// ============================================================================
+// Option-name resolution — the single source of truth
+// ============================================================================
+//
+// Shared by the options parser (which parses flags) and command_parser's
+// pre-split classifier (which decides whether the token after a flag is that
+// flag's value or a positional). Both must answer "which field does this
+// flag name, and does it take a value?" identically, or the same command
+// line gets split one way and parsed another.
+
+/// The custom long name declared via `meta.options.<field>.name`, if any.
+fn customNameFor(comptime meta: anytype, comptime field_name: []const u8) ?[]const u8 {
+    if (@TypeOf(meta) == @TypeOf(null)) return null;
+    if (!@hasField(@TypeOf(meta), "options")) return null;
+    if (!@hasField(@TypeOf(meta.options), field_name)) return null;
+    const field_meta = @field(meta.options, field_name);
+    if (@TypeOf(field_meta) == []const u8) return null;
+    if (!@hasField(@TypeOf(field_meta), "name")) return null;
+    return field_meta.name;
+}
+
+/// Does the argv long-option name `option_name` address the field
+/// `field_name`? A field with a custom `meta.options.<field>.name` matches
+/// ONLY that custom name; otherwise the field matches both its literal name
+/// and its dashes-for-underscores spelling.
+pub fn longNameMatchesField(
+    comptime meta: anytype,
+    comptime field_name: []const u8,
+    option_name: []const u8,
+) bool {
+    if (comptime customNameFor(meta, field_name)) |custom| {
+        return std.mem.eql(u8, custom, option_name);
+    }
+    const dashed = comptime blk: {
+        var buf: [field_name.len]u8 = undefined;
+        for (field_name, 0..) |c, i| buf[i] = if (c == '_') '-' else c;
+        const frozen = buf;
+        break :blk frozen;
+    };
+    return std.mem.eql(u8, field_name, option_name) or std.mem.eql(u8, &dashed, option_name);
+}
+
+/// The short flag character for a field: `meta.options.<field>.short` when
+/// declared, otherwise the field name's first character.
+pub fn shortCharForField(comptime meta: anytype, comptime field_name: []const u8) u8 {
+    if (@TypeOf(meta) != @TypeOf(null) and @hasField(@TypeOf(meta), "options")) {
+        if (@hasField(@TypeOf(meta.options), field_name)) {
+            const field_meta = @field(meta.options, field_name);
+            if (@TypeOf(field_meta) != []const u8 and @hasField(@TypeOf(field_meta), "short")) {
+                return field_meta.short;
+            }
+        }
+    }
+    return if (field_name.len > 0) field_name[0] else 0;
+}
+
+/// Whether the long option `option_name` takes a value. Null means no field
+/// matches (an unknown option — the parser reports it with a diagnostic).
+pub fn longOptionTakesValue(
+    comptime OptionsType: type,
+    comptime meta: anytype,
+    option_name: []const u8,
+) ?bool {
+    inline for (@typeInfo(OptionsType).@"struct".fields) |field| {
+        if (longNameMatchesField(meta, field.name, option_name)) {
+            return field.type != bool;
+        }
+    }
+    return null;
+}
+
+/// Whether the short option `char` takes a value. Null means unknown.
+pub fn shortOptionTakesValue(
+    comptime OptionsType: type,
+    comptime meta: anytype,
+    char: u8,
+) ?bool {
+    inline for (@typeInfo(OptionsType).@"struct".fields) |field| {
+        if (shortCharForField(meta, field.name) == char) {
+            return field.type != bool;
+        }
+    }
+    return null;
+}
+
+test "longNameMatchesField honors custom names exclusively" {
+    const meta = .{ .options = .{ .output_file = .{ .name = "out" } } };
+    // Custom name matches...
+    try std.testing.expect(longNameMatchesField(meta, "output_file", "out"));
+    // ...and the field's own spellings no longer do.
+    try std.testing.expect(!longNameMatchesField(meta, "output_file", "output_file"));
+    try std.testing.expect(!longNameMatchesField(meta, "output_file", "output-file"));
+}
+
+test "longNameMatchesField accepts both spellings without custom name" {
+    try std.testing.expect(longNameMatchesField(null, "output_file", "output_file"));
+    try std.testing.expect(longNameMatchesField(null, "output_file", "output-file"));
+    try std.testing.expect(!longNameMatchesField(null, "output_file", "output"));
+}
+
+test "takes-value resolution matches parser semantics" {
+    const Options = struct {
+        verbose: bool = false,
+        count: u32 = 0,
+        output_file: ?[]const u8 = null,
+    };
+    const meta = .{ .options = .{ .output_file = .{ .name = "out", .short = 'o' } } };
+
+    try std.testing.expectEqual(@as(?bool, false), longOptionTakesValue(Options, meta, "verbose"));
+    try std.testing.expectEqual(@as(?bool, true), longOptionTakesValue(Options, meta, "count"));
+    try std.testing.expectEqual(@as(?bool, true), longOptionTakesValue(Options, meta, "out"));
+    try std.testing.expectEqual(@as(?bool, null), longOptionTakesValue(Options, meta, "output-file")); // custom name shadows
+    try std.testing.expectEqual(@as(?bool, null), longOptionTakesValue(Options, meta, "bogus"));
+
+    try std.testing.expectEqual(@as(?bool, false), shortOptionTakesValue(Options, meta, 'v'));
+    try std.testing.expectEqual(@as(?bool, true), shortOptionTakesValue(Options, meta, 'c'));
+    try std.testing.expectEqual(@as(?bool, true), shortOptionTakesValue(Options, meta, 'o'));
+    try std.testing.expectEqual(@as(?bool, null), shortOptionTakesValue(Options, meta, 'x'));
+}


### PR DESCRIPTION
## Summary

Grade tracker item 20 — the "three disagreeing heuristics" finding. The three places that answered *"does this flag take a value?"*:

| Site | Rules it used | What went wrong |
|---|---|---|
| `command_parser` pre-split | field names only, always eat next token | **custom meta names broke**: `--out result.txt` (meta-renamed `output_file`) classified `result.txt` as a positional, then parsing failed `MissingOptionValue` — split and parse disagreed about the same token |
| `options/parser` | full rules (custom names, dashes, meta shorts) | correct, but its short-char derivation was copy-pasted 3× |
| `args.zig findNextPositional` | pure guess, no Options type | assumed **every** flag eats the next token — a boolean flag followed by a real positional lost the positional |

**The fix:**
- `options/utils.zig` now owns resolution — `longNameMatchesField` / `shortCharForField` / `longOptionTakesValue` / `shortOptionTakesValue` — used by both the pre-split classifier and the parser. The pre-split also adopts the parser's "next token is a value, not another flag" rule, so the streams can't diverge.
- `parseArgs` gets an explicit contract: **positionals only, consumed in order** — it can't know the Options type, so it must not guess. `findNextPositional` is deleted; the test that enshrined the guessing is replaced with one asserting the literal contract. (Framework flow is unaffected: `parseCommandLine` pre-splits with the real Options type and hands parseArgs pure positionals.)
- The 3× `expected_char` paste collapses into `shortCharForField` (retires that half of tracker item 33).

**Behavior changes** (both fixes): meta-renamed options now work with space-separated values through the full pipeline; direct `parseArgs` callers passing mixed argv now get literal treatment instead of lossy guessing.

## Verification

- New tests: custom-name classification end-to-end, boolean-flag-then-positional, flag-never-a-value (diagnostic names the right option), negative numbers as values and positionals, plus unit tests on each resolution helper (incl. custom-name-shadows-field-name)
- Full root suite (9 packages), zcli binary, e2e — all green; fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)