### PR TITLE
Phase 4: ghauth example — the zcli_secrets + auth idiom (ADR-0003/0004)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,14 @@ jobs:
         with:
           version: 0.16.0
 
+      # The `ghauth` example opts into zcli_secrets, whose Linux backend links
+      # libsecret at build time (ADR-0003). Compiling the examples therefore
+      # needs the dev headers on Linux; macOS/Windows keychains link nothing.
+      - name: Install Secret Service deps (for the ghauth example)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libsecret-1-dev libglib2.0-dev
+
       # The canonical example CLIs are the idiom source AND the drift-detector
       # (ADR-0004): compiling them here means a framework change that breaks the
       # documented idioms fails CI, rather than silently rotting the examples

--- a/build.zig
+++ b/build.zig
@@ -116,6 +116,7 @@ pub fn build(b: *std.Build) void {
     const example_projects = [_]ProjectInfo{
         .{ .name = "showcase", .path = "examples/showcase" },
         .{ .name = "repostat", .path = "examples/repostat" },
+        .{ .name = "ghauth", .path = "examples/ghauth" },
         .{ .name = "vterm_example", .path = "packages/vterm/example" },
     };
 

--- a/examples/ghauth/README.md
+++ b/examples/ghauth/README.md
@@ -1,0 +1,44 @@
+# ghauth — a `zcli_secrets` + `zcli.http` example
+
+An authenticated GitHub client. `login` stashes a token in your OS keychain,
+`whoami` uses it to call the API, `logout` forgets it.
+
+```
+$ export GITHUB_TOKEN=ghp_xxx
+$ ghauth login
+Saved your GitHub token to the OS keychain. Try `ghauth whoami`.
+$ ghauth whoami
+Ada Lovelace (@ada)
+$ ghauth logout
+Removed your stored GitHub token.
+```
+
+A **canonical example** (ADR-0004): a compiled, CI-checked teaching artifact for
+the credential-storage idiom. See
+[`src/commands/`](src/commands).
+
+What it demonstrates:
+
+- **`zcli_secrets`** — enabled with `zcli.builtin(.secrets, .{})` in `build.zig`,
+  then reached as `context.plugins.zcli_secrets.{set,get,delete}` with no import.
+  The token lives in the OS keychain (macOS Keychain, Linux Secret Service,
+  Windows Credential Manager) — never a plaintext file.
+- **The auth flow is freeform command code, not a framework feature** (ADR-0003):
+  `login` just reads `$GITHUB_TOKEN` (kept out of argv so it never lands in shell
+  history). A real CLI might swap that for an OAuth device-code flow — the plugin
+  only ever stores/reads the resulting opaque credential.
+- **`zcli.http` with auth** — `whoami` sends `Authorization: Bearer …`; the client
+  strips that header if a redirect ever leaves GitHub's origin, so a token can't
+  leak to another host.
+- **Graceful states** — clear errors for "no `$GITHUB_TOKEN`", "not logged in",
+  and a rejected (401) token.
+
+> Enabling `zcli_secrets` links a native keychain library (libsecret on Linux;
+> nothing extra on macOS/Windows). That's the opt-in cost ADR-0003 keeps off
+> projects that don't store secrets.
+
+Run it:
+
+```
+GITHUB_TOKEN=ghp_xxx zig build run -- whoami
+```

--- a/examples/ghauth/build.zig
+++ b/examples/ghauth/build.zig
@@ -1,0 +1,44 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const zcli_dep = b.dependency("zcli", .{ .target = target, .optimize = optimize });
+    const zcli_module = zcli_dep.module("zcli");
+
+    const exe = b.addExecutable(.{
+        .name = "ghauth",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    exe.root_module.addImport("zcli", zcli_module);
+
+    const zcli = @import("zcli");
+    const cmd_registry = zcli.generate(b, exe, zcli_dep, zcli_module, .{
+        .commands_dir = "src/commands",
+        .plugins = &.{
+            zcli.builtin(.help, .{}),
+            zcli.builtin(.version, .{}),
+            zcli.builtin(.not_found, .{}),
+            // Opt in to credential storage. Enabling it here is what makes
+            // `context.plugins.zcli_secrets` available and links the OS keychain
+            // backend (Keychain / Secret Service / Credential Manager). ADR-0003.
+            zcli.builtin(.secrets, .{}),
+        },
+        .app_name = "ghauth",
+        .app_description = "An authenticated GitHub client (a zcli_secrets + zcli.http example)",
+    });
+    exe.root_module.addImport("command_registry", cmd_registry);
+
+    b.installArtifact(exe);
+
+    const run_cmd = b.addRunArtifact(exe);
+    run_cmd.step.dependOn(b.getInstallStep());
+    if (b.args) |args| run_cmd.addArgs(args);
+    const run_step = b.step("run", "Run the application");
+    run_step.dependOn(&run_cmd.step);
+}

--- a/examples/ghauth/build.zig.zon
+++ b/examples/ghauth/build.zig.zon
@@ -1,0 +1,18 @@
+.{
+    .name = .ghauth,
+    .version = "0.1.0",
+    .fingerprint = 0xd4ebcd8897fb2505,
+    .minimum_zig_version = "0.16.0",
+    .dependencies = .{
+        // Local path because this example lives in-repo (so CI compiles it
+        // against unreleased changes as a drift-detector). Your own project
+        // doesn't hand-write this — `zcli init` fetches a released zcli:
+        //   .zcli = .{ .url = "git+https://github.com/ryanhair/zcli#<tag>", .hash = "..." },
+        .zcli = .{ .path = "../.." },
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}

--- a/examples/ghauth/src/commands/login.zig
+++ b/examples/ghauth/src/commands/login.zig
@@ -1,0 +1,34 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
+
+pub const meta = .{
+    .description = "Store your GitHub token (read from $GITHUB_TOKEN)",
+    .examples = &.{"login"},
+};
+
+pub const Args = struct {};
+pub const Options = struct {};
+
+pub fn execute(_: Args, _: Options, context: *Context) !void {
+    const stderr = context.stderr();
+
+    // The auth flow that *produces* a credential is freeform command code, not a
+    // framework feature (ADR-0003). Here it's just reading an env var — kept out
+    // of argv so the token never lands in the user's shell history. A real CLI
+    // might instead run an OAuth device-code flow and end up with a token here.
+    const token = context.environ.get("GITHUB_TOKEN") orelse {
+        try stderr.print("Error: set GITHUB_TOKEN to a personal access token, then run `ghauth login`.\n", .{});
+        return error.MissingToken;
+    };
+    if (token.len == 0) {
+        try stderr.print("Error: GITHUB_TOKEN is set but empty.\n", .{});
+        return error.MissingToken;
+    }
+
+    // zcli_secrets only stores/reads the opaque credential — it puts it in the
+    // OS keychain, never a plaintext file.
+    try context.plugins.zcli_secrets.set(context, "token", token);
+
+    try context.stdout().print("Saved your GitHub token to the OS keychain. Try `ghauth whoami`.\n", .{});
+}

--- a/examples/ghauth/src/commands/logout.zig
+++ b/examples/ghauth/src/commands/logout.zig
@@ -1,0 +1,18 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
+
+pub const meta = .{
+    .description = "Forget the stored GitHub token",
+    .examples = &.{"logout"},
+};
+
+pub const Args = struct {};
+pub const Options = struct {};
+
+pub fn execute(_: Args, _: Options, context: *Context) !void {
+    // `delete` is a no-op (success) if nothing is stored, so `logout` is always
+    // safe to run.
+    try context.plugins.zcli_secrets.delete(context, "token");
+    try context.stdout().print("Removed your stored GitHub token.\n", .{});
+}

--- a/examples/ghauth/src/commands/whoami.zig
+++ b/examples/ghauth/src/commands/whoami.zig
@@ -1,0 +1,66 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
+
+pub const meta = .{
+    .description = "Show the GitHub user the stored token belongs to",
+    .examples = &.{"whoami"},
+};
+
+pub const Args = struct {};
+pub const Options = struct {};
+
+/// Only the fields we render; `Response.json` ignores the rest.
+const User = struct {
+    login: []const u8,
+    name: ?[]const u8 = null,
+};
+
+pub fn execute(_: Args, _: Options, context: *Context) !void {
+    const arena = context.allocator;
+    const io = context.io;
+    const stderr = context.stderr();
+
+    // The stored bytes are owned by the arena, so no free is needed.
+    const token = (try context.plugins.zcli_secrets.get(context, "token")) orelse {
+        try stderr.print("Not logged in. Run `ghauth login` first.\n", .{});
+        return error.NotLoggedIn;
+    };
+
+    var client = zcli.http.Client.init(arena, io, .{});
+    defer client.deinit();
+
+    // The Authorization header carries the credential; zcli.http drops it if a
+    // redirect ever leaves GitHub's origin, so a token can't leak to another host.
+    const auth = try std.fmt.allocPrint(arena, "Bearer {s}", .{token});
+    var response = client.request(.GET, "https://api.github.com/user", .{
+        .headers = &.{
+            .{ .name = "User-Agent", .value = "zcli-ghauth" },
+            .{ .name = "Accept", .value = "application/vnd.github+json" },
+            .{ .name = "Authorization", .value = auth },
+        },
+    }) catch |err| {
+        try stderr.print("Error: request to GitHub failed: {s}\n", .{@errorName(err)});
+        return err;
+    };
+    defer response.deinit();
+
+    if (response.status == .unauthorized) {
+        try stderr.print("Your token was rejected (401). Run `ghauth login` with a valid token.\n", .{});
+        return error.Unauthorized;
+    }
+    if (response.status != .ok) {
+        try stderr.print("Error: GitHub returned {d}.\n", .{@intFromEnum(response.status)});
+        return error.RequestFailed;
+    }
+
+    const parsed = try response.json(User, arena);
+    const user = parsed.value;
+
+    const stdout = context.stdout();
+    if (user.name) |name| {
+        try stdout.print("{s} (@{s})\n", .{ name, user.login });
+    } else {
+        try stdout.print("@{s}\n", .{user.login});
+    }
+}

--- a/examples/ghauth/src/main.zig
+++ b/examples/ghauth/src/main.zig
@@ -1,0 +1,15 @@
+const std = @import("std");
+const registry = @import("command_registry");
+
+pub const std_options: std.Options = .{
+    .log_level = .warn,
+};
+
+pub fn main(init: std.process.Init) !void {
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
+    var app = registry.init();
+    app.run(init.gpa, init.io, init.environ_map, args) catch |err| switch (err) {
+        error.CommandNotFound => std.process.exit(1),
+        else => return err,
+    };
+}


### PR DESCRIPTION
Second canonical example (ADR-0004), completing the primitive coverage: an **authenticated GitHub client** demonstrating credential storage + an authed HTTP call.

```
$ export GITHUB_TOKEN=ghp_xxx
$ ghauth login      # reads $GITHUB_TOKEN, stores it in the OS keychain
$ ghauth whoami     # reads the token, GETs /user with Authorization: Bearer …
Ada Lovelace (@ada)
$ ghauth logout     # forgets it
```

It's the teaching artifact for the pattern **ADR-0003 deliberately leaves as freeform command code** rather than a framework feature:

- **`zcli_secrets`** — enabled with `zcli.builtin(.secrets, .{})`, reached as `context.plugins.zcli_secrets.{set,get,delete}` (no import). Token lives in the OS keychain (Keychain / Secret Service / Credential Manager), never a plaintext file. `get` returns arena-owned bytes → no manual free (same idiom as `repostat`).
- **The auth flow is ordinary command code** — `login` reads an env var (kept out of argv so it never hits shell history); a real CLI might swap that for an OAuth device-code flow. The plugin only ever stores/reads the resulting opaque credential.
- **`zcli.http` with auth** — `Authorization: Bearer …`, which the client drops if a redirect leaves GitHub's origin (a token can't leak cross-host).
- **Graceful states** — clear errors for no `$GITHUB_TOKEN`, not-logged-in, and a rejected (401) token.

## CI
The `examples` job now installs `libsecret-1-dev`/`libglib2.0-dev`, because enabling `zcli_secrets` links the Linux Secret Service backend at build time. That's ADR-0003's opt-in cost — paid only by projects that store secrets; macOS/Windows keychains link nothing.

## Verified
- **End-to-end against the real macOS Keychain:** `login` stores → `whoami` reads it and makes the authed request (401 on a throwaway token proves both the read *and* the call) → `logout` clears it → `whoami` then reports "not logged in".
- `zig build build-examples` compiles all four examples; `zig fmt --check` clean.

## LLM-facing care (same as #66)
- `context.io` used directly (post-migration `std.Io`), no `.io` unwrap.
- The `.zcli = .{ .path = "../.." }` dep carries the "this is in-repo; your project uses `zcli init`" comment.

With this, the canonical set covers the primitives (HTTP, secrets) + structure/config/output (showcase). Next in Phase 4: **`zcli guide`** (`@embedFile`s these examples), then the **`AGENTS.md`** capstone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)