### PR TITLE
zinput: Unicode-aware text input — codepoint keys, grapheme backspace (grade fix 25)

### DIFF
--- a/GRADE_TODO.md
+++ b/GRADE_TODO.md
@@ -37,7 +37,7 @@ Grades at audit time: Architecture A-, Docs/DX A-, Testing B+, Security B, Zig p
 - [x] 22. **`IO` two-phase init pointer-stability trap** — `finalize()` wires writers to in-struct buffers; any copy after finalize dangles (`zcli.zig:344-391`). Restructure to prevent misuse (heap/pin, or factory that returns a pointer).
 - [x] 23. **parseCommandLine leak on error path** — frees only the slice, not parsed option arrays, when `parseArgs` fails outside an arena (`command_parser.zig:128-132`); plus muddled belt-and-suspenders frees of arena memory in `Context.deinit`.
 - [x] 24. **errors.zig fossils** — discarded `allocator` params kept "for API compatibility" (`errors.zig:11`, `:33`, `:97`) contrary to the no-backward-compat rule; doc references a nonexistent "zcli-suggestions plugin"; `editDistance` silently caps at 62 chars with a 32KB stack matrix.
-- [ ] 25. **zinput text input is byte-oriented** — `char: u8` echo/backspace per byte breaks multibyte UTF-8 (`packages/zinput/src/text.zig`), inconsistent with the grapheme-aware wrapping elsewhere in the stack.
+- [x] 25. **zinput text input is byte-oriented** *(fixed at the source: `terminal.Key.char` is now a `u21` codepoint — `readKey` assembles UTF-8, invalid input decodes to U+FFFD; backspace in text/password/search deletes one grapheme cluster and erases its true display width)* — `char: u8` echo/backspace per byte breaks multibyte UTF-8 (`packages/zinput/src/text.zig`), inconsistent with the grapheme-aware wrapping elsewhere in the stack.
 
 ## Structure / dead code
 

--- a/packages/terminal/src/key.zig
+++ b/packages/terminal/src/key.zig
@@ -12,7 +12,9 @@ const esc_timeout_ms = 75;
 
 /// A parsed key input from the terminal.
 pub const Key = union(enum) {
-    char: u8,
+    /// A typed Unicode codepoint. Multibyte UTF-8 sequences are assembled by
+    /// `readKey`, so one keypress (or one pasted character) is one `.char`.
+    char: u21,
     enter,
     backspace,
     delete,
@@ -28,7 +30,7 @@ pub const Key = union(enum) {
 
     pub fn format(self: Key, writer: anytype) !void {
         switch (self) {
-            .char => |c| try writer.print("'{c}'", .{c}),
+            .char => |c| try writer.print("'{u}'", .{c}),
             .enter => try writer.writeAll("<enter>"),
             .backspace => try writer.writeAll("<backspace>"),
             .delete => try writer.writeAll("<delete>"),
@@ -93,10 +95,27 @@ fn readKeyImpl(reader: anytype, esc_handle: ?backend.Handle) !Key {
         '\x1b' => parseEscapeSequence(reader, esc_handle),
         // Ctrl+A through Ctrl+Z (1-26, excluding 9=tab, 10=newline, 13=cr, 27=esc)
         1...8, 11...12, 14...26 => .{ .ctrl = byte + 'a' - 1 },
-        // Printable characters
-        32...126 => .{ .char = byte },
+        // Lead byte of a multibyte UTF-8 sequence
+        0x80...0xff => .{ .char = readUtf8Tail(reader, byte) },
+        // Printable ASCII (plus the few remaining C0 codes callers ignore)
         else => .{ .char = byte },
     };
+}
+
+/// U+FFFD REPLACEMENT CHARACTER — what invalid UTF-8 input decodes to.
+pub const replacement_char: u21 = 0xFFFD;
+
+/// Assemble the rest of a multibyte UTF-8 sequence whose lead byte was already
+/// read. The continuation bytes arrive in the same terminal write as the lead
+/// byte, so they're already buffered. Anything invalid (stray continuation
+/// byte, bad lead, overlong encoding) decodes to U+FFFD rather than surfacing
+/// raw bytes as separate keys.
+fn readUtf8Tail(reader: anytype, lead: u8) u21 {
+    const len = std.unicode.utf8ByteSequenceLength(lead) catch return replacement_char;
+    var seq: [4]u8 = undefined;
+    seq[0] = lead;
+    for (seq[1..len]) |*b| b.* = readByteFn(reader) catch return replacement_char;
+    return std.unicode.utf8Decode(seq[0..len]) catch replacement_char;
 }
 
 fn parseEscapeSequence(reader: anytype, esc_handle: ?backend.Handle) !Key {
@@ -205,6 +224,42 @@ test "readKey parses printable char" {
     var reader: std.Io.Reader = .fixed(&buf);
     const k = try readKey(&reader);
     try std.testing.expect(k.char == 'a');
+}
+
+test "readKey assembles multibyte UTF-8 into one char" {
+    // 2-byte (é), 3-byte (你), and 4-byte (😊) sequences each yield one key.
+    var buf = "é你😊".*;
+    var reader: std.Io.Reader = .fixed(&buf);
+    try std.testing.expectEqual(Key{ .char = 'é' }, try readKey(&reader));
+    try std.testing.expectEqual(Key{ .char = '你' }, try readKey(&reader));
+    try std.testing.expectEqual(Key{ .char = '😊' }, try readKey(&reader));
+    try std.testing.expectError(error.EndOfStream, readKey(&reader));
+}
+
+test "readKey maps invalid UTF-8 to U+FFFD" {
+    // Stray continuation byte (no lead).
+    var cont = [_]u8{0xa9};
+    var r1: std.Io.Reader = .fixed(&cont);
+    try std.testing.expectEqual(Key{ .char = replacement_char }, try readKey(&r1));
+
+    // Lead byte with a truncated tail (followed by ASCII, which gets consumed
+    // as the would-be continuation byte and fails the decode).
+    var trunc = "\xc3a".*;
+    var r2: std.Io.Reader = .fixed(&trunc);
+    try std.testing.expectEqual(Key{ .char = replacement_char }, try readKey(&r2));
+
+    // Overlong encoding of '/' (0xc0 0xaf) — an invalid lead in modern UTF-8.
+    var overlong = "\xc0\xaf".*;
+    var r3: std.Io.Reader = .fixed(&overlong);
+    try std.testing.expectEqual(Key{ .char = replacement_char }, try readKey(&r3));
+}
+
+test "Key format renders a multibyte char" {
+    const allocator = std.testing.allocator;
+    const k: Key = .{ .char = '你' };
+    const str = try std.fmt.allocPrint(allocator, "{f}", .{k});
+    defer allocator.free(str);
+    try std.testing.expectEqualStrings("'你'", str);
 }
 
 test "readKey parses arrow up" {

--- a/packages/terminal/src/terminal.zig
+++ b/packages/terminal/src/terminal.zig
@@ -26,6 +26,8 @@ pub const displayWidth = wrap.displayWidth;
 pub const wrapToWidth = wrap.wrapToWidth;
 pub const wrapForEach = wrap.wrapForEach;
 pub const wrapCount = wrap.wrapCount;
+pub const trailingGraphemeLen = wrap.trailingGraphemeLen;
+pub const graphemeCount = wrap.graphemeCount;
 
 // ============================================================================
 // Raw mode, echo, window size, TTY detection

--- a/packages/terminal/src/wrap.zig
+++ b/packages/terminal/src/wrap.zig
@@ -65,6 +65,25 @@ pub fn displayWidth(text: []const u8) usize {
     return total;
 }
 
+/// Byte length of the trailing grapheme cluster of `text` (0 for empty text).
+/// Line editors use this to delete one *visible* character per backspace —
+/// popping bytes or codepoints would tear multibyte chars or strip combining
+/// marks off their base.
+pub fn trailingGraphemeLen(text: []const u8) usize {
+    var last: usize = 0;
+    var it = Graphemes.iterator(text);
+    while (it.next()) |g| last = g.len;
+    return last;
+}
+
+/// Number of grapheme clusters in `text` (what a user perceives as characters).
+pub fn graphemeCount(text: []const u8) usize {
+    var n: usize = 0;
+    var it = Graphemes.iterator(text);
+    while (it.next()) |_| n += 1;
+    return n;
+}
+
 fn isBreakSpace(text: []const u8, g: Graphemes.Grapheme) bool {
     return g.len == 1 and (text[g.offset] == ' ' or text[g.offset] == '\t');
 }
@@ -247,6 +266,26 @@ test "displayWidth: emoji and combining marks" {
 test "displayWidth: skips ANSI escapes" {
     // Without skipping, zg would count the '[36m' bytes → 6.
     try testing.expectEqual(@as(usize, 2), displayWidth("\x1b[36mhi\x1b[0m"));
+}
+
+test "trailingGraphemeLen: ascii, CJK, combining, ZWJ emoji" {
+    try testing.expectEqual(@as(usize, 0), trailingGraphemeLen(""));
+    try testing.expectEqual(@as(usize, 1), trailingGraphemeLen("abc"));
+    // 你 is 3 bytes.
+    try testing.expectEqual(@as(usize, 3), trailingGraphemeLen("a你"));
+    // 'e' + combining acute = one 3-byte cluster.
+    try testing.expectEqual(@as(usize, 3), trailingGraphemeLen("cafe\u{0301}"));
+    // Family ZWJ sequence is a single cluster.
+    const family = "👨\u{200D}👩\u{200D}👧";
+    try testing.expectEqual(family.len, trailingGraphemeLen("x" ++ family));
+}
+
+test "graphemeCount counts clusters, not bytes" {
+    try testing.expectEqual(@as(usize, 0), graphemeCount(""));
+    try testing.expectEqual(@as(usize, 3), graphemeCount("abc"));
+    try testing.expectEqual(@as(usize, 2), graphemeCount("你好"));
+    // café with a combining accent: 4 clusters, 6 bytes.
+    try testing.expectEqual(@as(usize, 4), graphemeCount("cafe\u{0301}"));
 }
 
 fn expectWrap(text: []const u8, width: usize, expected: []const []const u8) !void {

--- a/packages/zinput/src/number.zig
+++ b/packages/zinput/src/number.zig
@@ -109,17 +109,17 @@ fn readNumberTty(writer: anytype, reader: anytype, config: NumberConfig) !i64 {
                 }
             },
             .char => |c| {
-                // Accept digits and leading minus
+                // Accept digits and leading minus (all ASCII, so the u8 casts hold)
                 if (c >= '0' and c <= '9') {
                     if (len < buf.len) {
-                        buf[len] = c;
+                        buf[len] = @intCast(c);
                         len += 1;
-                        try writer.print("{c}", .{c});
+                        try writer.print("{c}", .{@as(u8, @intCast(c))});
                     }
                 } else if (c == '-' and len == 0) {
-                    buf[len] = c;
+                    buf[len] = @intCast(c);
                     len += 1;
-                    try writer.print("{c}", .{c});
+                    try writer.print("{c}", .{@as(u8, @intCast(c))});
                 }
                 // Silently ignore other characters
             },

--- a/packages/zinput/src/password.zig
+++ b/packages/zinput/src/password.zig
@@ -47,8 +47,8 @@ pub fn password(writer: anytype, reader: anytype, allocator: std.mem.Allocator, 
             },
             .backspace => {
                 if (buf.items.len > 0) {
-                    _ = buf.pop();
-                    try renderMask(writer, config, buf.items.len);
+                    zinput.popTrailingGrapheme(&buf);
+                    try renderMask(writer, config, terminal.graphemeCount(buf.items));
                 }
             },
             .ctrl => |c| {
@@ -58,8 +58,9 @@ pub fn password(writer: anytype, reader: anytype, allocator: std.mem.Allocator, 
                 }
             },
             .char => |c| {
-                try buf.append(allocator, c);
-                try renderMask(writer, config, buf.items.len);
+                // One mask glyph per typed character, not per UTF-8 byte.
+                _ = try zinput.appendCodepoint(allocator, &buf, c);
+                try renderMask(writer, config, terminal.graphemeCount(buf.items));
             },
             else => {},
         }

--- a/packages/zinput/src/search.zig
+++ b/packages/zinput/src/search.zig
@@ -80,7 +80,7 @@ pub fn search(writer: anytype, reader: anytype, allocator: std.mem.Allocator, co
                 },
                 .backspace => {
                     if (query.items.len > 0) {
-                        _ = query.pop();
+                        zinput.popTrailingGrapheme(&query);
                         allocator.free(filtered);
                         filtered = try buildFiltered(allocator, config.choices, query.items);
                         cursor = 0;
@@ -95,7 +95,7 @@ pub fn search(writer: anytype, reader: anytype, allocator: std.mem.Allocator, co
                     }
                 },
                 .char => |c| {
-                    try query.append(allocator, c);
+                    _ = try zinput.appendCodepoint(allocator, &query, c);
                     allocator.free(filtered);
                     filtered = try buildFiltered(allocator, config.choices, query.items);
                     cursor = 0;

--- a/packages/zinput/src/text.zig
+++ b/packages/zinput/src/text.zig
@@ -89,8 +89,7 @@ pub fn text(writer: anytype, reader: anytype, allocator: std.mem.Allocator, conf
             },
             .backspace => {
                 if (buf.items.len > 0) {
-                    _ = buf.pop();
-                    try writer.writeAll("\x08 \x08"); // move back, erase, move back
+                    try zinput.eraseTrailingGrapheme(writer, &buf);
                     if (use_preview) try repaintPreview(writer, config.preview.?, buf.items);
                 }
             },
@@ -101,8 +100,7 @@ pub fn text(writer: anytype, reader: anytype, allocator: std.mem.Allocator, conf
                 }
             },
             .char => |c| {
-                try buf.append(allocator, c);
-                try writer.print("{c}", .{c});
+                try writer.writeAll(try zinput.appendCodepoint(allocator, &buf, c));
                 if (use_preview) try repaintPreview(writer, config.preview.?, buf.items);
             },
             else => {},

--- a/packages/zinput/src/zinput.zig
+++ b/packages/zinput/src/zinput.zig
@@ -50,6 +50,35 @@ pub const search = search_prompt.search;
 pub const number = number_prompt.number;
 pub const editor = editor_prompt.editor;
 
+/// Append a typed codepoint to `buf` as UTF-8, returning the appended bytes
+/// (a slice into `buf.items`) so the caller can echo them.
+pub fn appendCodepoint(allocator: std.mem.Allocator, buf: *std.ArrayList(u8), c: u21) ![]const u8 {
+    var utf8: [4]u8 = undefined;
+    const n = std.unicode.utf8Encode(c, &utf8) catch unreachable; // readKey only yields valid scalars
+    try buf.appendSlice(allocator, utf8[0..n]);
+    return buf.items[buf.items.len - n ..];
+}
+
+/// Shrink `buf` by its trailing grapheme cluster — one *visible* character,
+/// however many codepoints compose it. No-op on an empty buffer. For prompts
+/// that repaint their whole line; `eraseTrailingGrapheme` also erases in place.
+pub fn popTrailingGrapheme(buf: *std.ArrayList(u8)) void {
+    buf.items.len -= terminal.trailingGraphemeLen(buf.items);
+}
+
+/// Remove the trailing grapheme cluster from `buf` and erase it from the
+/// terminal line: backspace, space, backspace — once per display column, so a
+/// double-width CJK char or emoji clears both of its cells.
+pub fn eraseTrailingGrapheme(writer: anytype, buf: *std.ArrayList(u8)) !void {
+    if (buf.items.len == 0) return;
+    const tail = buf.items[buf.items.len - terminal.trailingGraphemeLen(buf.items) ..];
+    const cols = terminal.displayWidth(tail);
+    buf.items.len -= tail.len;
+    for (0..cols) |_| try writer.writeAll("\x08");
+    for (0..cols) |_| try writer.writeAll(" ");
+    for (0..cols) |_| try writer.writeAll("\x08");
+}
+
 /// Flush a writer if it supports flushing. Works with both pointer and value writer types.
 pub fn flushWriter(writer: anytype) void {
     const W = @TypeOf(writer);
@@ -72,4 +101,55 @@ pub const EditorConfig = editor_prompt.EditorConfig;
 
 test {
     std.testing.refAllDecls(@This());
+}
+
+test "appendCodepoint encodes multibyte UTF-8 and returns the echo slice" {
+    const allocator = std.testing.allocator;
+    var buf = std.ArrayList(u8).empty;
+    defer buf.deinit(allocator);
+
+    try std.testing.expectEqualStrings("a", try appendCodepoint(allocator, &buf, 'a'));
+    try std.testing.expectEqualStrings("é", try appendCodepoint(allocator, &buf, 'é'));
+    try std.testing.expectEqualStrings("你", try appendCodepoint(allocator, &buf, '你'));
+    try std.testing.expectEqualStrings("😊", try appendCodepoint(allocator, &buf, '😊'));
+    try std.testing.expectEqualStrings("aé你😊", buf.items);
+}
+
+test "popTrailingGrapheme removes whole clusters, not bytes" {
+    const allocator = std.testing.allocator;
+    var buf = std.ArrayList(u8).empty;
+    defer buf.deinit(allocator);
+
+    // 'e' + combining acute is one cluster: a single pop removes both codepoints.
+    try buf.appendSlice(allocator, "a你e\u{0301}");
+    popTrailingGrapheme(&buf);
+    try std.testing.expectEqualStrings("a你", buf.items);
+    popTrailingGrapheme(&buf);
+    try std.testing.expectEqualStrings("a", buf.items);
+    popTrailingGrapheme(&buf);
+    try std.testing.expectEqualStrings("", buf.items);
+    popTrailingGrapheme(&buf); // no-op on empty
+    try std.testing.expectEqualStrings("", buf.items);
+}
+
+test "eraseTrailingGrapheme erases one column per display cell" {
+    const allocator = std.testing.allocator;
+    var buf = std.ArrayList(u8).empty;
+    defer buf.deinit(allocator);
+    var out: [64]u8 = undefined;
+
+    // ASCII: one cell.
+    try buf.appendSlice(allocator, "ab");
+    var w1: std.Io.Writer = .fixed(&out);
+    try eraseTrailingGrapheme(&w1, &buf);
+    try std.testing.expectEqualStrings("a", buf.items);
+    try std.testing.expectEqualStrings("\x08 \x08", w1.buffered());
+
+    // Wide CJK: two cells, so two backspace/space pairs.
+    buf.clearRetainingCapacity();
+    try buf.appendSlice(allocator, "你");
+    var w2: std.Io.Writer = .fixed(&out);
+    try eraseTrailingGrapheme(&w2, &buf);
+    try std.testing.expectEqualStrings("", buf.items);
+    try std.testing.expectEqualStrings("\x08\x08  \x08\x08", w2.buffered());
 }

--- a/packages/zinput/test/render_e2e.zig
+++ b/packages/zinput/test/render_e2e.zig
@@ -148,6 +148,39 @@ test "emulator: select hang-indents wrapped continuation lines on screen" {
 }
 
 // ---------------------------------------------------------------------------
+// text input: echo + backspace-erase (grapheme/width aware)
+// ---------------------------------------------------------------------------
+
+test "emulator: backspace-erase clears a wide char's both cells" {
+    const alloc = testing.allocator;
+    var buf = std.ArrayList(u8).empty;
+    defer buf.deinit(alloc);
+    var out: [256]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&out);
+
+    // Type "ab" then 你 (2 cells), then backspace 你 away and type "c" — the
+    // screen must read exactly "abc" with no half-glyph debris in the cells the
+    // wide char occupied. A byte- or single-column erase fails this.
+    try w.writeAll(try zinput.appendCodepoint(alloc, &buf, 'a'));
+    try w.writeAll(try zinput.appendCodepoint(alloc, &buf, 'b'));
+    try w.writeAll(try zinput.appendCodepoint(alloc, &buf, '你'));
+    try zinput.eraseTrailingGrapheme(&w, &buf);
+    try w.writeAll(try zinput.appendCodepoint(alloc, &buf, 'c'));
+
+    try testing.expectEqualStrings("abc", buf.items);
+
+    var term = try vterm.VTerm.init(alloc, 20, 4);
+    defer term.deinit();
+    term.write(w.buffered());
+    const line = try term.getLine(alloc, 0);
+    defer alloc.free(line);
+    try testing.expectEqualStrings("abc", std.mem.trimEnd(u8, line, " "));
+    // Cursor sits right after the 'c' — erase walked back exactly two cells.
+    try testing.expectEqual(@as(u32, 3), term.cursor.x);
+    try testing.expectEqual(@as(u32, 0), term.cursor.y);
+}
+
+// ---------------------------------------------------------------------------
 // search
 // ---------------------------------------------------------------------------
 

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -958,6 +958,53 @@ test "interactive: add command drives the wizard and echoes typed input" {
     try testing.expect(fileExists(tmp.dir, "src/commands/deploy.zig"));
 }
 
+test "interactive: text prompt handles multibyte UTF-8 typing and backspace" {
+    if (builtin.os.tag == .windows) return;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try makeProjectDirs(tmp.dir);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const proj_abs = try tmpDirAbs(arena.allocator(), tmp);
+
+    // Description keystrokes: C a f é <backspace> e <enter>. The backspace lands
+    // on the 2-byte é — a grapheme-aware editor deletes it whole, leaving "Cafe";
+    // the old byte-oriented one popped a single byte, leaving invalid UTF-8
+    // ("Caf\xC3" + "e") in the generated file. See the wizard test above for the
+    // settle-delay rationale.
+    const settle_ms = 400;
+    var script = harness.InteractiveScript.init(testing.allocator);
+    defer script.deinit();
+    _ = script
+        .expect("Command path:").delay(settle_ms).send("greet")
+        .expect("Description:").delay(settle_ms).sendRaw("Caf\xc3\xa9\x7fe\r")
+        .expect("Add a positional argument?").delay(settle_ms).sendRaw("n")
+        .expect("Add an option?").delay(settle_ms).sendRaw("n")
+        .expect("What next?").delay(settle_ms).sendRaw("\r");
+
+    var result = harness.runInteractive(
+        testing.allocator,
+        io,
+        &.{ zcli_exe, "add", "command" },
+        script,
+        .{ .cwd = proj_abs, .allocate_pty = true, .total_timeout_ms = 20000 },
+    ) catch |err| {
+        // PTY allocation can be denied in some sandboxes; don't fail the suite.
+        std.debug.print("runInteractive unavailable: {any}\n", .{err});
+        return;
+    };
+    defer result.deinit();
+
+    // The é was echoed as a whole character while it was typed.
+    try expectContains(result.output, "Café");
+
+    try testing.expect(result.exit_code == 0);
+    const generated = try readFile(tmp.dir, arena.allocator(), "src/commands/greet.zig");
+    try expectContains(generated, ".description = \"Cafe\"");
+}
+
 test "interactive: init's plugin multi-select toggles an opt-in plugin" {
     if (builtin.os.tag == .windows) return;
 


### PR DESCRIPTION
## Summary

Grade item 25: interactive prompts were byte-oriented — `terminal.Key.char` was a `u8`, so typing "é" produced two `.char` keys and backspace popped one **byte**, corrupting the buffer into invalid UTF-8 and erasing only one of a wide char's two terminal cells. Inconsistent with the rest of the stack, which wraps and measures grapheme-aware via zg.

Fixed at the source rather than patching each prompt:

- **`terminal.Key.char` is now a `u21` codepoint.** `readKey` assembles multibyte UTF-8 sequences (continuation bytes arrive in the same terminal write as the lead byte, so they're already buffered — no timeout needed, same reasoning as escape sequences). Invalid input — stray continuation bytes, bad leads, overlong encodings — decodes to U+FFFD rather than surfacing raw bytes as separate keys.
- **Backspace deletes one grapheme cluster, not one byte.** A combining accent comes off with its base; a ZWJ emoji dies whole. The in-place erase (text prompt) walks back the cluster's true display width, so a CJK char or emoji clears both of its cells. New `terminal` helpers `trailingGraphemeLen`/`graphemeCount` back this; shared zinput helpers `appendCodepoint`/`popTrailingGrapheme`/`eraseTrailingGrapheme` keep text/password/search in sync.
- **password** masks one glyph per typed character (was: one per byte, so "é" grew two stars); **search** queries pop whole clusters; **number** casts its ASCII-only digits into its `u8` buffer.

### Semantic delta for `Key` consumers

Matching `Key{ .char = 'x' }` and switching on char literals is unchanged (`u8` and char literals coerce to `u21`). Code that *stores* `.char` into a `u8` now needs a cast — the only in-repo site was number.zig's digit buffer, guarded by its ASCII range check. `Key.format` renders `.char` with `{u}` instead of `{c}`.

Judgment call: backspace is **grapheme**-based, not codepoint-based, to match the wrapping layer's unit of "one visible character" — codepoint-based deletion would strip a combining accent off its base but leave the terminal cell showing the still-composed glyph, desyncing screen from buffer.

## Verification

All fix-guarding tests were mutation-verified (broke the fix, watched the test fail, restored):

- **key.zig unit tests**: 2/3/4-byte assembly (é/你/😊 each one key), stray continuation / truncated tail / overlong encoding → U+FFFD. *Mutation: reverting the 0x80–0xFF arm to `.char = byte` → 6 failures.*
- **zinput unit tests** for the three helpers, including "pop removes `e`+combining-acute as one cluster" and exact erase byte sequences. *Mutations: byte-pop and constant-width-1 erase each caught.*
- **vterm replay test** (cross-platform, runs on Windows CI too): types `ab你`, backspaces, types `c` — asserts the screen reads exactly `abc` and the cursor sits at column 3, which fails under a byte- or single-column erase.
- **PTY e2e** (`projects/zcli`): drives the real add-command wizard through a real PTY typing `Café`, backspacing the `é`, typing `e` — asserts the `é` echoed whole and the generated command file contains `.description = "Cafe"` (byte-wise backspace leaves invalid UTF-8 `Caf\xC3e` there instead). Ran with zero PTY-unavailable skips.

Battery: `packages/core zig build test` ✓ · repo root `zig build test` (all packages, re-run after rebasing onto #73's ghauth) ✓ · `projects/zcli zig build` ✓ · `projects/zcli zig build e2e` ✓ · `zig fmt --check` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)