### PR TITLE
testing: runCommand supports commands with required args (dogfood fix)

### DIFF
--- a/packages/testing/src/unit.zig
+++ b/packages/testing/src/unit.zig
@@ -48,20 +48,58 @@ pub const CommandResult = struct {
     }
 };
 
+/// True when every field of `T` has a default value, so `T{}` compiles.
+fn isDefaultConstructible(comptime T: type) bool {
+    inline for (@typeInfo(T).@"struct".fields) |field| {
+        if (field.default_value_ptr == null) return false;
+    }
+    return true;
+}
+
+/// Field attributes for a `runCommand` `args`/`options` field: it carries a
+/// default (so the caller may omit it) only when `T` is default-constructible.
+/// When `T` has a required field, the config field is required too — so
+/// omitting `.args`/`.options` for such a command is a plain "missing struct
+/// field" compile error at the call site, not a cryptic one inside a default.
+fn fieldAttrs(comptime T: type) std.builtin.Type.StructField.Attributes {
+    const default_ptr: ?*const anyopaque = if (isDefaultConstructible(T)) blk: {
+        const value: T = .{};
+        break :blk &value;
+    } else null;
+    return .{ .default_value_ptr = default_ptr };
+}
+
+/// The `config` parameter type for `runCommand`, tailored to `Command` so that
+/// `args`/`options` are only optional-to-pass when default-constructible.
+fn RunConfig(comptime Command: type) type {
+    const default_alloc: std.mem.Allocator = std.testing.allocator;
+    const names = [_][]const u8{ "args", "options", "allocator" };
+    const types = [_]type{ Command.Args, Command.Options, std.mem.Allocator };
+    const attrs = [_]std.builtin.Type.StructField.Attributes{
+        fieldAttrs(Command.Args),
+        fieldAttrs(Command.Options),
+        .{ .default_value_ptr = &default_alloc },
+    };
+    return @Struct(.auto, null, &names, &types, &attrs);
+}
+
 /// Run a command's execute() function in-process with captured I/O.
 ///
 /// The command module must have Args, Options, and execute declarations.
 /// Plugins can be provided to populate context.plugins.
+///
+/// Pass `.args`/`.options` to drive the command. They may be omitted only
+/// when the command's Args/Options are default-constructible (every field has
+/// a default); a command with a required positional or option must be given
+/// `.args`/`.options` or the call fails to compile with "missing struct field".
 pub fn runCommand(
     comptime Command: type,
     comptime plugins: []const type,
-    config: struct {
-        args: Command.Args = .{},
-        options: Command.Options = .{},
-        allocator: std.mem.Allocator = std.testing.allocator,
-    },
+    config: RunConfig(Command),
 ) !CommandResult {
     const allocator = config.allocator;
+    const args = config.args;
+    const options = config.options;
 
     // Capture output using allocating writers
     var stdout_aw: std.Io.Writer.Allocating = .init(allocator);
@@ -96,7 +134,7 @@ pub fn runCommand(
     // Execute the command
     var success = true;
     var err: ?anyerror = null;
-    Command.execute(config.args, config.options, &context) catch |e| {
+    Command.execute(args, options, &context) catch |e| {
         success = false;
         err = e;
     };
@@ -202,6 +240,24 @@ test "runCommand passes args and options" {
     defer result.deinit();
 
     try std.testing.expectEqualStrings("widget: 5\n", result.stdout);
+}
+
+test "runCommand with a required (no-default) arg" {
+    const TestCommand = struct {
+        pub const Args = struct {
+            name: []const u8,
+        };
+        pub const Options = struct {};
+
+        pub fn execute(args: Args, _: Options, context: anytype) !void {
+            try context.stdout().print("hello {s}\n", .{args.name});
+        }
+    };
+
+    var result = try runCommand(TestCommand, &.{}, .{ .args = .{ .name = "Ada" } });
+    defer result.deinit();
+
+    try std.testing.expectEqualStrings("hello Ada\n", result.stdout);
 }
 
 test "runCommand with plugin data" {

--- a/projects/zcli/src/commands/guide.zig
+++ b/projects/zcli/src/commands/guide.zig
@@ -268,6 +268,12 @@ const topics = [_]Topic{
         \\asserting on rendered color/layout). Pass plugin types as the second arg to
         \\populate context.plugins.
         \\
+        \\runCommand runs execute() in-process against the real filesystem and the
+        \\real cwd — it captures I/O, not the disk. A command that reads or writes
+        \\files touches actual files during `zig build test`, so a leftover file can
+        \\make the next run behave differently. Point file I/O at a temp dir or a
+        \\unique path, and clean up in the test.
+        \\
         ,
     },
 };


### PR DESCRIPTION
## What

Fixes a `runCommand` (`packages/testing`) bug surfaced by an ADR-0004 **dogfooding pass**: a command whose `Args` (or `Options`) has a **required, no-default field** could not be unit-tested at all.

`runCommand`'s config declared `args: Command.Args = .{}`. Zig type-checks that `.{}` default against the field type **even when the caller passes `.args`**, so a required field failed to compile:

```
error: missing struct field: name
```

Required positionals are the common case — and `zcli guide testing`'s own worked example (`.args = .{ .name = "Ada" }`) would not compile. LLM-facing docs teaching a pattern that doesn't build.

## Fix

Build the `config` parameter type per-command with `@Struct` (0.16's split of `@Type`): the `args`/`options` fields carry a **synthesized default only when the type is default-constructible** (every field has a default). A command with a required field makes the config field required too — so omitting `.args`/`.options` for it is now a plain **`missing struct field: args`** compile error at the call site, instead of a cryptic one buried inside a default. No-arg commands still work with a bare `.{}`.

The three helpers (`isDefaultConstructible`, `fieldAttrs`, `RunConfig`) are kept **private** to `unit.zig` — no public `hasRequiredArgs` re-export (that was deliberately removed in an earlier review).

Also updates the `testing` guide topic: the worked example now compiles, plus a note that `runCommand` runs against the **real cwd/filesystem** — a command doing file I/O touches real files during `zig build test`, so point I/O at a temp dir / unique path (another dogfood finding).

## Verification

- New test `runCommand with a required (no-default) arg` — fails to compile before the change, passes after.
- Probed the negative case: omitting `.args` for a required command yields `error: missing struct field: args`.
- All test tiers green: `packages/testing`, `packages/core`, and meta-CLI `projects/zcli` (`zig build test`, exit 0). Existing `.{}` callers (no-arg commands) unaffected.
- 0.16 comptime/`@Struct` semantics verified against the `zig-docs` MCP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)