### PR TITLE
init/guide: document + wire cross-command code sharing (shared_modules)

### DIFF
--- a/projects/zcli/src/commands/guide.zig
+++ b/projects/zcli/src/commands/guide.zig
@@ -102,6 +102,45 @@ const topics = [_]Topic{
         ,
     },
     .{
+        .name = "sharing",
+        .summary = "reuse a helper module across commands",
+        .body =
+        \\sharing — reuse code across commands
+        \\
+        \\When two or more commands need the same helper (a `store.zig`, an API
+        \\client, shared types), put it in its own module and register it once. This
+        \\is build wiring you edit by hand — unlike command structure, there is no
+        \\`zcli add` for it.
+        \\
+        \\1. Write the helper, e.g. `src/store.zig`.
+        \\2. In build.zig, create a module for it and add it to `shared_modules`:
+        \\
+        \\  const store_module = b.createModule(.{
+        \\      .root_source_file = b.path("src/store.zig"),
+        \\      .target = target,
+        \\      .optimize = optimize,
+        \\  });
+        \\
+        \\  const shared_modules = [_]zcli.SharedModule{
+        \\      .{ .name = "store", .module = store_module },
+        \\  };
+        \\
+        \\3. Pass `shared_modules` to BOTH `zcli.generate(...)` and
+        \\   `zcli.addCommandTests(...)` — a generated project already wires the one
+        \\   list into both. If a module reaches `generate` but not the tests, `zig
+        \\   build` is green while `zig build test` fails with "no module named
+        \\   'store'". One list, two call sites.
+        \\
+        \\4. Import it from any command (or its test) by the registered name:
+        \\
+        \\  const store = @import("store");
+        \\
+        \\A shared module can itself import zcli packages — e.g.
+        \\`store_module.addImport("ztheme", zcli_dep.module("ztheme"));`.
+        \\
+        ,
+    },
+    .{
         .name = "arena",
         .summary = "the per-command allocator (never free)",
         .body =

--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -228,8 +228,19 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         \\
         \\    exe.root_module.addImport("zcli", zcli_module);
         \\
-        \\    // Generate command registry with built-in plugins
         \\    const zcli = @import("zcli");
+        \\
+        \\    // Shared modules: helper code (e.g. a `store.zig`) imported by more
+        \\    // than one command. Create it with `b.createModule(...)`, then add an
+        \\    // entry here — this one list is wired into your commands AND their
+        \\    // tests below, so you never register it twice. Editing this build
+        \\    // config by hand is expected; `zcli add`/`rm`/`mv` manage command
+        \\    // *structure*, not build wiring.
+        \\    const shared_modules = [_]zcli.SharedModule{{
+        \\        // .{{ .name = "store", .module = store_module }},
+        \\    }};
+        \\
+        \\    // Generate command registry with built-in plugins
         \\    const cmd_registry = zcli.generate(b, exe, zcli_dep, zcli_module, .{{
         \\        .commands_dir = "src/commands",
         \\        // Local plugins in src/plugins/ are auto-discovered (add with
@@ -237,6 +248,7 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         \\        .plugins_dir = "src/plugins",
         \\        .plugins = &.{{
         \\{s}        }},
+        \\        .shared_modules = &shared_modules,
         \\        .app_name = "{s}",
         \\        .app_version = "{s}",
         \\        .app_description = "{s}",
@@ -261,6 +273,7 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         \\        .commands_dir = "src/commands",
         \\        .target = target,
         \\        .optimize = optimize,
+        \\        .shared_modules = &shared_modules,
         \\    }});
         \\}}
         \\
@@ -409,8 +422,10 @@ const agents_section = agents_begin ++
     \\1. Never `free`/`deinit` memory you allocate in `execute()` — `context.allocator` is
     \\   a per-command arena, reclaimed automatically. (Do still `deinit` non-memory
     \\   resources: files, sockets, `http.Client`.)
-    \\2. Change structure with `zcli add`/`rm`/`mv`, not by editing files by hand. Write
-    \\   freeform code only inside `execute()` bodies.
+    \\2. Change command *structure* with `zcli add`/`rm`/`mv`, not by editing files by
+    \\   hand — write freeform code inside `execute()` bodies. (Editing `build.zig`
+    \\   config, like plugins or shared modules, by hand is expected: that's build
+    \\   wiring, not structure.)
     \\3. Print through `context.stdout()` / `context.stderr()` — never `std.debug.print` or
     \\   a raw stdout handle.
     \\4. Don't hand-roll terminal I/O — use `zinput` (prompts), `zprogress` (progress),
@@ -420,7 +435,7 @@ const agents_section = agents_begin ++
     \\6. File path = command path: `src/commands/foo/bar.zig` → `app foo bar`; a directory's
     \\   `index.zig` is the group landing; plugins live in `src/plugins/`.
     \\
-    \\`zcli guide` topics: structure, arena, output, prompts, http, secrets, plugins, testing.
+    \\`zcli guide` topics: structure, sharing, arena, output, prompts, http, secrets, plugins, testing.
     \\
 ++ agents_end ++ "\n";
 

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -84,6 +84,16 @@ fn readFile(dir: std.Io.Dir, a: std.mem.Allocator, path: []const u8) ![]u8 {
     return dir.readFileAlloc(io, path, a, .limited(1 << 20));
 }
 
+/// Replace the first occurrence of `needle` with `replacement` in `path`,
+/// erroring if `needle` is absent — so a test that edits generated code fails
+/// loudly the moment the generator's output drifts from what it expects.
+fn replaceInFile(dir: std.Io.Dir, a: std.mem.Allocator, path: []const u8, needle: []const u8, replacement: []const u8) !void {
+    const orig = try readFile(dir, a, path);
+    const at = std.mem.indexOf(u8, orig, needle) orelse return error.NeedleNotFound;
+    const out = try std.mem.concat(a, u8, &.{ orig[0..at], replacement, orig[at + needle.len ..] });
+    try dir.writeFile(io, .{ .sub_path = path, .data = out });
+}
+
 fn expectContains(haystack: []const u8, needle: []const u8) !void {
     if (std.mem.indexOf(u8, haystack, needle) == null) {
         std.debug.print(
@@ -958,6 +968,84 @@ test "scaffolded commands are unit-testable via zig build test" {
         var r = try run(proj, &build_test);
         defer r.deinit();
         try testing.expect(r.exit_code != 0);
+    }
+}
+
+test "a shared module reaches both commands and their tests" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    {
+        var r = try run(tmp.dir, &.{ zcli_exe, "init", "app" });
+        defer r.deinit();
+        try expectOk(r);
+    }
+
+    var proj = try tmp.dir.openDir(io, "app", .{});
+    defer proj.close(io);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const proj_abs = try tmpSubdirAbs(a, tmp, "app");
+    try pointDependencyAtLocalTree(proj, proj_abs);
+
+    // A helper module imported by a command AND its co-located test.
+    try proj.writeFile(io, .{
+        .sub_path = "src/store.zig",
+        .data = "pub fn tag() []const u8 {\n    return \"from-store\";\n}\n",
+    });
+
+    // Populate the `shared_modules` list init leaves empty (with a commented
+    // example). Matching that exact block also asserts the template still ships
+    // the anchor — if init's output drifts, replaceInFile errors loudly.
+    try replaceInFile(proj, a, "build.zig",
+        \\    const shared_modules = [_]zcli.SharedModule{
+        \\        // .{ .name = "store", .module = store_module },
+        \\    };
+    ,
+        \\    const store_module = b.createModule(.{
+        \\        .root_source_file = b.path("src/store.zig"),
+        \\        .target = target,
+        \\        .optimize = optimize,
+        \\    });
+        \\    const shared_modules = [_]zcli.SharedModule{
+        \\        .{ .name = "store", .module = store_module },
+        \\    };
+    );
+
+    // A command importing `store` in both execute() and its runCommand test.
+    // `zig build test` passes only if `store` reaches the command's *test*
+    // binary — i.e. shared_modules flowed to addCommandTests, not just
+    // generate(). One list, two call sites (see `zcli guide sharing`).
+    try proj.writeFile(io, .{
+        .sub_path = "src/commands/greet.zig",
+        .data =
+        \\const std = @import("std");
+        \\const zcli = @import("zcli");
+        \\const store = @import("store");
+        \\const Context = @import("command_registry").Context;
+        \\pub const meta = .{ .description = "greet" };
+        \\pub const Args = struct { name: []const u8 };
+        \\pub const Options = struct {};
+        \\pub fn execute(args: Args, _: Options, context: *Context) !void {
+        \\    try context.stdout().print("hi {s} ({s})\n", .{ args.name, store.tag() });
+        \\}
+        \\test "greet uses the shared store module" {
+        \\    const zcli_testing = @import("zcli-testing");
+        \\    var r = try zcli_testing.runCommand(@This(), &.{}, .{ .args = .{ .name = "Ada" } });
+        \\    defer r.deinit();
+        \\    try std.testing.expect(r.success);
+        \\    try std.testing.expect(std.mem.indexOf(u8, r.stdout, store.tag()) != null);
+        \\}
+        \\
+        ,
+    });
+
+    {
+        var r = try run(proj, &.{ "zig", "build", "test" });
+        defer r.deinit();
+        try expectOk(r);
     }
 }
 


### PR DESCRIPTION
## What

Closes the biggest **documentation + DX gap** an ADR-0004 dogfooding pass hit: sharing a helper module (e.g. `src/store.zig`) across commands.

Two problems:
1. **No docs.** Nothing in `AGENTS.md` or `zcli guide` explained `shared_modules` — the cold agent had to read zcli's own source (`examples/showcase/build.zig`, `build_utils/command_tests.zig`) to figure it out.
2. **A two-place footgun.** `shared_modules` must be registered in *both* `zcli.generate(...)` **and** `zcli.addCommandTests(...)`. Miss the second and `zig build` is green while `zig build test` fails with a confusing `no module named 'store'`.
3. **Fuzzy boundary.** `AGENTS.md` invariant #2 ("change structure with `zcli add`/`rm`/`mv`, not by editing files") made it unclear that editing `build.zig` *config* is expected and normal.

## Changes

**Docs**
- New **`zcli guide sharing`** topic — when to reuse a module, how to create/register it, and the *one list, two call sites* rule (with the exact failure mode if you miss the tests wiring).
- `AGENTS.md` invariant #2 now distinguishes command **structure** (managed by `zcli add`/`rm`/`mv`) from `build.zig` **config** (plugins, shared modules — edited by hand). Topics line now lists `sharing`.

**Template (`init`)**
- The generated `build.zig` defines `shared_modules` **once as a `const`** and passes it to **both** `generate()` and `addCommandTests()`. New projects add a single entry, wired into commands *and* their tests at once — the register-it-twice footgun is gone.

**Test**
- e2e regression: proves a *populated* shared module reaches both a command's `execute()` and its co-located `runCommand` test in a generated project. (The existing test only exercised an empty list, which wouldn't catch a dropped tests-wiring.) The rewrite matches the template's exact `shared_modules` block, so drift in `init`'s output fails the test loudly.

## Verification

- Generated a project against the local tree, added a real `store` module, wired it into the `const`, and confirmed **`zig build` and `zig build test` both green** with a command and its test importing `store` (runtime output `Hello, Ada! (from-store)`; test asserts on `store.tag()`).
- `zcli guide sharing` renders; overview lists it.
- Meta-CLI `zig build` + `zig build test` clean; `ast-check` clean on all three files.
- The new **e2e** test is CI-gated (running the full e2e locally risks the `zig fetch` global-cache-lock hazard); the identical scenario was verified manually as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)