### PR TITLE
guide: add storage topic + notes persistence example (dogfood pass 2)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -117,6 +117,7 @@ pub fn build(b: *std.Build) void {
         .{ .name = "showcase", .path = "examples/showcase" },
         .{ .name = "repostat", .path = "examples/repostat" },
         .{ .name = "ghauth", .path = "examples/ghauth" },
+        .{ .name = "notes", .path = "examples/notes" },
         .{ .name = "vterm_example", .path = "packages/vterm/example" },
     };
 

--- a/examples/notes/README.md
+++ b/examples/notes/README.md
@@ -1,0 +1,25 @@
+# notes
+
+A tiny note keeper built with [zcli](../../README.md) — the canonical example
+for **saving and loading data in a JSON file**, and for **sharing a helper
+module across commands**.
+
+```
+notes add greeting "Hello, there!"
+notes add todo "Buy milk"
+notes list          # greeting, todo
+notes show greeting # Hello, there!
+```
+
+Data is persisted to `notes.json` in the current directory.
+
+## What it demonstrates
+
+- **`src/store.zig`** — load/save a typed struct as JSON with `std.json`:
+  `parseFromSlice` in, `std.json.fmt` out. No hand-written parsing or string
+  building. This file is embedded verbatim into `zcli guide storage`.
+- **A shared module** — `store` is imported by all three commands, registered
+  once in `build.zig` as a `shared_modules` entry and wired into both
+  `generate()` and `addCommandTests()`. See `zcli guide sharing`.
+- **The arena** — commands load into `context.allocator` and never free; the
+  per-command arena reclaims it. See `zcli guide arena`.

--- a/examples/notes/build.zig
+++ b/examples/notes/build.zig
@@ -1,0 +1,61 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const zcli_dep = b.dependency("zcli", .{ .target = target, .optimize = optimize });
+    const zcli_module = zcli_dep.module("zcli");
+
+    const exe = b.addExecutable(.{
+        .name = "notes",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    exe.root_module.addImport("zcli", zcli_module);
+
+    const zcli = @import("zcli");
+
+    // The persistence helper, shared by every command (see `zcli guide sharing`
+    // and `zcli guide storage`). Registered once here and wired into both the
+    // generated commands and their tests.
+    const store_module = b.createModule(.{
+        .root_source_file = b.path("src/store.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const shared_modules = [_]zcli.SharedModule{
+        .{ .name = "store", .module = store_module },
+    };
+
+    const cmd_registry = zcli.generate(b, exe, zcli_dep, zcli_module, .{
+        .commands_dir = "src/commands",
+        .plugins = &.{
+            zcli.builtin(.help, .{}),
+            zcli.builtin(.version, .{}),
+            zcli.builtin(.not_found, .{}),
+        },
+        .shared_modules = &shared_modules,
+        .app_name = "notes",
+        .app_description = "A tiny note keeper (a JSON-file persistence example)",
+    });
+    exe.root_module.addImport("command_registry", cmd_registry);
+
+    b.installArtifact(exe);
+
+    const run_cmd = b.addRunArtifact(exe);
+    run_cmd.step.dependOn(b.getInstallStep());
+    if (b.args) |args| run_cmd.addArgs(args);
+    const run_step = b.step("run", "Run the application");
+    run_step.dependOn(&run_cmd.step);
+
+    _ = zcli.addCommandTests(b, zcli_dep, zcli_module, .{
+        .commands_dir = "src/commands",
+        .target = target,
+        .optimize = optimize,
+        .shared_modules = &shared_modules,
+    });
+}

--- a/examples/notes/build.zig.zon
+++ b/examples/notes/build.zig.zon
@@ -1,0 +1,18 @@
+.{
+    .name = .notes,
+    .version = "0.1.0",
+    .fingerprint = 0x011ba68c18ba30c4,
+    .minimum_zig_version = "0.16.0",
+    .dependencies = .{
+        // Local path because this example lives in-repo (so CI compiles it
+        // against unreleased changes as a drift-detector). Your own project
+        // doesn't hand-write this — `zcli init` fetches a released zcli:
+        //   .zcli = .{ .url = "git+https://github.com/ryanhair/zcli#<tag>", .hash = "..." },
+        .zcli = .{ .path = "../.." },
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}

--- a/examples/notes/src/commands/add.zig
+++ b/examples/notes/src/commands/add.zig
@@ -1,0 +1,33 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const store = @import("store");
+const Context = @import("command_registry").Context;
+
+pub const meta = .{
+    .description = "Save a note under a title",
+    .examples = &.{
+        "add greeting \"Hello, there!\"",
+    },
+};
+
+pub const Args = struct {
+    title: []const u8,
+    body: []const u8,
+};
+
+pub const Options = struct {};
+
+pub fn execute(args: Args, _: Options, context: *Context) !void {
+    const arena = context.allocator;
+    var notes = try store.load(context.io, arena);
+
+    // Append the new note. Everything is arena-allocated, so there is nothing
+    // to free — the whole arena is reclaimed when the command returns.
+    const grown = try arena.alloc(store.Note, notes.notes.len + 1);
+    @memcpy(grown[0..notes.notes.len], notes.notes);
+    grown[notes.notes.len] = .{ .title = args.title, .body = args.body };
+    notes.notes = grown;
+
+    try store.save(context.io, notes);
+    try context.stdout().print("Saved note '{s}'\n", .{args.title});
+}

--- a/examples/notes/src/commands/list.zig
+++ b/examples/notes/src/commands/list.zig
@@ -1,0 +1,22 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const store = @import("store");
+const Context = @import("command_registry").Context;
+
+pub const meta = .{
+    .description = "List every saved note title",
+};
+
+pub const Args = struct {};
+pub const Options = struct {};
+
+pub fn execute(_: Args, _: Options, context: *Context) !void {
+    const notes = try store.load(context.io, context.allocator);
+    if (notes.notes.len == 0) {
+        try context.stdout().writeAll("No notes yet.\n");
+        return;
+    }
+    for (notes.notes) |note| {
+        try context.stdout().print("{s}\n", .{note.title});
+    }
+}

--- a/examples/notes/src/commands/show.zig
+++ b/examples/notes/src/commands/show.zig
@@ -1,0 +1,29 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const store = @import("store");
+const Context = @import("command_registry").Context;
+
+pub const meta = .{
+    .description = "Print the body of a named note",
+    .examples = &.{
+        "show greeting",
+    },
+};
+
+pub const Args = struct {
+    title: []const u8,
+};
+
+pub const Options = struct {};
+
+pub fn execute(args: Args, _: Options, context: *Context) !void {
+    const notes = try store.load(context.io, context.allocator);
+    if (store.find(notes, args.title)) |note| {
+        try context.stdout().print("{s}\n", .{note.body});
+    } else {
+        // A missing note is a plain user error: report it and exit non-zero,
+        // rather than returning an error (which would print a Zig stack trace).
+        try context.stderr().print("No note titled '{s}'\n", .{args.title});
+        context.exit(1);
+    }
+}

--- a/examples/notes/src/main.zig
+++ b/examples/notes/src/main.zig
@@ -1,0 +1,11 @@
+const std = @import("std");
+const registry = @import("command_registry");
+
+pub fn main(init: std.process.Init) !void {
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
+    var app = registry.init();
+    app.run(init.gpa, init.io, init.environ_map, args) catch |err| switch (err) {
+        error.CommandNotFound => std.process.exit(1),
+        else => return err,
+    };
+}

--- a/examples/notes/src/store.zig
+++ b/examples/notes/src/store.zig
@@ -1,0 +1,63 @@
+//! store.zig — load and save notes as a JSON file, shared across commands.
+//!
+//! This is a shared module (see `zcli guide sharing`): every command imports
+//! `store` and calls load()/save(), so persistence lives in exactly one place.
+//! The on-disk format is whatever `std.json` makes of `Notes` — a typed struct
+//! goes out, the same typed struct comes back, with no hand-written parsing.
+
+const std = @import("std");
+
+/// One saved note. Field names become the JSON object keys.
+pub const Note = struct {
+    title: []const u8,
+    body: []const u8,
+};
+
+/// The whole file: a top-level object with a `notes` array. Defaulting every
+/// field means an absent or empty file still decodes to a valid, empty value.
+pub const Notes = struct {
+    notes: []Note = &.{},
+};
+
+/// Where the data lives, relative to the current working directory.
+pub const filename = "notes.json";
+
+/// Load the notes file into `arena`-owned memory, or an empty set if it does
+/// not exist yet. `io` is `context.io` (a `std.Io`) and `arena` is
+/// `context.allocator`, so the result is reclaimed when the command ends —
+/// never free it yourself (see `zcli guide arena`).
+pub fn load(io: std.Io, arena: std.mem.Allocator) !Notes {
+    const cwd = std.Io.Dir.cwd();
+    const bytes = cwd.readFileAlloc(io, filename, arena, .limited(4 * 1024 * 1024)) catch |err| switch (err) {
+        error.FileNotFound => return .{}, // first run — nothing saved yet
+        else => return err,
+    };
+    // parseFromSlice fills a typed value directly — no walking a generic
+    // `std.json.Value`. `.alloc_always` copies strings into the arena so they
+    // outlive `bytes`; the parser's own arena is taken from `arena` too, so the
+    // command arena reclaims all of it at once.
+    const parsed = try std.json.parseFromSlice(Notes, arena, bytes, .{ .allocate = .alloc_always });
+    return parsed.value;
+}
+
+/// Write `notes` back to disk as pretty-printed JSON. `std.json.fmt` renders
+/// any value as JSON through the `{f}` format specifier — no manual string
+/// building, no stringify call to look up.
+pub fn save(io: std.Io, notes: Notes) !void {
+    const cwd = std.Io.Dir.cwd();
+    const file = try cwd.createFile(io, filename, .{}); // truncates and rewrites
+    defer file.close(io);
+
+    var buf: [4096]u8 = undefined;
+    var fw = file.writer(io, &buf);
+    try fw.interface.print("{f}", .{std.json.fmt(notes, .{ .whitespace = .indent_2 })});
+    try fw.interface.flush(); // the file writer is buffered — flush before close
+}
+
+/// Find a note by title, or null if there isn't one.
+pub fn find(notes: Notes, title: []const u8) ?Note {
+    for (notes.notes) |note| {
+        if (std.mem.eql(u8, note.title, title)) return note;
+    }
+    return null;
+}

--- a/projects/zcli/build.zig
+++ b/projects/zcli/build.zig
@@ -46,6 +46,9 @@ pub fn build(b: *std.Build) void {
     guide_examples_module.addAnonymousImport("ghauth/whoami.zig", .{
         .root_source_file = b.path("../../examples/ghauth/src/commands/whoami.zig"),
     });
+    guide_examples_module.addAnonymousImport("notes/store.zig", .{
+        .root_source_file = b.path("../../examples/notes/src/store.zig"),
+    });
 
     // Create the executable
     const exe = b.addExecutable(.{

--- a/projects/zcli/src/commands/guide.zig
+++ b/projects/zcli/src/commands/guide.zig
@@ -136,9 +136,43 @@ const topics = [_]Topic{
         \\  const store = @import("store");
         \\
         \\A shared module can itself import zcli packages — e.g.
-        \\`store_module.addImport("ztheme", zcli_dep.module("ztheme"));`.
+        \\`store_module.addImport("ztheme", zcli_dep.module("ztheme"));`. For a
+        \\complete shared module that persists data, see `zcli guide storage`.
         \\
         ,
+    },
+    .{
+        .name = "storage",
+        .summary = "save and load data (JSON files)",
+        .body =
+        \\storage — save and load data (JSON files)
+        \\
+        \\Commands persist state by reading and writing files themselves — there is
+        \\no zcli storage API, just the standard library. `context.io` is a `std.Io`;
+        \\pass it to `std.Io.Dir` to touch the filesystem:
+        \\
+        \\  const cwd = std.Io.Dir.cwd();
+        \\  const bytes = try cwd.readFileAlloc(context.io, "data.json", context.allocator, .limited(1 << 20));
+        \\  try cwd.writeFile(context.io, .{ .sub_path = "data.json", .data = bytes });
+        \\
+        \\For structured data, let `std.json` carry it both ways — a typed struct
+        \\decodes from bytes, and any value re-encodes through the `{f}` specifier;
+        \\no walking a generic tree, no hand-written string building:
+        \\
+        \\  const parsed = try std.json.parseFromSlice(MyData, arena, bytes, .{ .allocate = .alloc_always });
+        \\  const data = parsed.value;                                     // bytes  -> struct
+        \\  const json = std.json.fmt(data, .{ .whitespace = .indent_2 });  // struct -> JSON, print with "{f}"
+        \\
+        \\Load into `context.allocator` (the arena) and never free — the data lives
+        \\until the command ends (see `zcli guide arena`). Paths are relative to the
+        \\working directory, so a command reads and writes where the user ran it;
+        \\a test that drives such a command touches real files (see `zcli guide
+        \\testing`).
+        \\
+        \\Worked example — examples/notes/src/store.zig, a persistence helper shared
+        \\by every command (see `zcli guide sharing`):
+        \\
+        ++ "\n" ++ examples.notes_store,
     },
     .{
         .name = "arena",

--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -435,7 +435,7 @@ const agents_section = agents_begin ++
     \\6. File path = command path: `src/commands/foo/bar.zig` → `app foo bar`; a directory's
     \\   `index.zig` is the group landing; plugins live in `src/plugins/`.
     \\
-    \\`zcli guide` topics: structure, sharing, arena, output, prompts, http, secrets, plugins, testing.
+    \\`zcli guide` topics: structure, sharing, storage, arena, output, prompts, http, secrets, plugins, testing.
     \\
 ++ agents_end ++ "\n";
 

--- a/projects/zcli/src/guide_examples.zig
+++ b/projects/zcli/src/guide_examples.zig
@@ -9,3 +9,4 @@
 pub const repostat_repo = @embedFile("repostat/repo.zig");
 pub const ghauth_login = @embedFile("ghauth/login.zig");
 pub const ghauth_whoami = @embedFile("ghauth/whoami.zig");
+pub const notes_store = @embedFile("notes/store.zig");

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -459,6 +459,16 @@ test "guide lists topics and embeds the canonical example source" {
         try expectContains(r.stdout, "https://api.github.com/repos/");
     }
 
+    // Same for `storage`, embedding examples/notes/src/store.zig — the canonical
+    // JSON-persistence idiom (typed parse + std.json.fmt).
+    {
+        var r = try run(tmp.dir, &.{ zcli_exe, "guide", "storage" });
+        defer r.deinit();
+        try expectOk(r);
+        try expectContains(r.stdout, "std.json.parseFromSlice");
+        try expectContains(r.stdout, "std.json.fmt(notes");
+    }
+
     // An unknown topic fails (non-zero) with the topic list, no stack trace.
     {
         var r = try run(tmp.dir, &.{ zcli_exe, "guide", "nope" });


### PR DESCRIPTION
## What

Closes the highest-value gap from **cold dogfooding pass 2**: `zcli guide` had no story for **saving and loading data**. Topics exist for `output`, `http`, and `secrets`, but persistence — a bread-and-butter CLI need — sent the cold agent straight into unguided Zig-0.16 stdlib territory. It hand-rolled a JSON stringifier because it never discovered `std.json.fmt`, and pulled file APIs from out-of-band notes rather than any zcli-facing doc.

Per the design discussion, this is **option A**: a canonical, CI-compiled, embedded example — **no new runtime API**. File I/O stays native `std.Io.Dir` (simple, few footguns, wrong thing for zcli to wrap); the churn/JSON pain is solved by *showing* the version-matched idiom, which is exactly what the guide's embedded-example machinery is for. (A serialization helper / `zcli.store` remains a deliberately deferred one-way-door decision.)

## Changes

- **`examples/notes/`** — a tiny note keeper (`add`/`list`/`show`). Its **`src/store.zig`** is the canonical JSON-persistence idiom: `std.json.parseFromSlice` in, one-line `std.json.fmt` out, `std.Io.Dir` for file access, arena-owned results (never freed). `store` is imported by all three commands, so it *also* serves as the concrete shared-module the `sharing` topic was missing — registered once in `build.zig` and wired into both `generate()` and `addCommandTests()`.
- **New `zcli guide storage` topic** — embeds `store.zig` verbatim, states that `context.io` is a `std.Io` you pass to `std.Io.Dir` (a gap the cold agent hit), and links the arena/testing topics. `sharing` now cross-references it.
- Wired the example into **`build-examples`** (the CI drift-detector — a framework change that breaks the idiom fails CI) and the guide's cross-package `@embedFile`; added `storage` to the scaffolded `AGENTS.md` topics line.
- **e2e drift-guard**: `zcli guide storage` must embed the compiled `store.zig` (`std.json.parseFromSlice` + `std.json.fmt`), mirroring the existing http-embed assertion.

## Why this shape

The friction was **churn + JSON**, not the file primitive. Version-matched *examples* (not a wrapper) are how zcli already absorbs stdlib churn — so the fix is a wrapped **example**, in the same ADR-0008 pattern as repostat (http) and ghauth (secrets). The `notes` store.zig demonstrates the exact idiom the agent failed to find (`std.json.fmt` + typed `parseFromSlice`), closing the file-I/O, JSON, `context.io`, and "concrete shared module" gaps at once.

## Verification

- `examples/notes` builds and round-trips JSON: `add greeting "..."` → `list` → `show greeting`, and a missing note exits non-zero cleanly (`context.exit`, no stack trace).
- `zig build build-notes` (CI's build-examples path), `zig fmt --check packages projects examples build.zig`, meta-CLI `zig build test`, and `ast-check` all clean.
- `zcli guide storage` renders the embedded compiled source; overview lists the topic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)