### PR TITLE
context: add context.fail() for friendly command errors

### DIFF
--- a/examples/notes/src/commands/show.zig
+++ b/examples/notes/src/commands/show.zig
@@ -21,9 +21,10 @@ pub fn execute(args: Args, _: Options, context: *Context) !void {
     if (store.find(notes, args.title)) |note| {
         try context.stdout().print("{s}\n", .{note.body});
     } else {
-        // A missing note is a plain user error: report it and exit non-zero,
-        // rather than returning an error (which would print a Zig stack trace).
-        try context.stderr().print("No note titled '{s}'\n", .{args.title});
-        context.exit(1);
+        // Returning an error is the normal way to fail a command: zcli exits
+        // non-zero and reports it. The stack trace is Debug-only — a release
+        // build just prints `error: NoteNotFound`. (Want a custom message and
+        // exit code instead? Print it, then call context.exit(code).)
+        return error.NoteNotFound;
     }
 }

--- a/examples/notes/src/commands/show.zig
+++ b/examples/notes/src/commands/show.zig
@@ -21,10 +21,10 @@ pub fn execute(args: Args, _: Options, context: *Context) !void {
     if (store.find(notes, args.title)) |note| {
         try context.stdout().print("{s}\n", .{note.body});
     } else {
-        // Returning an error is the normal way to fail a command: zcli exits
-        // non-zero and reports it. The stack trace is Debug-only — a release
-        // build just prints `error: NoteNotFound`. (Want a custom message and
-        // exit code instead? Print it, then call context.exit(code).)
-        return error.NoteNotFound;
+        // Fail with a message the user should see. context.fail prints it and
+        // exits non-zero cleanly — no `error: Name`, no stack trace. (A plain
+        // `return error.X` is for unexpected bugs, where the name and Debug
+        // trace help you debug.)
+        return context.fail("No note titled '{s}'", .{args.title});
     }
 }

--- a/packages/core/src/context.zig
+++ b/packages/core/src/context.zig
@@ -186,5 +186,19 @@ pub fn ContextFor(comptime plugins: []const type) type {
             self.stdio.flush();
             std.process.exit(code);
         }
+
+        /// Fail the command with a friendly, user-facing message: print `fmt`
+        /// (formatted with `args`) to stderr, then return `error.CommandFailed`.
+        /// zcli reports that as a clean non-zero exit — just your message, no
+        /// `error: CommandFailed` line and no stack trace, in every build mode.
+        ///
+        /// Use it for expected failures a user should see ("no such note"), and
+        /// `return` it directly: `return context.fail("no note: {s}", .{name});`.
+        /// For an *unexpected* failure, return a plain error instead — its name
+        /// and Debug-only trace are what you want while debugging.
+        pub fn fail(self: *Self, comptime fmt: []const u8, args: anytype) error{CommandFailed} {
+            self.stderr().print(fmt ++ "\n", args) catch {};
+            return error.CommandFailed;
+        }
     };
 }

--- a/packages/core/src/registry.zig
+++ b/packages/core/src/registry.zig
@@ -104,9 +104,19 @@ fn isReportedCliError(err: anyerror) bool {
         error.ArgumentInvalidValue,
         error.ArgumentTooMany,
         error.ResourceLimitExceeded,
+        // A command that failed via context.fail() already printed its own
+        // user-facing message; exit non-zero without the name/trace.
+        error.CommandFailed,
         => true,
         else => false,
     };
+}
+
+test "isReportedCliError: context.fail's error exits cleanly, unexpected errors don't" {
+    try std.testing.expect(isReportedCliError(error.CommandFailed));
+    try std.testing.expect(isReportedCliError(error.ArgumentMissingRequired));
+    // An unexpected failure keeps its name + trace (propagated, not swallowed).
+    try std.testing.expect(!isReportedCliError(error.OutOfMemory));
 }
 
 /// Build an alias path by replacing the last component with the alias name
@@ -779,13 +789,13 @@ fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const Comma
         /// Convenient run method that handles process args, io, and environment
         pub fn run(self: *Self, allocator: std.mem.Allocator, io: std.Io, environ: *const std.process.Environ.Map, args: []const []const u8) !void {
             self.execute(allocator, io, environ, if (args.len > 0) args[1..] else args) catch |err| {
-                // CLI-entry semantics: parse/routing failures were already
-                // reported to the user (diagnostic rendering, a plugin, or
-                // the framework fallback message) — exit(1) without letting
-                // the raw error trace follow the friendly message. Anything
-                // else is a real command failure; propagate it so the trace
-                // aids debugging. Library/test callers who want the error
-                // itself use execute() directly.
+                // CLI-entry semantics: some failures already showed the user a
+                // message — parse/routing diagnostics, a plugin, the framework
+                // fallback, or a command's own context.fail(). Exit(1) without
+                // letting a raw error trace follow that friendly message.
+                // Anything else is an unexpected failure; propagate it so the
+                // name and trace aid debugging. Library/test callers who want
+                // the error itself use execute() directly.
                 if (isReportedCliError(err)) std.process.exit(1);
                 return err;
             };

--- a/packages/testing/src/unit.zig
+++ b/packages/testing/src/unit.zig
@@ -263,6 +263,26 @@ test "runCommand with a required (no-default) arg" {
     try std.testing.expectEqualStrings("hello Ada\n", result.stdout);
 }
 
+test "runCommand captures context.fail as a failure with the message" {
+    const TestCommand = struct {
+        pub const Args = struct { name: []const u8 };
+        pub const Options = struct {};
+
+        pub fn execute(args: Args, _: Options, context: anytype) !void {
+            return context.fail("no such thing: {s}", .{args.name});
+        }
+    };
+
+    var result = try runCommand(TestCommand, &.{}, .{ .args = .{ .name = "widget" } });
+    defer result.deinit();
+
+    // context.fail() is a returned error, not a process exit — so a unit test
+    // can assert on it: the command failed, and its message reached stderr.
+    try std.testing.expect(!result.success);
+    try std.testing.expectEqual(error.CommandFailed, result.err.?);
+    try std.testing.expect(std.mem.indexOf(u8, result.stderr, "no such thing: widget") != null);
+}
+
 test "runCommand with plugin data" {
     const MockPlugin = struct {
         pub const plugin_id = "mock";

--- a/projects/zcli/src/commands/guide.zig
+++ b/projects/zcli/src/commands/guide.zig
@@ -41,8 +41,8 @@ pub fn execute(args: Args, _: Options, context: *Context) !void {
     const stderr = context.stderr();
     try stderr.print("Unknown guide topic: '{s}'\n\n", .{requested});
     try printTopicList(stderr);
-    // A mistyped topic is a plain user error — exit non-zero without dumping a
-    // Zig stack trace (which returning the error would).
+    // We've already printed the full topic list as guidance, so exit non-zero
+    // cleanly here rather than returning an error on top of that help.
     context.exit(1);
 }
 
@@ -88,9 +88,13 @@ const topics = [_]Topic{
         \\  src/commands/users/index.zig   → the "users" group landing (empty Args)
         \\  src/plugins/<name>.zig         → an auto-discovered plugin
         \\
-        \\A command file declares `meta`, `Args`, `Options`, and `execute`. Change
-        \\structure with the scaffolder — it does the multi-site edits (struct field +
-        \\meta entry + arg ordering) correctly — not by hand:
+        \\A command file declares `meta`, `Args`, `Options`, and `execute`. `execute`
+        \\returns `!void`: return any error to fail the command with a non-zero exit —
+        \\that's the normal way to fail, and the stack trace you see is Debug-only
+        \\(release builds just print `error: Name`). Call `context.exit(code)` when you
+        \\want to print your own message and choose the code. Change structure with the
+        \\scaffolder — it does the multi-site edits (struct field + meta entry + arg
+        \\ordering) correctly — not by hand:
         \\
         \\  zcli add command <path>        zcli rm command <path>       zcli mv <from> <to>
         \\  zcli add arg <cmd> <name>      zcli add option <cmd> <name>

--- a/projects/zcli/src/commands/guide.zig
+++ b/projects/zcli/src/commands/guide.zig
@@ -89,10 +89,11 @@ const topics = [_]Topic{
         \\  src/plugins/<name>.zig         → an auto-discovered plugin
         \\
         \\A command file declares `meta`, `Args`, `Options`, and `execute`. `execute`
-        \\returns `!void`: return any error to fail the command with a non-zero exit —
-        \\that's the normal way to fail, and the stack trace you see is Debug-only
-        \\(release builds just print `error: Name`). Call `context.exit(code)` when you
-        \\want to print your own message and choose the code. Change structure with the
+        \\returns `!void`, so returning an error fails the command with a non-zero
+        \\exit. For a failure the user should read, `return context.fail("no note:
+        \\{s}", .{name})` — it prints your message and exits cleanly (no `error:
+        \\Name`, no stack trace). A plain `return error.X` is for unexpected bugs:
+        \\its name and Debug-only trace aid debugging. Change structure with the
         \\scaffolder — it does the multi-site edits (struct field + meta entry + arg
         \\ordering) correctly — not by hand:
         \\
@@ -343,7 +344,9 @@ const topics = [_]Topic{
         \\
         \\`r` also exposes `.stderr`, `.err`, and `.term` (a virtual terminal for
         \\asserting on rendered color/layout). Pass plugin types as the second arg to
-        \\populate context.plugins.
+        \\populate context.plugins. A command that fails with `context.fail(...)` is
+        \\assertable too — `!r.success`, `r.err.? == error.CommandFailed`, and the
+        \\message in `r.stderr` — because it returns an error instead of exiting.
         \\
         \\runCommand runs execute() in-process against the real filesystem and the
         \\real cwd — it captures I/O, not the disk. A command that reads or writes

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -469,7 +469,8 @@ test "guide lists topics and embeds the canonical example source" {
         try expectContains(r.stdout, "std.json.fmt(notes");
     }
 
-    // An unknown topic fails (non-zero) with the topic list, no stack trace.
+    // An unknown topic fails (non-zero) and prints the topic list as guidance,
+    // exiting cleanly rather than leaking a raw `error:` line.
     {
         var r = try run(tmp.dir, &.{ zcli_exe, "guide", "nope" });
         defer r.deinit();


### PR DESCRIPTION
## What

Gives command authors a first-class way to **fail with a friendly message** — reconciling three things that were previously in tension:

- A plain `return error.NoteNotFound` is idiomatic and its stack trace is **Debug-only**, but it can't carry a message: the user sees `error: NoteNotFound`, not `No note titled 'nope'`.
- Printing a message + `context.exit(1)` gives a friendly message, but `context.exit` hard-exits the process, so such a command **can't be unit-tested** with `runCommand`.

## `context.fail`

```zig
} else return context.fail("No note titled '{s}'", .{args.title});
```

It prints the formatted message to stderr and returns `error.CommandFailed`. That error is added to `isReportedCliError()`, the *existing* seam zcli already uses for its own parse/routing errors — so `run()` exits non-zero **cleanly: no `error:` line, no stack trace, in every build mode**. (The `defer stdio.flush()` in `execute()` runs as the error unwinds, so the message survives the `exit(1)`.)

Because it returns an error **value** rather than exiting the process, it stays fully testable:

```zig
try std.testing.expect(!r.success);
try std.testing.expectEqual(error.CommandFailed, r.err.?);
try std.testing.expect(std.mem.indexOf(u8, r.stderr, "No note titled") != null);
```

The honest distinction is preserved: `context.fail(...)` for **expected** user errors (friendly, clean); plain `return error.X` for **unexpected** bugs, where the name + Debug trace aid debugging.

## Changes

- **`context.fail(fmt, args)`** on `ContextFor` (so commands and `TestContext` both have it); `error.CommandFailed` added to `isReportedCliError` with a classification test.
- **`examples/notes` `show`** uses it — friendly message back, still testable, still clean exit.
- **guide `structure` topic** teaches the fail-with-message vs fail-with-bug distinction; **`testing` topic** notes a `context.fail` is assertable via `!r.success` / `.err` / `.stderr`.
- **`runCommand` test** proves the capture end to end.
- Also (original scope of this PR): removed the earlier comments/framing that steered developers *away* from returning Zig errors — the trace is Debug-only, and the `structure` topic now normalizes error returns.

## Verification

- `notes show nope` under ReleaseSafe prints `No note titled 'nope'` and exits 1 — **no trace, no `error:` line**.
- `packages/core`, `packages/testing`, and meta-CLI `zig build test`, plus `zig fmt --check`, all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)