### PR TITLE
scaffolder: report user mistakes with context.fail (no stack traces)

### DIFF
--- a/projects/zcli/src/commands/add/arg.zig
+++ b/projects/zcli/src/commands/add/arg.zig
@@ -59,44 +59,54 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
 
     // Preflight: must be inside a zcli project.
     std.Io.Dir.cwd().access(io, "src/commands", .{}) catch {
-        try stderr.print("Error: Not in a zcli project directory\n", .{});
-        try stderr.print("Run this command from the root of your zcli project (where build.zig is)\n", .{});
-        return error.NotInZcliProject;
+        return context.fail("Error: Not in a zcli project directory\nRun this command from the root of your zcli project (where build.zig is)", .{});
     };
 
     const parts = spec.parsePath(arena, args.command) catch {
-        try stderr.print("Error: Invalid command path: '{s}'\n", .{args.command});
-        return error.InvalidCommandPath;
+        return context.fail("Error: Invalid command path: '{s}'", .{args.command});
     };
     const file_path = try spec.buildFilePath(arena, parts);
 
     const name = spec.normalizeName(arena, args.name) catch |err| {
-        try stderr.print("Error: Invalid argument name '{s}': {s}\n", .{ args.name, @errorName(err) });
-        return err;
+        return context.fail("Error: Invalid argument name '{s}': {s}", .{ args.name, @errorName(err) });
     };
 
-    const arg = try buildSpec(arena, stderr, name, options);
-    const anchor = try resolveAnchor(arena, stderr, options);
+    // buildSpec / resolveAnchor print the specific problem; their validation
+    // failures are user mistakes, so exit cleanly (no trace).
+    const arg = buildSpec(arena, stderr, name, options) catch |err| switch (err) {
+        error.MissingType,
+        error.ContradictoryFlags,
+        error.PositionalMultipleMustBeString,
+        => return error.CommandFailed,
+        else => return err,
+    };
+    const anchor = resolveAnchor(arena, stderr, options) catch |err| switch (err) {
+        error.ContradictoryFlags => return error.CommandFailed,
+        else => return err,
+    };
 
     // Read the target command's source (NUL-terminated for the AST parser).
     const raw = std.Io.Dir.cwd().readFileAlloc(io, file_path, arena, .limited(max_source_bytes)) catch {
-        try stderr.print("Error: Command not found: {s}\n", .{file_path});
-        try stderr.print("Create it first with `zcli add command {s}`\n", .{args.command});
-        return error.CommandNotFound;
+        return context.fail("Error: Command not found: {s}\nCreate it first with `zcli add command {s}`", .{ file_path, args.command });
     };
     const source = try arena.dupeZ(u8, raw);
 
     // Validate placement against the real file before touching it: duplicate
     // name, unknown anchor, and the ordering rules (required-before-optional,
-    // `multiple` last).
+    // `multiple` last). validateOrder prints the specific problem; all its
+    // failures are user mistakes, so exit cleanly (no trace).
     const existing = try splice.fieldShapes(arena, source, "Args");
-    try validateOrder(arena, stderr, file_path, existing, arg, anchor);
+    validateOrder(arena, stderr, file_path, existing, arg, anchor) catch |err| switch (err) {
+        splice.SpliceError.DuplicateField,
+        splice.SpliceError.AnchorNotFound,
+        error.MultipleNotLast,
+        error.BadArgOrder,
+        => return error.CommandFailed,
+        else => return err,
+    };
 
     const updated = splice.insertArg(arena, source, arg, anchor) catch |err| switch (err) {
-        splice.SpliceError.DuplicateField => {
-            try stderr.print("Error: {s} already has an argument named '{s}'\n", .{ file_path, name });
-            return err;
-        },
+        splice.SpliceError.DuplicateField => return context.fail("Error: {s} already has an argument named '{s}'", .{ file_path, name }),
         else => {
             try stderr.print("Error: could not edit {s}: {s}\n", .{ file_path, @errorName(err) });
             return err;

--- a/projects/zcli/src/commands/add/command.zig
+++ b/projects/zcli/src/commands/add/command.zig
@@ -42,13 +42,10 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
     const arena = arena_state.allocator();
 
     const io = context.io;
-    const stderr = context.stderr();
 
     // Preflight: must be inside a zcli project.
     std.Io.Dir.cwd().access(io, "src/commands", .{}) catch {
-        try stderr.print("Error: Not in a zcli project directory\n", .{});
-        try stderr.print("Run this command from the root of your zcli project (where build.zig is)\n", .{});
-        return error.NotInZcliProject;
+        return context.fail("Error: Not in a zcli project directory\nRun this command from the root of your zcli project (where build.zig is)", .{});
     };
 
     // Interactive on a TTY, classic skeleton when piped. Args and options are
@@ -66,24 +63,19 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
 // ---------------------------------------------------------------------------
 
 fn skeleton(arena: std.mem.Allocator, context: *Context, args: Args, options: Options) !void {
-    const stderr = context.stderr();
     const io = context.io;
 
     const raw_path = args.path orelse {
-        try stderr.print("Error: A command path is required when input is not interactive\n", .{});
-        try stderr.print("Usage: zcli add command <path> [--description \"...\"]\n", .{});
-        return error.MissingCommandPath;
+        return context.fail("Error: A command path is required when input is not interactive\nUsage: zcli add command <path> [--description \"...\"]", .{});
     };
 
     const parts = parsePath(arena, raw_path) catch {
-        try stderr.print("Error: Invalid command path: '{s}'\n", .{raw_path});
-        return error.InvalidCommandPath;
+        return context.fail("Error: Invalid command path: '{s}'", .{raw_path});
     };
 
     const file_path = try buildFilePath(arena, parts);
     if (generate.fileExists(io, file_path)) {
-        try stderr.print("Error: Command already exists: {s}\n", .{file_path});
-        return error.CommandAlreadyExists;
+        return context.fail("Error: Command already exists: {s}", .{file_path});
     }
 
     const description = options.description orelse "TODO: Add description";

--- a/projects/zcli/src/commands/add/group.zig
+++ b/projects/zcli/src/commands/add/group.zig
@@ -37,17 +37,13 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
     const arena = arena_state.allocator();
 
     const io = context.io;
-    const stderr = context.stderr();
 
     std.Io.Dir.cwd().access(io, "src/commands", .{}) catch {
-        try stderr.print("Error: Not in a zcli project directory\n", .{});
-        try stderr.print("Run this command from the root of your zcli project (where build.zig is)\n", .{});
-        return error.NotInZcliProject;
+        return context.fail("Error: Not in a zcli project directory\nRun this command from the root of your zcli project (where build.zig is)", .{});
     };
 
     const parts = spec.parsePath(arena, args.path) catch {
-        try stderr.print("Error: Invalid group path: '{s}'\n", .{args.path});
-        return error.InvalidCommandPath;
+        return context.fail("Error: Invalid group path: '{s}'", .{args.path});
     };
 
     // A group is a directory of subcommands, described by its index.zig.
@@ -56,8 +52,7 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
 
     const cwd = std.Io.Dir.cwd();
     if (fileExists(io, index_path)) {
-        try stderr.print("Error: group already described: {s}\n", .{index_path});
-        return error.GroupAlreadyExists;
+        return context.fail("Error: group already described: {s}", .{index_path});
     }
 
     // Create the group directory (and any missing parents).

--- a/projects/zcli/src/commands/add/option.zig
+++ b/projects/zcli/src/commands/add/option.zig
@@ -62,37 +62,38 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
 
     // Preflight: must be inside a zcli project.
     std.Io.Dir.cwd().access(io, "src/commands", .{}) catch {
-        try stderr.print("Error: Not in a zcli project directory\n", .{});
-        try stderr.print("Run this command from the root of your zcli project (where build.zig is)\n", .{});
-        return error.NotInZcliProject;
+        return context.fail("Error: Not in a zcli project directory\nRun this command from the root of your zcli project (where build.zig is)", .{});
     };
 
     const parts = spec.parsePath(arena, args.command) catch {
-        try stderr.print("Error: Invalid command path: '{s}'\n", .{args.command});
-        return error.InvalidCommandPath;
+        return context.fail("Error: Invalid command path: '{s}'", .{args.command});
     };
     const file_path = try spec.buildFilePath(arena, parts);
 
     const name = spec.normalizeName(arena, args.name) catch |err| {
-        try stderr.print("Error: Invalid option name '{s}': {s}\n", .{ args.name, @errorName(err) });
-        return err;
+        return context.fail("Error: Invalid option name '{s}': {s}", .{ args.name, @errorName(err) });
     };
 
-    const opt = try buildSpec(arena, stderr, name, options);
+    // buildSpec prints the specific problem to stderr; its validation failures
+    // are user mistakes, so exit cleanly (no trace). Anything else is unexpected.
+    const opt = buildSpec(arena, stderr, name, options) catch |err| switch (err) {
+        error.MissingType,
+        error.ContradictoryFlags,
+        error.UnsupportedArrayElement,
+        error.BadShort,
+        error.MissingDefault,
+        => return error.CommandFailed,
+        else => return err,
+    };
 
     // Read the target command's source (NUL-terminated for the AST parser).
     const raw = std.Io.Dir.cwd().readFileAlloc(io, file_path, arena, .limited(max_source_bytes)) catch {
-        try stderr.print("Error: Command not found: {s}\n", .{file_path});
-        try stderr.print("Create it first with `zcli add command {s}`\n", .{args.command});
-        return error.CommandNotFound;
+        return context.fail("Error: Command not found: {s}\nCreate it first with `zcli add command {s}`", .{ file_path, args.command });
     };
     const source = try arena.dupeZ(u8, raw);
 
     const updated = splice.insertOption(arena, source, opt) catch |err| switch (err) {
-        splice.SpliceError.DuplicateField => {
-            try stderr.print("Error: {s} already has an option named '{s}'\n", .{ file_path, name });
-            return err;
-        },
+        splice.SpliceError.DuplicateField => return context.fail("Error: {s} already has an option named '{s}'", .{ file_path, name }),
         else => {
             try stderr.print("Error: could not edit {s}: {s}\n", .{ file_path, @errorName(err) });
             return err;

--- a/projects/zcli/src/commands/add/plugin.zig
+++ b/projects/zcli/src/commands/add/plugin.zig
@@ -37,26 +37,21 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
     const arena = arena_state.allocator();
 
     const io = context.io;
-    const stderr = context.stderr();
     const cwd = std.Io.Dir.cwd();
 
     cwd.access(io, "src/commands", .{}) catch {
-        try stderr.print("Error: Not in a zcli project directory\n", .{});
-        try stderr.print("Run this command from the root of your zcli project (where build.zig is)\n", .{});
-        return error.NotInZcliProject;
+        return context.fail("Error: Not in a zcli project directory\nRun this command from the root of your zcli project (where build.zig is)", .{});
     };
 
     const name = spec.normalizeName(arena, args.name) catch |err| {
-        try stderr.print("Error: Invalid plugin name '{s}': {s}\n", .{ args.name, @errorName(err) });
-        return err;
+        return context.fail("Error: Invalid plugin name '{s}': {s}", .{ args.name, @errorName(err) });
     };
 
     // Single-file plugin, matching `add command`'s default (the directory form
     // `plugins/<name>/plugin.zig` remains available for plugins that grow).
     const file_path = try std.fmt.allocPrint(arena, "src/plugins/{s}.zig", .{name});
     if (fileExists(io, file_path)) {
-        try stderr.print("Error: plugin already exists: {s}\n", .{file_path});
-        return error.PluginAlreadyExists;
+        return context.fail("Error: plugin already exists: {s}", .{file_path});
     }
 
     cwd.createDir(io, "src/plugins", .default_dir) catch |err| switch (err) {

--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -106,17 +106,14 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         }
 
         if (has_visible_files) {
-            try stderr.print("Error: Current directory is not empty\n", .{});
-            try stderr.print("Tip: only hidden files and an existing AGENTS.md are allowed\n", .{});
-            return error.DirectoryNotEmpty;
+            return context.fail("Error: Current directory is not empty\nTip: only hidden files and an existing AGENTS.md are allowed", .{});
         }
 
         try stdout.print("Initializing zcli project in current directory: {s}\n", .{project_name});
     } else {
         // Check if directory already exists (access succeeds => the path exists).
         if (cwd.access(io, args.name, .{})) |_| {
-            try stderr.print("Error: Directory '{s}' already exists\n", .{args.name});
-            return error.PathAlreadyExists;
+            return context.fail("Error: Directory '{s}' already exists", .{args.name});
         } else |err| switch (err) {
             error.FileNotFound => {}, // Good, directory doesn't exist
             else => return err,

--- a/projects/zcli/src/commands/mv.zig
+++ b/projects/zcli/src/commands/mv.zig
@@ -33,42 +33,33 @@ pub fn execute(args: Args, _: Options, context: *Context) !void {
     const arena = arena_state.allocator();
 
     const io = context.io;
-    const stderr = context.stderr();
     const cwd = std.Io.Dir.cwd();
 
     cwd.access(io, "src/commands", .{}) catch {
-        try stderr.print("Error: Not in a zcli project directory\n", .{});
-        try stderr.print("Run this command from the root of your zcli project (where build.zig is)\n", .{});
-        return error.NotInZcliProject;
+        return context.fail("Error: Not in a zcli project directory\nRun this command from the root of your zcli project (where build.zig is)", .{});
     };
 
     const from_parts = spec.parsePath(arena, args.from) catch {
-        try stderr.print("Error: Invalid command path: '{s}'\n", .{args.from});
-        return error.InvalidCommandPath;
+        return context.fail("Error: Invalid command path: '{s}'", .{args.from});
     };
     const to_parts = spec.parsePath(arena, args.to) catch {
-        try stderr.print("Error: Invalid command path: '{s}'\n", .{args.to});
-        return error.InvalidCommandPath;
+        return context.fail("Error: Invalid command path: '{s}'", .{args.to});
     };
 
     const from_file = try spec.buildFilePath(arena, from_parts);
     if (!exists(io, from_file)) {
         if (exists(io, try fs.groupPath(arena, from_parts))) {
-            try stderr.print("Error: '{s}' is a command group; move its subcommands individually\n", .{args.from});
-            return error.IsAGroup;
+            return context.fail("Error: '{s}' is a command group; move its subcommands individually", .{args.from});
         }
-        try stderr.print("Error: Command not found: {s}\n", .{from_file});
-        return error.CommandNotFound;
+        return context.fail("Error: Command not found: {s}", .{from_file});
     }
 
     const to_file = try spec.buildFilePath(arena, to_parts);
     if (exists(io, to_file)) {
-        try stderr.print("Error: Destination already exists: {s}\n", .{to_file});
-        return error.CommandAlreadyExists;
+        return context.fail("Error: Destination already exists: {s}", .{to_file});
     }
     if (exists(io, try fs.groupPath(arena, to_parts))) {
-        try stderr.print("Error: Destination is a command group: {s}\n", .{args.to});
-        return error.CommandAlreadyExists;
+        return context.fail("Error: Destination is a command group: {s}", .{args.to});
     }
 
     // Create any parent group directories the destination needs.

--- a/projects/zcli/src/commands/rm/arg.zig
+++ b/projects/zcli/src/commands/rm/arg.zig
@@ -35,22 +35,17 @@ pub fn execute(args: Args, _: Options, context: *Context) !void {
     const arena = arena_state.allocator();
 
     const io = context.io;
-    const stderr = context.stderr();
 
     std.Io.Dir.cwd().access(io, "src/commands", .{}) catch {
-        try stderr.print("Error: Not in a zcli project directory\n", .{});
-        try stderr.print("Run this command from the root of your zcli project (where build.zig is)\n", .{});
-        return error.NotInZcliProject;
+        return context.fail("Error: Not in a zcli project directory\nRun this command from the root of your zcli project (where build.zig is)", .{});
     };
 
     if (args.names.len == 0) {
-        try stderr.print("Error: name at least one argument to remove\n", .{});
-        return error.MissingName;
+        return context.fail("Error: name at least one argument to remove", .{});
     }
 
     const parts = spec.parsePath(arena, args.command) catch {
-        try stderr.print("Error: Invalid command path: '{s}'\n", .{args.command});
-        return error.InvalidCommandPath;
+        return context.fail("Error: Invalid command path: '{s}'", .{args.command});
     };
     const file_path = try spec.buildFilePath(arena, parts);
 
@@ -58,14 +53,12 @@ pub fn execute(args: Args, _: Options, context: *Context) !void {
     const names = try arena.alloc([]const u8, args.names.len);
     for (args.names, 0..) |raw, i| {
         names[i] = spec.normalizeName(arena, raw) catch |err| {
-            try stderr.print("Error: Invalid argument name '{s}': {s}\n", .{ raw, @errorName(err) });
-            return err;
+            return context.fail("Error: Invalid argument name '{s}': {s}", .{ raw, @errorName(err) });
         };
     }
 
     const raw = std.Io.Dir.cwd().readFileAlloc(io, file_path, arena, .limited(max_source_bytes)) catch {
-        try stderr.print("Error: Command not found: {s}\n", .{file_path});
-        return error.CommandNotFound;
+        return context.fail("Error: Command not found: {s}", .{file_path});
     };
     var source = try arena.dupeZ(u8, raw);
 
@@ -73,13 +66,13 @@ pub fn execute(args: Args, _: Options, context: *Context) !void {
     // (Removal only relaxes ordering constraints, so no re-validation is needed.)
     const missing = try splice.missingFields(arena, source, "Args", names);
     if (missing.len > 0) {
-        try stderr.print("Error: {s} has no argument named ", .{file_path});
+        var msg = std.Io.Writer.Allocating.init(arena);
+        try msg.writer.print("Error: {s} has no argument named ", .{file_path});
         for (missing, 0..) |m, i| {
-            if (i > 0) try stderr.print(", ", .{});
-            try stderr.print("'{s}'", .{m});
+            if (i > 0) try msg.writer.print(", ", .{});
+            try msg.writer.print("'{s}'", .{m});
         }
-        try stderr.print("\n", .{});
-        return error.FieldNotFound;
+        return context.fail("{s}", .{msg.written()});
     }
 
     for (names) |name| {

--- a/projects/zcli/src/commands/rm/command.zig
+++ b/projects/zcli/src/commands/rm/command.zig
@@ -30,18 +30,14 @@ pub fn execute(args: Args, _: Options, context: *Context) !void {
     const arena = arena_state.allocator();
 
     const io = context.io;
-    const stderr = context.stderr();
     const cwd = std.Io.Dir.cwd();
 
     cwd.access(io, "src/commands", .{}) catch {
-        try stderr.print("Error: Not in a zcli project directory\n", .{});
-        try stderr.print("Run this command from the root of your zcli project (where build.zig is)\n", .{});
-        return error.NotInZcliProject;
+        return context.fail("Error: Not in a zcli project directory\nRun this command from the root of your zcli project (where build.zig is)", .{});
     };
 
     const parts = spec.parsePath(arena, args.path) catch {
-        try stderr.print("Error: Invalid command path: '{s}'\n", .{args.path});
-        return error.InvalidCommandPath;
+        return context.fail("Error: Invalid command path: '{s}'", .{args.path});
     };
 
     const file_path = try spec.buildFilePath(arena, parts);
@@ -49,11 +45,9 @@ pub fn execute(args: Args, _: Options, context: *Context) !void {
         // A group directory is not removed here — that would delete its
         // subcommands (and any index.zig) wholesale. Ask for the leaf files.
         if (exists(io, try fs.groupPath(arena, parts))) {
-            try stderr.print("Error: '{s}' is a command group; remove its subcommands first\n", .{args.path});
-            return error.IsAGroup;
+            return context.fail("Error: '{s}' is a command group; remove its subcommands first", .{args.path});
         }
-        try stderr.print("Error: Command not found: {s}\n", .{file_path});
-        return error.CommandNotFound;
+        return context.fail("Error: Command not found: {s}", .{file_path});
     }
 
     try cwd.deleteFile(io, file_path);

--- a/projects/zcli/src/commands/rm/option.zig
+++ b/projects/zcli/src/commands/rm/option.zig
@@ -35,22 +35,17 @@ pub fn execute(args: Args, _: Options, context: *Context) !void {
     const arena = arena_state.allocator();
 
     const io = context.io;
-    const stderr = context.stderr();
 
     std.Io.Dir.cwd().access(io, "src/commands", .{}) catch {
-        try stderr.print("Error: Not in a zcli project directory\n", .{});
-        try stderr.print("Run this command from the root of your zcli project (where build.zig is)\n", .{});
-        return error.NotInZcliProject;
+        return context.fail("Error: Not in a zcli project directory\nRun this command from the root of your zcli project (where build.zig is)", .{});
     };
 
     if (args.names.len == 0) {
-        try stderr.print("Error: name at least one option to remove\n", .{});
-        return error.MissingName;
+        return context.fail("Error: name at least one option to remove", .{});
     }
 
     const parts = spec.parsePath(arena, args.command) catch {
-        try stderr.print("Error: Invalid command path: '{s}'\n", .{args.command});
-        return error.InvalidCommandPath;
+        return context.fail("Error: Invalid command path: '{s}'", .{args.command});
     };
     const file_path = try spec.buildFilePath(arena, parts);
 
@@ -58,27 +53,25 @@ pub fn execute(args: Args, _: Options, context: *Context) !void {
     const names = try arena.alloc([]const u8, args.names.len);
     for (args.names, 0..) |raw, i| {
         names[i] = spec.normalizeName(arena, raw) catch |err| {
-            try stderr.print("Error: Invalid option name '{s}': {s}\n", .{ raw, @errorName(err) });
-            return err;
+            return context.fail("Error: Invalid option name '{s}': {s}", .{ raw, @errorName(err) });
         };
     }
 
     const raw = std.Io.Dir.cwd().readFileAlloc(io, file_path, arena, .limited(max_source_bytes)) catch {
-        try stderr.print("Error: Command not found: {s}\n", .{file_path});
-        return error.CommandNotFound;
+        return context.fail("Error: Command not found: {s}", .{file_path});
     };
     var source = try arena.dupeZ(u8, raw);
 
     // Reject the whole batch if any name is absent — never partially edit.
     const missing = try splice.missingFields(arena, source, "Options", names);
     if (missing.len > 0) {
-        try stderr.print("Error: {s} has no option named ", .{file_path});
+        var msg = std.Io.Writer.Allocating.init(arena);
+        try msg.writer.print("Error: {s} has no option named ", .{file_path});
         for (missing, 0..) |m, i| {
-            if (i > 0) try stderr.print(", ", .{});
-            try stderr.print("'{s}'", .{m});
+            if (i > 0) try msg.writer.print(", ", .{});
+            try msg.writer.print("'{s}'", .{m});
         }
-        try stderr.print("\n", .{});
-        return error.FieldNotFound;
+        return context.fail("{s}", .{msg.written()});
     }
 
     for (names) |name| {

--- a/projects/zcli/src/commands/tree.zig
+++ b/projects/zcli/src/commands/tree.zig
@@ -41,9 +41,7 @@ pub fn execute(args: Args, options: Options, context: anytype) !void {
     // source (metadata). Must be iterable for the discovery walk.
     var dir = std.Io.Dir.cwd().openDir(io, commands_dir, .{ .iterate = true }) catch |err| switch (err) {
         error.FileNotFound => {
-            const stderr = context.stderr();
-            try stderr.print("No '{s}' directory found. Run this from a zcli project root.\n", .{commands_dir});
-            context.exit(1); // flushes buffered output before exiting
+            return context.fail("No '{s}' directory found. Run this from a zcli project root.", .{commands_dir});
         },
         else => return err,
     };

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -334,6 +334,8 @@ test "add command outside a project fails clearly" {
     defer r.deinit();
     try testing.expect(r.exit_code != 0);
     try expectContains(r.stderr, "Not in a zcli project");
+    // A user mistake exits cleanly via context.fail() — no raw error trace.
+    try testing.expect(std.mem.indexOf(u8, r.stderr, "error: NotInZcliProject") == null);
 }
 
 test "unknown option prints the diagnostic message, exits 1, no error trace" {


### PR DESCRIPTION
## What

Dogfooding (cold pass 3) hit a sharp edge: zcli's **own** scaffolder didn't use the `context.fail` it just shipped. `zcli add option list status` printed a friendly message and then `return error.MissingDefault` — a raw error not in `isReportedCliError`, so it **dumped a Zig stack trace on a plain user mistake**. The whole `add`/`rm`/`mv` family had this pattern.

This converts the user-facing validation/usage errors across the scaffolder (`add/*`, `rm/*`, `mv`, `init`, `tree`) to `return context.fail("...", .{...})`: same message, clean non-zero exit, **no `error: Name`, no trace**.

## Before / after

```
$ zcli add option list status
Error: a non-nullable scalar option needs a --default (or pass --nullable)
error: MissingDefault                        ← gone
    add/option.zig:146 ... buildSpec          ← gone
    registry.zig:1131 ... executeResolvedCommand  ← gone
    (7 more frames)                           ← gone
```
Now: just the message, `exit 1`.

## Judgment per site (not a blanket sweep)

- **Converted:** not-in-a-project, invalid path, not found, already exists, missing/contradictory/unsupported flags, bad names, destination conflicts, "name at least one …". Merged the two-line "not in a project" messages into one call; dropped now-unused `const stderr` bindings.
- **Kept raw (trace preserved):** genuinely unexpected/internal failures — the `could not edit {file}: {splice error}` arms, filesystem/`createDir` errors, and `add/_generate.zig`'s internal `SubstringNotFound` assertion.
- **Unit-tested helpers untouched:** `buildSpec` / `validateOrder` / `resolveAnchor` still print + return their specific errors (their `expectError` tests are unchanged); their **call sites** now map those validation errors to `error.CommandFailed` so they exit cleanly.
- **tree**: `print + context.exit(1)` → `context.fail` — same output, but a returned error (testable) instead of a hard process exit.

## Scope

Limited to the agent-facing scaffolder (the surface a CLI-building agent uses constantly, and where the dogfood hit). The dev-ops commands (`release`, `gh/*`) have more operational (non-user-mistake) errors and can be a separate, more nuanced pass if wanted.

## Verification

- `zcli add option list status`, invalid paths, not-found, and not-in-project all exit 1 with **only** their message — zero stack-trace frames (checked).
- New e2e drift-guard: "add command outside a project" asserts no `error: NotInZcliProject` leaks.
- Meta-CLI `zig build test` and `zig fmt --check` clean. Existing e2e substring/exit assertions preserved (messages unchanged apart from the trailing newline; net −41 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)