### PR TITLE
guide: show how to keep test file I/O clean (testing topic)

### DIFF
--- a/projects/zcli/src/commands/guide.zig
+++ b/projects/zcli/src/commands/guide.zig
@@ -351,8 +351,21 @@ const topics = [_]Topic{
         \\runCommand runs execute() in-process against the real filesystem and the
         \\real cwd — it captures I/O, not the disk. A command that reads or writes
         \\files touches actual files during `zig build test`, so a leftover file can
-        \\make the next run behave differently. Point file I/O at a temp dir or a
-        \\unique path, and clean up in the test.
+        \\make the next run behave differently. Delete the file around such a test —
+        \\`io` in a test is `std.testing.io`:
+        \\
+        \\  test "add: persists a task" {
+        \\      const io = std.testing.io;
+        \\      std.Io.Dir.cwd().deleteFile(io, "tasks.json") catch {};        // start clean
+        \\      defer std.Io.Dir.cwd().deleteFile(io, "tasks.json") catch {};  // and don't leak it
+        \\      var r = try zcli_testing.runCommand(@This(), &.{}, .{ .args = .{ .title = "Buy milk" } });
+        \\      defer r.deinit();
+        \\      try std.testing.expect(r.success);
+        \\  }
+        \\
+        \\For I/O you drive directly (say a store module that takes a dir), hand it a
+        \\scratch dir instead: `var tmp = std.testing.tmpDir(.{}); defer tmp.cleanup();`
+        \\— `tmp.dir` is a `std.Io.Dir`.
         \\
         ,
     },


### PR DESCRIPTION
## What

Both cold dogfood passes (2 and 3) hit the **same** wall: the `testing` topic said *"point file I/O at a temp dir or a unique path, and clean up in the test"* but showed no API — so each agent guessed `std.testing.io` and `std.testing.tmpDir` from scratch (and noted it as a gap).

This replaces that dangling sentence with a concrete, copyable example:

- The `std.testing.io` **delete-before / `defer` delete-after** idiom for a command that persists to cwd (which is exactly what `runCommand` exercises — real filesystem, real cwd).
- A pointer to `std.testing.tmpDir(.{})` (`.dir` is a `std.Io.Dir`) for I/O the test drives directly, e.g. a store module that takes a dir.

These are the exact APIs both agents converged on — now documented instead of reverse-engineered.

## Verification

- `zcli guide testing` renders the new example.
- Meta-CLI `zig build test` and `zig fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)