### PR TITLE
guide: add a worked plugin example to the plugins topic

### DIFF
--- a/examples/notes/README.md
+++ b/examples/notes/README.md
@@ -23,3 +23,6 @@ Data is persisted to `notes.json` in the current directory.
   `generate()` and `addCommandTests()`. See `zcli guide sharing`.
 - **The arena** — commands load into `context.allocator` and never free; the
   per-command arena reclaims it. See `zcli guide arena`.
+- **A plugin** — `src/plugins/verbose.zig` (auto-discovered) adds a global
+  `--verbose` flag via `plugin_id` + `ContextData` + `global_options` +
+  `handleGlobalOption`. Embedded into `zcli guide plugins`.

--- a/examples/notes/build.zig
+++ b/examples/notes/build.zig
@@ -38,6 +38,9 @@ pub fn build(b: *std.Build) void {
             zcli.builtin(.version, .{}),
             zcli.builtin(.not_found, .{}),
         },
+        // Local plugins in src/plugins/ are auto-discovered (src/plugins/verbose.zig
+        // adds a global --verbose flag). See `zcli guide plugins`.
+        .plugins_dir = "src/plugins",
         .shared_modules = &shared_modules,
         .app_name = "notes",
         .app_description = "A tiny note keeper (a JSON-file persistence example)",

--- a/examples/notes/src/plugins/verbose.zig
+++ b/examples/notes/src/plugins/verbose.zig
@@ -1,0 +1,39 @@
+//! verbose.zig — a plugin adding a global `--verbose` flag.
+//!
+//! A plugin (src/plugins/<name>.zig, auto-discovered) adds cross-cutting
+//! behavior to every command. This one declares a `--verbose` flag and, when
+//! it's set, prints a diagnostic line before each command runs.
+
+const std = @import("std");
+const zcli = @import("zcli");
+
+/// Names this plugin's slot on the context. Commands — and this plugin's own
+/// hooks — read its state as `context.plugins.verbose`.
+pub const plugin_id = "verbose";
+
+/// This plugin's state, one instance per command run, reachable at
+/// `context.plugins.verbose`. Give every field a default.
+pub const ContextData = struct {
+    enabled: bool = false,
+};
+
+/// Global options show up in every command's `--help`. Declared here, handled
+/// by `handleGlobalOption` below.
+pub const global_options = [_]zcli.GlobalOption{
+    zcli.option("verbose", bool, .{ .short = 'v', .default = false, .description = "Print diagnostic output" }),
+};
+
+/// The framework calls this while parsing, once per declared global option it
+/// sees — before any command runs. Stash the value in our ContextData for the
+/// rest of the run to read.
+pub fn handleGlobalOption(context: anytype, name: []const u8, value: anytype) !void {
+    if (std.mem.eql(u8, name, "verbose")) context.plugins.verbose.enabled = value;
+}
+
+/// Hooks are @hasDecl-gated — declare only the ones you need. preExecute runs
+/// before every command; return the (possibly rewritten) args, or null to halt.
+pub fn preExecute(context: anytype, args: zcli.ParsedArgs) !?zcli.ParsedArgs {
+    if (context.plugins.verbose.enabled)
+        try context.stderr().writeAll("[verbose] verbose mode enabled\n");
+    return args;
+}

--- a/projects/zcli/build.zig
+++ b/projects/zcli/build.zig
@@ -49,6 +49,9 @@ pub fn build(b: *std.Build) void {
     guide_examples_module.addAnonymousImport("notes/store.zig", .{
         .root_source_file = b.path("../../examples/notes/src/store.zig"),
     });
+    guide_examples_module.addAnonymousImport("notes/verbose.zig", .{
+        .root_source_file = b.path("../../examples/notes/src/plugins/verbose.zig"),
+    });
 
     // Create the executable
     const exe = b.addExecutable(.{

--- a/projects/zcli/src/commands/guide.zig
+++ b/projects/zcli/src/commands/guide.zig
@@ -322,7 +322,16 @@ const topics = [_]Topic{
         \\Scaffold one with `zcli add plugin <name>` — the generated stub wires one
         \\working hook and comments the full catalog with exact signatures.
         \\
-        ,
+        \\A plugin can also carry state and add global flags. Declare `plugin_id`
+        \\and a `ContextData` struct (default every field); the framework gives it a
+        \\slot at `context.plugins.<plugin_id>` for the run that any command reads —
+        \\`if (context.plugins.verbose.enabled) ...`. Add a global flag with
+        \\`global_options` + `handleGlobalOption`; the handler fires during parsing,
+        \\before preExecute and the command, so the flag is set by the time they run.
+        \\
+        \\Worked example — examples/notes/src/plugins/verbose.zig:
+        \\
+        ++ "\n" ++ examples.notes_verbose_plugin,
     },
     .{
         .name = "testing",

--- a/projects/zcli/src/guide_examples.zig
+++ b/projects/zcli/src/guide_examples.zig
@@ -10,3 +10,4 @@ pub const repostat_repo = @embedFile("repostat/repo.zig");
 pub const ghauth_login = @embedFile("ghauth/login.zig");
 pub const ghauth_whoami = @embedFile("ghauth/whoami.zig");
 pub const notes_store = @embedFile("notes/store.zig");
+pub const notes_verbose_plugin = @embedFile("notes/verbose.zig");

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -471,6 +471,16 @@ test "guide lists topics and embeds the canonical example source" {
         try expectContains(r.stdout, "std.json.fmt(notes");
     }
 
+    // And `plugins`, embedding examples/notes/src/plugins/verbose.zig — the full
+    // plugin anatomy (plugin_id + ContextData + global_options + handler).
+    {
+        var r = try run(tmp.dir, &.{ zcli_exe, "guide", "plugins" });
+        defer r.deinit();
+        try expectOk(r);
+        try expectContains(r.stdout, "pub const plugin_id");
+        try expectContains(r.stdout, "pub fn handleGlobalOption");
+    }
+
     // An unknown topic fails (non-zero) and prints the topic list as guidance,
     // exiting cleanly rather than leaking a raw `error:` line.
     {


### PR DESCRIPTION
## What

Cold dogfood pass 4 built a working plugin — but had to infer its whole anatomy from the `zcli add plugin` stub's comments. The `plugins` topic listed the hook catalog but showed **no complete plugin**: no `plugin_id`, no `ContextData`, no `global_options`/`handleGlobalOption`, and nothing on how a command reads `context.plugins.<id>`.

This closes that gap the same way the `notes` example closed the storage gap.

- **`examples/notes/src/plugins/verbose.zig`** — a self-contained `--verbose` global-flag plugin (auto-discovered via `plugins_dir`). It declares `plugin_id` + `ContextData` + `global_options` + `handleGlobalOption` and reads its own state in a `preExecute` hook. It's CI-compiled (`build-examples`) and `@embedFile`'d into `zcli guide plugins` — a real, compiled artifact, not prose.
- **`plugins` topic prose** now explains plugin *state* (`plugin_id` + `ContextData`), how a command reads `context.plugins.<plugin_id>`, and that `handleGlobalOption` fires during parsing **before** `preExecute`/the command (the hook-ordering question the agent had to guess).
- **e2e drift-guard**: `zcli guide plugins` must embed the compiled plugin (`plugin_id` + `handleGlobalOption`).

## Verification

- `notes --verbose add greeting "hi"` prints `[verbose] verbose mode enabled` to **stderr** (nothing without the flag); `notes --help` lists `-v, --verbose`.
- `zig build build-notes` (CI's build-examples path), meta-CLI `zig build test`, the guide render, and `zig fmt --check` all clean.

## Note

This is the "worked example" half. The follow-up makes **plugin behavior first-class testable** (so a command reading `context.plugins.<id>` can be exercised in a `runCommand` test without the `@hasField` guard the agent needed) — a framework change to `addCommandTests`/`runCommand`, coming as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)