### PR TITLE
testing: make command plugin state first-class testable

### DIFF
--- a/packages/core/src/build_utils/command_tests.zig
+++ b/packages/core/src/build_utils/command_tests.zig
@@ -9,10 +9,12 @@
 const std = @import("std");
 const types = @import("types.zig");
 const command_discovery = @import("command_discovery.zig");
+const plugin_system = @import("plugin_system.zig");
 
 const DiscoveredCommands = types.DiscoveredCommands;
 const CommandInfo = types.CommandInfo;
 const SharedModule = types.SharedModule;
+const PluginInfo = types.PluginInfo;
 
 /// Create a `test` step that unit-tests every discovered command file.
 ///
@@ -39,21 +41,50 @@ pub fn addCommandTests(
     const shared_modules: []const SharedModule =
         if (@hasField(@TypeOf(config), "shared_modules")) config.shared_modules else &.{};
 
+    // Discover the project's local plugins so the stub Context includes them:
+    // a command that reads `context.plugins.<id>` then compiles under test, and
+    // a runCommand test can drive that plugin's state via `.plugins`.
+    const plugins_dir: ?[]const u8 =
+        if (@hasField(@TypeOf(config), "plugins_dir")) config.plugins_dir else null;
+    const local_plugins: []const PluginInfo =
+        if (plugins_dir) |dir| plugin_system.scanLocalPlugins(b, dir) catch &.{} else &.{};
+
     // A stub `command_registry` module: commands reference
-    // `@import("command_registry").Context`, and a TestContext makes their
-    // execute() signatures callable from runCommand.
+    // `@import("command_registry").Context`, and a TestContext (over the local
+    // plugins) makes their execute() signatures callable from runCommand.
+    var stub_aw = std.Io.Writer.Allocating.init(b.allocator);
+    defer stub_aw.deinit();
+    const w = &stub_aw.writer;
+    w.writeAll("const zcli = @import(\"zcli\");\n") catch @panic("OOM");
+    for (local_plugins, 0..) |_, i| w.print("const plugin_{d} = @import(\"plugin_{d}\");\n", .{ i, i }) catch @panic("OOM");
+    w.writeAll("pub const Context = zcli.TestContext(&.{") catch @panic("OOM");
+    for (local_plugins, 0..) |_, i| {
+        if (i != 0) w.writeAll(",") catch @panic("OOM");
+        w.print(" plugin_{d}", .{i}) catch @panic("OOM");
+    }
+    w.writeAll(if (local_plugins.len == 0) "});\n" else " });\n") catch @panic("OOM");
+
     const wf = b.addWriteFiles();
-    const stub_path = wf.add("command_registry.zig",
-        \\const zcli = @import("zcli");
-        \\pub const Context = zcli.TestContext(&.{});
-        \\
-    );
+    const stub_path = wf.add("command_registry.zig", b.dupe(stub_aw.written()));
     const registry_stub = b.addModule("command_registry_test_stub", .{
         .root_source_file = stub_path,
         .target = config.target,
         .optimize = config.optimize,
     });
     registry_stub.addImport("zcli", zcli_module);
+    // Wire each local plugin as a module the stub imports (with the same
+    // zcli + shared_modules a command gets, since a plugin may use them).
+    for (local_plugins, 0..) |plugin, i| {
+        const pmod = b.addModule(b.fmt("cmdtest_plugin_{d}", .{i}), .{
+            // scanLocalPlugins always sets project_path for the plugins it returns.
+            .root_source_file = b.path(plugin.project_path.?),
+            .target = config.target,
+            .optimize = config.optimize,
+        });
+        pmod.addImport("zcli", zcli_module);
+        for (shared_modules) |sm| pmod.addImport(sm.name, sm.module);
+        registry_stub.addImport(b.fmt("plugin_{d}", .{i}), pmod);
+    }
 
     const ctx = Ctx{
         .b = b,

--- a/packages/testing/src/unit.zig
+++ b/packages/testing/src/unit.zig
@@ -69,18 +69,42 @@ fn fieldAttrs(comptime T: type) std.builtin.Type.StructField.Attributes {
     return .{ .default_value_ptr = default_ptr };
 }
 
-/// The `config` parameter type for `runCommand`, tailored to `Command` so that
-/// `args`/`options` are only optional-to-pass when default-constructible.
-fn RunConfig(comptime Command: type) type {
+/// The Context type a `runCommand` builds for `Command`. When `Command.execute`
+/// takes a concrete `context: *Context` (a scaffolded command), that exact
+/// Context is used — so the project's plugins are already in scope and a test
+/// can set their state via `.plugins`. When execute takes `context: anytype`, a
+/// fresh `TestContext(plugins)` is built from the passed plugin list instead.
+fn ContextTypeFor(comptime Command: type, comptime plugins: []const type) type {
+    return contextParamType(Command) orelse zcli.TestContext(plugins);
+}
+
+/// The concrete type behind `execute`'s context parameter, or null when it is
+/// generic (`anytype`).
+fn contextParamType(comptime Command: type) ?type {
+    const params = @typeInfo(@TypeOf(Command.execute)).@"fn".params;
+    const param = params[params.len - 1].type orelse return null;
+    return switch (@typeInfo(param)) {
+        .pointer => |ptr| ptr.child,
+        else => param,
+    };
+}
+
+/// The `config` parameter type for `runCommand`, tailored to `Command`: `args`/
+/// `options` are only optional-to-pass when default-constructible, and `plugins`
+/// sets the command's plugin state (`.plugins = .{ .verbose = .{ .enabled = true } }`).
+fn RunConfig(comptime Command: type, comptime plugins: []const type) type {
     const default_alloc: std.mem.Allocator = std.testing.allocator;
-    const names = [_][]const u8{ "args", "options", "allocator" };
-    const types = [_]type{ Command.Args, Command.Options, std.mem.Allocator };
+    const PluginData = @FieldType(ContextTypeFor(Command, plugins), "plugins");
+    const default_plugins: PluginData = .{};
+    const names = [_][]const u8{ "args", "options", "allocator", "plugins" };
+    const field_types = [_]type{ Command.Args, Command.Options, std.mem.Allocator, PluginData };
     const attrs = [_]std.builtin.Type.StructField.Attributes{
         fieldAttrs(Command.Args),
         fieldAttrs(Command.Options),
         .{ .default_value_ptr = &default_alloc },
+        .{ .default_value_ptr = &default_plugins },
     };
-    return @Struct(.auto, null, &names, &types, &attrs);
+    return @Struct(.auto, null, &names, &field_types, &attrs);
 }
 
 /// Run a command's execute() function in-process with captured I/O.
@@ -95,7 +119,7 @@ fn RunConfig(comptime Command: type) type {
 pub fn runCommand(
     comptime Command: type,
     comptime plugins: []const type,
-    config: RunConfig(Command),
+    config: RunConfig(Command, plugins),
 ) !CommandResult {
     const allocator = config.allocator;
     const args = config.args;
@@ -122,15 +146,17 @@ pub fn runCommand(
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
 
-    // Create context with plugins (empty environment; commands that read env
-    // vars should take them as options instead)
+    // Build the command's own Context (so a scaffolded command's project plugins
+    // are in scope), with an empty environment; commands that read env vars
+    // should take them as options instead.
     const test_environ = std.process.Environ.Map.init(allocator);
-    const Ctx = zcli.TestContext(plugins);
+    const Ctx = ContextTypeFor(Command, plugins);
     var context = Ctx{
         .allocator = arena.allocator(),
         .io = std.testing.io,
         .stdio = &stdio,
         .environ = &test_environ,
+        .plugins = config.plugins,
     };
     defer context.deinit();
 
@@ -308,6 +334,39 @@ test "runCommand with plugin data" {
     defer result.deinit();
 
     try std.testing.expectEqualStrings("disabled\n", result.stdout);
+}
+
+test "runCommand sets plugin state for a command with a concrete context" {
+    // A scaffolded command takes a concrete `context: *Context` whose plugins
+    // come from the project (the command_registry stub). runCommand derives that
+    // Context from the command, so the plugin field is in scope and a test drives
+    // it via `.plugins` — no `@hasField` guard needed.
+    const FlagPlugin = struct {
+        pub const plugin_id = "flag";
+        pub const ContextData = struct { on: bool = false };
+    };
+    const Ctx = zcli.TestContext(&.{FlagPlugin});
+    const TestCommand = struct {
+        pub const Args = struct {};
+        pub const Options = struct {};
+
+        pub fn execute(_: Args, _: Options, context: *Ctx) !void {
+            try context.stdout().writeAll(if (context.plugins.flag.on) "flag on\n" else "flag off\n");
+        }
+    };
+
+    // Default: the plugin's ContextData default (pass `&.{}` — Context is derived).
+    {
+        var r = try runCommand(TestCommand, &.{}, .{});
+        defer r.deinit();
+        try std.testing.expectEqualStrings("flag off\n", r.stdout);
+    }
+    // Set the plugin state via `.plugins`.
+    {
+        var r = try runCommand(TestCommand, &.{}, .{ .plugins = .{ .flag = .{ .on = true } } });
+        defer r.deinit();
+        try std.testing.expectEqualStrings("flag on\n", r.stdout);
+    }
 }
 
 test "runCommand vterm contains text" {

--- a/projects/zcli/src/commands/guide.zig
+++ b/projects/zcli/src/commands/guide.zig
@@ -343,10 +343,18 @@ const topics = [_]Topic{
         \\  }
         \\
         \\`r` also exposes `.stderr`, `.err`, and `.term` (a virtual terminal for
-        \\asserting on rendered color/layout). Pass plugin types as the second arg to
-        \\populate context.plugins. A command that fails with `context.fail(...)` is
-        \\assertable too — `!r.success`, `r.err.? == error.CommandFailed`, and the
-        \\message in `r.stderr` — because it returns an error instead of exiting.
+        \\asserting on rendered color/layout). A command that reads a plugin's state
+        \\via `context.plugins.<id>` is testable directly — set that state with
+        \\`.plugins` (the project's plugins are already in scope; pass `&.{}`):
+        \\
+        \\  var r = try zcli_testing.runCommand(@This(), &.{}, .{
+        \\      .args = .{ .name = "Ada" },
+        \\      .plugins = .{ .verbose = .{ .enabled = true } },
+        \\  });
+        \\
+        \\A command that fails with `context.fail(...)` is assertable too —
+        \\`!r.success`, `r.err.? == error.CommandFailed`, and the message in
+        \\`r.stderr` — because it returns an error instead of exiting.
         \\
         \\runCommand runs execute() in-process against the real filesystem and the
         \\real cwd — it captures I/O, not the disk. A command that reads or writes

--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -270,6 +270,7 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         \\        .commands_dir = "src/commands",
         \\        .target = target,
         \\        .optimize = optimize,
+        \\        .plugins_dir = "src/plugins",
         \\        .shared_modules = &shared_modules,
         \\    }});
         \\}}

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -1062,6 +1062,81 @@ test "a shared module reaches both commands and their tests" {
     }
 }
 
+test "a command's plugin state is testable via runCommand .plugins" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    {
+        var r = try run(tmp.dir, &.{ zcli_exe, "init", "app" });
+        defer r.deinit();
+        try expectOk(r);
+    }
+
+    var proj = try tmp.dir.openDir(io, "app", .{});
+    defer proj.close(io);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const proj_abs = try tmpSubdirAbs(a, tmp, "app");
+    try pointDependencyAtLocalTree(proj, proj_abs);
+
+    // A plugin with state (a --verbose flag).
+    try proj.writeFile(io, .{
+        .sub_path = "src/plugins/verbose.zig",
+        .data =
+        \\const std = @import("std");
+        \\const zcli = @import("zcli");
+        \\pub const plugin_id = "verbose";
+        \\pub const ContextData = struct { enabled: bool = false };
+        \\pub const global_options = [_]zcli.GlobalOption{
+        \\    zcli.option("verbose", bool, .{ .short = 'v', .default = false, .description = "Verbose" }),
+        \\};
+        \\pub fn handleGlobalOption(context: anytype, name: []const u8, value: anytype) !void {
+        \\    if (std.mem.eql(u8, name, "verbose")) context.plugins.verbose.enabled = value;
+        \\}
+        \\
+        ,
+    });
+
+    // A command that reads `context.plugins.verbose` UNGUARDED, with a test that
+    // drives that state via `.plugins`. Compiles only if addCommandTests made the
+    // stub Context plugin-aware; passes only if runCommand set the plugin state.
+    try proj.writeFile(io, .{
+        .sub_path = "src/commands/greet.zig",
+        .data =
+        \\const std = @import("std");
+        \\const zcli = @import("zcli");
+        \\const Context = @import("command_registry").Context;
+        \\pub const meta = .{ .description = "greet" };
+        \\pub const Args = struct { name: []const u8 };
+        \\pub const Options = struct {};
+        \\pub fn execute(args: Args, _: Options, context: *Context) !void {
+        \\    if (context.plugins.verbose.enabled)
+        \\        try context.stderr().print("[verbose] greeting {s}\n", .{args.name});
+        \\    try context.stdout().print("Hello, {s}!\n", .{args.name});
+        \\}
+        \\test "greet: --verbose drives the diagnostic" {
+        \\    const zcli_testing = @import("zcli-testing");
+        \\    var r = try zcli_testing.runCommand(@This(), &.{}, .{
+        \\        .args = .{ .name = "Ada" },
+        \\        .plugins = .{ .verbose = .{ .enabled = true } },
+        \\    });
+        \\    defer r.deinit();
+        \\    try std.testing.expect(r.success);
+        \\    try std.testing.expect(std.mem.indexOf(u8, r.stderr, "[verbose] greeting Ada") != null);
+        \\}
+        \\
+        ,
+    });
+
+    {
+        var r = try run(proj, &.{ "zig", "build", "test" });
+        defer r.deinit();
+        try expectOk(r);
+    }
+}
+
 // ============================================================================
 // Layer 2 — interactive (PTY) tests
 // ============================================================================

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -1081,7 +1081,9 @@ test "a command's plugin state is testable via runCommand .plugins" {
     const proj_abs = try tmpSubdirAbs(a, tmp, "app");
     try pointDependencyAtLocalTree(proj, proj_abs);
 
-    // A plugin with state (a --verbose flag).
+    // A plugin with state (a --verbose flag). init doesn't scaffold src/plugins,
+    // so create it (writeFile doesn't make parent dirs).
+    try proj.createDir(io, "src/plugins", .default_dir);
     try proj.writeFile(io, .{
         .sub_path = "src/plugins/verbose.zig",
         .data =


### PR DESCRIPTION
## What

Cold dogfood pass 4 built a command that reads `context.plugins.<id>` but **couldn't test it**: the `addCommandTests` stub hardcoded `Context = zcli.TestContext(&.{})` (no plugin fields), so the read only compiled behind an `@hasField(@TypeOf(context.plugins), "verbose")` guard — which then **elided the plugin path in tests**. The plugin-ON behavior went unexercised, and the guide's "pass plugin types as the second arg" didn't work for scaffolded commands (it type-mismatches a concrete `*Context`).

This makes plugin behavior first-class testable. **Option 1** from the design discussion: backward-compatible, no call-site churn.

## Two interlocking changes

- **`addCommandTests` generates a plugin-aware stub.** It discovers the project's local plugins (`plugins_dir`), wires each as a module, and emits `pub const Context = zcli.TestContext(&.{ plugin_0, ... })`. A command reading `context.plugins.verbose` now compiles under test with **no guard**.
- **`runCommand` derives the command's own `Context`** by reflecting `execute()`'s `context: *Context` parameter (falling back to `TestContext(plugins)` for the `anytype` commands the framework's own tests use). `RunConfig` gains a `.plugins` field so a test sets plugin state directly:

```zig
var r = try zcli_testing.runCommand(@This(), &.{}, .{
    .args = .{ .name = "Ada" },
    .plugins = .{ .verbose = .{ .enabled = true } },
});
```

The `plugins` positional still works for `anytype` commands; for a scaffolded `*Context` command it's derived (pass `&.{}`) and state comes from `.plugins`. `init`'s generated `build.zig` now passes `plugins_dir` to `addCommandTests`; the guide `testing` topic teaches `.plugins`.

## Verification

End-to-end against a **generated** project: a command reading `context.plugins.verbose` **unguarded** compiles and `zig build test` passes with `.plugins` set. A **negative control** (`enabled = false` but asserting the `[verbose]` line) correctly **fails** — proving the state drives behavior and the test genuinely runs.

- New unit test for the concrete-context `.plugins` path; new e2e drift-guard (CI-gated).
- `packages/core`, `packages/testing`, meta-CLI `zig build test`, and `zig fmt --check` all clean.
- **All ~16 existing `runCommand` call sites unchanged** (backward-compatible).

## Follow-up (handoff coming separately)

A **clean 2-arg `runCommand(Command, config)`** redesign (Option 2) builds on this — it removes the now-vestigial `plugins` positional for concrete commands. I'll hand off the details separately; it should land on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)