### PR TITLE
website: derive version from root build.zig.zon (single source of truth)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -26,6 +26,9 @@ jobs:
           mv zine website/zine
           chmod +x website/zine
 
+      - name: Sync site data from build.zig.zon
+        run: ./website/sync-site-data.sh
+
       - name: Build site
         working-directory: website
         run: ./zine release

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ test_io
 examples/showcase/tasks.json
 /website/zine
 /website/public
+/website/assets/site-data.json
 **/CLAUDE.md
 docs/internal/
 **/docs/html/

--- a/website/build.zig
+++ b/website/build.zig
@@ -1,13 +1,36 @@
 const std = @import("std");
-const zine = @import("zine");
 
-pub fn build(b: *std.Build) !void {
-    // Build the website
-    const website = zine.website(b, .{});
-    b.getInstallStep().dependOn(&website.step);
+// The site is built by the prebuilt `zine` binary (./zine), NOT by Zig: Zine
+// 0.11.x's Zig integration doesn't compile on Zig 0.16, so `build.zig` can't
+// import `zine`. Instead these steps front that binary and regenerate the
+// build-derived data (assets/site-data.json) first — so the version shown on the
+// site is always in sync with the root build.zig.zon and you never have to
+// remember to run the sync by hand.
+//
+// Requires ./zine (download once from the zine v0.11.3 GitHub release; gitignored).
+pub fn build(b: *std.Build) void {
+    const root = b.path(".");
 
-    // Development server
-    const serve = b.step("serve", "Start the Zine development server");
-    const run_zine = zine.serve(b, .{});
-    serve.dependOn(&run_zine.step);
+    // Regenerate assets/site-data.json from the source-of-truth files (build.zig.zon, ...).
+    const sync = b.addSystemCommand(&.{"./sync-site-data.sh"});
+    sync.setCwd(root);
+
+    // `zig build serve` — dev server with live reload.
+    const serve = b.addSystemCommand(&.{"./zine"});
+    serve.setCwd(root);
+    serve.step.dependOn(&sync.step);
+    b.step("serve", "Start the Zine development server").dependOn(&serve.step);
+
+    // `zig build` / `zig build release` — production build into ./public.
+    // Zine refuses a non-empty output dir, so clear it first.
+    const clean = b.addSystemCommand(&.{ "rm", "-rf", "public" });
+    clean.setCwd(root);
+
+    const release = b.addSystemCommand(&.{ "./zine", "release" });
+    release.setCwd(root);
+    release.step.dependOn(&sync.step);
+    release.step.dependOn(&clean.step);
+
+    b.step("release", "Build the site into ./public").dependOn(&release.step);
+    b.getInstallStep().dependOn(&release.step);
 }

--- a/website/build.zig.zon
+++ b/website/build.zig.zon
@@ -2,11 +2,9 @@
     .name = .zcli_website,
     .version = "0.1.0",
     .fingerprint = 0x1180ef3171166a59,
-    .dependencies = .{
-        .zine = .{
-            .url = "git+https://github.com/kristoff-it/zine?ref=v0.11.3#2a001538f25198cd5945aa7da72459a7fc1e53ba",
-            .hash = "zine-0.11.3-ou6nIBmEFgBJ5JdclWDJ8X1zcZ_ro5EqTnJFyPakukFJ",
-        },
-    },
+    // No dependencies: the site is built by the prebuilt `zine` binary (see
+    // build.zig), not by Zig, so we don't pull in Zine's Zig package (which
+    // doesn't compile on 0.16 anyway).
+    .dependencies = .{},
     .paths = .{"."},
 }

--- a/website/layouts/docs.shtml
+++ b/website/layouts/docs.shtml
@@ -68,7 +68,7 @@
         <section id="start">
           <h1>Documentation</h1>
           <p class="sub">A batteries-included framework for building command-line interfaces in Zig. Drop <code>.zig</code> files in a directory and get a fully-featured CLI — with command discovery and routing wired up at compile time for zero-cost dispatch.</p>
-          <div class="callout"><b>Requires</b> Zig 0.16.0 or newer. zcli is currently v0.17.0 and MIT licensed.</div>
+          <div class="callout"><b>Requires</b> Zig 0.16.0 or newer. zcli is currently v<span :text="$site.asset('site-data.json').ziggy().get('version')"></span> and MIT licensed.</div>
         </section>
 
         <!-- ============ FAST PATH ============ -->

--- a/website/layouts/install.shtml
+++ b/website/layouts/install.shtml
@@ -93,13 +93,13 @@
     <div class="verify">
       <h4>Verify the install</h4>
 <pre><span class="pr" style="color:var(--accent)">$</span> myapp --version
-<span class="ok">myapp 0.1.0  ·  built with zcli v0.17.0</span></pre>
+<span class="ok">myapp 0.1.0  ·  built with zcli v<span :text="$site.asset('site-data.json').ziggy().get('version')"></span></span></pre>
     </div>
 
     <div class="grid">
       <div class="req"><div class="l">Requires</div><div class="v"><b>Zig 0.16.0</b> or newer</div></div>
       <div class="req"><div class="l">License</div><div class="v"><b>MIT</b> — © 2025 Ryan Hair</div></div>
-      <div class="req"><div class="l">Latest</div><div class="v"><b>v0.17.0</b></div></div>
+      <div class="req"><div class="l">Latest</div><div class="v"><b>v<span :text="$site.asset('site-data.json').ziggy().get('version')"></span></b></div></div>
     </div>
 
     <div style="text-align:center;margin:56px 0 96px;">

--- a/website/layouts/templates/base.shtml
+++ b/website/layouts/templates/base.shtml
@@ -18,7 +18,7 @@
 <header class="nav">
     <div class="wrap">
         <a class="brand" href="$site.page('').link()">
-            <span class="glyph">z</span> zcli <span class="ver mono">v0.17.0</span>
+            <span class="glyph">z</span> zcli <span class="ver mono">v<span :text="$site.asset('site-data.json').ziggy().get('version')"></span></span>
         </a>
         <nav>
             <a href="$site.page('').link().suffix('#features')">Features</a>

--- a/website/sync-site-data.sh
+++ b/website/sync-site-data.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env sh
+# Regenerate website/assets/site-data.json — the single place the site pulls
+# build-derived values from, so they never have to be hand-maintained in the
+# templates. Templates read fields via `$site.asset('site-data.json').ziggy().get('<field>')`
+# (Zine parses JSON as a Ziggy document).
+#
+# Currently sourced:
+#   version <- root build.zig.zon `.version`
+# Add more fields here as they're needed (pulled from wherever their source of truth is).
+#
+# Runs automatically in CI (deploy-docs.yml) before `zine release`; run it
+# manually before a local `zine` / `zine release` preview if any source changed.
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+zon="$script_dir/../build.zig.zon"
+out="$script_dir/assets/site-data.json"
+
+version=$(sed -n 's/^[[:space:]]*\.version = "\([^"]*\)".*/\1/p' "$zon" | head -n 1)
+
+if [ -z "$version" ]; then
+  echo "sync-site-data: could not find .version in $zon" >&2
+  exit 1
+fi
+
+cat > "$out" <<EOF
+{
+  "version": "$version"
+}
+EOF
+echo "sync-site-data: wrote version $version to $out"


### PR DESCRIPTION
The site version was hardcoded as `v0.17.0` in four template spots while the root `build.zig.zon` already said `0.18.0`. Templates now read the version from a generated `website/assets/site-data.json` (JSON, parsed via Zine's `ziggy()`), which `website/sync-site-data.sh` produces from `build.zig.zon`'s `.version` — an extensible data bucket for future build-derived fields. `site-data.json` is gitignored as a derived artifact, and CI regenerates it before `zine release`. `website/build.zig` was rewritten to be self-contained (no `@import("zine")`, which doesn't compile on Zig 0.16), so `zig build serve` / `zig build release` now work and shell out to the prebuilt `./zine` binary while depending on a sync step. The result: the displayed version can never drift from `build.zig.zon`, with no Makefile.