### PR TITLE
guide: note that .plugins field names are plugin_ids (testing topic)

### DIFF
--- a/projects/zcli/src/commands/guide.zig
+++ b/projects/zcli/src/commands/guide.zig
@@ -361,6 +361,9 @@ const topics = [_]Topic{
         \\      .plugins = .{ .verbose = .{ .enabled = true } },
         \\  });
         \\
+        \\Each `.plugins` field name is the plugin's `plugin_id` (here `.verbose`),
+        \\and its value is that plugin's `ContextData`.
+        \\
         \\A command that fails with `context.fail(...)` is assertable too —
         \\`!r.success`, `r.err.? == error.CommandFailed`, and the message in
         \\`r.stderr` — because it returns an error instead of exiting.


### PR DESCRIPTION
## What

Cold dogfood **pass 5** (a GitHub repo-tracker with real HTTP, a cache, and a **tested** plugin) built and tested a plugin-reading command using the new `.plugins` config from #95 — and it *worked first try*. The one small snag: the agent had to **infer** that `.plugins = .{ .verbose = ... }`'s field name maps to the plugin's `plugin_id = "verbose"`.

This states it explicitly in the `testing` topic: each `.plugins` field name is the plugin's `plugin_id`, and its value is that plugin's `ContextData`.

## Why so small

Pass 5 was the fifth consecutive cold success on a progressively harder task, and validated the two things we most wanted to confirm: **#95 plugin testability** (a fresh agent read `context.plugins.verbose` unguarded and drove it via `.plugins`) and the **`http`** surface (*"nearly copy-paste ready, worked first try, no gaps"*). The remaining friction was almost all Zig-language (`//!` doc-comment placement; `*const [N]T`→`[]T` coercion in a test literal) — not zcli. This one-liner is the only clearly-actionable zcli finding.

## Verification

Guide renders the new sentence; meta-CLI `zig build test` and `zig fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)