### PR TITLE
testing: drop the vestigial `plugins` positional from runCommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ Test commands directly without compiling a binary:
 const testing = @import("zcli-testing");
 
 test "deploy command" {
-    var result = try testing.runCommand(DeployCommand, &.{}, .{
+    var result = try testing.runCommand(DeployCommand, .{
         .args = .{ .service = "api" },
         .options = .{ .env = "staging" },
     });

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -42,7 +42,7 @@ const testing = @import("zcli-testing");
 const add = @import("commands/add.zig");
 
 test "add command prints confirmation" {
-    var result = try testing.runCommand(add, &.{}, .{
+    var result = try testing.runCommand(add, .{
         .args = .{ .name = "widget" },
         .options = .{ .verbose = false },
     });
@@ -54,7 +54,7 @@ test "add command prints confirmation" {
 }
 
 test "add command fails on empty name" {
-    var result = try testing.runCommand(add, &.{}, .{
+    var result = try testing.runCommand(add, .{
         .args = .{ .name = "" },
         .options = .{},
     });
@@ -67,33 +67,32 @@ test "add command fails on empty name" {
 
 ### Testing with plugins
 
-If your command accesses plugin data through `context.plugins`, pass the plugins to `runCommand`:
+A command takes a concrete `context: *Context` (the type `zcli add command` scaffolds), and `runCommand` derives that Context from the command — so your project's plugins are already in scope. If your command reads plugin data through `context.plugins`, set that state directly with `.plugins`:
 
 ```zig
-const zcli_output = @import("zcli_output");
-
 test "command respects output mode" {
-    var result = try testing.runCommand(list, &.{zcli_output}, .{
+    var result = try testing.runCommand(list, .{
         .args = .{},
         .options = .{},
+        .plugins = .{ .output = .{ .mode = .json } },
     });
     defer result.deinit();
 
-    // Plugin data starts at defaults (output_mode = .table)
+    // Omit `.plugins` to run against each plugin's ContextData defaults.
     try std.testing.expect(result.success);
 }
 ```
 
 ### API reference
 
-**`testing.runCommand(Command, plugins, config)`**
+**`testing.runCommand(Command, config)`**
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `Command` | `type` (comptime) | The command module with `Args`, `Options`, `execute` |
-| `plugins` | `[]const type` (comptime) | Plugins to register (for `context.plugins` access) |
+| `Command` | `type` (comptime) | The command module with `Args`, `Options`, and an `execute` taking a concrete `context: *Context` |
 | `config.args` | `Command.Args` | Positional arguments to pass |
 | `config.options` | `Command.Options` | Option values to pass |
+| `config.plugins` | derived from `Context` | Initial plugin state, e.g. `.{ .verbose = .{ .enabled = true } }`; defaults to each plugin's `ContextData` defaults |
 | `config.allocator` | `std.mem.Allocator` | Defaults to `std.testing.allocator` |
 
 **Returns `CommandResult`:**
@@ -114,7 +113,7 @@ The `result.term` field is a virtual terminal that has processed all ANSI escape
 
 ```zig
 test "status shows green checkmark" {
-    var result = try testing.runCommand(StatusCommand, &.{}, .{});
+    var result = try testing.runCommand(StatusCommand, .{});
     defer result.deinit();
 
     // Check rendered text (ANSI codes stripped)

--- a/packages/testing/src/unit.zig
+++ b/packages/testing/src/unit.zig
@@ -8,7 +8,7 @@
 //! const testing = @import("testing");
 //!
 //! test "add command" {
-//!     var result = try testing.runCommand(AddCommand, &.{}, .{
+//!     var result = try testing.runCommand(AddCommand, .{
 //!         .args = .{ .name = "widget" },
 //!         .options = .{ .verbose = true },
 //!     });
@@ -69,13 +69,17 @@ fn fieldAttrs(comptime T: type) std.builtin.Type.StructField.Attributes {
     return .{ .default_value_ptr = default_ptr };
 }
 
-/// The Context type a `runCommand` builds for `Command`. When `Command.execute`
-/// takes a concrete `context: *Context` (a scaffolded command), that exact
-/// Context is used — so the project's plugins are already in scope and a test
-/// can set their state via `.plugins`. When execute takes `context: anytype`, a
-/// fresh `TestContext(plugins)` is built from the passed plugin list instead.
-fn ContextTypeFor(comptime Command: type, comptime plugins: []const type) type {
-    return contextParamType(Command) orelse zcli.TestContext(plugins);
+/// The Context type a `runCommand` builds for `Command`, derived from the
+/// concrete `context: *Context` parameter of `Command.execute` (a scaffolded
+/// command). The project's plugins are already in scope on that Context, so a
+/// test can set their state via `.plugins`. A `context: anytype` command has no
+/// recoverable Context type and cannot be tested this way.
+fn ContextTypeFor(comptime Command: type) type {
+    return contextParamType(Command) orelse @compileError(
+        "runCommand needs a command with a concrete `context: *Context` (a scaffolded command); " ++
+            "`context: anytype` commands can't be tested this way — give it a concrete " ++
+            "`*zcli.TestContext(&.{...})`.",
+    );
 }
 
 /// The concrete type behind `execute`'s context parameter, or null when it is
@@ -92,9 +96,9 @@ fn contextParamType(comptime Command: type) ?type {
 /// The `config` parameter type for `runCommand`, tailored to `Command`: `args`/
 /// `options` are only optional-to-pass when default-constructible, and `plugins`
 /// sets the command's plugin state (`.plugins = .{ .verbose = .{ .enabled = true } }`).
-fn RunConfig(comptime Command: type, comptime plugins: []const type) type {
+fn RunConfig(comptime Command: type) type {
     const default_alloc: std.mem.Allocator = std.testing.allocator;
-    const PluginData = @FieldType(ContextTypeFor(Command, plugins), "plugins");
+    const PluginData = @FieldType(ContextTypeFor(Command), "plugins");
     const default_plugins: PluginData = .{};
     const names = [_][]const u8{ "args", "options", "allocator", "plugins" };
     const field_types = [_]type{ Command.Args, Command.Options, std.mem.Allocator, PluginData };
@@ -109,8 +113,9 @@ fn RunConfig(comptime Command: type, comptime plugins: []const type) type {
 
 /// Run a command's execute() function in-process with captured I/O.
 ///
-/// The command module must have Args, Options, and execute declarations.
-/// Plugins can be provided to populate context.plugins.
+/// The command must have Args, Options, and an `execute` taking a concrete
+/// `context: *Context` — the Context (with the project's plugins) is derived
+/// from it. Set plugin state via `.plugins = .{ .<id> = .{ ... } }`.
 ///
 /// Pass `.args`/`.options` to drive the command. They may be omitted only
 /// when the command's Args/Options are default-constructible (every field has
@@ -118,8 +123,7 @@ fn RunConfig(comptime Command: type, comptime plugins: []const type) type {
 /// `.args`/`.options` or the call fails to compile with "missing struct field".
 pub fn runCommand(
     comptime Command: type,
-    comptime plugins: []const type,
-    config: RunConfig(Command, plugins),
+    config: RunConfig(Command),
 ) !CommandResult {
     const allocator = config.allocator;
     const args = config.args;
@@ -150,7 +154,7 @@ pub fn runCommand(
     // are in scope), with an empty environment; commands that read env vars
     // should take them as options instead.
     const test_environ = std.process.Environ.Map.init(allocator);
-    const Ctx = ContextTypeFor(Command, plugins);
+    const Ctx = ContextTypeFor(Command);
     var context = Ctx{
         .allocator = arena.allocator(),
         .io = std.testing.io,
@@ -193,17 +197,18 @@ pub fn runCommand(
 
 // Tests
 test "runCommand captures stdout" {
+    const Ctx = zcli.TestContext(&.{});
     const TestCommand = struct {
         pub const Args = struct {};
         pub const Options = struct {};
 
-        pub fn execute(_: Args, _: Options, context: anytype) !void {
+        pub fn execute(_: Args, _: Options, context: *Ctx) !void {
             const writer = context.stdout();
             try writer.writeAll("hello world\n");
         }
     };
 
-    var result = try runCommand(TestCommand, &.{}, .{});
+    var result = try runCommand(TestCommand, .{});
     defer result.deinit();
 
     try std.testing.expectEqualStrings("hello world\n", result.stdout);
@@ -212,17 +217,18 @@ test "runCommand captures stdout" {
 }
 
 test "runCommand captures stderr" {
+    const Ctx = zcli.TestContext(&.{});
     const TestCommand = struct {
         pub const Args = struct {};
         pub const Options = struct {};
 
-        pub fn execute(_: Args, _: Options, context: anytype) !void {
+        pub fn execute(_: Args, _: Options, context: *Ctx) !void {
             const writer = context.stderr();
             try writer.writeAll("error occurred\n");
         }
     };
 
-    var result = try runCommand(TestCommand, &.{}, .{});
+    var result = try runCommand(TestCommand, .{});
     defer result.deinit();
 
     try std.testing.expect(result.stdout.len == 0);
@@ -230,16 +236,17 @@ test "runCommand captures stderr" {
 }
 
 test "runCommand captures error" {
+    const Ctx = zcli.TestContext(&.{});
     const TestCommand = struct {
         pub const Args = struct {};
         pub const Options = struct {};
 
-        pub fn execute(_: Args, _: Options, _: anytype) !void {
+        pub fn execute(_: Args, _: Options, _: *Ctx) !void {
             return error.TestError;
         }
     };
 
-    var result = try runCommand(TestCommand, &.{}, .{});
+    var result = try runCommand(TestCommand, .{});
     defer result.deinit();
 
     try std.testing.expect(!result.success);
@@ -248,6 +255,7 @@ test "runCommand captures error" {
 }
 
 test "runCommand passes args and options" {
+    const Ctx = zcli.TestContext(&.{});
     const TestCommand = struct {
         pub const Args = struct {
             name: []const u8 = "default",
@@ -256,13 +264,13 @@ test "runCommand passes args and options" {
             count: u32 = 1,
         };
 
-        pub fn execute(args: Args, options: Options, context: anytype) !void {
+        pub fn execute(args: Args, options: Options, context: *Ctx) !void {
             const writer = context.stdout();
             try writer.print("{s}: {d}\n", .{ args.name, options.count });
         }
     };
 
-    var result = try runCommand(TestCommand, &.{}, .{
+    var result = try runCommand(TestCommand, .{
         .args = .{ .name = "widget" },
         .options = .{ .count = 5 },
     });
@@ -272,34 +280,36 @@ test "runCommand passes args and options" {
 }
 
 test "runCommand with a required (no-default) arg" {
+    const Ctx = zcli.TestContext(&.{});
     const TestCommand = struct {
         pub const Args = struct {
             name: []const u8,
         };
         pub const Options = struct {};
 
-        pub fn execute(args: Args, _: Options, context: anytype) !void {
+        pub fn execute(args: Args, _: Options, context: *Ctx) !void {
             try context.stdout().print("hello {s}\n", .{args.name});
         }
     };
 
-    var result = try runCommand(TestCommand, &.{}, .{ .args = .{ .name = "Ada" } });
+    var result = try runCommand(TestCommand, .{ .args = .{ .name = "Ada" } });
     defer result.deinit();
 
     try std.testing.expectEqualStrings("hello Ada\n", result.stdout);
 }
 
 test "runCommand captures context.fail as a failure with the message" {
+    const Ctx = zcli.TestContext(&.{});
     const TestCommand = struct {
         pub const Args = struct { name: []const u8 };
         pub const Options = struct {};
 
-        pub fn execute(args: Args, _: Options, context: anytype) !void {
+        pub fn execute(args: Args, _: Options, context: *Ctx) !void {
             return context.fail("no such thing: {s}", .{args.name});
         }
     };
 
-    var result = try runCommand(TestCommand, &.{}, .{ .args = .{ .name = "widget" } });
+    var result = try runCommand(TestCommand, .{ .args = .{ .name = "widget" } });
     defer result.deinit();
 
     // context.fail() is a returned error, not a process exit — so a unit test
@@ -317,11 +327,12 @@ test "runCommand with plugin data" {
         };
     };
 
+    const Ctx = zcli.TestContext(&.{MockPlugin});
     const TestCommand = struct {
         pub const Args = struct {};
         pub const Options = struct {};
 
-        pub fn execute(_: Args, _: Options, context: anytype) !void {
+        pub fn execute(_: Args, _: Options, context: *Ctx) !void {
             if (context.plugins.mock.enabled) {
                 try context.stdout().writeAll("enabled\n");
             } else {
@@ -330,7 +341,7 @@ test "runCommand with plugin data" {
         }
     };
 
-    var result = try runCommand(TestCommand, &.{MockPlugin}, .{});
+    var result = try runCommand(TestCommand, .{});
     defer result.deinit();
 
     try std.testing.expectEqualStrings("disabled\n", result.stdout);
@@ -355,31 +366,32 @@ test "runCommand sets plugin state for a command with a concrete context" {
         }
     };
 
-    // Default: the plugin's ContextData default (pass `&.{}` — Context is derived).
+    // Default: the plugin's ContextData default (Context is derived).
     {
-        var r = try runCommand(TestCommand, &.{}, .{});
+        var r = try runCommand(TestCommand, .{});
         defer r.deinit();
         try std.testing.expectEqualStrings("flag off\n", r.stdout);
     }
     // Set the plugin state via `.plugins`.
     {
-        var r = try runCommand(TestCommand, &.{}, .{ .plugins = .{ .flag = .{ .on = true } } });
+        var r = try runCommand(TestCommand, .{ .plugins = .{ .flag = .{ .on = true } } });
         defer r.deinit();
         try std.testing.expectEqualStrings("flag on\n", r.stdout);
     }
 }
 
 test "runCommand vterm contains text" {
+    const Ctx = zcli.TestContext(&.{});
     const TestCommand = struct {
         pub const Args = struct {};
         pub const Options = struct {};
 
-        pub fn execute(_: Args, _: Options, context: anytype) !void {
+        pub fn execute(_: Args, _: Options, context: *Ctx) !void {
             try context.stdout().writeAll("Hello World\n");
         }
     };
 
-    var result = try runCommand(TestCommand, &.{}, .{});
+    var result = try runCommand(TestCommand, .{});
     defer result.deinit();
 
     try std.testing.expect(result.term.containsText("Hello World"));
@@ -391,11 +403,12 @@ test "runCommand arena reclaims allocations for a command that never frees" {
     // context.allocator and never call free. runCommand uses
     // std.testing.allocator, which panics on leak, so this test fails if the
     // arena is removed. See docs/adr/0001-arena-per-command-allocator.md.
+    const Ctx = zcli.TestContext(&.{});
     const TestCommand = struct {
         pub const Args = struct {};
         pub const Options = struct {};
 
-        pub fn execute(_: Args, _: Options, context: anytype) !void {
+        pub fn execute(_: Args, _: Options, context: *Ctx) !void {
             // Several allocations of different sizes, none freed.
             var i: usize = 0;
             while (i < 8) : (i += 1) {
@@ -407,7 +420,7 @@ test "runCommand arena reclaims allocations for a command that never frees" {
         }
     };
 
-    var result = try runCommand(TestCommand, &.{}, .{});
+    var result = try runCommand(TestCommand, .{});
     defer result.deinit();
 
     try std.testing.expect(result.success);
@@ -415,16 +428,17 @@ test "runCommand arena reclaims allocations for a command that never frees" {
 }
 
 test "runCommand vterm detects ANSI formatting" {
+    const Ctx = zcli.TestContext(&.{});
     const TestCommand = struct {
         pub const Args = struct {};
         pub const Options = struct {};
 
-        pub fn execute(_: Args, _: Options, context: anytype) !void {
+        pub fn execute(_: Args, _: Options, context: *Ctx) !void {
             try context.stdout().writeAll("\x1b[1mBold text\x1b[0m\n");
         }
     };
 
-    var result = try runCommand(TestCommand, &.{}, .{});
+    var result = try runCommand(TestCommand, .{});
     defer result.deinit();
 
     // VTerm parses ANSI — text is there without escape codes

--- a/projects/zcli/src/commands/add/_generate.zig
+++ b/projects/zcli/src/commands/add/_generate.zig
@@ -138,7 +138,7 @@ fn writeTestBlock(w: *std.Io.Writer, parts: []const []const u8) !void {
         \\" {
         \\    // Scaffolded smoke test — replace with real assertions. Example:
         \\    //   const zcli_testing = @import("zcli-testing");
-        \\    //   var r = try zcli_testing.runCommand(@This(), &.{}, .{});
+        \\    //   var r = try zcli_testing.runCommand(@This(), .{});
         \\    //   defer r.deinit();
         \\    //   try std.testing.expect(r.success);
         \\    // For a command with arguments, pass them via the config's args field.
@@ -246,7 +246,7 @@ test "generateSource: empty command is the minimal skeleton" {
     // always compiles and passes, and `zig build test` discovers it.
     try expectContains(src, "test \"ping\" {");
     try expectContains(src, "_ = @This();");
-    try expectContains(src, "runCommand(@This()"); // the example pattern in the comment
+    try expectContains(src, "runCommand(@This(), .{});"); // the 2-arg example pattern in the comment
 }
 
 test "generateSource: multiple is independent of element type" {

--- a/projects/zcli/src/commands/guide.zig
+++ b/projects/zcli/src/commands/guide.zig
@@ -345,7 +345,7 @@ const topics = [_]Topic{
         \\
         \\  test "greet: says hello" {
         \\      const zcli_testing = @import("zcli-testing");
-        \\      var r = try zcli_testing.runCommand(@This(), &.{}, .{ .args = .{ .name = "Ada" } });
+        \\      var r = try zcli_testing.runCommand(@This(), .{ .args = .{ .name = "Ada" } });
         \\      defer r.deinit();
         \\      try std.testing.expect(r.success);
         \\      try std.testing.expectEqualStrings("Hello, Ada!\n", r.stdout);
@@ -354,9 +354,9 @@ const topics = [_]Topic{
         \\`r` also exposes `.stderr`, `.err`, and `.term` (a virtual terminal for
         \\asserting on rendered color/layout). A command that reads a plugin's state
         \\via `context.plugins.<id>` is testable directly — set that state with
-        \\`.plugins` (the project's plugins are already in scope; pass `&.{}`):
+        \\`.plugins` (the project's plugins are already in scope):
         \\
-        \\  var r = try zcli_testing.runCommand(@This(), &.{}, .{
+        \\  var r = try zcli_testing.runCommand(@This(), .{
         \\      .args = .{ .name = "Ada" },
         \\      .plugins = .{ .verbose = .{ .enabled = true } },
         \\  });
@@ -375,7 +375,7 @@ const topics = [_]Topic{
         \\      const io = std.testing.io;
         \\      std.Io.Dir.cwd().deleteFile(io, "tasks.json") catch {};        // start clean
         \\      defer std.Io.Dir.cwd().deleteFile(io, "tasks.json") catch {};  // and don't leak it
-        \\      var r = try zcli_testing.runCommand(@This(), &.{}, .{ .args = .{ .title = "Buy milk" } });
+        \\      var r = try zcli_testing.runCommand(@This(), .{ .args = .{ .title = "Buy milk" } });
         \\      defer r.deinit();
         \\      try std.testing.expect(r.success);
         \\  }

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -951,7 +951,7 @@ test "scaffolded commands are unit-testable via zig build test" {
         \\}
         \\test "hi runs via runCommand" {
         \\    const zcli_testing = @import("zcli-testing");
-        \\    var r = try zcli_testing.runCommand(@This(), &.{}, .{});
+        \\    var r = try zcli_testing.runCommand(@This(), .{});
         \\    defer r.deinit();
         \\    try std.testing.expect(r.success);
         \\    try std.testing.expect(std.mem.indexOf(u8, r.stdout, "hi there") != null);
@@ -1056,7 +1056,7 @@ test "a shared module reaches both commands and their tests" {
         \\}
         \\test "greet uses the shared store module" {
         \\    const zcli_testing = @import("zcli-testing");
-        \\    var r = try zcli_testing.runCommand(@This(), &.{}, .{ .args = .{ .name = "Ada" } });
+        \\    var r = try zcli_testing.runCommand(@This(), .{ .args = .{ .name = "Ada" } });
         \\    defer r.deinit();
         \\    try std.testing.expect(r.success);
         \\    try std.testing.expect(std.mem.indexOf(u8, r.stdout, store.tag()) != null);
@@ -1130,7 +1130,7 @@ test "a command's plugin state is testable via runCommand .plugins" {
         \\}
         \\test "greet: --verbose drives the diagnostic" {
         \\    const zcli_testing = @import("zcli-testing");
-        \\    var r = try zcli_testing.runCommand(@This(), &.{}, .{
+        \\    var r = try zcli_testing.runCommand(@This(), .{
         \\        .args = .{ .name = "Ada" },
         \\        .plugins = .{ .verbose = .{ .enabled = true } },
         \\    });


### PR DESCRIPTION
Follow-up to #95 (Option 1). Option 1 made `runCommand` derive a scaffolded command's `Context` by reflecting its concrete `context: *Context` param, which left the `plugins` positional as dead weight for real commands — callers passed `&.{}` and it was ignored. This removes it (Option 2).

```zig
// before
runCommand(X, &.{}, .{ … })
// after
runCommand(X, .{ … })
```

Plugin state is still set via `.plugins = .{ .<id> = .{ … } }`.

## The one constraint
A command can be `runCommand`-tested only if its `execute` takes a concrete `context: *Context` (exactly what `zcli add command` scaffolds). A `context: anytype` command now hits a clear `@compileError` pointing at `*zcli.TestContext(&.{…})`.

This is scoped surgically to the unit-test helper. **Plugin hooks** (`handleGlobalOption`, `preExecute`, `onError`, …) and the framework pipeline — which must stay `context: anytype` — are untouched; `runCommand` never reaches them. Verified zero plugin/hook files are in the diff.

## Changes
- `packages/testing/src/unit.zig` — 2-arg signature; `RunConfig`/`ContextTypeFor` drop `plugins`; `@compileError` for `anytype`; ~13 in-file test-command fixtures converted to concrete `*Ctx`.
- `projects/zcli/src/commands/guide.zig` — the `testing` topic examples.
- `projects/zcli/src/commands/add/_generate.zig` — scaffold stub → 2-arg; drift assertion tightened to `runCommand(@This(), .{});`.
- `projects/zcli/test/e2e.zig` — the three generated-project test bodies.
- `README.md`, `docs/TESTING.md` — examples + the API-reference table (dropped the `plugins` param, documented the `.plugins` config field).

## Verification
- `packages/testing`: all 12 `runCommand` tests pass.
- `projects/zcli`: `zig build` + `zig build test` green (compiles the guide topic + the `_generate` scaffold-string assertion).
- `zig fmt --check packages projects examples build.zig` clean.
- **Generated-project dogfood**: built HEAD `zcli`, `init`'d a temp app, repointed `.zcli` at the local tree, `zcli add command greet` → emitted stub uses the 2-arg form; added a `verbose` plugin + a command reading `context.plugins.verbose` with a 2-arg `.plugins` test → `zig build test` passed; runtime confirmed (`--verbose` drives the stderr diagnostic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)