### PR TITLE
testing: make commands that use zcli_secrets runCommand-testable

### DIFF
--- a/packages/core/src/build_utils/command_tests.zig
+++ b/packages/core/src/build_utils/command_tests.zig
@@ -41,28 +41,52 @@ pub fn addCommandTests(
     const shared_modules: []const SharedModule =
         if (@hasField(@TypeOf(config), "shared_modules")) config.shared_modules else &.{};
 
-    // Discover the project's local plugins so the stub Context includes them:
-    // a command that reads `context.plugins.<id>` then compiles under test, and
-    // a runCommand test can drive that plugin's state via `.plugins`.
+    // Plugins visible to the command-test stub Context, so a command that reads
+    // `context.plugins.<id>` compiles and a runCommand test can drive it via
+    // `.plugins`. Two sources:
+    //   - the project's local plugins (src/plugins/, discovered);
+    //   - an in-memory `zcli_secrets` — so a command that uses secure storage is
+    //     unit-testable without touching the OS keychain (or linking a native
+    //     backend). The real keychain plugin is what the app links and runs; this
+    //     stands in only for `zig build test`.
     const plugins_dir: ?[]const u8 =
         if (@hasField(@TypeOf(config), "plugins_dir")) config.plugins_dir else null;
     const local_plugins: []const PluginInfo =
         if (plugins_dir) |dir| plugin_system.scanLocalPlugins(b, dir) catch &.{} else &.{};
 
+    var stub_plugins = std.ArrayList(*std.Build.Module).empty;
+    defer stub_plugins.deinit(b.allocator);
+    for (local_plugins) |plugin| {
+        const pmod = b.addModule(b.fmt("cmdtest_plugin_{s}", .{plugin.name}), .{
+            // scanLocalPlugins always sets project_path for the plugins it returns.
+            .root_source_file = b.path(plugin.project_path.?),
+            .target = config.target,
+            .optimize = config.optimize,
+        });
+        pmod.addImport("zcli", zcli_module);
+        for (shared_modules) |sm| pmod.addImport(sm.name, sm.module);
+        stub_plugins.append(b.allocator, pmod) catch @panic("OOM");
+    }
+    stub_plugins.append(b.allocator, b.addModule("cmdtest_secrets_stub", .{
+        .root_source_file = zcli_dep.path("packages/core/src/plugins/zcli_secrets/test_backend.zig"),
+        .target = config.target,
+        .optimize = config.optimize,
+    })) catch @panic("OOM");
+
     // A stub `command_registry` module: commands reference
-    // `@import("command_registry").Context`, and a TestContext (over the local
-    // plugins) makes their execute() signatures callable from runCommand.
+    // `@import("command_registry").Context`, and a TestContext (over the plugins
+    // above) makes their execute() signatures callable from runCommand.
     var stub_aw = std.Io.Writer.Allocating.init(b.allocator);
     defer stub_aw.deinit();
     const w = &stub_aw.writer;
     w.writeAll("const zcli = @import(\"zcli\");\n") catch @panic("OOM");
-    for (local_plugins, 0..) |_, i| w.print("const plugin_{d} = @import(\"plugin_{d}\");\n", .{ i, i }) catch @panic("OOM");
+    for (stub_plugins.items, 0..) |_, i| w.print("const plugin_{d} = @import(\"plugin_{d}\");\n", .{ i, i }) catch @panic("OOM");
     w.writeAll("pub const Context = zcli.TestContext(&.{") catch @panic("OOM");
-    for (local_plugins, 0..) |_, i| {
+    for (stub_plugins.items, 0..) |_, i| {
         if (i != 0) w.writeAll(",") catch @panic("OOM");
         w.print(" plugin_{d}", .{i}) catch @panic("OOM");
     }
-    w.writeAll(if (local_plugins.len == 0) "});\n" else " });\n") catch @panic("OOM");
+    w.writeAll(" });\n") catch @panic("OOM");
 
     const wf = b.addWriteFiles();
     const stub_path = wf.add("command_registry.zig", b.dupe(stub_aw.written()));
@@ -72,19 +96,7 @@ pub fn addCommandTests(
         .optimize = config.optimize,
     });
     registry_stub.addImport("zcli", zcli_module);
-    // Wire each local plugin as a module the stub imports (with the same
-    // zcli + shared_modules a command gets, since a plugin may use them).
-    for (local_plugins, 0..) |plugin, i| {
-        const pmod = b.addModule(b.fmt("cmdtest_plugin_{d}", .{i}), .{
-            // scanLocalPlugins always sets project_path for the plugins it returns.
-            .root_source_file = b.path(plugin.project_path.?),
-            .target = config.target,
-            .optimize = config.optimize,
-        });
-        pmod.addImport("zcli", zcli_module);
-        for (shared_modules) |sm| pmod.addImport(sm.name, sm.module);
-        registry_stub.addImport(b.fmt("plugin_{d}", .{i}), pmod);
-    }
+    for (stub_plugins.items, 0..) |pmod, i| registry_stub.addImport(b.fmt("plugin_{d}", .{i}), pmod);
 
     const ctx = Ctx{
         .b = b,

--- a/packages/core/src/plugins/zcli_secrets/test_backend.zig
+++ b/packages/core/src/plugins/zcli_secrets/test_backend.zig
@@ -1,0 +1,52 @@
+//! In-memory `zcli_secrets` backend for `zig build test`.
+//!
+//! `addCommandTests` wires THIS into the command-test stub Context in place of
+//! the real keychain-backed plugin, so a command that calls
+//! `context.plugins.zcli_secrets.<op>(...)` is unit-testable via `runCommand`
+//! without touching the OS keychain (and without linking a native backend). Its
+//! public surface mirrors the real plugin's `plugin_id` + `ContextData`. The
+//! real plugin — and its live keychain round-trip test — are untouched.
+//!
+//! State lives process-globally (leaked via the page allocator), which is fine
+//! for a test binary: secrets set in one `runCommand` are visible to the next.
+
+const std = @import("std");
+
+pub const plugin_id = "zcli_secrets";
+
+const Entry = struct { service: []const u8, name: []const u8, value: []const u8 };
+var entries: std.ArrayListUnmanaged(Entry) = .empty;
+const store_alloc = std.heap.page_allocator;
+
+fn find(service: []const u8, name: []const u8) ?usize {
+    for (entries.items, 0..) |e, i| {
+        if (std.mem.eql(u8, e.service, service) and std.mem.eql(u8, e.name, name)) return i;
+    }
+    return null;
+}
+
+/// Mirrors the real plugin's ContextData: keyed by `(context.app_name, name)`.
+pub const ContextData = struct {
+    pub fn get(_: *ContextData, context: anytype, name: []const u8) !?[]const u8 {
+        if (find(context.app_name, name)) |i|
+            return try context.allocator.dupe(u8, entries.items[i].value);
+        return null;
+    }
+
+    pub fn set(_: *ContextData, context: anytype, name: []const u8, value: []const u8) !void {
+        const val = try store_alloc.dupe(u8, value);
+        if (find(context.app_name, name)) |i| {
+            entries.items[i].value = val;
+            return;
+        }
+        try entries.append(store_alloc, .{
+            .service = try store_alloc.dupe(u8, context.app_name),
+            .name = try store_alloc.dupe(u8, name),
+            .value = val,
+        });
+    }
+
+    pub fn delete(_: *ContextData, context: anytype, name: []const u8) !void {
+        if (find(context.app_name, name)) |i| _ = entries.orderedRemove(i);
+    }
+};

--- a/projects/zcli/src/commands/guide.zig
+++ b/projects/zcli/src/commands/guide.zig
@@ -293,6 +293,10 @@ const topics = [_]Topic{
         \\(reading an env var, an OAuth device-code exchange, ...) is your own command
         \\code (ADR-0003).
         \\
+        \\Testing: `runCommand` swaps an in-memory keychain for `zig build test`, so a
+        \\command that stores/reads secrets is unit-testable and its tests never touch
+        \\the real OS keychain (see `zcli guide testing`).
+        \\
         \\Worked example — examples/ghauth/src/commands/login.zig:
         \\
         ++ "\n" ++ examples.ghauth_login ++

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -1149,6 +1149,63 @@ test "a command's plugin state is testable via runCommand .plugins" {
     }
 }
 
+test "a command that uses zcli_secrets is runCommand-testable without the keychain" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    {
+        var r = try run(tmp.dir, &.{ zcli_exe, "init", "app" });
+        defer r.deinit();
+        try expectOk(r);
+    }
+
+    var proj = try tmp.dir.openDir(io, "app", .{});
+    defer proj.close(io);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const proj_abs = try tmpSubdirAbs(arena.allocator(), tmp, "app");
+    try pointDependencyAtLocalTree(proj, proj_abs);
+
+    // A command that reads a secret via the *builtin* zcli_secrets plugin, with
+    // a co-located test. addCommandTests wires an in-memory zcli_secrets into the
+    // test stub, so this compiles and its runCommand test runs without the real
+    // OS keychain (and without a native link) — even though secrets is a builtin,
+    // not a local src/plugins/ plugin. Before that, `context.plugins.zcli_secrets`
+    // didn't exist in the stub and the test wouldn't compile.
+    try proj.writeFile(io, .{
+        .sub_path = "src/commands/reveal.zig",
+        .data =
+        \\const std = @import("std");
+        \\const zcli = @import("zcli");
+        \\const Context = @import("command_registry").Context;
+        \\pub const meta = .{ .description = "reveal a stored secret" };
+        \\pub const Args = struct { name: []const u8 };
+        \\pub const Options = struct {};
+        \\pub fn execute(args: Args, _: Options, context: *Context) !void {
+        \\    const secret = (try context.plugins.zcli_secrets.get(context, args.name)) orelse
+        \\        return context.fail("no secret named '{s}'", .{args.name});
+        \\    try context.stdout().print("{s}\n", .{secret});
+        \\}
+        \\test "reveal: missing secret fails cleanly" {
+        \\    const zcli_testing = @import("zcli-testing");
+        \\    var r = try zcli_testing.runCommand(@This(), .{ .args = .{ .name = "absent" } });
+        \\    defer r.deinit();
+        \\    try std.testing.expect(!r.success);
+        \\    try std.testing.expect(r.err.? == error.CommandFailed);
+        \\    try std.testing.expect(std.mem.indexOf(u8, r.stderr, "no secret named 'absent'") != null);
+        \\}
+        \\
+        ,
+    });
+
+    {
+        var r = try run(proj, &.{ "zig", "build", "test" });
+        defer r.deinit();
+        try expectOk(r);
+    }
+}
+
 // ============================================================================
 // Layer 2 — interactive (PTY) tests
 // ============================================================================


### PR DESCRIPTION
## What

Closes a real hole that dogfood **pass 6** (a `zcli_secrets` secret keeper) surfaced, opened by #95.

#95 made **local** plugins (`src/plugins/`) testable by putting them in the `addCommandTests` stub Context. But **builtin** plugins — `zcli_secrets`, enabled via `generate()`'s plugin list rather than `plugins_dir` — were absent from the stub. So a command doing `context.plugins.zcli_secrets.get(...)` **failed to compile** in a `runCommand` test:

```
error: no field named 'zcli_secrets' in struct 'PluginDataType(&.{})'
```

The cold agent couldn't find the testing story and fell back to a compile-only `_ = @This()` test — which Zig lazily analyzes, so it silently passed *without even checking `execute()`*. Net: secrets-command behavior was effectively untestable.

## Fix

`addCommandTests` now always wires an **in-memory `zcli_secrets`** (`packages/core/src/plugins/zcli_secrets/test_backend.zig`) into the command-test stub Context. A secrets command therefore compiles under test, and its `runCommand` tests round-trip through an in-memory store — **never the real OS keychain, and with no native link**.

The real keychain plugin (and its live round-trip test, `secrets_live_test.zig`) are **untouched**. A `builtin.is_test` switch inside the real plugin would have hijacked that live test (it drives the same public API *as a test*), so the substitution is done at the build-graph level in the stub instead — leaving the shipped plugin exactly as-is.

## Verification

- **e2e** (new): a generated command that reads a secret via `context.plugins.zcli_secrets` + a co-located `runCommand` test (missing secret → `context.fail`) now builds green with `zig build test`, without the keychain. Reproduced locally against a real generated project; keychain confirmed untouched.
- `packages/core`, `packages/testing`, the `notes` example (local plugin + the fake secrets coexisting in one stub), and the meta-CLI all `zig build test` green.
- `zcli guide secrets` now notes that `runCommand` swaps an in-memory keychain, so secrets commands are testable.

## Scope

The stub always includes an (unused-if-absent) `zcli_secrets` field — harmless, and it means a secrets command is testable whether or not the project enabled the builtin. Other builtins whose `ContextData` a command reads (rare — `config`/`output`) are still not in the stub; a clean future generalization would thread the enabled builtin list into `addCommandTests`, but secrets is the one with the external side effect and the one dogfooding hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)