### PR TITLE
init: AGENTS.md opens with a forceful "run zcli guide first" step (B1)

### DIFF
--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -402,10 +402,15 @@ const agents_section = agents_begin ++
     \\
     \\## Building this CLI with zcli
     \\
+    \\**Start here: before writing or changing any code, run `zcli guide`.** It is the
+    \\version-matched source of truth for how to do everything in this project —
+    \\persistence, testing, errors, plugins, HTTP, and more. Reach for it first: don't
+    \\hand-roll what it documents, and don't read zcli's own source — `zcli guide
+    \\<topic>` has the worked, compile-checked example.
+    \\
     \\This project is built with [zcli](https://github.com/ryanhair/zcli): its command
-    \\structure *is* the files under `src/commands/`. For version-matched API detail and
-    \\worked examples, run **`zcli guide`** (and `zcli guide <topic>`) — it always matches
-    \\the exact zcli this project builds against.
+    \\structure *is* the files under `src/commands/`. `zcli guide` always matches the
+    \\exact zcli this project builds against.
     \\
     \\**The loop**
     \\


### PR DESCRIPTION
## What

Dogfood **pass 7** ran a *less-capable* agent (haiku) on a moderate task. It produced a working CLI but **bypassed the framework**: never used `zcli guide`, hand-rolled a fake `Context` instead of `runCommand`, and hand-rolled JSON instead of `std.json.fmt`. The whole ADR-0004 approach hinges on the agent *using* `zcli guide`, and a weaker agent defaulted to brute-forcing from base Zig + reading source the moment it hit friction reaching the guide.

This makes the scaffolded `AGENTS.md` **open with an imperative Start-here step** that reaches for `zcli guide` first and explicitly counters both failure modes: *"don't hand-roll what it documents, and don't read zcli's own source."*

Stays thin and drift-proof per ADR-0008 — it still only points at the version-matched guide and embeds **no** idioms.

## Why just this (B1)

It's the cheapest, most-principled option: zero drift, preserves the thin-AGENTS.md invariant, and can only help. We're deliberately *not* embedding idioms into `AGENTS.md` or shipping the guide as a file (which would reintroduce drift) off a single weak-agent run. Next step is a cleaner weak-agent experiment (with `zcli` on PATH, factoring out the harness artifact) to see whether B1 is enough; if not, we document Sonnet-level as the general capability floor.

## Verification

Meta-CLI `zig build test` + `zig fmt --check` clean; generated `AGENTS.md` renders the new opener.

🤖 Generated with [Claude Code](https://claude.com/claude-code)