### PR TITLE
ci: verify Zine tarball checksum before executing it in deploy-docs (grade2 fix 1)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -20,8 +20,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download Zine
+        # Verify before executing: this job holds the Cloudflare token and
+        # publishes install.sh, and GitHub release assets are mutable — a
+        # swapped tarball must fail the build, not run. Update the hash
+        # alongside the version when bumping Zine.
         run: |
           curl -fsSL -o zine.tar.xz https://github.com/kristoff-it/zine/releases/download/v0.11.3/x86_64-linux-musl.tar.xz
+          echo "c25e5372b8a5d2759f2b7e581aefb90c8019ff0056a230a97efe3c8edab3bc19  zine.tar.xz" | sha256sum -c -
           tar -xf zine.tar.xz
           mv zine website/zine
           chmod +x website/zine


### PR DESCRIPTION
First PR of the second grade pass (security finding #1, HIGH).

## Problem

`deploy-docs.yml` curls the Zine static-site generator from a third-party GitHub release with **no verification** and executes it — in the same job that:
1. holds `CLOUDFLARE_API_TOKEN`, and
2. copies `install.sh` into `website/public/` and deploys it to the site root.

GitHub release *assets* are mutable without the tag changing. An attacker with upstream release access could swap the v0.11.3 tarball for one that exfiltrates the token or rewrites `website/public/install.sh` before deploy — compromising the `curl -fsSL https://zcli.sh/install.sh | sh` channel for every future user. This is the single point where the installer's own mandatory-checksum discipline can be bypassed upstream.

## Fix

Pin the tarball to its SHA-256 (`c25e5372…bc19`, computed from the currently-published asset) and `sha256sum -c` before extracting or executing. A swapped asset now fails the build instead of running. A comment in the workflow notes the hash must be updated alongside the version when bumping Zine.

## Verification

- Downloaded the live asset and confirmed the hash matches what the workflow has been running.
- Workflow YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)