### PR TITLE
docs: sync the front door with 0.16 reality (grade2 fix 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ Deploying api to staging
 
 ---
 
+## Installing the zcli CLI
+
+```bash
+curl -fsSL https://zcli.sh/install.sh | sh
+```
+
+The `zcli` binary is the meta-CLI for working on zcli projects: `zcli init` scaffolds a new project, `add`/`rm`/`mv` manage commands and plugins, `tree` prints the command hierarchy, `dev` watches and rebuilds, `guide` teaches the framework's idioms, and `release` cuts releases. It's the fastest way to start — but the framework is an ordinary Zig dependency, so the manual setup below works too.
+
+---
+
 ## Quick Start
 
 ### 1. Add zcli to your project
@@ -80,10 +90,10 @@ pub fn build(b: *std.Build) !void {
     const zcli = @import("zcli");
     const cmd_registry = try zcli.generate(b, exe, zcli_dep, zcli_module, .{
         .commands_dir = "src/commands",
-        .plugins = &[_]zcli.PluginConfig{
-            .{ .name = "zcli_help", .path = "packages/core/src/plugins/zcli_help" },
-            .{ .name = "zcli_version", .path = "packages/core/src/plugins/zcli_version" },
-            .{ .name = "zcli_not_found", .path = "packages/core/src/plugins/zcli_not_found" },
+        .plugins = &.{
+            zcli.builtin(.help, .{}),
+            zcli.builtin(.version, .{}),
+            zcli.builtin(.not_found, .{}),
         },
         .app_name = "myapp",
         .app_description = "My CLI application",
@@ -98,13 +108,13 @@ pub fn build(b: *std.Build) !void {
 
 ```zig
 // src/main.zig
+const std = @import("std");
 const registry = @import("command_registry");
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
+pub fn main(init: std.process.Init) !void {
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
     var app = registry.init();
-    app.run(gpa.allocator()) catch |err| switch (err) {
+    app.run(init.gpa, init.io, init.environ_map, args) catch |err| switch (err) {
         error.CommandNotFound => std.process.exit(1),
         else => return err,
     };
@@ -206,7 +216,7 @@ pub const meta = .{ .description = "Manage users" };
 
 ## Plugins
 
-zcli ships with seven plugins. Add them in `build.zig`:
+zcli ships with eight plugins. Add them in `build.zig`:
 
 | Plugin | Provides | Default? |
 |--------|----------|----------|
@@ -216,6 +226,7 @@ zcli ships with seven plugins. Add them in `build.zig`:
 | **zcli_completions** | `completions generate/install/uninstall` for bash, zsh, fish | Optional |
 | **zcli_config** | Transparent config file loading (JSON, TOML, YAML) | Optional |
 | **zcli_output** | `--output` flag (json, table, plain) | Optional |
+| **zcli_secrets** | Opt-in credential storage in the OS keychain (get/set/delete) | Optional |
 | **zcli_github_upgrade** | `upgrade` command via GitHub releases | Optional |
 
 ### Plugin context data
@@ -258,12 +269,12 @@ The `zcli_config` plugin transparently loads option defaults from a config file.
 
 ```zig
 // In build.zig plugins:
-.{ .name = "zcli_config", .path = "packages/core/src/plugins/zcli_config" },
+zcli.builtin(.config, .{}),
 ```
 
 Config file discovery (by extension priority):
 1. `--config <path>` flag
-2. `./{app_name}.config.json` / `.toml` / `.yaml` / `.yml`
+2. `.{app_name}.config.json` / `.toml` / `.yaml` / `.yml` (in the current directory)
 3. `$XDG_CONFIG_HOME/{app_name}/config.json` / `.toml` / `.yaml` / `.yml`
 
 Values cascade: **CLI flags > command config > global config > struct defaults**.
@@ -361,23 +372,21 @@ All prompts fall back to line-based input when stdin is not a TTY. The `prefix` 
 ## Progress Indicators
 
 ```zig
-const zprogress = zcli.zprogress;
+const zprogress = zcli.zprogress;  // or @import("zprogress")
 
-// Spinner
-var spinner = zprogress.spinner(.{ .style = .dots });
-spinner.start("Loading...");
-// ... do work, call spinner.tick() in a loop ...
-spinner.succeed("Done!");      // ✔ Done!
-spinner.fail("Failed");        // ✖ Failed
-spinner.warn("Warning");       // ⚠ Warning
+// Spinner — indeterminate work
+var spinner = zprogress.spinner(io, .{ .style = .dots });
+spinner.start("Connecting to server...");
+spinner.setText("Uploading changes...");
+spinner.succeed("Synced successfully"); // or .fail() / .warn() / .info() / .stop()
 
-// Progress bar
-var bar = zprogress.progressBar(.{
-    .total = 100,
+// Progress bar — known total
+var bar = zprogress.progressBar(io, .{
+    .total = items.len,
     .show_eta = true,
-    .show_rate = true,
 });
-for (0..100) |i| {
+for (items, 0..) |item, i| {
+    process(item);
     bar.update(i + 1, null);
 }
 bar.finish();
@@ -390,9 +399,10 @@ bar.finish();
 ## Theming
 
 ```zig
-const ztheme = zcli.ztheme;
+const ztheme = zcli.ztheme;  // or @import("ztheme")
 
-var theme_ctx = ztheme.Theme.init(allocator);
+// In a zcli command you already have one: `context.theme`. Standalone:
+const theme_ctx = ztheme.Theme.init(init.environ_map, io);
 
 // Fluent API
 try ztheme.theme("Error").red().bold().render(writer, &theme_ctx);
@@ -453,10 +463,16 @@ test "deploy command" {
 ### Integration testing (subprocess)
 
 ```zig
+const std = @import("std");
 const testing = @import("zcli-testing");
 
 test "help flag" {
-    var result = try testing.runSubprocess(allocator, "./zig-out/bin/myapp", &.{"--help"});
+    var result = try testing.runSubprocess(
+        std.testing.allocator,
+        std.testing.io,
+        "./zig-out/bin/myapp",
+        &.{"--help"},
+    );
     defer result.deinit();
     try testing.expectExitCode(result, 0);
     try testing.expectContains(result.stdout, "USAGE:");
@@ -466,8 +482,9 @@ test "help flag" {
 ### Snapshot testing
 
 ```zig
-try testing.expectSnapshot(allocator, result.stdout, @src(), "help_output", .{});
-// Update: UPDATE_SNAPSHOTS=1 zig build test
+try testing.expectSnapshot(allocator, io, std.Io.Dir.cwd(), result.stdout, @src(), "help_output", .{});
+// Update snapshots by threading `.update = true` from a build option:
+// zig build test -Dupdate-snapshots
 ```
 
 ---
@@ -494,7 +511,7 @@ All packages work standalone — you can use `zinput`, `zprogress`, `ztheme`, or
 The [showcase](examples/showcase/) is a fully functional task tracker CLI that demonstrates every zcli feature:
 
 - **14 commands** with args, options, aliases, and nested groups
-- **Interactive prompts** — text, confirm, select, search, number, password, editor
+- **Interactive prompts** — text, confirm, select, search, number, editor
 - **Progress indicators** — spinners and progress bars
 - **Colored output** — status badges, themed formatting
 - **JSON persistence** — read/write tasks to disk

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -662,13 +662,14 @@ pub const commands = struct {
 
 **Plugin Registration:**
 
-Plugins are registered in build.zig and processed in order:
+Plugins are registered in build.zig:
 
 ```zig
 const cmd_registry = try zcli.generate(b, exe, zcli_dep, zcli_module, .{
     .plugins = &.{
-        .{ .name = "zcli_help", .path = "path/to/plugin" },      // First priority
-        .{ .name = "zcli_not_found", .path = "path/to/plugin" }, // Second priority
+        zcli.builtin(.help, .{}),
+        zcli.builtin(.not_found, .{}),
+        .{ .name = "my_plugin", .path = "src/plugins/my_plugin" }, // handrolled
     },
     // ... other config
 });
@@ -676,7 +677,7 @@ const cmd_registry = try zcli.generate(b, exe, zcli_dep, zcli_module, .{
 
 **Plugin Execution Order:**
 
-1. Plugins execute in registration order (no priority system)
+1. Plugins are sorted by priority at compile time — a plugin may declare `pub const priority: i32` (default 50); higher values run first, and ties keep registration order
 2. All `handleGlobalOption` hooks called for each global option
 3. All `preExecute` hooks called before command execution
 4. Command executes

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -20,19 +20,34 @@ pub const ZcliError = error{
     ArgumentMissingRequired,
     ArgumentInvalidValue,
     ArgumentTooMany,
-    
+
     // Option parsing errors
     OptionUnknown,
     OptionMissingValue,
     OptionInvalidValue,
     OptionBooleanWithValue,
     OptionDuplicate,
-    
-    // System errors
-    OutOfMemory,
-    
+
     // Command routing errors
     CommandNotFound,
+    SubcommandNotFound,
+
+    // Build-time errors
+    BuildCommandDiscoveryFailed,
+    BuildRegistryGenerationFailed,
+    BuildOutOfMemory,
+
+    // System errors
+    SystemOutOfMemory,
+    SystemFileNotFound,
+    SystemAccessDenied,
+
+    // Special cases
+    HelpRequested,
+    VersionRequested,
+
+    // Resource limits
+    ResourceLimitExceeded,
 };
 ```
 
@@ -52,8 +67,10 @@ When errors occur, zcli provides detailed diagnostic information through the `Zc
 Parse positional arguments into a struct:
 
 ```zig
-pub fn parseArgs(comptime ArgsType: type, args: []const []const u8) ZcliError!ArgsType
+pub fn parseArgs(comptime ArgsType: type, args: []const []const u8, diag: ?*?ZcliDiagnostic) ZcliError!ArgsType
 ```
+
+The final `diag` parameter is an optional out-parameter: pass `null` if you only need the error, or a `*?ZcliDiagnostic` to capture rich context about the failure (see [Diagnostic-Driven Error Messages](#diagnostic-driven-error-messages) below).
 
 **Example:**
 ```zig
@@ -62,7 +79,7 @@ const Args = struct {
     count: u32 = 1,
 };
 
-const parsed = parseArgs(Args, &.{"Alice", "42"}) catch |err| switch (err) {
+const parsed = parseArgs(Args, &.{"Alice", "42"}, null) catch |err| switch (err) {
     error.ArgumentMissingRequired => {
         std.debug.print("Missing required argument\n", .{});
         return;
@@ -86,6 +103,7 @@ pub fn parseOptions(
     comptime OptionsType: type,
     allocator: std.mem.Allocator,
     args: []const []const u8,
+    diag: ?*?ZcliDiagnostic,
 ) ZcliError!OptionsResult(OptionsType)
 ```
 
@@ -97,7 +115,7 @@ const Options = struct {
     files: [][]const u8 = &.{},
 };
 
-const result = parseOptions(Options, allocator, args) catch |err| switch (err) {
+const result = parseOptions(Options, allocator, args, null) catch |err| switch (err) {
     error.OptionUnknown => {
         std.debug.print("Unknown option provided\n", .{});
         return;
@@ -118,7 +136,7 @@ defer cleanupOptions(Options, result.options, allocator);
 ### Basic Pattern
 
 ```zig
-const parsed = parseOptions(Options, allocator, args) catch |err| {
+const parsed = parseOptions(Options, allocator, args, null) catch |err| {
     std.debug.print("Parse error: {}\n", .{err});
     std.process.exit(1);
 };
@@ -128,7 +146,7 @@ defer cleanupOptions(Options, parsed.options, allocator);
 ### Detailed Error Handling
 
 ```zig
-const parsed = parseOptions(Options, allocator, args) catch |err| switch (err) {
+const parsed = parseOptions(Options, allocator, args, null) catch |err| switch (err) {
     error.OptionUnknown => {
         std.debug.print("Unknown option. Run with --help for usage.\n", .{});
         std.process.exit(2);
@@ -141,13 +159,43 @@ const parsed = parseOptions(Options, allocator, args) catch |err| switch (err) {
         std.debug.print("Missing required argument. Run with --help for usage.\n", .{});
         std.process.exit(2);
     },
-    error.OutOfMemory => return error.OutOfMemory,
+    error.SystemOutOfMemory => return error.SystemOutOfMemory,
     else => {
         std.debug.print("Unexpected error: {}\n", .{err});
         std.process.exit(1);
     },
 };
 ```
+
+### Diagnostic-Driven Error Messages
+
+The `catch`-and-switch patterns above only know *which* error occurred. To tell the user *what* went wrong — which option, what value, what was expected — pass a diagnostic out-parameter and format it with `formatDiagnostic`:
+
+```zig
+var diag: ?zcli.ZcliDiagnostic = null;
+const result = parseOptions(Options, allocator, args, &diag) catch {
+    if (diag) |d| {
+        const msg = try zcli.formatDiagnostic(d, allocator);
+        defer allocator.free(msg);
+        std.debug.print("{s}\n", .{msg});
+    }
+    std.process.exit(2);
+};
+defer cleanupOptions(Options, result.options, allocator);
+```
+
+The formatted messages carry the full context, for example:
+
+```
+Missing required argument 'name' at position 1. Expected type: []const u8
+Invalid value 'abc' for option '--count'. Expected type: u32
+Boolean option '--verbose' does not accept a value (got 'yes')
+Unknown option '--verbos'
+Did you mean:
+  --verbose
+```
+
+`OptionUnknown` and `CommandNotFound` diagnostics include "did you mean?" suggestions computed by edit distance. This is exactly how the framework produces its own error output — commands get it for free.
 
 ## Framework Integration
 
@@ -157,7 +205,9 @@ When using the zcli framework, error handling is automatic:
 
 ```zig
 // In your command's execute function
-pub fn execute(args: Args, options: Options, context: *zcli.Context) !void {
+const Context = @import("command_registry").Context;
+
+pub fn execute(args: Args, options: Options, context: *Context) !void {
     // args and options are already parsed and validated
     // Any parsing errors were handled by the framework
     try context.stdout().print("Hello, {s}!\n", .{args.name});
@@ -175,8 +225,9 @@ The framework automatically:
 Commands can return errors which will be handled by the framework:
 
 ```zig
-pub fn execute(args: Args, options: Options, context: *zcli.Context) !void {
-    const file = std.fs.cwd().openFile(args.filename, .{}) catch |err| switch (err) {
+pub fn execute(args: Args, options: Options, context: *Context) !void {
+    const io = context.io;
+    const file = std.Io.Dir.cwd().openFile(io, args.filename, .{}) catch |err| switch (err) {
         error.FileNotFound => {
             try context.stderr().print("Error: File '{s}' not found\n", .{args.filename});
             return;
@@ -187,8 +238,8 @@ pub fn execute(args: Args, options: Options, context: *zcli.Context) !void {
         },
         else => return err, // Let framework handle unexpected errors
     };
-    defer file.close();
-    
+    defer file.close(io);
+
     // Process file...
 }
 ```
@@ -200,7 +251,7 @@ pub fn execute(args: Args, options: Options, context: *zcli.Context) !void {
 When using `parseOptions` directly, always clean up array options:
 
 ```zig
-const result = try parseOptions(Options, allocator, args);
+const result = try parseOptions(Options, allocator, args, null);
 defer cleanupOptions(Options, result.options, allocator);
 ```
 
@@ -225,9 +276,15 @@ Error contexts are lightweight and don't require explicit cleanup.
 
 ### Complete Command-Line Parser
 
+For standalone parsing outside the framework, the unified entry point re-exported at the package root is `zcli.parseCommandLine` — it handles positionals and options together in a single pass:
+
 ```zig
 const std = @import("std");
 const zcli = @import("zcli");
+
+const Args = struct {
+    input: []const u8,
+};
 
 const Options = struct {
     verbose: bool = false,
@@ -235,38 +292,33 @@ const Options = struct {
     threads: u32 = 1,
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
-    
-    const args = try std.process.argsAlloc(allocator);
-    defer std.process.argsFree(allocator, args);
-    
-    const result = zcli.parseOptions(Options, allocator, args[1..]) catch |err| switch (err) {
-        error.OptionUnknown => {
-            std.debug.print("Unknown option. Use --help for usage information.\n", .{});
-            std.process.exit(2);
-        },
-        error.OptionInvalidValue => {
-            std.debug.print("Invalid option value provided.\n", .{});
-            std.process.exit(2);
-        },
-        error.OutOfMemory => return error.OutOfMemory,
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
+
+    var diag: ?zcli.ZcliDiagnostic = null;
+    const result = zcli.parseCommandLine(Args, Options, null, allocator, init.environ_map, args[1..], &diag) catch |err| switch (err) {
+        error.SystemOutOfMemory => return error.SystemOutOfMemory,
         else => {
-            std.debug.print("Parse error: {}\n", .{err});
-            std.process.exit(1);
+            if (diag) |d| {
+                const msg = try zcli.formatDiagnostic(d, allocator);
+                defer allocator.free(msg);
+                std.debug.print("{s}\n", .{msg});
+            } else {
+                std.debug.print("Parse error: {}\n", .{err});
+            }
+            std.process.exit(2);
         },
     };
-    defer zcli.cleanupOptions(Options, result.options, allocator);
-    
+    defer result.deinit();
+
     if (result.options.verbose) {
         std.debug.print("Verbose mode enabled\n", .{});
     }
     if (result.options.output) |output| {
         std.debug.print("Output: {s}\n", .{output});
     }
-    std.debug.print("Threads: {}\n", .{result.options.threads});
+    std.debug.print("Input: {s}, threads: {}\n", .{ result.args.input, result.options.threads });
 }
 ```
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -175,6 +175,7 @@ const testing = @import("zcli-testing");
 test "help flag shows usage" {
     var result = try testing.runSubprocess(
         std.testing.allocator,
+        std.testing.io,
         "./zig-out/bin/myapp",
         &.{"--help"},
     );
@@ -188,6 +189,7 @@ test "help flag shows usage" {
 test "version flag" {
     var result = try testing.runSubprocess(
         std.testing.allocator,
+        std.testing.io,
         "./zig-out/bin/myapp",
         &.{"--version"},
     );
@@ -200,6 +202,7 @@ test "version flag" {
 test "unknown command shows suggestions" {
     var result = try testing.runSubprocess(
         std.testing.allocator,
+        std.testing.io,
         "./zig-out/bin/myapp",
         &.{"hlep"},
     );
@@ -233,6 +236,7 @@ Compare command output against saved golden files. Useful for verifying help tex
 test "help output matches snapshot" {
     var result = try testing.runSubprocess(
         std.testing.allocator,
+        std.testing.io,
         "./zig-out/bin/myapp",
         &.{"--help"},
     );

--- a/examples/showcase/README.md
+++ b/examples/showcase/README.md
@@ -1,0 +1,40 @@
+# showcase — the kitchen-sink example
+
+A fully functional task tracker CLI (`tasks`) that exercises every zcli
+feature in one app. Where [notes](../notes/), [repostat](../repostat/), and
+[ghauth](../ghauth/) each teach one idiom, this is the tour.
+
+```
+$ tasks init          # interactive project wizard
+$ tasks add "My task" # add via flags, or `tasks add` for the prompt flow
+$ tasks list          # colored, themed task list (alias: ls)
+$ tasks search        # type-to-filter search prompt
+$ tasks sync          # spinner + progress bar demo
+$ tasks sprint create # nested command group
+```
+
+What it demonstrates:
+
+- **14 commands** in `src/commands/` — args, options, aliases (`ls`, `rm`),
+  and a nested `sprint` group with its own `index.zig`.
+- **Six zinput prompt types** — text, confirm, select, number, search, and
+  editor (`init`, `add`, `edit`, `search`), each falling back to line input
+  when piped.
+- **zprogress** — spinners and progress bars in `sync` and `import`.
+- **ztheme** — semantic colors and status badges via `context.theme`.
+- **A shared module** — `src/store.zig` (JSON persistence to `tasks.json`)
+  registered once as a `shared_modules` entry in `build.zig`.
+- **Six built-in plugins** — `zcli.builtin(.help/.version/.not_found/
+  .completions/.output/.config, .{})`, including per-command defaults from
+  `.tasks.config.json`.
+- **Doc generation** — `zcli.generateDocs` writes markdown + HTML docs on
+  every build.
+- **Per-command unit tests** — `zcli.addCommandTests` wires each command
+  file's `test` blocks into `zig build test`.
+
+Run it:
+
+```
+zig build
+./zig-out/bin/tasks --help
+```

--- a/packages/markdown_fmt/README.md
+++ b/packages/markdown_fmt/README.md
@@ -52,8 +52,13 @@ All format specifiers are preserved: `{s}`, `{d}`, `{d:.2}`, `{x}`, etc.
 const std = @import("std");
 const md = @import("markdown_fmt");
 
-pub fn main() !void {
-    const stdout = std.io.getStdOut().writer();
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+
+    var stdout_buf: [4096]u8 = undefined;
+    var stdout_writer = std.Io.File.stdout().writer(io, &stdout_buf);
+    const stdout = &stdout_writer.interface;
+
     const fmt = md.formatter(stdout);
 
     // Headers
@@ -86,6 +91,9 @@ pub fn main() !void {
 
     // Semantic colors
     try fmt.write("<success>All tests passed!</success>\n", .{});
+
+    // Writers are buffered in Zig 0.16 — flush before exit.
+    try stdout.flush();
 }
 ````
 

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -26,7 +26,7 @@ The testing tiers ship with the zcli dependency — no separate dependency entry
 - **Unit**: `runCommand(Command, .{ .args = ..., .options = ... })` → `CommandResult` (`.stdout`, `.stderr`, `.success`, `.err`, `.term`)
 - **Integration**: `runSubprocess(allocator, io, exe_path, args)` → `Result` (`.stdout`, `.stderr`, `.exit_code`)
 - **Assertions**: `expectExitCode`, `expectExitCodeNot`, `expectContains`, `expectNotContains`, `expectEqualStrings`, `expectValidJson`, `expectStdoutEmpty`, `expectStderrEmpty`
-- **Snapshots**: `expectSnapshot(...)` against golden files, with `maskDynamicContent` (UUIDs, timestamps, addresses) and `stripAnsi`; update with `UPDATE_SNAPSHOTS=1`
+- **Snapshots**: `expectSnapshot(...)` against golden files, with `maskDynamicContent` (UUIDs, timestamps, addresses) and `stripAnsi`; update by threading `.update = true` from a build option (`zig build test -Dupdate-snapshots`)
 - **E2E**: `e2e.InteractiveScript` builder (`.expect`, `.send`, `.sendHidden`, `.sendControl`, `.sendSignal`, `.delay`, `.withTimeout`, `.optional`), executed by `e2e.runInteractive(...)` → `InteractiveResult` (`.exit_code`, `.output`, `.success`, `.transcript`); `runInteractiveDualMode` runs the same script with and without a PTY
 
 ## Quick taste

--- a/packages/zinput/README.md
+++ b/packages/zinput/README.md
@@ -33,7 +33,8 @@ exe.root_module.addImport("zinput", zinput_dep.module("zinput"));
 ```zig
 const zinput = @import("zinput");
 
-// Free-form text (returns owned ?[]const u8; null when the user submits nothing)
+// Free-form text (returns an owned []u8 — caller frees; empty submit returns
+// the default if set, otherwise an empty string)
 const title = try zinput.text(writer, reader, allocator, .{
     .message = "Task title:",
 });


### PR DESCRIPTION
Third PR of the grade2 pass — the docs/DX findings (HIGH #3 plus the LOW docs items).

## The pattern

Everything the earlier audit passes touched (DESIGN.md, BUILD.md, per-package READMEs, CONTRIBUTING, the init template) was verified accurate. The two things they skipped — **the root README's code blocks** and **docs/ERROR_HANDLING.md** — still showed pre-0.16 APIs. The README is the first thing a new user reads, and its quickstart main.zig did not compile.

## Fixes (every snippet verified against source, mostly copied from already-correct places)

- **README quickstart main.zig**: now the init template's `pub fn main(init: std.process.Init)` + `app.run(init.gpa, init.io, init.environ_map, args)` — was 1-arg `app.run(gpa.allocator())` with no `std` import.
- **README snippets**: `Theme.init(env, io)`, `spinner(io, ...)`, 4-arg `runSubprocess`, 7-arg `expectSnapshot`, `zig build test -Dupdate-snapshots` (the `UPDATE_SNAPSHOTS=1` env var never existed — also fixed in packages/testing/README.md where the self-check grep caught it).
- **README structure**: quickstart teaches `zcli.builtin(.help, .{})` like the init template (was raw `packages/core/src/plugins/...` paths that bake in framework-internal layout); plugin count 7→8 with the missing **zcli_secrets** row; config filename `.{app_name}.config.json` gets its leading dot (matches plugin.zig:228); new short "Installing the zcli CLI" section with the install one-liner and the meta-CLI command list.
- **docs/ERROR_HANDLING.md**: full 0.16 pass — `diag: ?*?ZcliDiagnostic` on the parse APIs, io-threaded fs examples, and the closing example now uses `zcli.parseCommandLine` (7-arg, verified) because `parseArgs`/`parseOptions` are **not** package-root exports; added a diagnostic-formatting section showing real `formatDiagnostic` output.
- **docs/TESTING.md**: the four `runSubprocess` examples gain `io`.
- **docs/DESIGN.md §11**: plugins are comptime **priority-sorted** (default 50, stable ties in registration order — verified against registry.zig's strict-`<` bubble sort and plugin_types.zig), not "registration order, no priority system".
- **packages/markdown_fmt/README.md**: removed-API `std.io.getStdOut()` → 0.16 writer pattern. **packages/zinput/README.md**: `text` returns `![]u8`, never null.
- **examples/showcase/README.md**: new, matching its three siblings (and the root README's showcase bullet no longer claims a nonexistent `password` prompt).

## Found along the way (deferred — source comments, not docs)

Three stale *doc comments in .zig files* kept out of this docs-only PR: `args.zig:56` / `options/parser.zig:74` claim `zcli.parseArgs`/`zcli.parseOptions` exports that don't exist, `zcli.zig`'s `parseCommandLine` doc comment shows a 6-arg call missing `diag`, and `zcli_config/plugin.zig:12` writes the config filename without its leading dot. Queued for the next code PR.

## Verification

Self-check grep for `getStdOut|std.fs.cwd()|gpa.allocator()|UPDATE_SNAPSHOTS|GeneralPurposeAllocator|argsAlloc` across README.md, docs/, and all package/example READMEs: clean. Signatures spot-checked against command_parser.zig:50, diagnostic_errors.zig:168, capability.zig:101, zprogress.zig:535, runner.zig:45, snapshot.zig:22, plugin_types.zig (default priority 50), zcli_config/plugin.zig:225-248.

🤖 Generated with [Claude Code](https://claude.com/claude-code)