### PR TITLE
ci: gate releases on tests, smoke-run artifacts, pin actions to SHAs (grade2 fix 4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Zig
-        uses: mlugg/setup-zig@v2
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.16.0
 
@@ -32,10 +32,10 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Zig
-        uses: mlugg/setup-zig@v2
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.16.0
 
@@ -49,10 +49,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Zig
-        uses: mlugg/setup-zig@v2
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.16.0
 
@@ -87,10 +87,10 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Zig
-        uses: mlugg/setup-zig@v2
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.16.0
 
@@ -153,10 +153,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Zig
-        uses: mlugg/setup-zig@v2
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.16.0
 
@@ -184,10 +184,10 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Zig
-        uses: mlugg/setup-zig@v2
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.16.0
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Download Zine
         run: |
@@ -37,7 +37,7 @@ jobs:
         run: cp install.sh website/public/install.sh
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,42 @@ on:
       - "*-v*"  # CLI releases (e.g., zcli-v0.9.0)
       - "v*"    # Library releases (e.g., v0.9.0)
 
+# Only the jobs that publish get write access.
+permissions:
+  contents: read
+
 jobs:
+  # Nothing enforces that a tag points at a commit that passed CI, so the
+  # release gates on the same unit + e2e coverage CI runs. A bad tag must
+  # fail here, not ship.
+  test:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    if: startsWith(github.ref, 'refs/tags/zcli-v')
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: 0.16.0
+
+      - name: Run unit tests
+        run: zig build test
+
+      - name: Run e2e tests
+        working-directory: projects/zcli
+        run: zig build e2e
+
   build:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    needs: test
     # Only build binaries for CLI releases (zcli-v*)
     if: startsWith(github.ref, 'refs/tags/zcli-v')
     strategy:
@@ -18,6 +50,7 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-linux
             zig_target: x86_64-linux-musl
+            smoke: true # static musl binary runs on the x64 runner
           - os: ubuntu-latest
             target: aarch64-linux
             zig_target: aarch64-linux-musl
@@ -27,6 +60,7 @@ jobs:
           - os: macos-latest
             target: aarch64-macos
             zig_target: aarch64-macos
+            smoke: true # macos-latest runners are arm64
           - os: ubuntu-latest
             target: x86_64-windows
             zig_target: x86_64-windows
@@ -36,10 +70,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Zig
-        uses: mlugg/setup-zig@v2
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.16.0
 
@@ -60,6 +94,16 @@ jobs:
             chmod +x dist/zcli-${{ matrix.target }}
           fi
 
+      # Prove the artifact we're about to publish actually starts, on the
+      # targets the runner can execute natively. Mirrors ci.yml's Windows
+      # smoke test.
+      - name: Smoke test the binary
+        if: matrix.smoke
+        working-directory: projects/zcli
+        run: |
+          ./dist/zcli-${{ matrix.target }} --version
+          ./dist/zcli-${{ matrix.target }} --help
+
       - name: Generate checksum
         shell: bash
         run: |
@@ -71,7 +115,7 @@ jobs:
           fi
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: zcli-${{ matrix.target }}
           path: projects/zcli/dist/zcli-${{ matrix.target }}*
@@ -87,10 +131,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: dist
 
@@ -109,7 +153,7 @@ jobs:
           rm *.sha256
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           files: release/*
           generate_release_notes: true
@@ -128,7 +172,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Extract version from tag
         id: version
@@ -181,7 +225,7 @@ jobs:
           EOF
 
       - name: Create Library Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           body_path: release-notes.md
           name: zcli Framework v${{ steps.version.outputs.version }}


### PR DESCRIPTION
Fourth PR of the grade2 pass — the release-pipeline findings (MEDIUM, from both the security and testing reviews).

## Problems

1. **Releases shipped untested.** release.yml triggered on tag push with no `needs:` on any test job — a tag pointing at a commit that never passed CI would build and publish. The natively-built binaries were also never executed before upload.
2. **Mutable action pins in a `contents: write` job.** Every third-party action was pinned by major tag. The release job publishes the exact binaries + `checksums.txt` that install.sh and the self-upgrade plugin verify against — a maliciously retagged action could substitute artifacts that downstream checksum verification would then happily validate. `softprops/action-gh-release@v1` was additionally an old, unmaintained line.

## Changes

- **Test gate**: new `test` job (ubuntu + macos) running the root unit suite and the projects/zcli e2e suite — the same coverage ci.yml runs — with `build` (and transitively `release`) gated behind it.
- **Smoke-run**: the two artifacts the runners can execute natively (x86_64-linux musl on the x64 runner, aarch64-macos on the arm64 runner) run `--version` and `--help` before checksum/upload, mirroring ci.yml's existing Windows smoke test.
- **SHA pinning**: all 22 `uses:` sites across ci.yml / release.yml / deploy-docs.yml pinned to full commit SHAs with `# vX.Y.Z` comments (resolved from what each tag points at today): checkout v4.3.1, setup-zig v2.2.1, upload/download-artifact v4.6.2/v4.3.0, wrangler-action v3.15.0, and action-gh-release bumped v1 → **v2.6.2** (inputs unchanged).
- **Least privilege**: workflow-level `permissions: contents: read`; only the two publishing jobs keep `contents: write`.

## Verification

- All three YAMLs parse.
- gh-release v2 input compatibility checked (`files`, `body_path`, `name`, `generate_release_notes`, `draft`, `prerelease` all supported).
- Note: this touches the same file as #108 (deploy-docs.yml) in different hunks — whichever merges second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)