### PR TITLE
fix(codegen): escape generated string literals; validate init project name (grade2 fix 5)

### DIFF
--- a/packages/core/src/build_utils/code_generation.zig
+++ b/packages/core/src/build_utils/code_generation.zig
@@ -88,7 +88,7 @@ fn generateGroupImports(writer: anytype, _: []const u8, group_info: *const Comma
 
                 for (subcmd_info.path) |part| {
                     const sanitized_part = try sanitizeIdentifier(subcommands.allocator, part);
-                    defer if (sanitized_part.ptr != part.ptr) subcommands.allocator.free(sanitized_part);
+                    defer subcommands.allocator.free(sanitized_part);
                     try module_name_parts.append(subcommands.allocator, try subcommands.allocator.dupe(u8, sanitized_part));
                 }
 
@@ -117,7 +117,7 @@ fn generateGroupImports(writer: anytype, _: []const u8, group_info: *const Comma
 
                 for (subcmd_info.path) |part| {
                     const sanitized_part = try sanitizeIdentifier(subcommands.allocator, part);
-                    defer if (sanitized_part.ptr != part.ptr) subcommands.allocator.free(sanitized_part);
+                    defer subcommands.allocator.free(sanitized_part);
                     try module_name_parts.append(subcommands.allocator, try subcommands.allocator.dupe(u8, sanitized_part));
                 }
 
@@ -139,7 +139,7 @@ fn generateGroupImports(writer: anytype, _: []const u8, group_info: *const Comma
 fn generatePluginImports(writer: anytype, plugins: []const PluginInfo, allocator: std.mem.Allocator) !void {
     for (plugins) |plugin_info| {
         const plugin_var_name = try pluginVarName(allocator, plugin_info.name);
-        defer if (plugin_var_name.ptr != plugin_info.name.ptr) allocator.free(plugin_var_name);
+        defer allocator.free(plugin_var_name);
 
         if (plugin_info.init) |init_code| {
             // Plugin has initialization code - call it on import
@@ -154,8 +154,27 @@ fn generatePluginImports(writer: anytype, plugins: []const PluginInfo, allocator
     }
 }
 
+/// Render `s` escaped for the inside of a double-quoted Zig string literal.
+/// App metadata comes from build.zig and command paths from the filesystem —
+/// a quote, backslash, or newline in them must not break out of (or inject
+/// code after) the generated literal.
+fn escapeStringLiteral(allocator: std.mem.Allocator, s: []const u8) ![]u8 {
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    try std.zig.stringEscape(s, &aw.writer);
+    var al = aw.toArrayList();
+    return al.toOwnedSlice(allocator);
+}
+
 /// Generate the simple comptime registry
 fn generateSimpleRegistry(writer: anytype, commands: DiscoveredCommands, config: BuildConfig, plugins: []const PluginInfo, allocator: std.mem.Allocator) !void {
+    const app_name = try escapeStringLiteral(allocator, config.app_name);
+    defer allocator.free(app_name);
+    const app_version = try escapeStringLiteral(allocator, config.app_version);
+    defer allocator.free(app_version);
+    const app_description = try escapeStringLiteral(allocator, config.app_description);
+    defer allocator.free(app_description);
+
     // Generate the registry type (private)
     try writer.print(
         \\const RegistryType = zcli.Registry.init(.{{
@@ -163,7 +182,7 @@ fn generateSimpleRegistry(writer: anytype, commands: DiscoveredCommands, config:
         \\    .app_version = "{s}",
         \\    .app_description = "{s}",
         \\}})
-    , .{ config.app_name, config.app_version, config.app_description });
+    , .{ app_name, app_version, app_description });
 
     // Register commands
     try generateCommandRegistrations(writer, commands, allocator);
@@ -187,7 +206,7 @@ fn generateSimpleRegistry(writer: anytype, commands: DiscoveredCommands, config:
         \\    return RegistryType.init();
         \\}}
         \\
-    , .{ config.app_name, config.app_version, config.app_description });
+    , .{ app_name, app_version, app_description });
 }
 
 /// Generate metadata for pure command groups
@@ -212,7 +231,9 @@ fn generatePureGroupsFromMap(writer: anytype, command_map: *const std.StringHash
             try writer.writeAll("    &.{");
             for (cmd_info.path, 0..) |component, idx| {
                 if (idx > 0) try writer.writeAll(", ");
-                try writer.print("\"{s}\"", .{component});
+                const component_lit = try escapeStringLiteral(allocator, component);
+                defer allocator.free(component_lit);
+                try writer.print("\"{s}\"", .{component_lit});
             }
             try writer.writeAll("},\n");
         }
@@ -239,8 +260,10 @@ fn generateCommandRegistrations(writer: anytype, commands: DiscoveredCommands, a
 
                 const command_path_str = try std.mem.join(allocator, " ", cmd_info.path);
                 defer allocator.free(command_path_str);
+                const command_path_lit = try escapeStringLiteral(allocator, command_path_str);
+                defer allocator.free(command_path_lit);
 
-                try writer.print("\n    .register(\"{s}\", {s})", .{ command_path_str, module_name });
+                try writer.print("\n    .register(\"{s}\", {s})", .{ command_path_lit, module_name });
             }
             // Register subcommands
             try generateGroupRegistrations(writer, cmd_name, &cmd_info, allocator);
@@ -254,8 +277,10 @@ fn generateCommandRegistrations(writer: anytype, commands: DiscoveredCommands, a
             // Use the actual command path from CommandInfo (it's now an array)
             const command_path_str = try std.mem.join(allocator, " ", cmd_info.path);
             defer allocator.free(command_path_str);
+            const command_path_lit = try escapeStringLiteral(allocator, command_path_str);
+            defer allocator.free(command_path_lit);
 
-            try writer.print("\n    .register(\"{s}\", {s})", .{ command_path_str, module_name });
+            try writer.print("\n    .register(\"{s}\", {s})", .{ command_path_lit, module_name });
         }
     }
 }
@@ -275,7 +300,7 @@ fn generateGroupRegistrations(writer: anytype, _: []const u8, group_info: *const
 
                 for (subcmd_info.path) |part| {
                     const sanitized_part = try sanitizeIdentifier(allocator, part);
-                    defer if (sanitized_part.ptr != part.ptr) allocator.free(sanitized_part);
+                    defer allocator.free(sanitized_part);
                     try module_name_parts.append(allocator, try allocator.dupe(u8, sanitized_part));
                 }
 
@@ -292,8 +317,10 @@ fn generateGroupRegistrations(writer: anytype, _: []const u8, group_info: *const
 
                 const command_path_str = try std.mem.join(allocator, " ", subcmd_info.path);
                 defer allocator.free(command_path_str);
+                const command_path_lit = try escapeStringLiteral(allocator, command_path_str);
+                defer allocator.free(command_path_lit);
 
-                try writer.print("\n    .register(\"{s}\", {s})", .{ command_path_str, module_name_with_index });
+                try writer.print("\n    .register(\"{s}\", {s})", .{ command_path_lit, module_name_with_index });
 
                 // Also recurse for its subcommands
                 try generateGroupRegistrations(writer, subcmd_name, &subcmd_info, allocator);
@@ -307,7 +334,7 @@ fn generateGroupRegistrations(writer: anytype, _: []const u8, group_info: *const
 
                 for (subcmd_info.path) |part| {
                     const sanitized_part = try sanitizeIdentifier(allocator, part);
-                    defer if (sanitized_part.ptr != part.ptr) allocator.free(sanitized_part);
+                    defer allocator.free(sanitized_part);
                     try module_name_parts.append(allocator, try allocator.dupe(u8, sanitized_part));
                 }
 
@@ -322,8 +349,10 @@ fn generateGroupRegistrations(writer: anytype, _: []const u8, group_info: *const
                 // Use the actual command path from the CommandInfo (it's now an array)
                 const command_path_str = try std.mem.join(allocator, " ", subcmd_info.path);
                 defer allocator.free(command_path_str);
+                const command_path_lit = try escapeStringLiteral(allocator, command_path_str);
+                defer allocator.free(command_path_lit);
 
-                try writer.print("\n    .register(\"{s}\", {s})", .{ command_path_str, module_name });
+                try writer.print("\n    .register(\"{s}\", {s})", .{ command_path_lit, module_name });
             }
         }
     }
@@ -333,20 +362,23 @@ fn generateGroupRegistrations(writer: anytype, _: []const u8, group_info: *const
 fn generatePluginRegistrations(writer: anytype, plugins: []const PluginInfo, allocator: std.mem.Allocator) !void {
     for (plugins) |plugin_info| {
         const plugin_var_name = try pluginVarName(allocator, plugin_info.name);
-        defer if (plugin_var_name.ptr != plugin_info.name.ptr) allocator.free(plugin_var_name);
+        defer allocator.free(plugin_var_name);
 
         try writer.print("\n    .registerPlugin({s})", .{plugin_var_name});
     }
 }
 
-/// Convert plugin name to valid Zig variable name (replace hyphens with underscores)
-fn pluginVarName(allocator: std.mem.Allocator, plugin_name: []const u8) ![]const u8 {
-    return std.mem.replaceOwned(u8, allocator, plugin_name, "-", "_") catch plugin_name;
+/// Convert plugin name to valid Zig variable name (replace hyphens with
+/// underscores). Always returns an allocation the caller owns — the previous
+/// `catch plugin_name` swallowed OOM and emitted the unsanitized name.
+fn pluginVarName(allocator: std.mem.Allocator, plugin_name: []const u8) ![]u8 {
+    return std.mem.replaceOwned(u8, allocator, plugin_name, "-", "_");
 }
 
-/// Sanitize command name to valid Zig identifier (replace hyphens with underscores)
-fn sanitizeIdentifier(allocator: std.mem.Allocator, name: []const u8) ![]const u8 {
-    return std.mem.replaceOwned(u8, allocator, name, "-", "_") catch name;
+/// Sanitize command name to valid Zig identifier (replace hyphens with
+/// underscores). Always returns an allocation the caller owns.
+fn sanitizeIdentifier(allocator: std.mem.Allocator, name: []const u8) ![]u8 {
+    return std.mem.replaceOwned(u8, allocator, name, "-", "_");
 }
 
 // ============================================================================
@@ -392,6 +424,33 @@ const PluginTestHelper = struct {
         });
     }
 };
+
+test "app metadata is escaped into valid string literals" {
+    const allocator = std.testing.allocator;
+
+    var commands = DiscoveredCommands{
+        .allocator = allocator,
+        .root = std.StringHashMap(CommandInfo).init(allocator),
+    };
+    defer commands.deinit();
+
+    const config = BuildConfig{
+        .commands_dir = "src/commands",
+        .plugins_dir = null,
+        .plugins = &.{},
+        .app_name = "my-app",
+        .app_version = "1.0.0",
+        .app_description = "say \"hi\"\nback\\slash",
+    };
+
+    const source = try generateComptimeRegistrySource(allocator, commands, config, &.{});
+    defer allocator.free(source);
+
+    // Quote, newline, and backslash must all be escaped inside the literal —
+    // an unescaped one terminates the string and injects the rest as code.
+    try std.testing.expect(std.mem.indexOf(u8, source, ".app_description = \"say \\\"hi\\\"\\nback\\\\slash\",") != null);
+    try std.testing.expect(std.mem.indexOf(u8, source, "\"say \"hi\"") == null);
+}
 
 test "plugin registry generation with imports" {
     const allocator = std.testing.allocator;

--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -72,6 +72,19 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
     } else try allocator.dupe(u8, args.name);
     defer allocator.free(project_name);
 
+    // The name lands in generated Zig/zon source (`.name = .{s}`,
+    // `.app_name = "{s}"`) and becomes the directory and executable name —
+    // restrict it to identifier-safe characters up front rather than escaping
+    // it into every context separately.
+    if (project_name.len == 0 or std.ascii.isDigit(project_name[0])) {
+        return context.fail("Error: Invalid project name '{s}'\n  Names must be non-empty and must not start with a digit", .{project_name});
+    }
+    for (project_name) |c| {
+        if (!std.ascii.isAlphanumeric(c) and c != '-' and c != '_') {
+            return context.fail("Error: Invalid project name '{s}'\n  Use only letters, digits, '-' and '_'", .{project_name});
+        }
+    }
+
     // Create a sanitized identifier-safe version (replace dashes with underscores)
     const project_identifier = blk: {
         var sanitized = try allocator.alloc(u8, project_name.len);
@@ -82,8 +95,13 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
     };
     defer allocator.free(project_identifier);
 
-    const app_description = options.description orelse "A CLI application built with zcli";
-    const app_version = options.version orelse "0.1.0";
+    // Free-text options are embedded in generated string literals — escape so
+    // `--description 'say "hi"'` scaffolds a project that still compiles
+    // instead of breaking (or injecting code into) build.zig / build.zig.zon.
+    const app_description = try escapeStringLiteral(allocator, options.description orelse "A CLI application built with zcli");
+    defer allocator.free(app_description);
+    const app_version = try escapeStringLiteral(allocator, options.version orelse "0.1.0");
+    defer allocator.free(app_version);
 
     // Validate the target directory before prompting or creating anything, so we
     // never leave a half-created project behind if validation fails or the user
@@ -447,6 +465,23 @@ const AgentsResult = enum { created, appended, refreshed };
 /// content: create the file if absent, replace the marker-delimited block if it
 /// exists (an idempotent re-run / upgrade), or append it if the file exists but
 /// has no zcli section yet.
+/// Render `s` escaped for the inside of a double-quoted Zig/zon string
+/// literal (same rule as the registry codegen's escapeStringLiteral).
+fn escapeStringLiteral(allocator: std.mem.Allocator, s: []const u8) ![]u8 {
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    try std.zig.stringEscape(s, &aw.writer);
+    var al = aw.toArrayList();
+    return al.toOwnedSlice(allocator);
+}
+
+test "escapeStringLiteral escapes quotes, backslashes, and newlines" {
+    const allocator = std.testing.allocator;
+    const escaped = try escapeStringLiteral(allocator, "say \"hi\"\nback\\slash");
+    defer allocator.free(escaped);
+    try std.testing.expectEqualStrings("say \\\"hi\\\"\\nback\\\\slash", escaped);
+}
+
 fn scaffoldAgentsMd(allocator: std.mem.Allocator, io: std.Io, dir: std.Io.Dir) !AgentsResult {
     const existing = dir.readFileAlloc(io, "AGENTS.md", allocator, .limited(4 * 1024 * 1024)) catch |err| switch (err) {
         error.FileNotFound => {

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -171,6 +171,39 @@ test "init scaffolds a project with the expected files and wiring" {
     try expectContains(agents, "per-command arena");
 }
 
+test "init escapes free-text --description into a valid string literal" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--description", "say \"hi\"\\back" });
+    defer r.deinit();
+    try expectOk(r);
+
+    var proj = try tmp.dir.openDir(io, "myapp", .{});
+    defer proj.close(io);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // The quote and backslash must be escaped — unescaped, the literal
+    // terminates early and the generated build.zig doesn't compile.
+    const build_zig = try readFile(proj, a, "build.zig");
+    try expectContains(build_zig, ".app_description = \"say \\\"hi\\\"\\\\back\"");
+}
+
+test "init rejects a project name that would break generated source" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "bad\"name" });
+    defer r.deinit();
+    try testing.expect(r.exit_code != 0);
+    try expectContains(r.stderr, "Invalid project name");
+    // Nothing half-created is left behind.
+    try testing.expect(!fileExists(tmp.dir, "bad\"name"));
+}
+
 test "init . scaffolds into the current directory" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();


### PR DESCRIPTION
Fifth PR of the grade2 pass (MEDIUM finding from the Zig-idioms review, plus the related OOM-swallow LOW).

## Problem

`code_generation.zig` emitted app metadata and command paths into generated Zig source with bare `{s}`, and `init.zig` did the same with `--description` into the scaffolded build.zig. `zcli init my-app --description 'say "hi"'` produced a project that doesn't compile; more generally, a quote/backslash/newline in any emitted literal terminates the string and the remainder is parsed as code.

## Changes

- **Escaping**: new private `escapeStringLiteral` (wraps 0.16's `std.zig.stringEscape`) applied to every data-carrying literal the generator emits: `.app_name`/`.app_version`/`.app_description` (both blocks), all four `.register("<path>", ...)` sites, and pure-group path components. Same helper in init.zig for `--description`/`--version` into the generated build.zig/zon.
- **init name validation**: the project name becomes a zon enum literal (`.name = .myapp`), a directory, and an exe name — escaping can't make a bad name work, so init now rejects non-identifier-safe names up front (letters/digits/`-`/`_`, no leading digit) with a clear message. Note: `zcli init .` in a directory whose *name* is identifier-unsafe now fails with that message instead of silently generating a broken build.zig.zon — a behavior change in the honest direction.
- **OOM-swallow fix**: `pluginVarName`/`sanitizeIdentifier` did `replaceOwned(...) catch plugin_name` — on OOM they'd emit the *unsanitized* (invalid-identifier) name. They now propagate errors and always return an owned slice, which also deletes the fragile `if (x.ptr != y.ptr) free` ownership dance at all six call sites.

## Tests

- `code_generation.zig`: new test proving quote/newline/backslash in app metadata land escaped and the raw sequence is absent.
- `init.zig`: unit test for the escape helper.
- e2e: two new tests — `--description 'say "hi"\back'` scaffolds with the escaped literal in build.zig, and `init 'bad"name'` fails cleanly leaving nothing behind.
- Local: `zig build test-core` **982/982**, projects/zcli `zig build test` **58/58**. The local e2e run got interrupted — **relying on CI's e2e jobs (ubuntu+macos) for the e2e tier on this PR**; will follow up if they flag anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)