### PR TITLE
fix: small correctness batch — vterm split-write UTF-8, dev child cleanup, parser edges (grade2 fix 7a)

### DIFF
--- a/packages/core/src/args.zig
+++ b/packages/core/src/args.zig
@@ -53,7 +53,9 @@ pub const ZcliDiagnostic = diagnostic_errors.ZcliDiagnostic;
 /// };
 ///
 /// const args = [_][]const u8{ "Alice", "25", "true" };
-/// const parsed = try zcli.parseArgs(Args, &args, null);
+/// // Not re-exported at the package root — reachable via zcli.parseCommandLine,
+/// // or directly as parseArgs within this module:
+/// const parsed = try parseArgs(Args, &args, null);
 /// // parsed.name = "Alice", parsed.age = 25, parsed.verbose = true
 /// ```
 ///

--- a/packages/core/src/build_utils/command_discovery.zig
+++ b/packages/core/src/build_utils/command_discovery.zig
@@ -55,10 +55,12 @@ fn scanDirectory(
 ) !void {
     // Prevent excessive nesting
     if (depth >= max_depth) {
-        // Convert path array to string for logging
-        const path_string = if (current_path.len == 0) "" else std.mem.join(allocator, "/", current_path) catch "unknown";
-        defer if (current_path.len > 0) allocator.free(path_string);
-        logging.maxNestingDepthReached(max_depth, path_string);
+        // Convert path array to string for logging. On OOM log without the
+        // path — the old `catch "unknown"` fallback flowed into the free
+        // below, which is UB on a string literal.
+        const joined: ?[]u8 = if (current_path.len == 0) null else std.mem.join(allocator, "/", current_path) catch null;
+        defer if (joined) |p| allocator.free(p);
+        logging.maxNestingDepthReached(max_depth, joined orelse "");
         return;
     }
     var iterator = dir.iterate();

--- a/packages/core/src/command_parser.zig
+++ b/packages/core/src/command_parser.zig
@@ -227,20 +227,17 @@ fn hasArrayFields(comptime OptionsType: type) bool {
     return false;
 }
 
-/// Check if an args type has varargs fields (last field is an array)
+/// Check if an args type has a varargs field (last field is a slice of
+/// strings). Delegates to args.zig's isVarArgs so the two classifiers cannot
+/// drift — a plain trailing string (`[]const u8`) is a positional, not
+/// varargs, and must not cause the positional slice to be retained.
 fn hasVarargsFields(comptime ArgsType: type) bool {
     const type_info = @typeInfo(ArgsType);
     if (type_info != .@"struct") return false;
     if (type_info.@"struct".fields.len == 0) return false;
 
-    // Check if the last field is an array/slice
     const last_field = type_info.@"struct".fields[type_info.@"struct".fields.len - 1];
-    if (@typeInfo(last_field.type) == .pointer) {
-        const ptr_info = @typeInfo(last_field.type).pointer;
-        return ptr_info.size == .slice;
-    }
-
-    return false;
+    return args_parser.isVarArgs(last_field.type);
 }
 
 // Tests

--- a/packages/core/src/options/parser.zig
+++ b/packages/core/src/options/parser.zig
@@ -71,8 +71,10 @@ const ResourceTracker = @import("../resource_limits.zig").ResourceTracker;
 ///     files: [][]const u8 = &.{}, // --files a.txt b.txt
 /// };
 ///
-/// const result = try zcli.parseOptions(Options, allocator, args, null);
-/// defer zcli.cleanupOptions(Options, result.options, allocator);
+/// // Not re-exported at the package root — reachable via zcli.parseCommandLine,
+/// // or directly as parseOptions within this module:
+/// const result = try parseOptions(Options, allocator, args, null);
+/// defer cleanupOptions(Options, result.options, allocator);
 /// ```
 ///
 /// ## Memory Management
@@ -274,13 +276,26 @@ pub fn parseOptionsWithMeta(
         }
     }
 
-    // Finalize array fields by converting ArrayLists to slices
+    // Finalize array fields by converting ArrayLists to slices. If a later
+    // field's conversion fails, the slices already handed to `result` must be
+    // freed here — their lists are empty by then, so the deinit defer above
+    // no longer owns that memory. (The framework's arena masks this, but the
+    // parser is also usable as a library with any allocator.)
+    var converted = [_]bool{false} ** struct_info.fields.len;
+    errdefer {
+        inline for (struct_info.fields, 0..) |field, i| {
+            if (comptime utils.isArrayType(field.type)) {
+                if (converted[i]) allocator.free(@field(result, field.name));
+            }
+        }
+    }
     inline for (struct_info.fields, 0..) |field, i| {
         if (comptime utils.isArrayType(field.type)) {
             if (array_lists[i]) |*list_union| {
                 @field(result, field.name) = array_utils.arrayListUnionToOwnedSlice(field.type, allocator, list_union) catch {
                     return ZcliError.SystemOutOfMemory;
                 };
+                converted[i] = true;
             }
         }
     }
@@ -669,8 +684,10 @@ fn parseShortOptionsWithMeta(
 ///
 /// ## Examples
 /// ```zig
-/// const result = try zcli.parseOptions(Options, allocator, args, null);
-/// defer zcli.cleanupOptions(Options, result.options, allocator);
+/// // Not re-exported at the package root — reachable via zcli.parseCommandLine,
+/// // or directly as parseOptions within this module:
+/// const result = try parseOptions(Options, allocator, args, null);
+/// defer cleanupOptions(Options, result.options, allocator);
 ///
 /// // Use result.options safely here
 /// for (result.options.files) |file| {

--- a/packages/core/src/plugins/zcli_config/plugin.zig
+++ b/packages/core/src/plugins/zcli_config/plugin.zig
@@ -9,7 +9,7 @@ const zcli = @import("zcli");
 ///
 /// Config file discovery (by extension):
 ///   1. --config <path>
-///   2. ./{app_name}.config.json / .toml / .yaml / .yml
+///   2. .{app_name}.config.json / .toml / .yaml / .yml (in the current directory — note the leading dot)
 ///   3. $XDG_CONFIG_HOME/{app_name}/config.json / .toml / .yaml / .yml
 pub const plugin_id = "zcli_config";
 

--- a/packages/core/src/zcli.zig
+++ b/packages/core/src/zcli.zig
@@ -213,7 +213,8 @@ pub const Config = registry.Config;
 ///
 /// **Memory Management**: ⚠️ CRITICAL - Call `result.deinit()` to cleanup!
 /// ```zig
-/// const result = try parseCommandLine(Args, Options, null, allocator, context.environ, args);
+/// var diag: ?ZcliDiagnostic = null;
+/// const result = try parseCommandLine(Args, Options, null, allocator, context.environ, args, &diag);
 /// defer result.deinit(); // REQUIRED!
 /// // Use result.args and result.options...
 /// ```

--- a/packages/vterm/src/tests/basic_test.zig
+++ b/packages/vterm/src/tests/basic_test.zig
@@ -136,6 +136,48 @@ test "unicode characters - basic support" {
     try testing.expectEqual(@as(u16, 2), term.cursor.x);
 }
 
+test "UTF-8 sequence split across write() calls" {
+    var term = try VTerm.init(testing.allocator, 10, 5);
+    defer term.deinit();
+
+    // "é" is 0xC3 0xA9; feed the two bytes in separate write() calls, as a
+    // pipe/PTY reader legitimately can. The lead byte must be carried over,
+    // not dropped (which smeared the continuation into a skipped garbage
+    // byte and lost the character).
+    term.write("A\xC3");
+    term.write("\xA9B");
+
+    try testing.expectEqual(@as(u21, 'A'), term.getCell(0, 0).char);
+    try testing.expectEqual(@as(u21, 'é'), term.getCell(1, 0).char);
+    try testing.expectEqual(@as(u21, 'B'), term.getCell(2, 0).char);
+}
+
+test "UTF-8 4-byte sequence split byte-by-byte across writes" {
+    var term = try VTerm.init(testing.allocator, 10, 5);
+    defer term.deinit();
+
+    // 😀 U+1F600 = F0 9F 98 80, one byte per write().
+    term.write("\xF0");
+    term.write("\x9F");
+    term.write("\x98");
+    term.write("\x80");
+
+    try testing.expectEqual(@as(u21, 0x1F600), term.getCell(0, 0).char);
+}
+
+test "ASCII byte aborts a pending partial UTF-8 sequence" {
+    var term = try VTerm.init(testing.allocator, 10, 5);
+    defer term.deinit();
+
+    // A lead byte with no continuation, then ASCII: the fragment is dropped
+    // and must not swallow the following character or a later sequence.
+    term.write("\xC3");
+    term.write("AB");
+
+    try testing.expectEqual(@as(u21, 'A'), term.getCell(0, 0).char);
+    try testing.expectEqual(@as(u21, 'B'), term.getCell(1, 0).char);
+}
+
 test "Cell helper functions" {
     const Cell = vterm.Cell;
 

--- a/packages/vterm/src/vterm.zig
+++ b/packages/vterm/src/vterm.zig
@@ -99,6 +99,13 @@ pub const VTerm = struct {
     param_count: u8,
     private_sequence: bool, // Track if this is a private sequence (starts with ?)
 
+    // A UTF-8 sequence can be split across write() calls; the partial sequence
+    // is stashed here and completed by the next write. Dropping the lead byte
+    // instead would smear the continuation bytes into mojibake.
+    utf8_partial: [4]u8,
+    utf8_partial_have: u8,
+    utf8_partial_expected: u8,
+
     // Current text attributes - NEW in Phase 2
     current_fg: u8,
     current_bg: u8,
@@ -189,6 +196,10 @@ pub const VTerm = struct {
             .params = [_]u16{0} ** 16,
             .param_count = 0,
             .private_sequence = false,
+
+            .utf8_partial = undefined,
+            .utf8_partial_have = 0,
+            .utf8_partial_expected = 0,
 
             // Text attributes - NEW in Phase 2
             .current_fg = 7, // Default white
@@ -402,6 +413,21 @@ pub const VTerm = struct {
                 .Ground => {
                     // Check if this is a UTF-8 multi-byte character
                     if (byte >= 0x80) {
+                        if (self.utf8_partial_expected > 0) {
+                            // Continuation of a sequence split across write() calls.
+                            self.utf8_partial[self.utf8_partial_have] = byte;
+                            self.utf8_partial_have += 1;
+                            i += 1;
+                            if (self.utf8_partial_have == self.utf8_partial_expected) {
+                                const seq = self.utf8_partial[0..self.utf8_partial_expected];
+                                self.utf8_partial_expected = 0;
+                                self.utf8_partial_have = 0;
+                                const char = std.unicode.utf8Decode(seq) catch continue;
+                                self.putChar(char);
+                            }
+                            continue;
+                        }
+
                         // This is part of a UTF-8 sequence
                         const utf8_len = std.unicode.utf8ByteSequenceLength(byte) catch {
                             i += 1;
@@ -417,9 +443,19 @@ pub const VTerm = struct {
                             self.putChar(char);
                             i += utf8_len;
                         } else {
-                            i += 1;
+                            // The sequence's tail lies beyond this write();
+                            // stash what we have and finish on the next call.
+                            const avail = bytes.len - i;
+                            @memcpy(self.utf8_partial[0..avail], bytes[i..]);
+                            self.utf8_partial_have = @intCast(avail);
+                            self.utf8_partial_expected = @intCast(utf8_len);
+                            i = bytes.len;
                         }
                     } else {
+                        // An ASCII byte aborts any pending partial sequence —
+                        // the stream was invalid; drop the fragment.
+                        self.utf8_partial_expected = 0;
+                        self.utf8_partial_have = 0;
                         self.handleGround(byte);
                         i += 1;
                     }

--- a/projects/zcli/src/commands/dev.zig
+++ b/projects/zcli/src/commands/dev.zig
@@ -68,6 +68,9 @@ pub fn execute(args: Args, options: Options, context: anytype) !void {
 
     // The app started by `-- <command>`, if any. Killed and restarted each cycle.
     var app_child: ?std.process.Child = null;
+    // The loop below only exits via error (Ctrl-C kills the whole process
+    // group) — don't leave the spawned app running past dev itself.
+    defer if (app_child) |*c| c.kill(io);
 
     // Build once up front, then rebuild on every change.
     runCycle(io, &cycle_arena, status, theme, args.command, &app_child);


### PR DESCRIPTION
Seventh PR of the grade2 pass — the LOW-severity correctness findings from the Zig-idioms review, batched (each is a few lines; none warrants its own PR). The remaining structural items (registry.zig split, serde re-export, build/runtime type split) come separately.

## Fixes

1. **vterm mangled UTF-8 split across `write()` calls** (vterm.zig Ground state): the lead byte of a sequence whose tail lay beyond the buffer was skipped, and the next write's continuation bytes were re-parsed as leads — the codepoint vanished. Pipes/PTYs legitimately deliver split sequences. Partial sequences are now carried in parser state (`utf8_partial*`) and completed by the next write; an ASCII byte aborts a stale fragment. Tests: 2-byte split, 4-byte emoji fed byte-by-byte, abort path.
2. **`zcli dev` leaked the `-- <cmd>` child on error exit** — the loop only exits via error (Ctrl-C kills the process group), so the spawned app outlived dev. Now `defer`-killed.
3. **Invalid free on OOM in discovery's max-depth logging** (command_discovery.zig): `join(...) catch "unknown"` flowed into `allocator.free` — freeing a string literal. Logs without the path on OOM instead.
4. **Leak in options array finalization** (options/parser.zig): if converting a later array field to an owned slice failed, earlier fields' already-converted slices were unreachable (their lists empty, the cleanup defer owning nothing). `errdefer` frees converted fields. Arena masks this in the framework path; it's real for library callers.
5. **`hasVarargsFields` disagreed with `args.isVarArgs`** — a trailing `[]const u8` string positional was classified varargs, needlessly retaining `_positional_slice` and setting a cleanup allocator. Now delegates to `isVarArgs` (single definition, can't drift).
6. **Four stale doc comments**: `zcli.parseArgs`/`zcli.parseOptions` examples (not package-root exports — noted, examples now use the module-local names), `parseCommandLine`'s example missing its `diag` arg, and zcli_config's discovery comment missing the leading dot the code builds (`.{app_name}.config.json`) — the last of the docs-review deferrals from #110.

## Verification

Full root suite: **77/77 steps, 1372/1372 tests pass** (vterm 113→116 with the new coverage). `zig fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)