### PR TITLE
fix(e2e): deflake 'init .' tests vs project-name validation (grade2 fix 9)

### DIFF
--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -76,12 +76,14 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
     // `.app_name = "{s}"`) and becomes the directory and executable name —
     // restrict it to identifier-safe characters up front rather than escaping
     // it into every context separately.
+    // For `init .` the name is a fact of the environment, not a typo — say so.
+    const name_origin: []const u8 = if (use_current_dir) " (taken from the current directory's name)" else "";
     if (project_name.len == 0 or std.ascii.isDigit(project_name[0])) {
-        return context.fail("Error: Invalid project name '{s}'\n  Names must be non-empty and must not start with a digit", .{project_name});
+        return context.fail("Error: Invalid project name '{s}'{s}\n  Names must be non-empty and must not start with a digit", .{ project_name, name_origin });
     }
     for (project_name) |c| {
         if (!std.ascii.isAlphanumeric(c) and c != '-' and c != '_') {
-            return context.fail("Error: Invalid project name '{s}'\n  Use only letters, digits, '-' and '_'", .{project_name});
+            return context.fail("Error: Invalid project name '{s}'{s}\n  Use only letters, digits, '-' and '_'", .{ project_name, name_origin });
         }
     }
 

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -208,30 +208,60 @@ test "init . scaffolds into the current directory" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    var r = try run(tmp.dir, &.{ zcli_exe, "init", "." });
+    // `init .` derives the project name from the directory name, and tmpDir's
+    // random name can start with a digit (rejected by name validation) — run
+    // inside a stable, valid-named subdirectory.
+    try tmp.dir.createDir(io, "myapp", .default_dir);
+    var proj = try tmp.dir.openDir(io, "myapp", .{});
+    defer proj.close(io);
+
+    var r = try run(proj, &.{ zcli_exe, "init", "." });
     defer r.deinit();
     try expectOk(r);
 
-    try testing.expect(fileExists(tmp.dir, "build.zig"));
-    try testing.expect(fileExists(tmp.dir, "src/commands/hello.zig"));
+    try testing.expect(fileExists(proj, "build.zig"));
+    try testing.expect(fileExists(proj, "src/commands/hello.zig"));
+}
+
+test "init . rejects a directory name that can't be a project name" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // A leading digit can't become the zon `.name` enum literal; the error
+    // must say the name came from the directory, not leave the user guessing.
+    try tmp.dir.createDir(io, "7wonders", .default_dir);
+    var proj = try tmp.dir.openDir(io, "7wonders", .{});
+    defer proj.close(io);
+
+    var r = try run(proj, &.{ zcli_exe, "init", "." });
+    defer r.deinit();
+    try testing.expect(r.exit_code != 0);
+    try expectContains(r.stderr, "Invalid project name");
+    try expectContains(r.stderr, "current directory");
+    try testing.expect(!fileExists(proj, "build.zig"));
 }
 
 test "init . appends to a pre-existing AGENTS.md instead of refusing" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
 
+    // Stable subdirectory: see "init . scaffolds into the current directory".
+    try tmp.dir.createDir(io, "myapp", .default_dir);
+    var proj = try tmp.dir.openDir(io, "myapp", .{});
+    defer proj.close(io);
+
     // A directory whose only visible file is the user's own AGENTS.md — init
     // treats it as appendable, not a conflict (ADR-0008).
-    try tmp.dir.writeFile(io, .{ .sub_path = "AGENTS.md", .data = "# House rules\n\nRun the linter.\n" });
+    try proj.writeFile(io, .{ .sub_path = "AGENTS.md", .data = "# House rules\n\nRun the linter.\n" });
 
-    var r = try run(tmp.dir, &.{ zcli_exe, "init", "." });
+    var r = try run(proj, &.{ zcli_exe, "init", "." });
     defer r.deinit();
     try expectOk(r);
-    try testing.expect(fileExists(tmp.dir, "build.zig"));
+    try testing.expect(fileExists(proj, "build.zig"));
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
-    const agents = try readFile(tmp.dir, arena.allocator(), "AGENTS.md");
+    const agents = try readFile(proj, arena.allocator(), "AGENTS.md");
     try expectContains(agents, "# House rules"); // user content preserved
     try expectContains(agents, "Run the linter.");
     try expectContains(agents, "<!-- zcli:begin -->"); // zcli section appended


### PR DESCRIPTION
**Merge this before #117 (registry split)** — its e2e legs will flake ~30% of the time until this lands.

## Problem

#112's project-name validation rejects names starting with a digit. `zcli init .` derives the name from the directory, and the two `init .` e2e tests ran directly inside `testing.tmpDir`'s random-named dir — which starts with a digit ~1/6 of the time. Latent flake; it fired during #117's verification run (`Invalid project name '7AXBN3iDnC3Vd87I'`).

## Fix

- Both `init .` e2e tests now create and run inside a stable, valid-named subdirectory.
- New e2e test pins the rejection path itself (`init .` in a dir named `7wonders` fails cleanly, leaves nothing behind, and the message points at the directory).
- init's error now appends "(taken from the current directory's name)" for the `init .` path — there the name is a fact of the environment, not a typo the user can retype.

## Verification

58/58 unit, **26/26 e2e** (25 prior + the new rejection test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)