### PR TITLE
api: drop the blanket serde re-export for a two-function shim (grade2 fix 10)

### DIFF
--- a/packages/core/src/plugins/zcli_config/plugin.zig
+++ b/packages/core/src/plugins/zcli_config/plugin.zig
@@ -162,16 +162,14 @@ fn applyJsonObject(comptime OptionsType: type, options: *OptionsType, obj: std.j
 }
 
 fn applyFromTomlScoped(comptime OptionsType: type, options: *OptionsType, content: []const u8, allocator: std.mem.Allocator, _: []const []const u8) void {
-    // Parse TOML directly into the options struct type using serde
-    const serde = zcli.serde;
-    const parsed = serde.toml.fromSlice(OptionsType, allocator, content) catch return;
+    // Parse TOML directly into the options struct type (via zcli.config_parse)
+    const parsed = zcli.config_parse.fromToml(OptionsType, allocator, content) catch return;
     applyNonDefaults(OptionsType, options, parsed);
 }
 
 fn applyFromYamlScoped(comptime OptionsType: type, options: *OptionsType, content: []const u8, allocator: std.mem.Allocator, _: *ContextData, _: []const []const u8) void {
-    // Parse YAML directly into the options struct type using serde
-    const serde = zcli.serde;
-    const parsed = serde.yaml.fromSlice(OptionsType, allocator, content) catch return;
+    // Parse YAML directly into the options struct type (via zcli.config_parse)
+    const parsed = zcli.config_parse.fromYaml(OptionsType, allocator, content) catch return;
     applyNonDefaults(OptionsType, options, parsed);
 }
 

--- a/packages/core/src/zcli.zig
+++ b/packages/core/src/zcli.zig
@@ -11,7 +11,23 @@ pub const ztheme = @import("ztheme");
 pub const markdown_fmt = @import("markdown_fmt");
 pub const zprogress = @import("zprogress");
 pub const zinput = @import("zinput");
-pub const serde = @import("serde");
+
+/// Config-file deserialization shims for the zcli_config plugin. Plugin
+/// modules import only "zcli", so the plugin cannot depend on serde directly;
+/// these two functions are the entire surface it needs. serde itself is an
+/// internal dependency — re-exporting its whole API here would make a
+/// third-party crate part of zcli's public contract.
+pub const config_parse = struct {
+    const serde = @import("serde");
+
+    pub fn fromToml(comptime T: type, allocator: std.mem.Allocator, content: []const u8) !T {
+        return serde.toml.fromSlice(T, allocator, content);
+    }
+
+    pub fn fromYaml(comptime T: type, allocator: std.mem.Allocator, content: []const u8) !T {
+        return serde.yaml.fromSlice(T, allocator, content);
+    }
+};
 
 /// HTTP client with safe defaults (TLS verification on, bounded response body)
 /// over `std.http.Client`. See http.zig.


### PR DESCRIPTION
From the architecture review (MEDIUM, part of the public-surface finding): `pub const serde = @import("serde")` in zcli.zig made a third-party crate's **entire API** part of zcli's public contract — any serde upgrade becomes a potential zcli breaking change, and consumers can silently couple to it.

## Change

- Repo-wide, the only consumer was the zcli_config plugin (TOML/YAML; its JSON path already uses std.json). Plugin modules import only `"zcli"` (verified in module_creation.zig), so the plugin can't take serde as a direct dependency — instead `zcli.config_parse` now exposes exactly what it uses: `fromToml` / `fromYaml`, both `(comptime T, allocator, []const u8) !T` — **no serde types appear in the signatures**.
- `pub const serde` is deleted. Anyone who wants serde should depend on serde.

No docs referenced `zcli.serde` (grep-verified across docs/, README, examples).

## Verification

Root suite **1378/1378**, e2e **25/25** (config plugin's TOML/YAML paths covered by the existing plugin pipeline tests and the notes example).

Independent of #116/#117 — no file overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)