### PR TITLE
refactor: split runtime-safe discovery types out of build_utils/types.zig (grade2 fix 11)

### DIFF
--- a/packages/core/src/build_utils.zig
+++ b/packages/core/src/build_utils.zig
@@ -15,6 +15,7 @@ pub const PluginConfig = @import("build_utils/types.zig").PluginConfig;
 // reference the submodules so their tests are collected.
 test {
     _ = @import("build_utils/types.zig");
+    _ = @import("build_utils/discovery_types.zig");
     _ = @import("build_utils/command_discovery.zig");
     _ = @import("build_utils/code_generation.zig");
     _ = @import("build_utils/main.zig");

--- a/packages/core/src/build_utils/command_discovery.zig
+++ b/packages/core/src/build_utils/command_discovery.zig
@@ -1,9 +1,10 @@
 const std = @import("std");
 const logging = @import("../logging.zig");
-const types = @import("types.zig");
+const types = @import("discovery_types.zig");
 
 // Re-exported so runtime consumers (e.g. the `zcli tree` tool) can name the
-// types returned by discovery without reaching into build_utils/types.
+// types returned by discovery. discovery_types.zig is runtime-safe — the
+// std.Build-only build_utils/types.zig never enters the runtime module graph.
 pub const CommandInfo = types.CommandInfo;
 pub const CommandType = types.CommandType;
 pub const DiscoveredCommands = types.DiscoveredCommands;

--- a/packages/core/src/build_utils/discovery_types.zig
+++ b/packages/core/src/build_utils/discovery_types.zig
@@ -1,0 +1,77 @@
+const std = @import("std");
+
+// ============================================================================
+// DISCOVERY TYPES — the command-discovery data model
+//
+// Runtime-safe: nothing here references std.Build. These types are shared by
+// the build-time scanner and runtime discovery (zcli tree, zcli dev), so they
+// live apart from build_utils/types.zig, which holds std.Build-only types —
+// runtime code must never need to import that file.
+// ============================================================================
+
+/// Command type classification
+pub const CommandType = enum {
+    /// Leaf command - regular .zig file that can have Args and Options
+    leaf,
+    /// Pure command group - directory without index.zig, always shows help
+    pure_group,
+    /// Optional command group - directory with index.zig, can execute but no Args allowed
+    optional_group,
+};
+
+/// Information about a discovered command
+pub const CommandInfo = struct {
+    name: []const u8,
+    path: []const []const u8, // Array of command path components
+    file_path: []const u8, // Filesystem path for module loading
+    command_type: CommandType,
+    hidden: bool = false, // Whether this command should be hidden from help/completions
+    subcommands: ?std.StringHashMap(CommandInfo),
+
+    pub fn deinit(self: *CommandInfo, allocator: std.mem.Allocator) void {
+        // Free allocated strings
+        allocator.free(self.name);
+        allocator.free(self.file_path);
+        // Free path components
+        for (self.path) |component| {
+            allocator.free(component);
+        }
+        allocator.free(self.path);
+
+        // Free subcommands if they exist
+        if (self.subcommands) |*subcmds| {
+            var iterator = subcmds.iterator();
+            while (iterator.next()) |entry| {
+                // Free subcommand keys
+                allocator.free(entry.key_ptr.*);
+                // Free subcommand values
+                entry.value_ptr.deinit(allocator);
+            }
+            subcmds.deinit();
+        }
+    }
+};
+
+/// Container for all discovered commands
+pub const DiscoveredCommands = struct {
+    allocator: std.mem.Allocator,
+    root: std.StringHashMap(CommandInfo),
+
+    pub fn init(allocator: std.mem.Allocator) DiscoveredCommands {
+        return DiscoveredCommands{
+            .allocator = allocator,
+            .root = std.StringHashMap(CommandInfo).init(allocator),
+        };
+    }
+
+    pub fn deinit(self: *DiscoveredCommands) void {
+        var iterator = self.root.iterator();
+        while (iterator.next()) |entry| {
+            // Free the HashMap key (allocated string)
+            self.allocator.free(entry.key_ptr.*);
+            // Free the command info
+            entry.value_ptr.deinit(self.allocator);
+        }
+        self.root.deinit();
+    }
+};

--- a/packages/core/src/build_utils/types.zig
+++ b/packages/core/src/build_utils/types.zig
@@ -1,8 +1,17 @@
 const std = @import("std");
 
 // ============================================================================
-// SHARED TYPES - Used across build utility modules
+// BUILD-TIME TYPES - Used across build utility modules
+//
+// Everything here may reference std.Build. The runtime-safe discovery types
+// (CommandType/CommandInfo/DiscoveredCommands) live in discovery_types.zig and
+// are re-exported below for build-time convenience — runtime code imports
+// discovery_types.zig (via command_discovery) and never this file.
 // ============================================================================
+
+pub const CommandType = @import("discovery_types.zig").CommandType;
+pub const CommandInfo = @import("discovery_types.zig").CommandInfo;
+pub const DiscoveredCommands = @import("discovery_types.zig").DiscoveredCommands;
 
 /// Information about a plugin (local or external)
 pub const PluginInfo = struct {
@@ -16,73 +25,6 @@ pub const PluginInfo = struct {
     /// the project-relative source path, resolved with `b.path`. Null for
     /// framework built-ins, which live in the zcli package (`zcli_dep.path`).
     project_path: ?[]const u8 = null,
-};
-
-/// Command type classification
-pub const CommandType = enum {
-    /// Leaf command - regular .zig file that can have Args and Options
-    leaf,
-    /// Pure command group - directory without index.zig, always shows help
-    pure_group,
-    /// Optional command group - directory with index.zig, can execute but no Args allowed
-    optional_group,
-};
-
-/// Information about a discovered command
-pub const CommandInfo = struct {
-    name: []const u8,
-    path: []const []const u8, // Array of command path components
-    file_path: []const u8, // Filesystem path for module loading
-    command_type: CommandType,
-    hidden: bool = false, // Whether this command should be hidden from help/completions
-    subcommands: ?std.StringHashMap(CommandInfo),
-
-    pub fn deinit(self: *CommandInfo, allocator: std.mem.Allocator) void {
-        // Free allocated strings
-        allocator.free(self.name);
-        allocator.free(self.file_path);
-        // Free path components
-        for (self.path) |component| {
-            allocator.free(component);
-        }
-        allocator.free(self.path);
-
-        // Free subcommands if they exist
-        if (self.subcommands) |*subcmds| {
-            var iterator = subcmds.iterator();
-            while (iterator.next()) |entry| {
-                // Free subcommand keys
-                allocator.free(entry.key_ptr.*);
-                // Free subcommand values
-                entry.value_ptr.deinit(allocator);
-            }
-            subcmds.deinit();
-        }
-    }
-};
-
-/// Container for all discovered commands
-pub const DiscoveredCommands = struct {
-    allocator: std.mem.Allocator,
-    root: std.StringHashMap(CommandInfo),
-
-    pub fn init(allocator: std.mem.Allocator) DiscoveredCommands {
-        return DiscoveredCommands{
-            .allocator = allocator,
-            .root = std.StringHashMap(CommandInfo).init(allocator),
-        };
-    }
-
-    pub fn deinit(self: *DiscoveredCommands) void {
-        var iterator = self.root.iterator();
-        while (iterator.next()) |entry| {
-            // Free the HashMap key (allocated string)
-            self.allocator.free(entry.key_ptr.*);
-            // Free the command info
-            entry.value_ptr.deinit(self.allocator);
-        }
-        self.root.deinit();
-    }
 };
 
 /// Shared module that should be available to all commands


### PR DESCRIPTION
From the architecture review (MEDIUM): `build_utils/types.zig` blurred the build-time/runtime boundary — one file held both the runtime discovery data model (`CommandType`/`CommandInfo`/`DiscoveredCommands`, reached by `zcli tree`/`zcli dev` through `command_discovery`) and `std.Build`-only types (`PluginInfo` with `*std.Build.Dependency`, `SharedModule`, `CommandModule`…). Lazy analysis made it compile, but the boundary existed only by accident.

## Change

- **`discovery_types.zig` (new, 77 lines)**: the three discovery types, moved verbatim, with a header stating the invariant (nothing here may reference std.Build).
- **`types.zig`**: re-exports them for its build-time consumers (zero call-site churn) and documents itself as std.Build-only.
- **`command_discovery.zig`** (the shared build/runtime entry point): now imports `discovery_types.zig` — the std.Build-only file is *structurally* out of the runtime module graph, not merely unanalyzed.
- `registry/tests.zig` deliberately keeps importing `types.zig`: its code-generation tests construct `BuildConfig`, which is build-time functionality — the correct side of the boundary for that file.

## Verification

Root suite **1382/1382**, e2e **26/26**, `zig fmt` clean. Built on top of merged #116/#117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)