### PR TITLE
fix: b.graph.zig_exe for subproject builds; narrow PTY e2e skips (grade2 fix 12)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -109,8 +109,10 @@ pub fn build(b: *std.Build) void {
         const print_start = b.addSystemCommand(&.{"echo"});
         print_start.addArg(b.fmt("\n==> Running tests for {s} ({s})", .{ project.name, project.path }));
 
-        // Run the test step from the subproject directory
-        const project_test_run = b.addSystemCommand(&.{"zig"});
+        // Run the test step from the subproject directory. b.graph.zig_exe is
+        // the compiler running THIS build — a bare "zig" from PATH can resolve
+        // to a different toolchain under version managers like mise.
+        const project_test_run = b.addSystemCommand(&.{b.graph.zig_exe});
         project_test_run.addArgs(&.{ "build", "test" });
         project_test_run.setCwd(b.path(project.path));
         project_test_run.step.dependOn(&print_start.step);
@@ -146,7 +148,7 @@ pub fn build(b: *std.Build) void {
         const example_build_step = b.step(b.fmt("build-{s}", .{example.name}), b.fmt("Build {s} example", .{example.name}));
 
         // Run the build for this example
-        const example_build_run = b.addSystemCommand(&.{"zig"});
+        const example_build_run = b.addSystemCommand(&.{b.graph.zig_exe});
         example_build_run.addArgs(&.{"build"});
         example_build_run.setCwd(b.path(example.path));
 
@@ -166,7 +168,7 @@ pub fn build(b: *std.Build) void {
         const cli_build_step = b.step(b.fmt("build-{s}", .{cli.name}), b.fmt("Build {s} CLI", .{cli.name}));
 
         // Run the build for this CLI
-        const cli_build_run = b.addSystemCommand(&.{"zig"});
+        const cli_build_run = b.addSystemCommand(&.{b.graph.zig_exe});
         cli_build_run.addArgs(&.{"build"});
         cli_build_run.setCwd(b.path(cli.path));
 

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -1313,10 +1313,16 @@ test "interactive: add command drives the wizard and echoes typed input" {
         &.{ zcli_exe, "add", "command" },
         script,
         .{ .cwd = proj_abs, .allocate_pty = true, .total_timeout_ms = 20000 },
-    ) catch |err| {
-        // PTY allocation can be denied in some sandboxes; don't fail the suite.
-        std.debug.print("runInteractive unavailable: {any}\n", .{err});
-        return;
+    ) catch |err| switch (err) {
+        // PTY allocation can be denied in some sandboxes; skip rather than fail
+        // (CI greps the log for this line and fails if the tier silently
+        // skipped). Every other error is a real harness/test failure — a
+        // catch-all here made harness bugs read as skips.
+        error.PtyAllocationFailed => {
+            std.debug.print("runInteractive unavailable: {any}\n", .{err});
+            return;
+        },
+        else => return err,
     };
     defer result.deinit();
 
@@ -1363,10 +1369,16 @@ test "interactive: text prompt handles multibyte UTF-8 typing and backspace" {
         &.{ zcli_exe, "add", "command" },
         script,
         .{ .cwd = proj_abs, .allocate_pty = true, .total_timeout_ms = 20000 },
-    ) catch |err| {
-        // PTY allocation can be denied in some sandboxes; don't fail the suite.
-        std.debug.print("runInteractive unavailable: {any}\n", .{err});
-        return;
+    ) catch |err| switch (err) {
+        // PTY allocation can be denied in some sandboxes; skip rather than fail
+        // (CI greps the log for this line and fails if the tier silently
+        // skipped). Every other error is a real harness/test failure — a
+        // catch-all here made harness bugs read as skips.
+        error.PtyAllocationFailed => {
+            std.debug.print("runInteractive unavailable: {any}\n", .{err});
+            return;
+        },
+        else => return err,
     };
     defer result.deinit();
 
@@ -1406,10 +1418,16 @@ test "interactive: init's plugin multi-select toggles an opt-in plugin" {
         &.{ zcli_exe, "init", "myapp" },
         script,
         .{ .cwd = proj_abs, .allocate_pty = true, .total_timeout_ms = 30000 },
-    ) catch |err| {
-        // PTY allocation can be denied in some sandboxes; don't fail the suite.
-        std.debug.print("runInteractive unavailable: {any}\n", .{err});
-        return;
+    ) catch |err| switch (err) {
+        // PTY allocation can be denied in some sandboxes; skip rather than fail
+        // (CI greps the log for this line and fails if the tier silently
+        // skipped). Every other error is a real harness/test failure — a
+        // catch-all here made harness bugs read as skips.
+        error.PtyAllocationFailed => {
+            std.debug.print("runInteractive unavailable: {any}\n", .{err});
+            return;
+        },
+        else => return err,
     };
     defer result.deinit();
 


### PR DESCRIPTION
Two LOW hygiene findings from the architecture and testing reviews.

## Changes

1. **Root build.zig** invoked subproject builds/tests via `addSystemCommand(&.{"zig"})` — a bare PATH lookup that can resolve to a different toolchain than the one running the parent build under version managers like mise. All three sites now use `b.graph.zig_exe` (the exact compiler executing this build), with a comment stating why.

2. **PTY e2e tests** (`add command` wizard, UTF-8 backspace, dual-mode) skipped on `catch |err|` — *any* error read as "PTY unavailable", so a harness regression or real failure looked like an environment skip in local runs (CI's `runInteractive unavailable` grep only protects CI). The skip now matches `error.PtyAllocationFailed` exclusively; everything else propagates as a failure. The grep-target log line is unchanged.

Also checked here: the four stale doc comments deferred from #110 (args.zig, options/parser.zig, zcli.zig's parseCommandLine example, zcli_config's filename comment) — all were already fixed by the #115 correctness batch, so nothing to do.

## Verification

Root suite **1382/1382**, e2e **26/26** (PTY tier ran, not skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)