### PR TITLE
refactor: shared identifier/module-name derivation; validatePlugin hook-typo backstop (grade2 fix 13)

### DIFF
--- a/packages/core/src/build_utils.zig
+++ b/packages/core/src/build_utils.zig
@@ -16,6 +16,7 @@ pub const PluginConfig = @import("build_utils/types.zig").PluginConfig;
 test {
     _ = @import("build_utils/types.zig");
     _ = @import("build_utils/discovery_types.zig");
+    _ = @import("build_utils/module_names.zig");
     _ = @import("build_utils/command_discovery.zig");
     _ = @import("build_utils/code_generation.zig");
     _ = @import("build_utils/main.zig");

--- a/packages/core/src/build_utils/code_generation.zig
+++ b/packages/core/src/build_utils/code_generation.zig
@@ -1,5 +1,7 @@
 const std = @import("std");
 const types = @import("types.zig");
+const identifier = @import("../identifier.zig");
+const module_names = @import("module_names.zig");
 
 const PluginInfo = types.PluginInfo;
 const DiscoveredCommands = types.DiscoveredCommands;
@@ -53,7 +55,7 @@ fn generateCommandImports(writer: anytype, commands: DiscoveredCommands) !void {
         if (cmd_info.command_type != .leaf) {
             // Generate import for optional group with index file
             if (cmd_info.command_type == .optional_group) {
-                const module_name = try std.fmt.allocPrint(commands.allocator, "{s}_index", .{cmd_name});
+                const module_name = try module_names.indexModuleName(commands.allocator, cmd_name);
                 defer commands.allocator.free(module_name);
 
                 try writer.print("const {s} = @import(\"{s}\");\n", .{ module_name, module_name });
@@ -61,11 +63,8 @@ fn generateCommandImports(writer: anytype, commands: DiscoveredCommands) !void {
             // Generate imports for subcommands
             try generateGroupImports(writer, cmd_name, &cmd_info);
         } else {
-            const module_name = if (std.mem.eql(u8, cmd_name, "test"))
-                "cmd_test"
-            else
-                try std.fmt.allocPrint(commands.allocator, "cmd_{s}", .{cmd_name});
-            defer if (!std.mem.eql(u8, cmd_name, "test")) commands.allocator.free(module_name);
+            const module_name = try module_names.leafModuleName(commands.allocator, cmd_name);
+            defer commands.allocator.free(module_name);
 
             try writer.print("const {s} = @import(\"{s}\");\n", .{ module_name, module_name });
         }
@@ -83,24 +82,7 @@ fn generateGroupImports(writer: anytype, _: []const u8, group_info: *const Comma
 
             if (subcmd_info.command_type == .optional_group) {
                 // Generate import for optional group with index file
-                var module_name_parts = std.ArrayList([]const u8).empty;
-                defer module_name_parts.deinit(subcommands.allocator);
-
-                for (subcmd_info.path) |part| {
-                    const sanitized_part = try sanitizeIdentifier(subcommands.allocator, part);
-                    defer subcommands.allocator.free(sanitized_part);
-                    try module_name_parts.append(subcommands.allocator, try subcommands.allocator.dupe(u8, sanitized_part));
-                }
-
-                const module_name = try std.mem.join(subcommands.allocator, "_", module_name_parts.items);
-                defer {
-                    for (module_name_parts.items) |part| {
-                        subcommands.allocator.free(part);
-                    }
-                    subcommands.allocator.free(module_name);
-                }
-
-                const module_name_with_index = try std.fmt.allocPrint(subcommands.allocator, "{s}_index", .{module_name});
+                const module_name_with_index = try module_names.pathIndexModuleName(subcommands.allocator, subcmd_info.path);
                 defer subcommands.allocator.free(module_name_with_index);
 
                 try writer.print("const {s} = @import(\"{s}\");\n", .{ module_name_with_index, module_name_with_index });
@@ -111,23 +93,10 @@ fn generateGroupImports(writer: anytype, _: []const u8, group_info: *const Comma
                 // Pure groups have no imports, just recurse
                 try generateGroupImports(writer, subcmd_name, &subcmd_info);
             } else {
-                // Generate module name from full command path to match module_creation.zig
-                var module_name_parts = std.ArrayList([]const u8).empty;
-                defer module_name_parts.deinit(subcommands.allocator);
-
-                for (subcmd_info.path) |part| {
-                    const sanitized_part = try sanitizeIdentifier(subcommands.allocator, part);
-                    defer subcommands.allocator.free(sanitized_part);
-                    try module_name_parts.append(subcommands.allocator, try subcommands.allocator.dupe(u8, sanitized_part));
-                }
-
-                const module_name = try std.mem.join(subcommands.allocator, "_", module_name_parts.items);
-                defer {
-                    for (module_name_parts.items) |part| {
-                        subcommands.allocator.free(part);
-                    }
-                    subcommands.allocator.free(module_name);
-                }
+                // Module name from the full command path — same derivation
+                // module_creation.zig uses, via module_names.
+                const module_name = try module_names.pathModuleName(subcommands.allocator, subcmd_info.path);
+                defer subcommands.allocator.free(module_name);
 
                 try writer.print("const {s} = @import(\"{s}\");\n", .{ module_name, module_name });
             }
@@ -255,7 +224,7 @@ fn generateCommandRegistrations(writer: anytype, commands: DiscoveredCommands, a
         if (cmd_info.command_type != .leaf) {
             // Register optional group with index file as a command
             if (cmd_info.command_type == .optional_group) {
-                const module_name = try std.fmt.allocPrint(allocator, "{s}_index", .{cmd_name});
+                const module_name = try module_names.indexModuleName(allocator, cmd_name);
                 defer allocator.free(module_name);
 
                 const command_path_str = try std.mem.join(allocator, " ", cmd_info.path);
@@ -268,11 +237,8 @@ fn generateCommandRegistrations(writer: anytype, commands: DiscoveredCommands, a
             // Register subcommands
             try generateGroupRegistrations(writer, cmd_name, &cmd_info, allocator);
         } else {
-            const module_name = if (std.mem.eql(u8, cmd_name, "test"))
-                "cmd_test"
-            else
-                try std.fmt.allocPrint(allocator, "cmd_{s}", .{cmd_name});
-            defer if (!std.mem.eql(u8, cmd_name, "test")) allocator.free(module_name);
+            const module_name = try module_names.leafModuleName(allocator, cmd_name);
+            defer allocator.free(module_name);
 
             // Use the actual command path from CommandInfo (it's now an array)
             const command_path_str = try std.mem.join(allocator, " ", cmd_info.path);
@@ -295,24 +261,7 @@ fn generateGroupRegistrations(writer: anytype, _: []const u8, group_info: *const
 
             if (subcmd_info.command_type == .optional_group) {
                 // Register the optional group itself
-                var module_name_parts = std.ArrayList([]const u8).empty;
-                defer module_name_parts.deinit(allocator);
-
-                for (subcmd_info.path) |part| {
-                    const sanitized_part = try sanitizeIdentifier(allocator, part);
-                    defer allocator.free(sanitized_part);
-                    try module_name_parts.append(allocator, try allocator.dupe(u8, sanitized_part));
-                }
-
-                const module_name = try std.mem.join(allocator, "_", module_name_parts.items);
-                defer {
-                    for (module_name_parts.items) |part| {
-                        allocator.free(part);
-                    }
-                    allocator.free(module_name);
-                }
-
-                const module_name_with_index = try std.fmt.allocPrint(allocator, "{s}_index", .{module_name});
+                const module_name_with_index = try module_names.pathIndexModuleName(allocator, subcmd_info.path);
                 defer allocator.free(module_name_with_index);
 
                 const command_path_str = try std.mem.join(allocator, " ", subcmd_info.path);
@@ -328,23 +277,10 @@ fn generateGroupRegistrations(writer: anytype, _: []const u8, group_info: *const
                 // Pure groups are not registered, just recurse
                 try generateGroupRegistrations(writer, subcmd_name, &subcmd_info, allocator);
             } else {
-                // Generate module name from full command path to match module_creation.zig
-                var module_name_parts = std.ArrayList([]const u8).empty;
-                defer module_name_parts.deinit(allocator);
-
-                for (subcmd_info.path) |part| {
-                    const sanitized_part = try sanitizeIdentifier(allocator, part);
-                    defer allocator.free(sanitized_part);
-                    try module_name_parts.append(allocator, try allocator.dupe(u8, sanitized_part));
-                }
-
-                const module_name = try std.mem.join(allocator, "_", module_name_parts.items);
-                defer {
-                    for (module_name_parts.items) |part| {
-                        allocator.free(part);
-                    }
-                    allocator.free(module_name);
-                }
+                // Module name from the full command path — same derivation
+                // module_creation.zig uses, via module_names.
+                const module_name = try module_names.pathModuleName(allocator, subcmd_info.path);
+                defer allocator.free(module_name);
 
                 // Use the actual command path from the CommandInfo (it's now an array)
                 const command_path_str = try std.mem.join(allocator, " ", subcmd_info.path);
@@ -368,17 +304,11 @@ fn generatePluginRegistrations(writer: anytype, plugins: []const PluginInfo, all
     }
 }
 
-/// Convert plugin name to valid Zig variable name (replace hyphens with
-/// underscores). Always returns an allocation the caller owns — the previous
-/// `catch plugin_name` swallowed OOM and emitted the unsanitized name.
+/// Convert a plugin name to a valid Zig variable name. Uses the shared
+/// identifier rule (identifier.zig) — the same one context.pluginFieldName
+/// applies to plugin ids at comptime.
 fn pluginVarName(allocator: std.mem.Allocator, plugin_name: []const u8) ![]u8 {
-    return std.mem.replaceOwned(u8, allocator, plugin_name, "-", "_");
-}
-
-/// Sanitize command name to valid Zig identifier (replace hyphens with
-/// underscores). Always returns an allocation the caller owns.
-fn sanitizeIdentifier(allocator: std.mem.Allocator, name: []const u8) ![]u8 {
-    return std.mem.replaceOwned(u8, allocator, name, "-", "_");
+    return identifier.sanitize(allocator, plugin_name);
 }
 
 // ============================================================================

--- a/packages/core/src/build_utils/module_creation.zig
+++ b/packages/core/src/build_utils/module_creation.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const types = @import("types.zig");
+const module_names = @import("module_names.zig");
 const command_config_lookup = @import("command_config_lookup.zig");
 
 const PluginInfo = types.PluginInfo;
@@ -54,7 +55,7 @@ pub fn createDiscoveredModules(
         if (cmd_info.command_type != .leaf) {
             // Create module for optional group with index file
             if (cmd_info.command_type == .optional_group) {
-                const module_name = b.fmt("{s}_index", .{cmd_name});
+                const module_name = module_names.indexModuleName(b.allocator, cmd_name) catch @panic("OOM");
                 const full_path = b.fmt("{s}/{s}", .{ commands_dir, cmd_info.file_path });
                 const cmd_module = b.addModule(module_name, .{
                     .root_source_file = b.path(full_path),
@@ -78,10 +79,7 @@ pub fn createDiscoveredModules(
             // Create modules for subcommands
             createGroupModules(b, registry_module, zcli_module, cmd_name, &cmd_info, commands_dir, shared_modules, command_configs);
         } else {
-            const module_name = if (std.mem.eql(u8, cmd_name, "test"))
-                "cmd_test"
-            else
-                b.fmt("cmd_{s}", .{cmd_name});
+            const module_name = module_names.leafModuleName(b.allocator, cmd_name) catch @panic("OOM");
 
             const full_path = b.fmt("{s}/{s}", .{ commands_dir, cmd_info.file_path });
             const cmd_module = b.addModule(module_name, .{
@@ -121,17 +119,9 @@ fn createGroupModules(
             const subcmd_info = entry.value_ptr.*;
 
             if (subcmd_info.command_type == .optional_group) {
-                // Create module for nested optional group
-                var module_name_parts = std.ArrayList([]const u8).empty;
-                defer module_name_parts.deinit(b.allocator);
-
-                for (subcmd_info.path) |part| {
-                    const sanitized_part = std.mem.replaceOwned(u8, b.allocator, part, "-", "_") catch part;
-                    module_name_parts.append(b.allocator, sanitized_part) catch unreachable;
-                }
-
-                const module_name = std.mem.join(b.allocator, "_", module_name_parts.items) catch unreachable;
-                const module_name_with_index = b.fmt("{s}_index", .{module_name});
+                // Create module for nested optional group — same derivation
+                // code_generation.zig emits imports with, via module_names.
+                const module_name_with_index = module_names.pathIndexModuleName(b.allocator, subcmd_info.path) catch @panic("OOM");
 
                 const full_path = b.fmt("{s}/{s}", .{ commands_dir, subcmd_info.file_path });
                 const cmd_module = b.addModule(module_name_with_index, .{
@@ -156,17 +146,10 @@ fn createGroupModules(
                 // Pure groups have no module, just recurse
                 createGroupModules(b, registry_module, zcli_module, subcmd_name, &subcmd_info, commands_dir, shared_modules, command_configs);
             } else {
-                // Generate module name from the full command path to handle nested directories
-                // This ensures unique module names even for deeply nested commands
-                var module_name_parts = std.ArrayList([]const u8).empty;
-                defer module_name_parts.deinit(b.allocator);
-
-                for (subcmd_info.path) |part| {
-                    const sanitized_part = std.mem.replaceOwned(u8, b.allocator, part, "-", "_") catch part;
-                    module_name_parts.append(b.allocator, sanitized_part) catch unreachable;
-                }
-
-                const module_name = std.mem.join(b.allocator, "_", module_name_parts.items) catch unreachable;
+                // Module name from the full command path (unique even for
+                // deeply nested commands) — same derivation code_generation.zig
+                // emits imports with, via module_names.
+                const module_name = module_names.pathModuleName(b.allocator, subcmd_info.path) catch @panic("OOM");
 
                 const full_path = b.fmt("{s}/{s}", .{ commands_dir, subcmd_info.file_path });
                 const cmd_module = b.addModule(module_name, .{

--- a/packages/core/src/build_utils/module_names.zig
+++ b/packages/core/src/build_utils/module_names.zig
@@ -1,0 +1,79 @@
+//! Single source of truth for the generated registry's module names.
+//! code_generation.zig emits `const X = @import("X");` lines and
+//! module_creation.zig registers the modules under the build graph — both
+//! derive names here, so an emitted import string can never drift from a
+//! registered module name. All names pass through identifier.sanitize, so a
+//! dash-named command file ("my-cmd.zig") yields a valid identifier on both
+//! sides.
+
+const std = @import("std");
+const identifier = @import("../identifier.zig");
+
+/// Top-level leaf command: `cmd_<name>`. The prefix keeps top-level command
+/// modules from colliding with other module-level decls (and keeps "test"
+/// legal — `@import("test")` aside, `const test = ...` is not).
+pub fn leafModuleName(allocator: std.mem.Allocator, cmd_name: []const u8) ![]u8 {
+    const sanitized = try identifier.sanitize(allocator, cmd_name);
+    defer allocator.free(sanitized);
+    return std.fmt.allocPrint(allocator, "cmd_{s}", .{sanitized});
+}
+
+/// Top-level optional group (directory with index.zig): `<name>_index`.
+pub fn indexModuleName(allocator: std.mem.Allocator, cmd_name: []const u8) ![]u8 {
+    const sanitized = try identifier.sanitize(allocator, cmd_name);
+    defer allocator.free(sanitized);
+    return std.fmt.allocPrint(allocator, "{s}_index", .{sanitized});
+}
+
+/// Nested command: sanitized path parts joined with '_' (unique even for
+/// deeply nested commands).
+pub fn pathModuleName(allocator: std.mem.Allocator, path: []const []const u8) ![]u8 {
+    var parts = try std.ArrayList([]const u8).initCapacity(allocator, path.len);
+    defer {
+        for (parts.items) |part| allocator.free(part);
+        parts.deinit(allocator);
+    }
+    for (path) |part| {
+        parts.appendAssumeCapacity(try identifier.sanitize(allocator, part));
+    }
+    return std.mem.join(allocator, "_", parts.items);
+}
+
+/// Nested optional group: `<path joined>_index`.
+pub fn pathIndexModuleName(allocator: std.mem.Allocator, path: []const []const u8) ![]u8 {
+    const base = try pathModuleName(allocator, path);
+    defer allocator.free(base);
+    return std.fmt.allocPrint(allocator, "{s}_index", .{base});
+}
+
+const testing = std.testing;
+
+test "leafModuleName sanitizes dashes" {
+    const name = try leafModuleName(testing.allocator, "my-cmd");
+    defer testing.allocator.free(name);
+    try testing.expectEqualStrings("cmd_my_cmd", name);
+}
+
+test "leafModuleName handles the 'test' command without special-casing" {
+    const name = try leafModuleName(testing.allocator, "test");
+    defer testing.allocator.free(name);
+    try testing.expectEqualStrings("cmd_test", name);
+}
+
+test "indexModuleName sanitizes dashes" {
+    const name = try indexModuleName(testing.allocator, "my-group");
+    defer testing.allocator.free(name);
+    try testing.expectEqualStrings("my_group_index", name);
+}
+
+test "pathModuleName joins sanitized parts" {
+    const name = try pathModuleName(testing.allocator, &.{ "gh", "add-item" });
+    defer testing.allocator.free(name);
+    try testing.expectEqualStrings("gh_add_item", name);
+}
+
+test "pathIndexModuleName appends _index" {
+    const name = try pathIndexModuleName(testing.allocator, &.{ "sprint", "sub-group" });
+    defer testing.allocator.free(name);
+    try testing.expectEqualStrings("sprint_sub_group_index", name);
+}

--- a/packages/core/src/context.zig
+++ b/packages/core/src/context.zig
@@ -11,6 +11,7 @@
 
 const std = @import("std");
 const zcli = @import("zcli.zig");
+const identifier = @import("identifier.zig");
 
 /// Field name in `context.plugins` for a plugin's ContextData: its
 /// `plugin_id` with every non-identifier character replaced by '_'.
@@ -27,7 +28,9 @@ pub fn pluginFieldName(comptime Plugin: type) [:0]const u8 {
         var result_idx: usize = 0;
         for (id) |c| {
             if (result_idx >= result.len - 1) break;
-            result[result_idx] = if (std.ascii.isAlphanumeric(c) or c == '_') c else '_';
+            // Shared rule (identifier.zig) — build-time codegen sanitizes
+            // plugin/module names with the same function.
+            result[result_idx] = identifier.sanitizeChar(c);
             result_idx += 1;
         }
         result[result_idx] = 0;

--- a/packages/core/src/identifier.zig
+++ b/packages/core/src/identifier.zig
@@ -1,0 +1,35 @@
+//! The single identifier-sanitization rule for user-supplied names that
+//! become Zig identifiers: plugin ids → `context.plugins.<field>` (applied at
+//! comptime by context.pluginFieldName) and plugin/command names → generated
+//! registry module names (applied by build_utils/module_names.zig). One rule,
+//! two call sites — if they disagreed, generated field/module access would
+//! break obscurely.
+
+const std = @import("std");
+
+/// Every byte that is not alphanumeric or '_' becomes '_'.
+pub fn sanitizeChar(c: u8) u8 {
+    return if (std.ascii.isAlphanumeric(c) or c == '_') c else '_';
+}
+
+/// Sanitize a whole name. Caller owns the returned slice.
+pub fn sanitize(allocator: std.mem.Allocator, name: []const u8) ![]u8 {
+    const out = try allocator.alloc(u8, name.len);
+    for (name, 0..) |c, i| out[i] = sanitizeChar(c);
+    return out;
+}
+
+test "sanitize maps every non-identifier byte to underscore" {
+    const allocator = std.testing.allocator;
+    const out = try sanitize(allocator, "my-plugin.v2 beta");
+    defer allocator.free(out);
+    try std.testing.expectEqualStrings("my_plugin_v2_beta", out);
+}
+
+test "sanitizeChar is usable at comptime" {
+    comptime {
+        std.debug.assert(sanitizeChar('-') == '_');
+        std.debug.assert(sanitizeChar('a') == 'a');
+        std.debug.assert(sanitizeChar('_') == '_');
+    }
+}

--- a/packages/core/src/plugin_types.zig
+++ b/packages/core/src/plugin_types.zig
@@ -220,6 +220,106 @@ pub fn getPriority(comptime T: type) i32 {
     return 50;
 }
 
+/// The lifecycle hooks detected by exact name above. Kept next to the has*
+/// functions so a new hook is added to both or the validator complains about
+/// nothing.
+const hook_names = [_][]const u8{
+    "transformArgs",
+    "handleGlobalOption",
+    "preParse",
+    "postParse",
+    "preExecute",
+    "postExecute",
+    "onError",
+};
+
+/// Non-hook decl names that are part of the plugin contract (never flagged).
+const contract_names = hook_names ++ [_][]const u8{
+    "global_options",
+    "commands",
+    "priority",
+    "plugin_id",
+    "ContextData",
+    "deinitContextData",
+    "init",
+};
+
+/// Comptime backstop against silently-dead hooks. Hooks are detected by exact
+/// name (`@hasDecl`), so a typo'd hook — `preExeucte` — compiles fine and
+/// simply never fires. Called by Registry.registerPlugin: any *function* decl
+/// whose name is within edit distance 2 of a hook (but isn't one) is rejected
+/// with a pointer at the hook it resembles.
+pub fn validatePlugin(comptime Plugin: type) void {
+    comptime {
+        if (@typeInfo(Plugin) != .@"struct") return;
+        for (@typeInfo(Plugin).@"struct".decls) |decl| {
+            if (isContractName(decl.name)) continue;
+            // Only functions can be hooks; consts near a hook name are inert.
+            if (@typeInfo(@TypeOf(@field(Plugin, decl.name))) != .@"fn") continue;
+            for (hook_names) |hook| {
+                // Cheap length gate before the DP — comptime branch quota.
+                const len_diff = if (decl.name.len > hook.len) decl.name.len - hook.len else hook.len - decl.name.len;
+                if (len_diff > 2) continue;
+                if (editDistance(decl.name, hook) <= 2) {
+                    @compileError("plugin function '" ++ decl.name ++ "' looks like a misspelling of the lifecycle hook '" ++ hook ++
+                        "' and would never be called — hooks are detected by exact name. Fix the spelling, or rename the function away from the hook.");
+                }
+            }
+        }
+    }
+}
+
+fn isContractName(comptime name: []const u8) bool {
+    for (contract_names) |contract| {
+        if (std.mem.eql(u8, name, contract)) return true;
+    }
+    return false;
+}
+
+/// Comptime Levenshtein distance (names here are short; the DP is tiny).
+fn editDistance(comptime a: []const u8, comptime b: []const u8) usize {
+    comptime {
+        var prev: [b.len + 1]usize = undefined;
+        for (0..b.len + 1) |j| prev[j] = j;
+        for (a, 0..) |ca, i| {
+            var curr: [b.len + 1]usize = undefined;
+            curr[0] = i + 1;
+            for (b, 0..) |cb, j| {
+                const cost: usize = if (ca == cb) 0 else 1;
+                curr[j + 1] = @min(@min(curr[j] + 1, prev[j + 1] + 1), prev[j] + cost);
+            }
+            prev = curr;
+        }
+        return prev[b.len];
+    }
+}
+
+test "editDistance catches the classic transposition typo" {
+    comptime {
+        std.debug.assert(editDistance("preExeucte", "preExecute") == 2);
+        std.debug.assert(editDistance("postExecute", "preExecute") == 3);
+        std.debug.assert(editDistance("preExecute", "preExecute") == 0);
+        std.debug.assert(editDistance("onErorr", "onError") == 2);
+    }
+}
+
+test "validatePlugin accepts a well-formed plugin with helpers" {
+    const Plugin = struct {
+        pub const plugin_id = "valid_plugin";
+        pub const priority = 10;
+        pub fn preExecute(context: anytype, args: anytype) !?@TypeOf(args) {
+            _ = context;
+            return args;
+        }
+        // A helper far from any hook name must not be flagged.
+        pub fn isHelpRequested(context: anytype) bool {
+            _ = context;
+            return false;
+        }
+    };
+    comptime validatePlugin(Plugin);
+}
+
 // ============================================================================
 // Plugin Registry Entry
 // ============================================================================

--- a/packages/core/src/registry/builder.zig
+++ b/packages/core/src/registry/builder.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const zcli = @import("../zcli.zig");
+const plugin_types = @import("../plugin_types.zig");
 
 const paths = @import("paths.zig");
 const compiled = @import("compiled.zig");
@@ -97,6 +98,9 @@ fn RegistryBuilder(comptime config: Config, comptime commands: []const CommandEn
             new_plugins ++ [_]type{Plugin},
         ) {
             _ = self;
+            // Backstop against silently-dead misspelled hooks (exact-name
+            // detection has no diagnostics of its own).
+            comptime plugin_types.validatePlugin(Plugin);
             return RegistryBuilder(
                 config,
                 commands,


### PR DESCRIPTION
Three LOW findings from the architecture review, all in the same blast radius (name derivation between comptime, codegen, and the build graph).

## 1. One identifier rule — `identifier.zig`

`context.pluginFieldName` (comptime: any non-identifier byte → `_`) and codegen's `sanitizeIdentifier`/`pluginVarName` (dash → `_` only) implemented the same concept differently. If they ever disagreed on a plugin name, generated field/module access would break obscurely. Both now share `identifier.sanitizeChar`/`sanitize`. Also kills the remaining `replaceOwned … catch part` OOM-swallow in module_creation (same bug class #112 fixed in codegen).

## 2. One module-name derivation — `build_utils/module_names.zig`

code_generation.zig emits `const X = @import("X");` and module_creation.zig registers modules under `X` — the derivation was duplicated in full (path-join + sanitize + `_index` suffix + a vestigial `"test" → "cmd_test"` special case whose branches produce byte-identical output). Both files now call `leafModuleName`/`indexModuleName`/`pathModuleName`/`pathIndexModuleName`, so import strings and registered names cannot drift. **Bug fixed along the way**: top-level names weren't sanitized on either side, so a dash-named command file (`my-cmd.zig`, legal per discovery's `isValidCommandName`) generated `const cmd_my-cmd` — invalid Zig.

## 3. `validatePlugin` — silently-dead hook backstop

Hooks are detected by exact name (`@hasDecl`), so `pub fn preExeucte` compiles and never fires. `Registry.registerPlugin` now runs a comptime check: any plugin **function** within Levenshtein distance 2 of a lifecycle hook name (that isn't an exact contract name) fails compilation with a message naming the hook it resembles. Non-function decls and helpers like `isHelpRequested` are untouched; the check flags nothing across the builtin plugins, example local plugins, or test fixtures.

## Verification

- Root suite **1432/1432** (new: identifier ×2, module_names ×5, plugin_types editDistance/validatePlugin tests), e2e **26/26**.
- No public API change: `module_names`/`identifier` are internal; `validatePlugin` is additive validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)