### PR TITLE
api: drop the derivable zcli_module param from the build API (grade2 fix 14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ pub fn build(b: *std.Build) !void {
     exe.root_module.addImport("zcli", zcli_module);
 
     const zcli = @import("zcli");
-    const cmd_registry = try zcli.generate(b, exe, zcli_dep, zcli_module, .{
+    const cmd_registry = try zcli.generate(b, exe, zcli_dep, .{
         .commands_dir = "src/commands",
         .plugins = &.{
             zcli.builtin(.help, .{}),
@@ -421,7 +421,7 @@ Generate markdown, man pages, or HTML documentation from your command metadata â
 
 ```zig
 // In build.zig, after generate():
-zcli.generateDocs(b, cmd_registry, zcli_dep, zcli_module, .{
+zcli.generateDocs(b, cmd_registry, zcli_dep, .{
     .formats = &.{ "markdown", "man", "html" },
     .output_dir = "docs",
 });

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -151,7 +151,7 @@ Plugins are integrated in `build.zig`:
 ```zig
 const zcli_build = @import("zcli");
 
-const cmd_registry = try zcli.generate(b, exe, zcli_dep, zcli_module, .{
+const cmd_registry = try zcli.generate(b, exe, zcli_dep, .{
     .commands_dir = "src/commands",
     .plugins = &[_]zcli_build.PluginConfig{
         .{ .name = "zcli_help", .path = "packages/core/src/plugins/zcli_help" },
@@ -172,7 +172,7 @@ The build system starts by scanning the configured commands directory:
 
 ```zig
 // In build.zig
-const cmd_registry = try zcli.generate(b, exe, zcli_dep, zcli_module, .{
+const cmd_registry = try zcli.generate(b, exe, zcli_dep, .{
     .commands_dir = "src/commands",  // Starting point
     .app_name = "myapp",
     .app_description = "My CLI app",

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -63,7 +63,7 @@ pub fn build(b: *std.Build) !void {
     exe.root_module.addImport("zcli", zcli_module);
 
     // Build with plugins and command discovery
-    const cmd_registry = try zcli.generate(b, exe, zcli_dep, zcli_module, .{
+    const cmd_registry = try zcli.generate(b, exe, zcli_dep, .{
         .commands_dir = "src/commands",
         .app_name = "myapp",
         .app_description = "My CLI application",
@@ -594,7 +594,7 @@ pub fn build(b: *std.Build) !void {
     exe.root_module.addImport("zcli", zcli_module);
 
     // zcli build integration
-    const cmd_registry = try zcli.generate(b, exe, zcli_dep, zcli_module, .{
+    const cmd_registry = try zcli.generate(b, exe, zcli_dep, .{
         .commands_dir = "src/commands",
         .app_name = "myapp",
         .app_description = "My awesome CLI app",
@@ -665,7 +665,7 @@ pub const commands = struct {
 Plugins are registered in build.zig:
 
 ```zig
-const cmd_registry = try zcli.generate(b, exe, zcli_dep, zcli_module, .{
+const cmd_registry = try zcli.generate(b, exe, zcli_dep, .{
     .plugins = &.{
         zcli.builtin(.help, .{}),
         zcli.builtin(.not_found, .{}),

--- a/examples/ghauth/build.zig
+++ b/examples/ghauth/build.zig
@@ -18,7 +18,7 @@ pub fn build(b: *std.Build) !void {
     exe.root_module.addImport("zcli", zcli_module);
 
     const zcli = @import("zcli");
-    const cmd_registry = try zcli.generate(b, exe, zcli_dep, zcli_module, .{
+    const cmd_registry = try zcli.generate(b, exe, zcli_dep, .{
         .commands_dir = "src/commands",
         .plugins = &.{
             zcli.builtin(.help, .{}),
@@ -44,7 +44,7 @@ pub fn build(b: *std.Build) !void {
 
     // Per-command unit tests (the scaffolded-project idiom): compiles each
     // command file as its own test root so its `test` blocks run.
-    _ = zcli.addCommandTests(b, zcli_dep, zcli_module, .{
+    _ = zcli.addCommandTests(b, zcli_dep, .{
         .commands_dir = "src/commands",
         .target = target,
         .optimize = optimize,

--- a/examples/notes/build.zig
+++ b/examples/notes/build.zig
@@ -31,7 +31,7 @@ pub fn build(b: *std.Build) !void {
         .{ .name = "store", .module = store_module },
     };
 
-    const cmd_registry = try zcli.generate(b, exe, zcli_dep, zcli_module, .{
+    const cmd_registry = try zcli.generate(b, exe, zcli_dep, .{
         .commands_dir = "src/commands",
         .plugins = &.{
             zcli.builtin(.help, .{}),
@@ -55,7 +55,7 @@ pub fn build(b: *std.Build) !void {
     const run_step = b.step("run", "Run the application");
     run_step.dependOn(&run_cmd.step);
 
-    _ = zcli.addCommandTests(b, zcli_dep, zcli_module, .{
+    _ = zcli.addCommandTests(b, zcli_dep, .{
         .commands_dir = "src/commands",
         .target = target,
         .optimize = optimize,

--- a/examples/repostat/build.zig
+++ b/examples/repostat/build.zig
@@ -18,7 +18,7 @@ pub fn build(b: *std.Build) !void {
     exe.root_module.addImport("zcli", zcli_module);
 
     const zcli = @import("zcli");
-    const cmd_registry = try zcli.generate(b, exe, zcli_dep, zcli_module, .{
+    const cmd_registry = try zcli.generate(b, exe, zcli_dep, .{
         .commands_dir = "src/commands",
         .plugins = &.{
             zcli.builtin(.help, .{}),
@@ -40,7 +40,7 @@ pub fn build(b: *std.Build) !void {
 
     // Per-command unit tests (the scaffolded-project idiom): compiles each
     // command file as its own test root so its `test` blocks run.
-    _ = zcli.addCommandTests(b, zcli_dep, zcli_module, .{
+    _ = zcli.addCommandTests(b, zcli_dep, .{
         .commands_dir = "src/commands",
         .target = target,
         .optimize = optimize,

--- a/examples/showcase/build.zig
+++ b/examples/showcase/build.zig
@@ -29,7 +29,7 @@ pub fn build(b: *std.Build) !void {
 
     const zcli = @import("zcli");
 
-    const cmd_registry = try zcli.generate(b, exe, zcli_dep, zcli_module, .{
+    const cmd_registry = try zcli.generate(b, exe, zcli_dep, .{
         .commands_dir = "src/commands",
         .plugins = &.{
             zcli.builtin(.help, .{}),
@@ -48,7 +48,7 @@ pub fn build(b: *std.Build) !void {
 
     exe.root_module.addImport("command_registry", cmd_registry);
 
-    zcli.generateDocs(b, cmd_registry, zcli_dep, zcli_module, .{
+    zcli.generateDocs(b, cmd_registry, zcli_dep, .{
         .formats = &.{ "markdown", "html" },
         .output_dir = "docs",
     });
@@ -65,7 +65,7 @@ pub fn build(b: *std.Build) !void {
 
     // Per-command unit tests (the scaffolded-project idiom): compiles each
     // command file as its own test root so its `test` blocks run.
-    _ = zcli.addCommandTests(b, zcli_dep, zcli_module, .{
+    _ = zcli.addCommandTests(b, zcli_dep, .{
         .commands_dir = "src/commands",
         .target = target,
         .optimize = optimize,

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -20,9 +20,9 @@ The zcli framework itself: argument/option parsing, the command registry and exe
 
 Re-exported through the zcli package root — `const zcli = @import("zcli");`:
 
-- `generate(b, exe, zcli_dep, zcli_module, config: GenerateConfig) !*Module` — discover commands, generate the registry
-- `generateDocs(b, registry, zcli_dep, zcli_module, config: DocsConfig)` — markdown/man/html docs on every build
-- `addCommandTests(b, zcli_dep, zcli_module, config: CommandTestsConfig)` — per-command unit-test wiring
+- `generate(b, exe, zcli_dep, config: GenerateConfig) !*Module` — discover commands, generate the registry
+- `generateDocs(b, registry, zcli_dep, config: DocsConfig)` — markdown/man/html docs on every build
+- `addCommandTests(b, zcli_dep, config: CommandTestsConfig)` — per-command unit-test wiring
 - `builtin(tag, config)` — register a shipped plugin by tag
 - Types: `GenerateConfig`, `DocsConfig`, `CommandTestsConfig`, `PluginConfig`, `SharedModule`
 

--- a/packages/core/src/build_utils/command_tests.zig
+++ b/packages/core/src/build_utils/command_tests.zig
@@ -33,9 +33,9 @@ const PluginInfo = types.PluginInfo;
 pub fn addCommandTests(
     b: *std.Build,
     zcli_dep: *std.Build.Dependency,
-    zcli_module: *std.Build.Module,
     config: types.CommandTestsConfig,
 ) *std.Build.Step {
+    const zcli_module = zcli_dep.module("zcli");
     const test_step = b.step("test", "Run command unit tests");
 
     const shared_modules = config.shared_modules;

--- a/packages/core/src/build_utils/main.zig
+++ b/packages/core/src/build_utils/main.zig
@@ -186,12 +186,15 @@ fn generatePluginRegistry(
 /// your build():
 ///
 /// ```zig
-/// const cmd_registry = try zcli.generate(b, exe, zcli_dep, zcli_module, .{ ... });
+/// const cmd_registry = try zcli.generate(b, exe, zcli_dep, .{ ... });
 /// ```
 ///
 /// The version is always read from the project's build.zig.zon — single
-/// source of truth, so there is no version field to pass.
-pub fn generate(b: *std.Build, exe: *std.Build.Step.Compile, zcli_dep: *std.Build.Dependency, zcli_module: *std.Build.Module, config: GenerateConfig) GenerateError!*std.Build.Module {
+/// source of truth, so there is no version field to pass. The zcli module is
+/// derived from `zcli_dep` (it is always `zcli_dep.module("zcli")`) for the
+/// same reason.
+pub fn generate(b: *std.Build, exe: *std.Build.Step.Compile, zcli_dep: *std.Build.Dependency, config: GenerateConfig) GenerateError!*std.Build.Module {
+    const zcli_module = zcli_dep.module("zcli");
     const app_version = readVersionFromZon(b);
 
     // Convert plugin configs to PluginInfo array
@@ -246,15 +249,16 @@ pub fn generate(b: *std.Build, exe: *std.Build.Step.Compile, zcli_dep: *std.Buil
 ///
 /// ```zig
 /// // Single format (default: markdown)
-/// zcli.generateDocs(b, cmd_registry, zcli_dep, zcli_module, .{});
+/// zcli.generateDocs(b, cmd_registry, zcli_dep, .{});
 ///
 /// // Multiple formats — each gets its own subdirectory
-/// zcli.generateDocs(b, cmd_registry, zcli_dep, zcli_module, .{
+/// zcli.generateDocs(b, cmd_registry, zcli_dep, .{
 ///     .formats = &.{ "markdown", "man" },
 ///     .output_dir = "docs",
 /// });
 /// ```
-pub fn generateDocs(b: *std.Build, registry_module: *std.Build.Module, zcli_dep: *std.Build.Dependency, zcli_module: *std.Build.Module, config: DocsConfig) void {
+pub fn generateDocs(b: *std.Build, registry_module: *std.Build.Module, zcli_dep: *std.Build.Dependency, config: DocsConfig) void {
+    const zcli_module = zcli_dep.module("zcli");
     const doc_exe = b.addExecutable(.{
         .name = "zcli-doc-gen",
         .root_module = b.createModule(.{

--- a/projects/zcli/build.zig
+++ b/projects/zcli/build.zig
@@ -68,7 +68,7 @@ pub fn build(b: *std.Build) !void {
     // Generate command registry using the plugin-aware build system
     const zcli = @import("zcli");
 
-    const cmd_registry = try zcli.generate(b, exe, zcli_dep, zcli_module, .{
+    const cmd_registry = try zcli.generate(b, exe, zcli_dep, .{
         .commands_dir = "src/commands",
         .plugins = &.{
             zcli.builtin(.help, .{}),
@@ -92,7 +92,7 @@ pub fn build(b: *std.Build) !void {
 
     exe.root_module.addImport("command_registry", cmd_registry);
 
-    zcli.generateDocs(b, cmd_registry, zcli_dep, zcli_module, .{
+    zcli.generateDocs(b, cmd_registry, zcli_dep, .{
         .formats = &.{ "markdown", "man", "html" },
     });
 

--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -258,7 +258,7 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         \\    }};
         \\
         \\    // Generate command registry with built-in plugins
-        \\    const cmd_registry = try zcli.generate(b, exe, zcli_dep, zcli_module, .{{
+        \\    const cmd_registry = try zcli.generate(b, exe, zcli_dep, .{{
         \\        .commands_dir = "src/commands",
         \\        // Local plugins in src/plugins/ are auto-discovered (add with
         \\        // `zcli add plugin <name>`). Harmless when the directory is absent.
@@ -285,7 +285,7 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         \\    // blocks use `zcli-testing`'s runCommand (bundled with the zcli
         \\    // dependency, so no extra dependency is needed). `zcli add command`
         \\    // scaffolds a starting test alongside each new command.
-        \\    _ = zcli.addCommandTests(b, zcli_dep, zcli_module, .{{
+        \\    _ = zcli.addCommandTests(b, zcli_dep, .{{
         \\        .commands_dir = "src/commands",
         \\        .target = target,
         \\        .optimize = optimize,


### PR DESCRIPTION
From the architecture review (LOW): `generate(b, exe, zcli_dep, zcli_module, config)` — `zcli_module` is always `zcli_dep.module("zcli")` (every call site in the repo passes exactly that), so the parameter is derivable ceremony that every zcli project has to type.

## Change

`generate`, `generateDocs`, and `addCommandTests` derive the module from `zcli_dep` internally. Updated: all five consumer build.zigs (projects/zcli + 4 examples), the init template, and every doc snippet (README, BUILD.md ×2, DESIGN.md ×3, core README signature list). Consumers keep their `zcli_module` local — they still need it for `exe.root_module.addImport("zcli", ...)`.

Breaking change for external consumers (one argument to delete, the compiler points at it); per project policy, no compatibility shim.

## Verification

- Root suite **1382/1382** — rebuilds projects/zcli and all examples with the new signatures.
- E2e **26/26** — the slow tier scaffolds a project from the updated init template and builds+runs it, proving the generated build.zig and the new `generate()` agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)