### PR TITLE
test: e2e coverage for the `zcli dev` watch/rebuild loop

### DIFF
--- a/packages/testing/src/e2e.zig
+++ b/packages/testing/src/e2e.zig
@@ -504,6 +504,14 @@ pub const InteractionStep = struct {
     exact_match: bool = false,
     /// Whether this step is optional (won't fail if not matched)
     optional: bool = false,
+    /// A callback to run at this point in the script — for driving a process
+    /// through something other than its stdin (e.g. mutating a watched file to
+    /// trigger `zcli dev`'s rebuild). Runs synchronously on the harness thread,
+    /// so any preceding `expect` has already matched: the effect is ordered
+    /// after the state that step proved.
+    action: ?*const fn (context: ?*anyopaque) void = null,
+    /// Opaque context passed to `action` (a pointer to test-owned state).
+    action_context: ?*anyopaque = null,
 };
 
 /// Builder for creating interactive test scripts
@@ -593,6 +601,17 @@ pub const InteractiveScript = struct {
     /// Expect prompt and send password
     pub fn expectAndSendPassword(self: *InteractiveScript, prompt: []const u8, password: []const u8) *InteractiveScript {
         return self.expect(prompt).sendHidden(password);
+    }
+
+    /// Run a callback at this point in the script. Use it to drive a process
+    /// through a side channel — e.g. touch a file that a watcher is watching —
+    /// between `expect`/`send` steps. `context` is passed back to the callback.
+    pub fn action(self: *InteractiveScript, callback: *const fn (context: ?*anyopaque) void, context: ?*anyopaque) *InteractiveScript {
+        self.steps.append(self.allocator, .{
+            .action = callback,
+            .action_context = context,
+        }) catch @panic("OOM");
+        return self;
     }
 
     /// Add a delay (for testing timing-sensitive interactions)
@@ -912,8 +931,16 @@ pub fn runInteractive(
             sleepMs(io, 100);
         }
 
-        // Pure delay steps.
-        if (step.expect == null and step.send == null and step.signal == null and step.timeout_ms > 0) {
+        if (step.action) |callback| {
+            callback(step.action_context);
+            if (transcript_buffer) |*tb| {
+                try transcriptPrint(tb, allocator, "Ran action\n", .{});
+            }
+        }
+
+        // Pure delay steps (an action step carries the default timeout_ms but is
+        // not a delay — don't sleep on it).
+        if (step.expect == null and step.send == null and step.signal == null and step.action == null and step.timeout_ms > 0) {
             sleepMs(io, step.timeout_ms);
         }
 

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -1441,3 +1441,130 @@ test "interactive: init's plugin multi-select toggles an opt-in plugin" {
     try expectContains(build_zig, "zcli.builtin(.not_found");
     try expectContains(build_zig, "zcli.builtin(.completions");
 }
+
+// ============================================================================
+// Layer 2 — `dev` watch/rebuild loop (long-running; driven over a PTY)
+// ============================================================================
+
+/// A file write performed mid-script via InteractiveScript.action — the side
+/// channel that drives `dev`. Unlike the wizard tests, `dev` reacts to file
+/// changes, not stdin, so the harness pokes the watched tree between `expect`s.
+/// The callback runs on the harness thread after the preceding `expect` matched,
+/// so the write is ordered strictly after the state that step proved (e.g. the
+/// watcher is armed once "watching src/" has appeared).
+const DevWrite = struct {
+    dir: std.Io.Dir,
+    path: []const u8,
+    data: []const u8,
+
+    fn run(context: ?*anyopaque) void {
+        const self: *DevWrite = @ptrCast(@alignCast(context.?));
+        self.dir.writeFile(io, .{ .sub_path = self.path, .data = self.data }) catch {};
+    }
+};
+
+// A valid hello.zig printing a chosen greeting. Each rebuild in the test below
+// uses a UNIQUE greeting so its `expect` waits for that specific cycle to finish
+// rather than matching an identical earlier line still in the cumulative buffer.
+fn helloPrinting(comptime greeting: []const u8) []const u8 {
+    return "const Context = @import(\"command_registry\").Context;\n" ++
+        "pub const meta = .{ .description = \"Say hello to someone\" };\n" ++
+        "pub const Args = struct { name: []const u8 };\n" ++
+        "pub const Options = struct {};\n" ++
+        "pub fn execute(args: Args, _: Options, context: *Context) !void {\n" ++
+        "    try context.stdout().print(\"" ++ greeting ++ ", {s}!\\n\", .{args.name});\n" ++
+        "}\n";
+}
+
+test "dev outside a project fails with a clear message" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // No src/ dir → dev refuses before arming the watcher and exits on its own,
+    // so the blocking `run` helper suffices (no long-running loop to escape).
+    var r = try run(tmp.dir, &.{ zcli_exe, "dev" });
+    defer r.deinit();
+    try testing.expect(r.exit_code != 0);
+    try expectContains(r.stderr, "No 'src' directory found");
+}
+
+test "dev builds, runs the app, restarts on change, survives a failed build, and recovers" {
+    if (builtin.os.tag == .windows) return;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    {
+        var r = try run(tmp.dir, &.{ zcli_exe, "init", "demo" });
+        defer r.deinit();
+        try expectOk(r);
+    }
+
+    var proj = try tmp.dir.openDir(io, "demo", .{});
+    defer proj.close(io);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const proj_abs = try tmpSubdirAbs(a, tmp, "demo");
+    try pointDependencyAtLocalTree(proj, proj_abs);
+
+    // The change source for each cycle. `dev` watches src/ recursively, so
+    // rewriting the compiled hello.zig triggers a rebuild; a parse error makes a
+    // rebuild fail on purpose (the watcher must survive it and recover).
+    const path = "src/commands/hello.zig";
+    var to_hola = DevWrite{ .dir = proj, .path = path, .data = helloPrinting("Hola") };
+    var to_broken = DevWrite{
+        .dir = proj,
+        .path = path,
+        .data = "// Intentionally invalid Zig so `zig build` fails — the dev watcher\n" ++
+            "// must survive this and rebuild cleanly once the file is fixed.\n" ++
+            "pub fn execute( <<< not valid zig\n",
+    };
+    var to_recovered = DevWrite{ .dir = proj, .path = path, .data = helloPrinting("Recovered") };
+
+    // Every `expect` after the arm targets a greeting (or the failure line) that
+    // appears exactly once, so each waits for its own rebuild rather than the
+    // repeated "change detected"/"build succeeded" framing shared by all cycles.
+    var script = harness.InteractiveScript.init(testing.allocator);
+    defer script.deinit();
+    _ = script
+        .expect("watching src/").withTimeout(20000)
+        .expect("Hello, World!").withTimeout(240000) // initial (cold) build + run
+        .action(DevWrite.run, &to_hola)
+        .expect("Hola, World!").withTimeout(120000) // rebuild + restart
+        .action(DevWrite.run, &to_broken)
+        .expect("build failed").withTimeout(120000) // a cycle the watcher survives
+        .action(DevWrite.run, &to_recovered)
+        .expect("Recovered, World!").withTimeout(120000) // recovery proves survival
+        .sendSignal(.SIGINT); // dev never exits on its own — stop the loop
+
+    var result = harness.runInteractive(
+        testing.allocator,
+        io,
+        &.{ zcli_exe, "dev", "--", "hello", "World" },
+        script,
+        // A PTY (not pipes) merges dev's stderr status lines with the app's
+        // stdout onto one stream, so "build failed" is captured alongside the
+        // greetings. total_timeout is a ceiling only — the run ends as soon as
+        // the last expect matches and SIGINT lands.
+        .{ .cwd = proj_abs, .allocate_pty = true, .total_timeout_ms = 600000 },
+    ) catch |err| switch (err) {
+        // PTY allocation can be denied in some sandboxes; skip rather than fail
+        // (CI greps the log for this line). Every other error is a real failure.
+        error.PtyAllocationFailed => {
+            std.debug.print("runInteractive unavailable: {any}\n", .{err});
+            return;
+        },
+        else => return err,
+    };
+    defer result.deinit();
+
+    // The whole loop ran end to end: the app was built and run, rebuilt and
+    // restarted on an edit, a broken edit failed the build without tearing down
+    // the watcher, and a fix rebuilt-and-reran — each proven by a once-only line.
+    try expectContains(result.output, "Hello, World!");
+    try expectContains(result.output, "Hola, World!");
+    try expectContains(result.output, "build failed");
+    try expectContains(result.output, "Recovered, World!");
+}


### PR DESCRIPTION
## What

`zcli dev` was the one meta-command with **no e2e coverage** — only unit tests for `appArgv`/`WatchState`. It's a long-running, filesystem-event-driven loop, so the suite's blocking `run()` helper deadlocks on it. This drives it over the PTY harness instead, terminated with SIGINT.

## Changes

**Harness — `packages/testing/src/e2e.zig`**
- Add a general `InteractiveScript.action(callback, ctx)` step. `dev` reacts to *file changes*, not stdin, so the input-driven harness had no way to drive it. The callback runs on the harness thread **after the preceding `expect` matched**, so a file write is ordered strictly after the state that step proved (e.g. the watcher is armed once `"watching src/"` printed). Excluded from the pure-delay branch. General-purpose beyond `dev` (mutate fs, poke a server mid-script).

**Tests — `projects/zcli/test/e2e.zig`**
- **Guard test:** `dev` outside a project exits with `"No 'src' directory found"` (uses the plain blocking `run()` — that path exits on its own).
- **One comprehensive test:** `dev -- hello World`, rewriting `hello.zig` with a **unique greeting per cycle** (`Hello`→`Hola`→broken→`Recovered`). In one scaffold it covers arm+build, `--` app spawn, rebuild-on-change, restart-on-change, a broken build the watcher **survives**, and recovery.

## Design notes

- **Unique per-cycle markers:** `expect` does `indexOf` on the *cumulative* buffer, so re-expecting a repeated status line (`"build succeeded"`, `"change detected"`) matches the first occurrence instantly → false pass. Unique greetings force each `expect` to wait for *its* rebuild.
- **PTY, not pipes:** dev's status (`"build failed"`) goes to stderr; the pipe path only reads child stdout. A PTY merges the streams so the failure line is captured alongside the app's greetings.
- Assertions target `result.output`, not exit_code/success — a SIGINT'd `dev` exits via signal (non-zero).

## Verification

`zig build e2e` → exit 0, no skip lines (`has_side_effects = true` forces the run to re-execute), ~2.5min. `zig fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)