### PR TITLE
test: run the zcli e2e suite on Windows CI (non-interactive tiers)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -196,21 +196,27 @@ jobs:
 
       # Runs the built zcli binary against throwaway temp projects, including a
       # tier that scaffolds a project and builds it against the local tree, and
-      # an interactive tier that drives prompts through a real PTY. The PTY
-      # harness is POSIX-only, so this runs on both Linux and macOS to cover
-      # both kernels' PTY behavior (the harness has caught macOS-specific bugs:
-      # its 4 KiB PTY buffer, EIO-on-close semantics).
+      # an interactive tier that drives prompts through a real PTY.
       #
-      # The interactive tests degrade to a skip — not a failure — where PTY
-      # allocation is denied, so a green run could silently lose that coverage;
-      # grep the log to prove the PTY tier actually ran.
+      # The interactive PTY harness is POSIX-only (no Windows ConPTY backend
+      # yet), so Linux and macOS cover both kernels' PTY behavior (the harness
+      # has caught macOS-specific bugs: its 4 KiB PTY buffer, EIO-on-close
+      # semantics). On Windows the interactive tier self-skips
+      # (runInteractive → UnsupportedPlatform); the non-interactive and
+      # scaffold-and-build tiers still run, exercising path handling, the
+      # .exe suffix, and the `zig build` subprocess flow natively.
+      #
+      # On POSIX the interactive tests degrade to a skip — not a failure — where
+      # PTY allocation is denied, so a green run could silently lose that
+      # coverage; grep the log to prove the PTY tier actually ran. That guard is
+      # POSIX-only: on Windows the tier is intentionally absent, not skipped.
       - name: Run e2e tests
         working-directory: projects/zcli
         shell: bash
         run: |
           set -eo pipefail
           zig build e2e 2>&1 | tee e2e.log
-          if grep -q "runInteractive unavailable" e2e.log; then
+          if [ "$RUNNER_OS" != "Windows" ] && grep -q "runInteractive unavailable" e2e.log; then
             echo "ERROR: interactive PTY tests were skipped (PTY allocation unavailable)"
             exit 1
           fi

--- a/packages/testing/src/e2e.zig
+++ b/packages/testing/src/e2e.zig
@@ -783,7 +783,28 @@ pub const InteractiveError = error{
 ///
 /// `io` is required for spawning the child and waiting on it; the byte-level I/O
 /// with the child uses raw posix.poll/read/write so it can poll with timeouts.
+///
+/// POSIX-only for now: driving a child through a real terminal here uses a PTY +
+/// termios + poll, which have no Windows equivalent in this file yet (a ConPTY
+/// backend is the planned follow-up). On Windows this returns
+/// error.UnsupportedPlatform — the comptime switch keeps the POSIX
+/// implementation from being analyzed there — so the interactive e2e tiers skip
+/// accordingly. The non-interactive tiers never touch this harness and run on
+/// Windows unchanged.
 pub fn runInteractive(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    command: []const []const u8,
+    script: InteractiveScript,
+    config: InteractiveConfig,
+) InteractiveError!InteractiveResult {
+    return switch (builtin.os.tag) {
+        .windows => InteractiveError.UnsupportedPlatform,
+        else => runInteractivePosix(allocator, io, command, script, config),
+    };
+}
+
+fn runInteractivePosix(
     allocator: std.mem.Allocator,
     io: std.Io,
     command: []const []const u8,
@@ -1223,59 +1244,65 @@ pub fn runInteractiveDualMode(
 // ============================================================================
 
 test "PtyManager initialization and cleanup" {
-    const allocator = std.testing.allocator;
+    // PtyManager is POSIX-only (PTY + termios + ioctl). The comptime block keeps
+    // its body from being analyzed on Windows, where those symbols don't exist.
+    if (builtin.os.tag != .windows) {
+        const allocator = std.testing.allocator;
 
-    var pty = PtyManager.init(allocator) catch |err| {
-        if (err == error.FileNotFound or err == error.AccessDenied) {
-            return;
-        }
-        return err;
-    };
-    defer pty.deinit();
+        var pty = PtyManager.init(allocator) catch |err| {
+            if (err == error.FileNotFound or err == error.AccessDenied) {
+                return;
+            }
+            return err;
+        };
+        defer pty.deinit();
 
-    try std.testing.expect(pty.master_fd != -1);
-    try std.testing.expect(pty.slave_fd != -1);
-    try std.testing.expect(pty.slave_name != null);
+        try std.testing.expect(pty.master_fd != -1);
+        try std.testing.expect(pty.slave_fd != -1);
+        try std.testing.expect(pty.slave_name != null);
+    }
 }
 
 test "PtyManager terminal settings" {
-    const allocator = std.testing.allocator;
+    if (builtin.os.tag != .windows) {
+        const allocator = std.testing.allocator;
 
-    if (builtin.os.tag == .windows) return;
+        // No controlling terminal → PTY operations may not work; skip.
+        if (!isFdTty(std.Io.File.stdin().handle)) return;
 
-    // No controlling terminal → PTY operations may not work; skip.
-    if (!isFdTty(std.Io.File.stdin().handle)) return;
+        var pty = PtyManager.init(allocator) catch {
+            return;
+        };
+        defer pty.deinit();
 
-    var pty = PtyManager.init(allocator) catch {
-        return;
-    };
-    defer pty.deinit();
-
-    try std.testing.expect(pty.master_fd != -1);
-    try std.testing.expect(pty.slave_fd != -1);
+        try std.testing.expect(pty.master_fd != -1);
+        try std.testing.expect(pty.slave_fd != -1);
+    }
 }
 
 test "PtyManager window size control" {
-    const allocator = std.testing.allocator;
+    if (builtin.os.tag != .windows) {
+        const allocator = std.testing.allocator;
 
-    var pty = PtyManager.init(allocator) catch |err| {
-        if (err == error.FileNotFound or err == error.AccessDenied) {
+        var pty = PtyManager.init(allocator) catch |err| {
+            if (err == error.FileNotFound or err == error.AccessDenied) {
+                return;
+            }
+            return err;
+        };
+        defer pty.deinit();
+
+        pty.setWindowSize(24, 80) catch {
             return;
-        }
-        return err;
-    };
-    defer pty.deinit();
+        };
 
-    pty.setWindowSize(24, 80) catch {
-        return;
-    };
+        const size = pty.getWindowSize() catch {
+            return;
+        };
 
-    const size = pty.getWindowSize() catch {
-        return;
-    };
-
-    try std.testing.expect(size.row == 24);
-    try std.testing.expect(size.col == 80);
+        try std.testing.expect(size.row == 24);
+        try std.testing.expect(size.col == 80);
+    }
 }
 
 test "runInteractive drives a command over pipes" {
@@ -1414,21 +1441,23 @@ test "InteractiveResult structure" {
 }
 
 test "createPtyFallback functionality" {
-    const allocator = std.testing.allocator;
+    if (builtin.os.tag != .windows) {
+        const allocator = std.testing.allocator;
 
-    const result = createPtyFallback(allocator) catch |err| {
-        std.log.err("PTY fallback creation failed: {any}", .{err});
-        return;
-    };
-    defer {
-        closeFd(result.master);
-        closeFd(result.slave);
-        allocator.free(result.slave_name);
+        const result = createPtyFallback(allocator) catch |err| {
+            std.log.err("PTY fallback creation failed: {any}", .{err});
+            return;
+        };
+        defer {
+            closeFd(result.master);
+            closeFd(result.slave);
+            allocator.free(result.slave_name);
+        }
+
+        try std.testing.expect(result.master != -1);
+        try std.testing.expect(result.slave != -1);
+        try std.testing.expectEqualStrings("/dev/pts/fake", result.slave_name);
     }
-
-    try std.testing.expect(result.master != -1);
-    try std.testing.expect(result.slave != -1);
-    try std.testing.expectEqualStrings("/dev/pts/fake", result.slave_name);
 }
 
 test "error handling in InteractiveError" {
@@ -1443,55 +1472,55 @@ test "error handling in InteractiveError" {
 }
 
 test "signal forwarding functionality" {
-    if (builtin.os.tag == .windows) return;
+    if (builtin.os.tag != .windows) {
+        const allocator = std.testing.allocator;
 
-    const allocator = std.testing.allocator;
+        var pty_manager = PtyManager.init(allocator) catch {
+            return;
+        };
+        defer pty_manager.deinit();
 
-    var pty_manager = PtyManager.init(allocator) catch {
-        return;
-    };
-    defer pty_manager.deinit();
+        // Invalid PID is rejected.
+        const invalid_result = pty_manager.forwardSignal(-1, .SIGTERM);
+        try std.testing.expectError(error.InvalidPid, invalid_result);
 
-    // Invalid PID is rejected.
-    const invalid_result = pty_manager.forwardSignal(-1, .SIGTERM);
-    try std.testing.expectError(error.InvalidPid, invalid_result);
+        try pty_manager.setupSignalForwarding(1); // init always exists
 
-    try pty_manager.setupSignalForwarding(1); // init always exists
-
-    try pty_manager.setWindowSize(25, 80);
-    pty_manager.synchronizeWindowSize(1) catch |err| {
-        std.log.info("Window size sync failed as expected in test: {any}", .{err});
-    };
+        try pty_manager.setWindowSize(25, 80);
+        pty_manager.synchronizeWindowSize(1) catch |err| {
+            std.log.info("Window size sync failed as expected in test: {any}", .{err});
+        };
+    }
 }
 
 test "terminal capability detection" {
-    if (builtin.os.tag == .windows) return;
+    if (builtin.os.tag != .windows) {
+        const allocator = std.testing.allocator;
 
-    const allocator = std.testing.allocator;
-
-    var pty_manager = PtyManager.init(allocator) catch {
-        var null_pty = PtyManager{
-            .allocator = allocator,
-            .master_fd = -1,
+        var pty_manager = PtyManager.init(allocator) catch {
+            var null_pty = PtyManager{
+                .allocator = allocator,
+                .master_fd = -1,
+            };
+            const caps = null_pty.detectTerminalCapabilities();
+            try std.testing.expect(!caps.has_pty);
+            try std.testing.expect(!caps.supports_window_size);
+            try std.testing.expect(!caps.supports_termios);
+            return;
         };
-        const caps = null_pty.detectTerminalCapabilities();
-        try std.testing.expect(!caps.has_pty);
-        try std.testing.expect(!caps.supports_window_size);
-        try std.testing.expect(!caps.supports_termios);
-        return;
-    };
-    defer pty_manager.deinit();
+        defer pty_manager.deinit();
 
-    const caps = pty_manager.detectTerminalCapabilities();
-    try std.testing.expect(caps.has_pty);
+        const caps = pty_manager.detectTerminalCapabilities();
+        try std.testing.expect(caps.has_pty);
 
-    _ = caps.supports_window_size;
-    _ = caps.supports_termios;
-    _ = caps.supports_raw_mode;
-    _ = caps.supports_echo_control;
-    _ = caps.supports_line_buffering;
+        _ = caps.supports_window_size;
+        _ = caps.supports_termios;
+        _ = caps.supports_raw_mode;
+        _ = caps.supports_echo_control;
+        _ = caps.supports_line_buffering;
 
-    pty_manager.autoAdjustWindowSize() catch |err| {
-        std.log.info("Auto window size adjustment failed as expected in test: {any}", .{err});
-    };
+        pty_manager.autoAdjustWindowSize() catch |err| {
+            std.log.info("Auto window size adjustment failed as expected in test: {any}", .{err});
+        };
+    }
 }

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -27,6 +27,11 @@ const fixtures_dir = build_options.fixtures_dir;
 // Harness
 // ============================================================================
 
+// The scaffolded demo binary path. `zig build` emits `demo.exe` on Windows and
+// `demo` elsewhere; the suffix is empty on POSIX, so this is a no-op there.
+const exe_ext = if (builtin.os.tag == .windows) ".exe" else "";
+const demo_bin = "./zig-out/bin/demo" ++ exe_ext;
+
 const RunResult = struct {
     stdout: []u8,
     stderr: []u8,
@@ -668,11 +673,11 @@ test "scaffolded project builds, runs, and round-trips add command" {
         defer r.deinit();
         try expectOk(r);
     }
-    try testing.expect(fileExists(proj, "zig-out/bin/demo"));
+    try testing.expect(fileExists(proj, "zig-out/bin/demo" ++ exe_ext));
 
     // The example command runs as generated.
     {
-        var r = try run(proj, &.{ "./zig-out/bin/demo", "hello", "World" });
+        var r = try run(proj, &.{ demo_bin, "hello", "World" });
         defer r.deinit();
         try expectOk(r);
         try expectContains(r.stdout, "Hello, World!");
@@ -680,7 +685,7 @@ test "scaffolded project builds, runs, and round-trips add command" {
 
     // Help lists the discovered command (the help plugin writes to stderr).
     {
-        var r = try run(proj, &.{ "./zig-out/bin/demo", "--help" });
+        var r = try run(proj, &.{ demo_bin, "--help" });
         defer r.deinit();
         try expectOk(r);
         try expectContains(r.stderr, "hello");
@@ -698,7 +703,7 @@ test "scaffolded project builds, runs, and round-trips add command" {
         try expectOk(r);
     }
     {
-        var r = try run(proj, &.{ "./zig-out/bin/demo", "ping" });
+        var r = try run(proj, &.{ demo_bin, "ping" });
         defer r.deinit();
         try expectOk(r);
         try expectContains(r.stdout, "TODO: Implement ping");
@@ -736,7 +741,7 @@ test "scaffolded project builds, runs, and round-trips add command" {
         try expectOk(r);
     }
     {
-        var r = try run(proj, &.{ "./zig-out/bin/demo", "ping", "-c", "3", "--loud", "--tags", "a", "--tags", "b" });
+        var r = try run(proj, &.{ demo_bin, "ping", "-c", "3", "--loud", "--tags", "a", "--tags", "b" });
         defer r.deinit();
         try expectOk(r);
         try expectContains(r.stdout, "TODO: Implement ping");
@@ -805,7 +810,7 @@ test "scaffolded project builds, runs, and round-trips add command" {
     }
     {
         // required + optional + variadic positionals, short flag, enum, multiple option.
-        var r = try run(proj, &.{ "./zig-out/bin/demo", "users", "create", "alice@example.com", "5", "x", "y", "-v", "--format", "json", "--ports", "8080", "--ports", "9090" });
+        var r = try run(proj, &.{ demo_bin, "users", "create", "alice@example.com", "5", "x", "y", "-v", "--format", "json", "--ports", "8080", "--ports", "9090" });
         defer r.deinit();
         try expectOk(r);
         try expectContains(r.stdout, "TODO: Implement users create");
@@ -840,7 +845,7 @@ test "scaffolded project builds, runs, and round-trips add command" {
     }
     {
         // The removed --ports/--note flags are gone; the trimmed command still runs.
-        var r = try run(proj, &.{ "./zig-out/bin/demo", "users", "create", "alice@example.com", "x", "y", "-v", "--format", "json" });
+        var r = try run(proj, &.{ demo_bin, "users", "create", "alice@example.com", "x", "y", "-v", "--format", "json" });
         defer r.deinit();
         try expectOk(r);
         try expectContains(r.stdout, "TODO: Implement users create");
@@ -865,14 +870,14 @@ test "scaffolded project builds, runs, and round-trips add command" {
     }
     {
         // The group runs on its own (landing execute)...
-        var r = try run(proj, &.{ "./zig-out/bin/demo", "server" });
+        var r = try run(proj, &.{ demo_bin, "server" });
         defer r.deinit();
         try expectOk(r);
         try expectContains(r.stdout, "TODO: Implement server");
     }
     {
         // ...and dispatches to its subcommand.
-        var r = try run(proj, &.{ "./zig-out/bin/demo", "server", "status" });
+        var r = try run(proj, &.{ demo_bin, "server", "status" });
         defer r.deinit();
         try expectOk(r);
         try expectContains(r.stdout, "TODO: Implement server status");
@@ -912,7 +917,7 @@ test "scaffolded project builds, runs, and round-trips add command" {
         try expectOk(r);
     }
     {
-        var r = try run(proj, &.{ "./zig-out/bin/demo", "hello", "World" });
+        var r = try run(proj, &.{ demo_bin, "hello", "World" });
         defer r.deinit();
         try expectOk(r);
         try expectContains(r.stdout, "Hello, World!");
@@ -943,7 +948,7 @@ test "scaffolded project builds, runs, and round-trips add command" {
     }
     {
         // The moved command runs at its new path (its execute() travelled intact).
-        var r = try run(proj, &.{ "./zig-out/bin/demo", "tools", "scratch" });
+        var r = try run(proj, &.{ demo_bin, "tools", "scratch" });
         defer r.deinit();
         try expectOk(r);
         try expectContains(r.stdout, "TODO: Implement scratch");
@@ -963,7 +968,7 @@ test "scaffolded project builds, runs, and round-trips add command" {
     }
     {
         // The removed command no longer resolves.
-        var r = try run(proj, &.{ "./zig-out/bin/demo", "tools", "scratch" });
+        var r = try run(proj, &.{ demo_bin, "tools", "scratch" });
         defer r.deinit();
         try testing.expect(r.exit_code != 0);
     }

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -81,6 +81,12 @@ fn run(cwd: std.Io.Dir, argv: []const []const u8) !RunResult {
 }
 
 fn fileExists(dir: std.Io.Dir, path: []const u8) bool {
+    // Windows rejects these characters in a path at the syscall layer with
+    // OBJECT_NAME_INVALID, which Zig surfaces as an unrecoverable panic rather
+    // than a catchable error. A name containing one can't exist, so treat it as
+    // absent instead of handing it to access(). (POSIX allows them, e.g. the
+    // `bad"name` project-name rejection test, where access just reports ENOENT.)
+    if (builtin.os.tag == .windows and std.mem.indexOfAny(u8, path, "<>\"|?*") != null) return false;
     dir.access(io, path, .{}) catch return false;
     return true;
 }
@@ -621,6 +627,10 @@ fn pointDependencyAtLocalTree(proj: std.Io.Dir, proj_abs: []const u8) !void {
 
     // from/to are absolute, so cwd/environ are unused.
     const rel = try std.fs.path.relative(a, "", null, proj_abs, repo_root);
+    // build.zig.zon paths use forward slashes on every platform. On Windows the
+    // relative path comes back with backslashes, which would be invalid escape
+    // sequences once embedded in the generated Zig string literal below.
+    std.mem.replaceScalar(u8, rel, '\\', '/');
 
     const orig = try readFile(proj, a, "build.zig.zon");
     const dep_start = std.mem.indexOf(u8, orig, ".dependencies") orelse return error.NoDependenciesBlock;


### PR DESCRIPTION
## What

Adds `windows-latest` to the e2e CI matrix so the zcli end-to-end suite runs on Windows for the first time.

## Why it wasn't running

The e2e suite imports the PTY harness (`packages/testing/src/e2e.zig`), and that harness didn't **compile** for Windows:
- `posix.fd_t` is a `HANDLE` on Windows, so the `master_fd: posix.fd_t = -1` field sentinels don't type-check;
- it calls libc-only `pipe`.

Both blockers live entirely inside the POSIX PTY path — which the platform-neutral parts of the suite never touch.

## How

- **Comptime-gate the POSIX PTY implementation.** `runInteractive` now dispatches through `switch (builtin.os.tag)` to `runInteractivePosix` (POSIX) or `error.UnsupportedPlatform` (Windows). Zig's lazy analysis means the POSIX body — and everything it references (`PtyManager`, termios, ioctl, poll) — is never compiled for Windows.
- **Prune the harness's own PTY tests on Windows** by moving their `if (windows) return` runtime guard into a comptime `if (!windows) { ... }` block, so the bodies aren't analyzed there.
- **Add `windows-latest` to the e2e matrix.** The interactive PTY tier self-skips (no ConPTY backend yet — planned follow-up); the **non-interactive** and **scaffold-and-build** tiers run, exercising path handling, the `.exe` suffix, and the `zig build` subprocess flow natively. The "PTY tier actually ran" grep guard is made POSIX-only.
- **Fix one portability gap:** the scaffold-build tier hard-coded `./zig-out/bin/demo`, but `zig build` emits `demo.exe` on Windows. A `demo_bin` constant appends the platform exe suffix (empty on POSIX → unchanged there).

## Verification

- Harness, zcli e2e, and the **full `zig build e2e` build graph** all cross-compile for `x86_64-windows` locally (only the Mac-can't-exec-a-Windows-binary *run* step fails, as expected).
- The harness's 13 tests and the **full macOS e2e suite** still pass unchanged.
- First real *runtime* validation of the Windows tiers is this PR's CI run.

## Follow-up

- **ConPTY backend** to run the interactive tier on Windows (spike already proven to compile) — separate PR.
- `release.yml` still runs e2e only on POSIX (test-on-POSIX / cross-build-for-Windows); left as-is pending a parity decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)