### PR TITLE
ci: run unit tests on Windows; slim the Windows job to the release build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -39,13 +39,15 @@ jobs:
         with:
           version: 0.16.0
 
-      # Runs the test suites for every package (packages/*) on both Linux and
-      # macOS — the terminal stack is now libc-free, so this guards portability.
+      # Runs the test suites for every package (packages/*) AND projects/zcli's
+      # own unit tests on all three OSes. Windows is a first-class leg now that
+      # the interactive `testing` harness compiles there (ConPTY backend); the
+      # terminal stack is libc-free, so this guards portability across the board.
       - name: Run tests
         run: zig build test
 
-  windows:
-    name: windows build + smoke test
+  windows-release-build:
+    name: windows release build
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -56,30 +58,16 @@ jobs:
         with:
           version: 0.16.0
 
-      # The terminal stack has a Windows console backend (raw mode / VT input via
-      # the console-mode API). Build the CLI natively here — a real Windows
-      # toolchain catches native linking/ABI issues that the release's
-      # cross-compile from Linux would not — then run the binary to prove it
-      # actually starts and dispatches on Windows.
+      # Build the CLI natively in ReleaseFast — a real Windows toolchain catches
+      # native linking/ABI + optimize-mode issues that the release's
+      # cross-compile from Linux would not. This is the only ReleaseFast Windows
+      # coverage on PRs (release.yml cross-compiles and is tag-triggered). The
+      # `test` job now runs the unit suites natively on Windows, and the `e2e`
+      # job builds the binary (Debug) and exercises it end to end, so a separate
+      # smoke step here would be redundant.
       - name: Build zcli (native Windows, ReleaseFast)
         working-directory: projects/zcli
         run: zig build -Doptimize=ReleaseFast
-
-      - name: Smoke test the binary
-        working-directory: projects/zcli
-        shell: bash
-        run: |
-          ./zig-out/bin/zcli.exe --version
-          ./zig-out/bin/zcli.exe --help
-
-      # Run every package's unit tests natively — Windows is a shipped release
-      # target, so "builds on Windows" isn't enough. Steps are enumerated
-      # instead of using the full `zig build test` aggregate because the
-      # PTY-based `testing` package is POSIX-only (and the aggregate also
-      # rebuilds every subproject via subprocess, which the build job above
-      # already covers for the CLI).
-      - name: Run portable unit tests
-        run: zig build test-core test-terminal test-vterm test-vterm_example test-zinput test-zprogress test-ztheme test-markdown_fmt
 
   secrets:
     name: zcli_secrets backend (${{ matrix.os }})


### PR DESCRIPTION
## What

Makes Windows a first-class **unit test** leg, and removes the coverage the new e2e job made redundant. Follow-up to #127/#128 (Windows e2e).

## Why now

The unit suites were POSIX-limited only because the interactive `testing` harness didn't compile on Windows. #128's ConPTY backend fixed that, so the restriction is obsolete.

## Changes

- **`test` job** → matrix gains `windows-latest`. `zig build test` runs every package's suite **and** projects/zcli's own unit tests natively on all three OSes — the latter also closes the *"zcli unit tests on Windows CI"* follow-up from the grade2 burn-down.
- **`windows` job** → renamed **`windows-release-build`**, slimmed to just the native **ReleaseFast** build:
  - dropped the **smoke** step — the `e2e` job already builds the binary and drives `init`/`add`/`tree`/`guide`/`release` on Windows, a far more thorough "it starts and dispatches" check than `--version`/`--help`.
  - dropped the enumerated **portable unit tests** — now covered by the `test` matrix.
  - kept **ReleaseFast native** — the one thing neither `e2e` (Debug) nor `release.yml` (tag-triggered, cross-compiled from Linux) covers on a PR.

## Verification

- The full `testing` package and projects/zcli's `zig build test` both **cross-compile for `x86_64-windows`** locally (only the Mac-can't-exec-a-Windows-binary run step fails).
- No committed snapshot golden files (generated at runtime) and `runner.zig`'s spawn helper isn't exercised by its tests, so the usual Windows CRLF/`.exe` runtime traps are unlikely — but **first-run Windows unit-test behavior is validated by this PR's CI**, and any line-ending/path fixes will land here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)