### PR TITLE
feat: put the Windows console into UTF-8 so multibyte I/O round-trips

### DIFF
--- a/packages/core/src/console_utf8.zig
+++ b/packages/core/src/console_utf8.zig
@@ -1,0 +1,65 @@
+//! Puts the Windows console into UTF-8 for the duration of a CLI run.
+//!
+//! A Windows console starts out on a legacy OEM/ANSI code page, and that code
+//! page is what `ReadFile`/`WriteFile` use to translate between bytes and
+//! characters. So a typed `é` comes back mangled and any UTF-8 the CLI prints
+//! renders as mojibake — unless both console code pages are switched to
+//! `CP_UTF8`. `enable()` does that and returns the prior code pages;
+//! `restore()` puts them back so the parent shell isn't left reconfigured.
+//!
+//! Everything here is a no-op on non-Windows platforms (POSIX terminals are
+//! already byte-transparent UTF-8), and the Win32 calls are compiled only into
+//! the Windows build.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+const UINT = std.os.windows.UINT;
+const BOOL = std.os.windows.BOOL;
+
+/// Code page identifier for UTF-8 (see the Win32 "Code Page Identifiers" list).
+const CP_UTF8: UINT = 65001;
+
+/// The console code pages `enable()` replaced, for `restore()` to put back. A
+/// field of 0 means "left unchanged" — either not Windows, no attached console,
+/// or it was already UTF-8 — so `restore()` skips it.
+pub const State = struct {
+    prev_in: UINT = 0,
+    prev_out: UINT = 0,
+
+    /// Restore the code pages captured by `enable()`. Safe to call more than
+    /// once and on any platform; only pages we actually changed are reverted.
+    pub fn restore(self: State) void {
+        if (builtin.os.tag == .windows) {
+            if (self.prev_in != 0) _ = win.SetConsoleCP(self.prev_in);
+            if (self.prev_out != 0) _ = win.SetConsoleOutputCP(self.prev_out);
+        }
+    }
+};
+
+/// Switch the attached console's input and output code pages to UTF-8, best
+/// effort. Returns the prior code pages for `restore()`; a page is only
+/// captured when the query and the switch both succeed, so a process with no
+/// console (redirected to a pipe/file) leaves the returned `State` empty.
+pub fn enable() State {
+    if (builtin.os.tag == .windows) {
+        var state: State = .{};
+        const in = win.GetConsoleCP();
+        if (in != 0 and in != CP_UTF8 and win.SetConsoleCP(CP_UTF8) != 0) state.prev_in = in;
+        const out = win.GetConsoleOutputCP();
+        if (out != 0 and out != CP_UTF8 and win.SetConsoleOutputCP(CP_UTF8) != 0) state.prev_out = out;
+        return state;
+    }
+    return .{};
+}
+
+// Zig 0.16's `std.os.windows` exposes none of the console code-page functions,
+// so declare the four needed. `GetConsole*CP` return the code page (0 if the
+// process has no console); `SetConsole*CP` return a BOOL (0 on failure). Only
+// referenced inside the Windows-gated blocks above, so this links nowhere else.
+const win = struct {
+    extern "kernel32" fn GetConsoleCP() callconv(.winapi) UINT;
+    extern "kernel32" fn SetConsoleCP(wCodePageID: UINT) callconv(.winapi) BOOL;
+    extern "kernel32" fn GetConsoleOutputCP() callconv(.winapi) UINT;
+    extern "kernel32" fn SetConsoleOutputCP(wCodePageID: UINT) callconv(.winapi) BOOL;
+};

--- a/packages/core/src/console_utf8.zig
+++ b/packages/core/src/console_utf8.zig
@@ -15,7 +15,6 @@ const std = @import("std");
 const builtin = @import("builtin");
 
 const UINT = std.os.windows.UINT;
-const BOOL = std.os.windows.BOOL;
 
 /// Code page identifier for UTF-8 (see the Win32 "Code Page Identifiers" list).
 const CP_UTF8: UINT = 65001;
@@ -55,11 +54,14 @@ pub fn enable() State {
 
 // Zig 0.16's `std.os.windows` exposes none of the console code-page functions,
 // so declare the four needed. `GetConsole*CP` return the code page (0 if the
-// process has no console); `SetConsole*CP` return a BOOL (0 on failure). Only
-// referenced inside the Windows-gated blocks above, so this links nowhere else.
+// process has no console); `SetConsole*CP` return a BOOL (0 on failure) — typed
+// as `c_int` to match the other kernel32 externs in this repo (backend_windows)
+// and to compare directly against 0, which `std.os.windows.BOOL` doesn't allow.
+// Only referenced inside the Windows-gated blocks above, so this links nowhere
+// else.
 const win = struct {
     extern "kernel32" fn GetConsoleCP() callconv(.winapi) UINT;
-    extern "kernel32" fn SetConsoleCP(wCodePageID: UINT) callconv(.winapi) BOOL;
+    extern "kernel32" fn SetConsoleCP(wCodePageID: UINT) callconv(.winapi) c_int;
     extern "kernel32" fn GetConsoleOutputCP() callconv(.winapi) UINT;
-    extern "kernel32" fn SetConsoleOutputCP(wCodePageID: UINT) callconv(.winapi) BOOL;
+    extern "kernel32" fn SetConsoleOutputCP(wCodePageID: UINT) callconv(.winapi) c_int;
 };

--- a/packages/core/src/registry/compiled.zig
+++ b/packages/core/src/registry/compiled.zig
@@ -4,6 +4,7 @@ const option_utils = @import("../options/utils.zig");
 const plugin_types = @import("../plugin_types.zig");
 const zcli = @import("../zcli.zig");
 
+const console_utf8 = @import("../console_utf8.zig");
 const paths = @import("paths.zig");
 const builder = @import("builder.zig");
 const comptimeJoinPath = paths.comptimeJoinPath;
@@ -559,6 +560,13 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
 
         /// Convenient run method that handles process args, io, and environment
         pub fn run(self: *Self, allocator: std.mem.Allocator, io: std.Io, environ: *const std.process.Environ.Map, args: []const []const u8) !void {
+            // Windows consoles default to a legacy code page, so without this a
+            // typed multibyte character arrives mangled and printed UTF-8 shows
+            // as mojibake. Switch to UTF-8 for the run and restore on the way
+            // out; a no-op on POSIX. `std.process.exit` skips deferred restores,
+            // so the reported-error path below restores explicitly.
+            const console = console_utf8.enable();
+            defer console.restore();
             self.execute(allocator, io, environ, if (args.len > 0) args[1..] else args) catch |err| {
                 // CLI-entry semantics: some failures already showed the user a
                 // message — parse/routing diagnostics, a plugin, the framework
@@ -567,7 +575,10 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
                 // Anything else is an unexpected failure; propagate it so the
                 // name and trace aid debugging. Library/test callers who want
                 // the error itself use execute() directly.
-                if (isReportedCliError(err)) std.process.exit(1);
+                if (isReportedCliError(err)) {
+                    console.restore();
+                    std.process.exit(1);
+                }
                 return err;
             };
         }

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -1368,12 +1368,18 @@ test "interactive: text prompt handles multibyte UTF-8 typing and backspace" {
     // the old byte-oriented one popped a single byte, leaving invalid UTF-8
     // ("Caf\xC3" + "e") in the generated file. See the wizard test above for the
     // settle-delay rationale.
+    //
+    // The é is typed and then erased, so the two are split by a settle delay: a
+    // real PTY streams every byte (the transient "Café" echo is always captured),
+    // but ConPTY emits screen-diff frames and would coalesce the type-then-erase
+    // into just the final "Cafe" — the pause lets it flush a frame while "Café"
+    // is still on screen, so the live-echo assertion below holds on both backends.
     const settle_ms = 400;
     var script = harness.InteractiveScript.init(testing.allocator);
     defer script.deinit();
     _ = script
         .expect("Command path:").delay(settle_ms).send("greet")
-        .expect("Description:").delay(settle_ms).sendRaw("Caf\xc3\xa9\x7fe\r")
+        .expect("Description:").delay(settle_ms).sendRaw("Caf\xc3\xa9").delay(settle_ms).sendRaw("\x7fe\r")
         .expect("Add a positional argument?").delay(settle_ms).sendRaw("n")
         .expect("Add an option?").delay(settle_ms).sendRaw("n")
         .expect("What next?").delay(settle_ms).sendRaw("\r");

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -1351,13 +1351,10 @@ test "interactive: add command drives the wizard and echoes typed input" {
 }
 
 test "interactive: text prompt handles multibyte UTF-8 typing and backspace" {
-    // ConPTY delivers console input through the child's input codepage, which
-    // isn't UTF-8 by default, so a typed `é` round-trips as U+FFFD under the
-    // ConPTY harness. Making this pass needs zcli to set the console input
-    // codepage to UTF-8 on Windows — a product change, tracked separately from
-    // the harness. The ASCII prompt tests already cover the ConPTY path.
-    if (builtin.os.tag == .windows) return;
-
+    // ConPTY delivers console input through the child's input code page. zcli
+    // now switches that to UTF-8 at startup (see console_utf8.zig / the run
+    // entry in packages/core), so a typed `é` round-trips intact under the
+    // ConPTY harness rather than collapsing to U+FFFD.
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
     try makeProjectDirs(tmp.dir);


### PR DESCRIPTION
## What

Every zcli-generated CLI now switches the Windows console to UTF-8 (`CP_UTF8` / 65001) at startup and restores the prior code pages on exit. This is the product change tracked as follow-up #1 from the Windows-CI-parity work.

## Why

A Windows console starts on a legacy OEM/ANSI code page, and that page is what `ReadFile`/`WriteFile` use to translate between bytes and characters. So a typed multibyte character (e.g. `é`) arrives mangled — under the ConPTY e2e harness it collapsed to `U+FFFD` — and any UTF-8 a CLI prints renders as mojibake. Per the [Win32 docs](https://learn.microsoft.com/windows/console/setconsolecp), `SetConsoleCP` sets the input code page used to "translate keyboard input into the corresponding character value"; pairing it with `SetConsoleOutputCP` covers output.

## How

- New `packages/core/src/console_utf8.zig`: `enable()` switches both console code pages to UTF-8 (best effort — a redirected/no-console process is left untouched) and returns the prior pages; `restore()` puts them back so the parent shell is left as found.
- Wired into the shared `run()` entry in `packages/core/src/registry/compiled.zig` that every generated CLI routes through. `std.process.exit` skips deferred restores, so the reported-error path restores explicitly before exiting; every path restores exactly once.
- No-op on POSIX (already byte-transparent UTF-8); the kernel32 calls are gated behind `if (builtin.os.tag == .windows)` blocks so they compile only into the Windows build.
- Un-skips the `interactive: text prompt handles multibyte UTF-8 typing and backspace` e2e test on Windows.

## Verification

- Native (macOS): `test-core` green, full `zig build e2e` green.
- Compile-checked `x86_64-windows` (host can't execute Windows binaries).
- Windows runtime correctness is proven by the now-un-skipped ConPTY test on the Windows CI job — that green job is the real confirmation the input-codepage fix is sufficient.
- Reviewed by a code-reviewer subagent (verdict: approve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)