### PR TITLE
ci: gate releases on native Windows unit + e2e too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,10 +188,9 @@ jobs:
       #
       # The interactive terminal harness runs on all three OSes: POSIX uses a PTY
       # (the harness has caught macOS-specific bugs: its 4 KiB PTY buffer,
-      # EIO-on-close semantics), Windows uses a ConPTY. The `zcli dev` interactive
-      # tier stays POSIX-only for now (its native fs-watch loop isn't
-      # Windows-ready), but the prompt-driven tiers exercise the terminal stack
-      # on every platform.
+      # EIO-on-close semantics), Windows uses a ConPTY. Every interactive tier —
+      # including `zcli dev`'s watch/rebuild loop (nightwatch's ReadDirectoryChangesW
+      # backend) — exercises the terminal stack on every platform.
       #
       # The interactive tests degrade to a skip — not a failure — where the
       # pseudo-terminal can't be allocated, so a green run could silently lose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -32,11 +32,23 @@ jobs:
           version: 0.16.0
 
       - name: Run unit tests
+        shell: bash
         run: zig build test
 
+      # Mirror ci.yml's e2e gate, guard included: the interactive tier degrades
+      # to a skip (not a failure) where a pseudo-terminal can't be allocated, so
+      # grep the log to prove it actually ran — a release must not ship with that
+      # coverage silently dropped on any OS.
       - name: Run e2e tests
         working-directory: projects/zcli
-        run: zig build e2e
+        shell: bash
+        run: |
+          set -eo pipefail
+          zig build e2e 2>&1 | tee e2e.log
+          if grep -q "runInteractive unavailable" e2e.log; then
+            echo "ERROR: interactive terminal tests were skipped (pseudo-terminal unavailable)"
+            exit 1
+          fi
 
   build:
     name: Build ${{ matrix.target }}


### PR DESCRIPTION
## What

Adds `windows-latest` to `release.yml`'s test gate, so a release tag is gated on native Windows unit + e2e — matching the coverage `ci.yml` now runs on every push. This is follow-up #3 from the Windows-CI-parity work.

## Why

The release gate ran only `ubuntu-latest` + `macos-latest`, while the Windows binaries (`x86_64-windows`, `aarch64-windows`) were **cross-compiled from ubuntu and shipped without ever being natively tested**. Now that native Windows runners are proven and fast (~3.5 min e2e), gating releases on them closes the loop — a tag can no longer ship a Windows-only regression.

## How

- `os: [ubuntu-latest, macos-latest]` → `+ windows-latest` in the test job matrix.
- The e2e step now **mirrors `ci.yml`'s exactly**: `shell: bash` + the `set -eo pipefail` / `grep "runInteractive unavailable"` guard. That guard fails the run if the interactive tier silently skips (pseudo-terminal unavailable) — a protection a *release* gate wants at least as much as CI, and `shell: bash` makes the step behave identically across all three OSes (the old bare `run:` relied on the default shell being bash, false on Windows).
- Added `shell: bash` to the unit-test step too, for the same cross-OS consistency.
- Refreshed a now-stale `ci.yml` comment that still called `zcli dev` POSIX-only — it runs on Windows as of #132.

## Verification

- Both workflow files parse as valid YAML.
- The e2e step is copied from `ci.yml`'s already-green Windows job, so the Windows behavior is already proven.
- Note: `release.yml` only triggers on `zcli-v*` tags, so this PR's own checks exercise `ci.yml`, not the changed gate — the release path is validated on the next actual release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)