### PR TITLE
feat(examples): add oauth-device, a device-flow (RFC 8628) example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,10 +151,11 @@ jobs:
         with:
           version: 0.16.0
 
-      # The `ghauth` example opts into zcli_secrets, whose Linux backend links
-      # libsecret at build time (ADR-0003). Compiling the examples therefore
-      # needs the dev headers on Linux; macOS/Windows keychains link nothing.
-      - name: Install Secret Service deps (for the ghauth example)
+      # The `ghauth` and `oauth-device` examples opt into zcli_secrets, whose
+      # Linux backend links libsecret at build time (ADR-0003). Compiling the
+      # examples therefore needs the dev headers on Linux; macOS/Windows
+      # keychains link nothing.
+      - name: Install Secret Service deps (for the zcli_secrets examples)
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends libsecret-1-dev libglib2.0-dev

--- a/build.zig
+++ b/build.zig
@@ -96,6 +96,7 @@ pub fn build(b: *std.Build) void {
         .{ .name = "showcase", .path = "examples/showcase" },
         .{ .name = "repostat", .path = "examples/repostat" },
         .{ .name = "ghauth", .path = "examples/ghauth" },
+        .{ .name = "oauth-device", .path = "examples/oauth-device" },
         .{ .name = "notes", .path = "examples/notes" },
     };
 
@@ -136,6 +137,7 @@ pub fn build(b: *std.Build) void {
         .{ .name = "showcase", .path = "examples/showcase" },
         .{ .name = "repostat", .path = "examples/repostat" },
         .{ .name = "ghauth", .path = "examples/ghauth" },
+        .{ .name = "oauth-device", .path = "examples/oauth-device" },
         .{ .name = "notes", .path = "examples/notes" },
         .{ .name = "vterm_example", .path = "packages/vterm/example" },
     };

--- a/examples/oauth-device/README.md
+++ b/examples/oauth-device/README.md
@@ -1,0 +1,76 @@
+# oauth-device — a `zcli.http` + `zcli_secrets` device-flow example
+
+The companion to [`ghauth`](../ghauth). Where `ghauth` pastes a token you already
+have, `oauth-device` *mints* one: `login` runs GitHub's OAuth **device flow**
+(RFC 8628), stashes the resulting token in your OS keychain, and then `whoami`
+and `logout` behave exactly like `ghauth` — because once the flow is done, it's
+the same opaque credential.
+
+```
+$ export GITHUB_CLIENT_ID=Iv1_xxxxxxxx      # your OAuth app's client ID
+$ oauth-device login
+To authorize, open:
+
+    https://github.com/login/device
+
+and enter the code:  WXYZ-1234
+
+Waiting for you to authorize…
+
+Authorized. Try `oauth-device whoami`.
+$ oauth-device whoami
+Ada Lovelace (@ada)
+$ oauth-device logout
+Removed your stored GitHub token.
+```
+
+A **canonical example** (ADR-0004): a compiled, CI-checked teaching artifact —
+here, for the "how do I actually implement OAuth in a CLI?" question.
+
+## Why this is an example, not a framework feature
+
+zcli deliberately does **not** ship an OAuth library. The two *hard* parts of CLI
+auth are already framework features you get for free:
+
+- **`zcli.http`** — a TLS-verified client that strips `Authorization` if a
+  redirect ever leaves the origin, so a bearer token can't leak to another host.
+- **`zcli_secrets`** — native keychain storage (macOS Keychain / Linux Secret
+  Service / Windows Credential Manager), never a plaintext file.
+
+What's left — the device flow itself — is ~150 lines of freeform command code
+(ADR-0003), and the part that varies (endpoints, `client_id`, scopes) is
+provider-specific. So it lives here as a pattern to copy, not as an abstraction
+to configure. Point it at another provider by swapping the three URLs and the
+client_id in [`src/commands/login.zig`](src/commands/login.zig); the flow is
+unchanged.
+
+## What it demonstrates
+
+- **The RFC 8628 device flow, end to end** — request a device + user code, show
+  the user where to enter it, then poll the token endpoint on the server's
+  interval. The easy-to-botch bit — deciding `authorization_pending` vs
+  `slow_down` vs a terminal error — is a pure `classifyError` function with a
+  unit test (`zig build test`).
+- **Flushing buffered stdout** — the user code is printed and `stdout.flush()`ed
+  *before* the polling loop blocks, so they can actually read it.
+- **`zcli.http` for form POSTs** — `application/x-www-form-urlencoded` bodies with
+  an `Accept: application/json` header so `Response.json` can parse the reply.
+- **`zcli_secrets` as the handoff** — `login` calls `set`, `whoami` calls `get`,
+  `logout` calls `delete`. The plugin only ever stores/reads the opaque token; it
+  neither knows nor cares that this one came from a device flow.
+- **`context.fail`** — every expected failure (denied, expired, timed out, no
+  `GITHUB_CLIENT_ID`, rejected token) is a clean one-line message and a non-zero
+  exit, no stack trace.
+
+> Enabling `zcli_secrets` links a native keychain library (libsecret on Linux;
+> nothing extra on macOS/Windows). That's the opt-in cost ADR-0003 keeps off
+> projects that don't store secrets.
+
+## Run it
+
+Register an OAuth app with **device flow enabled** at
+<https://github.com/settings/developers>, then:
+
+```
+GITHUB_CLIENT_ID=Iv1_xxxxxxxx zig build run -- login
+```

--- a/examples/oauth-device/build.zig
+++ b/examples/oauth-device/build.zig
@@ -1,0 +1,52 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) !void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const zcli_dep = b.dependency("zcli", .{ .target = target, .optimize = optimize });
+    const zcli_module = zcli_dep.module("zcli");
+
+    const exe = b.addExecutable(.{
+        .name = "oauth-device",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    exe.root_module.addImport("zcli", zcli_module);
+
+    const zcli = @import("zcli");
+    const cmd_registry = try zcli.generate(b, exe, zcli_dep, .{
+        .commands_dir = "src/commands",
+        .plugins = &.{
+            zcli.builtin(.help, .{}),
+            zcli.builtin(.version, .{}),
+            zcli.builtin(.not_found, .{}),
+            // Opt in to credential storage. Enabling it here is what makes
+            // `context.plugins.zcli_secrets` available and links the OS keychain
+            // backend (Keychain / Secret Service / Credential Manager). ADR-0003.
+            zcli.builtin(.secrets, .{}),
+        },
+        .app_name = "oauth-device",
+        .app_description = "GitHub via the OAuth device flow (a zcli.http + zcli_secrets example)",
+    });
+    exe.root_module.addImport("command_registry", cmd_registry);
+
+    b.installArtifact(exe);
+
+    const run_cmd = b.addRunArtifact(exe);
+    run_cmd.step.dependOn(b.getInstallStep());
+    if (b.args) |args| run_cmd.addArgs(args);
+    const run_step = b.step("run", "Run the application");
+    run_step.dependOn(&run_cmd.step);
+
+    // Per-command unit tests (the scaffolded-project idiom): compiles each
+    // command file as its own test root so its `test` blocks run.
+    _ = zcli.addCommandTests(b, zcli_dep, .{
+        .commands_dir = "src/commands",
+        .target = target,
+        .optimize = optimize,
+    });
+}

--- a/examples/oauth-device/build.zig.zon
+++ b/examples/oauth-device/build.zig.zon
@@ -1,0 +1,18 @@
+.{
+    .name = .oauth_device,
+    .version = "0.1.0",
+    .fingerprint = 0x63189596ba81fcf4,
+    .minimum_zig_version = "0.16.0",
+    .dependencies = .{
+        // Local path because this example lives in-repo (so CI compiles it
+        // against unreleased changes as a drift-detector). Your own project
+        // doesn't hand-write this — `zcli init` fetches a released zcli:
+        //   .zcli = .{ .url = "git+https://github.com/ryanhair/zcli#<tag>", .hash = "..." },
+        .zcli = .{ .path = "../.." },
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}

--- a/examples/oauth-device/src/commands/login.zig
+++ b/examples/oauth-device/src/commands/login.zig
@@ -1,0 +1,188 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
+
+pub const meta = .{
+    .description = "Authorize this CLI via GitHub's OAuth device flow (RFC 8628)",
+    .examples = &.{"login"},
+};
+
+pub const Args = struct {};
+pub const Options = struct {};
+
+// GitHub's device-flow endpoints. Another provider is the same shape with three
+// different URLs and a different client_id — the flow below doesn't change.
+const device_code_url = "https://github.com/login/device/code";
+const token_url = "https://github.com/login/oauth/access_token";
+const grant_type = "urn:ietf:params:oauth:grant-type:device_code";
+
+/// The fields we read from the device-code response (RFC 8628 §3.2). Unknown
+/// fields (`verification_uri_complete`, …) are ignored by `Response.json`.
+const DeviceCode = struct {
+    device_code: []const u8,
+    user_code: []const u8,
+    verification_uri: []const u8,
+    expires_in: u32,
+    interval: u32 = 5,
+};
+
+/// The token endpoint returns EITHER a success (`access_token`) OR a pending/
+/// terminal `error` (RFC 8628 §3.5). Model both as optionals and branch on
+/// which one arrived.
+const TokenResponse = struct {
+    access_token: ?[]const u8 = null,
+    @"error": ?[]const u8 = null,
+};
+
+/// What one poll of the token endpoint tells us to do next. This is the part of
+/// a device flow that's easy to get subtly wrong — so it's a pure function with
+/// a unit test, not buried in the polling loop.
+const PollOutcome = enum { keep_waiting, slow_down, denied, expired, unknown_error };
+
+fn classifyError(err: []const u8) PollOutcome {
+    if (std.mem.eql(u8, err, "authorization_pending")) return .keep_waiting;
+    if (std.mem.eql(u8, err, "slow_down")) return .slow_down;
+    if (std.mem.eql(u8, err, "access_denied")) return .denied;
+    if (std.mem.eql(u8, err, "expired_token")) return .expired;
+    return .unknown_error;
+}
+
+pub fn execute(_: Args, _: Options, context: *Context) !void {
+    const io = context.io;
+    const stdout = context.stdout();
+
+    // The client_id identifies your OAuth app; it isn't a secret (it ships in
+    // every copy of the client), so reading it from the environment is fine.
+    // Register an app with device flow enabled at github.com/settings/developers.
+    const client_id = context.environ.get("GITHUB_CLIENT_ID") orelse
+        return context.fail("Set GITHUB_CLIENT_ID to your GitHub OAuth app's client ID.", .{});
+
+    var client = zcli.http.Client.init(context.allocator, io, .{});
+    defer client.deinit();
+
+    // 1. Ask GitHub for a device code plus a short user code (RFC 8628 §3.1–3.2).
+    const device = try requestDeviceCode(&client, context, client_id);
+
+    // 2. Send the user off to authorize (§3.3). Flush so they actually SEE the
+    //    code before we block on polling — the stdout writer is buffered.
+    try stdout.print(
+        \\To authorize, open:
+        \\
+        \\    {s}
+        \\
+        \\and enter the code:  {s}
+        \\
+        \\Waiting for you to authorize…
+        \\
+    , .{ device.verification_uri, device.user_code });
+    try stdout.flush();
+
+    // 3. Poll the token endpoint until the user finishes, denies, or it expires.
+    const token = try pollForToken(&client, context, io, client_id, device);
+
+    // 4. The flow produced an opaque credential; `zcli_secrets` stashes it in
+    //    the OS keychain — never a plaintext file. From here it's identical to
+    //    the token `ghauth` pastes: the plugin doesn't care how it was minted.
+    try context.plugins.zcli_secrets.set(context, "token", token);
+
+    try stdout.print("\nAuthorized. Try `oauth-device whoami`.\n", .{});
+}
+
+/// POST the client_id and get back a device code, a user code, and where to
+/// enter it. Copies the fields we keep out of the response body before it's freed.
+fn requestDeviceCode(
+    client: *zcli.http.Client,
+    context: *Context,
+    client_id: []const u8,
+) !DeviceCode {
+    const arena = context.allocator;
+
+    // No `scope`: a scopeless GitHub token can still read `GET /user` (the public
+    // profile), which is all `whoami` needs — and it keeps this form body free of
+    // characters that would otherwise need URL-encoding.
+    const body = try std.fmt.allocPrint(arena, "client_id={s}", .{client_id});
+
+    var response = try client.post(device_code_url, .{
+        .body = body,
+        .content_type = "application/x-www-form-urlencoded",
+        .headers = &.{.{ .name = "Accept", .value = "application/json" }},
+    });
+    defer response.deinit();
+
+    if (response.status != .ok) {
+        return context.fail(
+            "GitHub rejected the device-code request ({d}). Is GITHUB_CLIENT_ID an OAuth app with device flow enabled?",
+            .{@intFromEnum(response.status)},
+        );
+    }
+
+    const d = (try response.json(DeviceCode, arena)).value;
+    // `response.json` may reference `response.body`, which the defer above frees
+    // when this function returns — so copy everything that outlives it.
+    return .{
+        .device_code = try arena.dupe(u8, d.device_code),
+        .user_code = try arena.dupe(u8, d.user_code),
+        .verification_uri = try arena.dupe(u8, d.verification_uri),
+        .expires_in = d.expires_in,
+        .interval = d.interval,
+    };
+}
+
+/// Poll the token endpoint on the server-mandated interval until it hands back a
+/// token or a terminal condition ends the flow (RFC 8628 §3.4–3.5).
+fn pollForToken(
+    client: *zcli.http.Client,
+    context: *Context,
+    io: std.Io,
+    client_id: []const u8,
+    device: DeviceCode,
+) ![]const u8 {
+    const arena = context.allocator;
+
+    const body = try std.fmt.allocPrint(
+        arena,
+        "client_id={s}&device_code={s}&grant_type={s}",
+        .{ client_id, device.device_code, grant_type },
+    );
+
+    var interval: u32 = device.interval;
+    var elapsed: u32 = 0;
+    while (elapsed < device.expires_in) {
+        // Wait the mandated interval before each poll; polling faster earns a
+        // `slow_down` (RFC 8628 §3.5).
+        try io.sleep(.fromSeconds(interval), .awake);
+        elapsed += interval;
+
+        var response = try client.post(token_url, .{
+            .body = body,
+            .content_type = "application/x-www-form-urlencoded",
+            .headers = &.{.{ .name = "Accept", .value = "application/json" }},
+        });
+        defer response.deinit();
+
+        const result = (try response.json(TokenResponse, arena)).value;
+        if (result.access_token) |token| {
+            // Copy it out: the body this may reference is freed by the defer above.
+            return arena.dupe(u8, token);
+        }
+
+        const err = result.@"error" orelse
+            return context.fail("The token endpoint returned neither a token nor an error.", .{});
+        switch (classifyError(err)) {
+            .keep_waiting => {},
+            .slow_down => interval += 5, // back off and keep polling
+            .denied => return context.fail("You denied the authorization request.", .{}),
+            .expired => return context.fail("The code expired before you authorized. Run `login` again.", .{}),
+            .unknown_error => return context.fail("GitHub returned an OAuth error: {s}", .{err}),
+        }
+    }
+    return context.fail("Timed out waiting for authorization. Run `login` again.", .{});
+}
+
+test "classifyError maps the RFC 8628 token-endpoint responses" {
+    try std.testing.expectEqual(PollOutcome.keep_waiting, classifyError("authorization_pending"));
+    try std.testing.expectEqual(PollOutcome.slow_down, classifyError("slow_down"));
+    try std.testing.expectEqual(PollOutcome.denied, classifyError("access_denied"));
+    try std.testing.expectEqual(PollOutcome.expired, classifyError("expired_token"));
+    try std.testing.expectEqual(PollOutcome.unknown_error, classifyError("nonsense"));
+}

--- a/examples/oauth-device/src/commands/logout.zig
+++ b/examples/oauth-device/src/commands/logout.zig
@@ -1,0 +1,18 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
+
+pub const meta = .{
+    .description = "Forget the stored GitHub token",
+    .examples = &.{"logout"},
+};
+
+pub const Args = struct {};
+pub const Options = struct {};
+
+pub fn execute(_: Args, _: Options, context: *Context) !void {
+    // `delete` is a no-op (success) if nothing is stored, so `logout` is always
+    // safe to run.
+    try context.plugins.zcli_secrets.delete(context, "token");
+    try context.stdout().print("Removed your stored GitHub token.\n", .{});
+}

--- a/examples/oauth-device/src/commands/whoami.zig
+++ b/examples/oauth-device/src/commands/whoami.zig
@@ -1,0 +1,61 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
+
+pub const meta = .{
+    .description = "Show the GitHub user the stored token belongs to",
+    .examples = &.{"whoami"},
+};
+
+pub const Args = struct {};
+pub const Options = struct {};
+
+/// Only the fields we render; `Response.json` ignores the rest.
+const User = struct {
+    login: []const u8,
+    name: ?[]const u8 = null,
+};
+
+pub fn execute(_: Args, _: Options, context: *Context) !void {
+    const arena = context.allocator;
+    const io = context.io;
+
+    // The stored bytes are owned by the arena, so no free is needed. The token
+    // got here via the `login` device flow — but `whoami` neither knows nor
+    // cares how it was minted; it just reads the opaque credential back.
+    const token = (try context.plugins.zcli_secrets.get(context, "token")) orelse
+        return context.fail("Not logged in. Run `oauth-device login` first.", .{});
+
+    var client = zcli.http.Client.init(arena, io, .{});
+    defer client.deinit();
+
+    // The Authorization header carries the credential; zcli.http drops it if a
+    // redirect ever leaves GitHub's origin, so a token can't leak to another host.
+    const auth = try std.fmt.allocPrint(arena, "Bearer {s}", .{token});
+    var response = client.request(.GET, "https://api.github.com/user", .{
+        .headers = &.{
+            .{ .name = "User-Agent", .value = "zcli-oauth-device" },
+            .{ .name = "Accept", .value = "application/vnd.github+json" },
+            .{ .name = "Authorization", .value = auth },
+        },
+    }) catch |err| {
+        return context.fail("Request to GitHub failed: {s}", .{@errorName(err)});
+    };
+    defer response.deinit();
+
+    if (response.status == .unauthorized) {
+        return context.fail("Your token was rejected (401). Run `oauth-device login` again.", .{});
+    }
+    if (response.status != .ok) {
+        return context.fail("GitHub returned {d}.", .{@intFromEnum(response.status)});
+    }
+
+    const user = (try response.json(User, arena)).value;
+
+    const stdout = context.stdout();
+    if (user.name) |name| {
+        try stdout.print("{s} (@{s})\n", .{ name, user.login });
+    } else {
+        try stdout.print("@{s}\n", .{user.login});
+    }
+}

--- a/examples/oauth-device/src/main.zig
+++ b/examples/oauth-device/src/main.zig
@@ -1,0 +1,15 @@
+const std = @import("std");
+const registry = @import("command_registry");
+
+pub const std_options: std.Options = .{
+    .log_level = .warn,
+};
+
+pub fn main(init: std.process.Init) !void {
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
+    var app = registry.init();
+    app.run(init.gpa, init.io, init.environ_map, args) catch |err| switch (err) {
+        error.CommandNotFound => std.process.exit(1),
+        else => return err,
+    };
+}

--- a/examples/showcase/README.md
+++ b/examples/showcase/README.md
@@ -1,8 +1,9 @@
 # showcase — the kitchen-sink example
 
 A fully functional task tracker CLI (`tasks`) that exercises every zcli
-feature in one app. Where [notes](../notes/), [repostat](../repostat/), and
-[ghauth](../ghauth/) each teach one idiom, this is the tour.
+feature in one app. Where [notes](../notes/), [repostat](../repostat/),
+[ghauth](../ghauth/), and [oauth-device](../oauth-device/) each teach one
+idiom, this is the tour.
 
 ```
 $ tasks init          # interactive project wizard


### PR DESCRIPTION
## What

Adds `examples/oauth-device` — the **device-flow companion to `ghauth`**. Where `ghauth` pastes a token you already have, `oauth-device login` *mints* one via GitHub's OAuth device flow (RFC 8628), stashes it in the OS keychain with `zcli_secrets`, and then `whoami`/`logout` behave exactly like `ghauth` — because once the flow is done, it's the same opaque credential.

```
$ export GITHUB_CLIENT_ID=Iv1_xxxxxxxx
$ oauth-device login
To authorize, open:

    https://github.com/login/device

and enter the code:  WXYZ-1234

Waiting for you to authorize…

Authorized. Try `oauth-device whoami`.
$ oauth-device whoami
Ada Lovelace (@ada)
```

## Why an example, not a framework feature

Reinforces **ADR-0003**: zcli ships no OAuth library. The two *hard* parts of CLI auth are already framework features:

- **`zcli.http`** — TLS-verified, strips `Authorization` if a redirect leaves the origin.
- **`zcli_secrets`** — native keychain storage, no plaintext fallback.

What's left is the flow itself — ~150 lines of freeform command code, with the provider-specific bits (URLs, `client_id`, scopes) as the only thing that varies. So it's a pattern to copy, not an abstraction to configure.

## What it demonstrates

- **The RFC 8628 device flow end to end** — request device+user code, show it, poll the token endpoint on the server interval honoring `slow_down`.
- **The easy-to-botch bit is a pure, unit-tested function** — `classifyError` maps `authorization_pending` / `slow_down` / `access_denied` / `expired_token` to an outcome enum (`zig build test`).
- **Flushing buffered stdout** before the polling loop blocks, so the user sees the code.
- **`zcli.http` form POSTs** (`application/x-www-form-urlencoded` + `Accept: application/json`).
- **`zcli_secrets` as the handoff** — `login` sets, `whoami` gets, `logout` deletes; the plugin doesn't care how the token was minted.
- **`context.fail`** for every expected failure (denied, expired, timed out, missing `GITHUB_CLIENT_ID`, rejected token).

## Wiring

- Added to `test_projects` + `example_projects` in the root `build.zig` (the CI drift-detector, ADR-0004).
- Updated the CI `examples`-job comment (libsecret now serves both secrets examples) and the showcase README's example index.

## Testing

Verified locally on macOS: `zig build`, `zig build test` (incl. `classifyError`), `--help`, and every offline error path pass; the full `zig build build-examples` aggregate is green.

> The live happy path (register an OAuth app + browser authorize) can't run in CI, but the flow follows GitHub's documented device-flow contract and every offline path is tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)