### PR TITLE
Require Args/Options on runnable commands; remove NoArgs/NoOptions

### DIFF
--- a/packages/core/src/plugin_pipeline_test.zig
+++ b/packages/core/src/plugin_pipeline_test.zig
@@ -78,8 +78,8 @@ const test_config = zcli.Config{
 const Greet = struct {
     var executed = false;
     pub const meta = .{ .description = "greet" };
-    pub const Args = zcli.NoArgs;
-    pub const Options = zcli.NoOptions;
+    pub const Args = struct {};
+    pub const Options = struct {};
     pub fn execute(_: Args, _: Options, _: anytype) !void {
         executed = true;
     }
@@ -88,8 +88,8 @@ const Greet = struct {
 const Checkout = struct {
     var executed = false;
     pub const meta = .{ .description = "checkout" };
-    pub const Args = zcli.NoArgs;
-    pub const Options = zcli.NoOptions;
+    pub const Args = struct {};
+    pub const Options = struct {};
     pub fn execute(_: Args, _: Options, _: anytype) !void {
         executed = true;
     }
@@ -99,7 +99,7 @@ const Echo = struct {
     var last: []const u8 = "";
     pub const meta = .{ .description = "echo" };
     pub const Args = struct { word: []const u8 };
-    pub const Options = zcli.NoOptions;
+    pub const Options = struct {};
     pub fn execute(args: Args, _: Options, _: anytype) !void {
         last = args.word;
     }
@@ -107,8 +107,8 @@ const Echo = struct {
 
 const Fail = struct {
     pub const meta = .{ .description = "fail" };
-    pub const Args = zcli.NoArgs;
-    pub const Options = zcli.NoOptions;
+    pub const Args = struct {};
+    pub const Options = struct {};
     pub fn execute(_: Args, _: Options, _: anytype) !void {
         return error.Boom;
     }
@@ -441,16 +441,16 @@ const PluginCmdProvider = struct {
         pub const pgreet = struct {
             var executed = false;
             pub const meta = .{ .description = "plugin greet" };
-            pub const Args = zcli.NoArgs;
-            pub const Options = zcli.NoOptions;
+            pub const Args = struct {};
+            pub const Options = struct {};
             pub fn execute(_: Args, _: Options, _: anytype) !void {
                 executed = true;
             }
         };
         pub const pfail = struct {
             pub const meta = .{ .description = "plugin fail" };
-            pub const Args = zcli.NoArgs;
-            pub const Options = zcli.NoOptions;
+            pub const Args = struct {};
+            pub const Options = struct {};
             pub fn execute(_: Args, _: Options, _: anytype) !void {
                 return error.Boom;
             }
@@ -463,7 +463,7 @@ const PluginCmdProvider = struct {
                 var last: []const u8 = "";
                 pub const meta = .{ .description = "nested plugin command" };
                 pub const Args = struct { name: []const u8 };
-                pub const Options = zcli.NoOptions;
+                pub const Options = struct {};
                 pub fn execute(args: Args, _: Options, _: anytype) !void {
                     last = args.name;
                 }
@@ -637,8 +637,8 @@ const StatefulPlugin = struct {
 const ReadState = struct {
     var seen: ?u32 = null;
     pub const meta = .{ .description = "read plugin state" };
-    pub const Args = zcli.NoArgs;
-    pub const Options = zcli.NoOptions;
+    pub const Args = struct {};
+    pub const Options = struct {};
     pub fn execute(_: Args, _: Options, context: anytype) !void {
         seen = context.plugins.stateful.count;
         context.plugins.stateful.count += 10;

--- a/packages/core/src/plugins/zcli_help/plugin.zig
+++ b/packages/core/src/plugins/zcli_help/plugin.zig
@@ -486,7 +486,7 @@ pub const commands = struct {
             command: ?[]const u8 = null,
         };
 
-        pub const Options = zcli.NoOptions;
+        pub const Options = struct {};
 
         pub const meta = .{
             .description = "Show help for commands",

--- a/packages/core/src/registry/compiled.zig
+++ b/packages/core/src/registry/compiled.zig
@@ -872,8 +872,11 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
                 return error.CommandNotFound;
             }
 
-            const ArgsType = if (@hasDecl(Module, "Args")) Module.Args else struct {};
-            const OptionsType = if (@hasDecl(Module, "Options")) Module.Options else struct {};
+            // Reached only after the `!@hasDecl(Module, "execute")` early return
+            // above, and `validateCommand` requires an executable command to
+            // declare both — so `Args`/`Options` are guaranteed present here.
+            const ArgsType = Module.Args;
+            const OptionsType = Module.Options;
             const cmd_meta = if (@hasDecl(Module, "meta")) Module.meta else null;
 
             // A regular command that declares no positionals but got a

--- a/packages/core/src/registry/tests.zig
+++ b/packages/core/src/registry/tests.zig
@@ -284,7 +284,7 @@ test "nested pure command groups" {
 
 // Test structures for compile-time validation
 const ValidOptionalGroup = struct {
-    pub const Args = zcli.NoArgs;
+    pub const Args = struct {};
     pub const Options = struct {
         verbose: bool = false,
     };
@@ -295,7 +295,7 @@ const InvalidOptionalGroup = struct {
     pub const Args = struct {
         name: []const u8, // This should fail validation!
     };
-    pub const Options = zcli.NoOptions;
+    pub const Options = struct {};
     pub fn execute(_: Args, _: Options, _: *zcli.Context) !void {}
 };
 
@@ -438,8 +438,8 @@ const RootCommand = struct {
         .description = "Root command",
     };
 
-    pub const Args = zcli.NoArgs;
-    pub const Options = zcli.NoOptions;
+    pub const Args = struct {};
+    pub const Options = struct {};
 
     pub fn execute(_: Args, _: Options, context: anytype) !void {
         try context.io.stdout.print("root executed\n", .{});
@@ -652,8 +652,8 @@ const NetworkLs = struct {
     pub const meta = .{
         .description = "List networks",
     };
-    pub const Args = zcli.NoArgs;
-    pub const Options = zcli.NoOptions;
+    pub const Args = struct {};
+    pub const Options = struct {};
     pub fn execute(_: Args, _: Options, context: anytype) !void {
         // Test command - no output needed
         _ = context;
@@ -791,16 +791,16 @@ test "metadata-only group routes through onError so the help plugin can render i
 }
 
 const OkCommand = struct {
-    pub const Args = zcli.NoArgs;
-    pub const Options = zcli.NoOptions;
+    pub const Args = struct {};
+    pub const Options = struct {};
     pub fn execute(_: Args, _: Options, context: anytype) !void {
         _ = context;
     }
 };
 
 const FailingCommand = struct {
-    pub const Args = zcli.NoArgs;
-    pub const Options = zcli.NoOptions;
+    pub const Args = struct {};
+    pub const Options = struct {};
     pub fn execute(_: Args, _: Options, context: anytype) !void {
         _ = context;
         return error.Boom;
@@ -995,8 +995,8 @@ const AliasTestCommand = struct {
         .description = "Test command with aliases",
         .aliases = &.{ "alias1", "alias2" },
     };
-    pub const Args = zcli.NoArgs;
-    pub const Options = zcli.NoOptions;
+    pub const Args = struct {};
+    pub const Options = struct {};
     pub fn execute(_: Args, _: Options, _: *zcli.Context) !void {}
 };
 
@@ -1004,8 +1004,8 @@ const NoAliasTestCommand = struct {
     pub const meta = .{
         .description = "Test command without aliases",
     };
-    pub const Args = zcli.NoArgs;
-    pub const Options = zcli.NoOptions;
+    pub const Args = struct {};
+    pub const Options = struct {};
     pub fn execute(_: Args, _: Options, _: *zcli.Context) !void {}
 };
 

--- a/packages/core/src/system_validation_test.zig
+++ b/packages/core/src/system_validation_test.zig
@@ -185,7 +185,9 @@ test "system validation: registry type creation" {
 
     const SimpleCommand = struct {
         pub const meta = .{ .description = "Simple command" };
-        pub fn execute(args: struct {}, options: struct {}, context: *zcli.Context) !void {
+        pub const Args = struct {};
+        pub const Options = struct {};
+        pub fn execute(args: Args, options: Options, context: *zcli.Context) !void {
             _ = args;
             _ = options;
             _ = context;
@@ -196,7 +198,8 @@ test "system validation: registry type creation" {
     const ArgsCommand = struct {
         pub const meta = .{ .description = "Command with args" };
         pub const Args = struct { name: []const u8 };
-        pub fn execute(args: Args, options: struct {}, context: *zcli.Context) !void {
+        pub const Options = struct {};
+        pub fn execute(args: Args, options: Options, context: *zcli.Context) !void {
             _ = args;
             _ = options;
             _ = context;
@@ -206,8 +209,9 @@ test "system validation: registry type creation" {
 
     const OptionsCommand = struct {
         pub const meta = .{ .description = "Command with options" };
+        pub const Args = struct {};
         pub const Options = struct { verbose: bool = false };
-        pub fn execute(args: struct {}, options: Options, context: *zcli.Context) !void {
+        pub fn execute(args: Args, options: Options, context: *zcli.Context) !void {
             _ = args;
             _ = options;
             _ = context;
@@ -263,7 +267,9 @@ test "system validation: plugin interface compilation" {
     };
 
     const SimpleCommand = struct {
-        pub fn execute(_: struct {}, _: struct {}, _: anytype) !void {}
+        pub const Args = struct {};
+        pub const Options = struct {};
+        pub fn execute(_: Args, _: Options, _: anytype) !void {}
     };
 
     const TestRegistry = registry.Registry.init(.{

--- a/packages/core/src/type_utils.zig
+++ b/packages/core/src/type_utils.zig
@@ -18,16 +18,6 @@ pub fn hasDefaultValue(comptime T: type, comptime field_name: []const u8) bool {
 }
 
 // ============================================================================
-// STANDARD EMPTY TYPES - For commands that don't need args or options
-// ============================================================================
-
-/// Empty args struct for commands that don't require positional arguments
-pub const NoArgs = struct {};
-
-/// Empty options struct for commands that don't require command-line options
-pub const NoOptions = struct {};
-
-// ============================================================================
 // TESTS
 // ============================================================================
 
@@ -40,16 +30,4 @@ test "hasDefaultValue" {
     try std.testing.expect(hasDefaultValue(TestStruct, "field_with_default"));
     try std.testing.expect(!hasDefaultValue(TestStruct, "field_without_default"));
     try std.testing.expect(!hasDefaultValue(TestStruct, "nonexistent_field"));
-}
-
-test "NoArgs and NoOptions are empty structs" {
-    const args = NoArgs{};
-    const options = NoOptions{};
-
-    _ = args;
-    _ = options;
-
-    // Verify they have no fields
-    try std.testing.expectEqual(@as(usize, 0), @typeInfo(NoArgs).@"struct".fields.len);
-    try std.testing.expectEqual(@as(usize, 0), @typeInfo(NoOptions).@"struct".fields.len);
 }

--- a/packages/core/src/zcli.zig
+++ b/packages/core/src/zcli.zig
@@ -5,7 +5,6 @@ const command_parser = @import("command_parser.zig");
 pub const plugin_types = @import("plugin_types.zig");
 pub const registry = @import("registry.zig");
 const diagnostic_errors = @import("diagnostic_errors.zig");
-const type_utils = @import("type_utils.zig");
 const option_utils = @import("options/utils.zig");
 pub const ztheme = @import("ztheme");
 pub const markdown_fmt = @import("markdown_fmt");
@@ -64,10 +63,6 @@ pub const ParsedArgs = plugin_types.ParsedArgs;
 pub const GlobalOptionsResult = plugin_types.GlobalOptionsResult;
 pub const PluginEntry = plugin_types.PluginEntry;
 pub const option = plugin_types.option;
-
-// Re-export standard empty types
-pub const NoArgs = type_utils.NoArgs;
-pub const NoOptions = type_utils.NoOptions;
 
 // ============================================================================
 // Context for Command Execution
@@ -266,16 +261,43 @@ fn commandContext(comptime path: []const u8) []const u8 {
 /// author (or an AI agent) can act on, not a template error buried deep in the
 /// framework.
 ///
-/// Checks that `Args`/`Options` are structs and the `meta` block is well-formed
-/// (delegated to `validateMeta`). The `execute` signature is intentionally *not*
-/// asserted here: a command's `execute` typically takes `context: *Context`,
-/// and `Context` is a projection of the very registry being built — reaching for
-/// `@TypeOf(execute)` at registration time forms a comptime dependency loop.
-/// A wrong `execute` shape still fails the build at the framework's own call
-/// site, pointing at the author's file.
+/// Requires that any command with an `execute` declares `Args` and `Options`,
+/// checks that `Args`/`Options` are structs, and checks the `meta` block is
+/// well-formed (delegated to `validateMeta`). The `execute` signature is
+/// intentionally *not* asserted here: a command's `execute` typically takes
+/// `context: *Context`, and `Context` is a projection of the very registry
+/// being built — reaching for `@TypeOf(execute)` at registration time forms a
+/// comptime dependency loop. A wrong `execute` shape still fails the build at
+/// the framework's own call site, pointing at the author's file.
 pub fn validateCommand(comptime path: []const u8, comptime Module: type) void {
     @setEvalBranchQuota(10000);
     const loc = commandContext(path);
+
+    // The command contract is declaration-driven: zcli reads a command's
+    // `Args`/`Options` *declarations* to build parsing and dispatch — it never
+    // inspects `execute`'s parameter types (see above). So a runnable command
+    // (one that declares `execute`) MUST declare both, even when empty. Naming
+    // a type in the signature, e.g. `execute(_: struct {}, ...)`, is not a
+    // declaration and leaves the contract undefined. Metadata-only command
+    // groups have no `execute` and are exempt — they never parse arguments.
+    if (@hasDecl(Module, "execute")) {
+        if (!@hasDecl(Module, "Args")) {
+            @compileError(loc ++ "missing `pub const Args`. zcli reads a command's positional " ++
+                "arguments from its `Args` declaration, not from `execute`'s parameters — writing " ++
+                "`execute(_: struct {}, ...)` names a type but declares nothing. Add a declaration:\n" ++
+                "    pub const Args = struct {};                     // no positional arguments\n" ++
+                "    pub const Args = struct { name: []const u8 };   // one required positional\n" ++
+                "and refer to it in execute: `execute(args: Args, ...)`.");
+        }
+        if (!@hasDecl(Module, "Options")) {
+            @compileError(loc ++ "missing `pub const Options`. zcli reads a command's flags from " ++
+                "its `Options` declaration, not from `execute`'s parameters — writing " ++
+                "`execute(_, _: struct {}, ...)` names a type but declares nothing. Add a declaration:\n" ++
+                "    pub const Options = struct {};                         // no flags\n" ++
+                "    pub const Options = struct { verbose: bool = false };  // one --verbose flag\n" ++
+                "and refer to it in execute: `execute(_, options: Options, ...)`.");
+        }
+    }
 
     const ArgsType = if (@hasDecl(Module, "Args")) Module.Args else struct {};
     const OptionsType = if (@hasDecl(Module, "Options")) Module.Options else struct {};
@@ -616,8 +638,8 @@ test "global options with different types" {
     };
 
     const TestCommand = struct {
-        pub const Args = NoArgs;
-        pub const Options = NoOptions;
+        pub const Args = struct {};
+        pub const Options = struct {};
 
         pub fn execute(args: Args, options: Options, context: anytype) !void {
             _ = args;
@@ -662,8 +684,8 @@ test "global options short flags" {
     };
 
     const TestCommand = struct {
-        pub const Args = NoArgs;
-        pub const Options = NoOptions;
+        pub const Args = struct {};
+        pub const Options = struct {};
 
         pub fn execute(args: Args, options: Options, context: anytype) !void {
             _ = args;
@@ -709,7 +731,7 @@ test "commands inherit global options" {
     };
 
     const TestCommand = struct {
-        pub const Args = NoArgs;
+        pub const Args = struct {};
         pub const Options = struct {
             local: bool = false,
         };
@@ -764,8 +786,8 @@ test "global option defaults" {
     };
 
     const TestCommand = struct {
-        pub const Args = NoArgs;
-        pub const Options = NoOptions;
+        pub const Args = struct {};
+        pub const Options = struct {};
 
         pub fn execute(args: Args, options: Options, context: anytype) !void {
             _ = args;
@@ -822,8 +844,8 @@ test "multiple plugins with global options" {
     };
 
     const TestCommand = struct {
-        pub const Args = NoArgs;
-        pub const Options = NoOptions;
+        pub const Args = struct {};
+        pub const Options = struct {};
 
         pub fn execute(args: Args, options: Options, context: anytype) !void {
             _ = args;


### PR DESCRIPTION
## What

Make the command contract strict and single-shaped:

- **A command that declares `execute` must declare both `pub const Args` and `pub const Options`** (empty is `struct {}`). Enforced at comptime in `validateCommand` with a clear, path-named compile error. Metadata-only command groups (no `execute`) stay exempt.
- **`zcli.NoArgs`/`NoOptions` are removed.** They were a redundant second spelling of `struct {}`; all former uses (registry/plugin test fixtures) are swept to `struct {}` — already the convention across every example, every `projects/zcli` command, and the `zcli add` scaffolder output.
- The `@hasDecl` fallback in the dispatch path (`compiled.zig`) collapses to `Module.Args`/`Options`, since presence is now guaranteed there.

## Why

Omitting the decls and naming a type only in `execute`'s signature (e.g. `execute(_: zcli.NoArgs, ...)`) *looked* like it should work but failed on nominal typing with a buried error. The framework is **declaration-driven** — it reads the `Args`/`Options` declarations, never `execute`'s parameter types (doing so forms a comptime dependency loop through `Context`). Rather than abstract away two boilerplate lines and keep a footgun, we enforce the one uniform command shape and give a fix-forward error.

The error fires at registration, before `execute`'s signature is analyzed, so it wins even for the original `zcli.NoArgs`-in-signature snippet:

```
command 'sprints': missing `pub const Args`. zcli reads a command's positional
arguments from its `Args` declaration, not from `execute`'s parameters — writing
`execute(_: struct {}, ...)` names a type but declares nothing. Add a declaration:
    pub const Args = struct {};                     // no positional arguments
    pub const Args = struct { name: []const u8 };   // one required positional
and refer to it in execute: `execute(args: Args, ...)`.
```

## Verification

- `packages/core` tests pass; `projects/zcli` build + tests pass (groups still exempt)
- All 5 examples build (`notes`, `ghauth`, `oauth-device`, `repostat`, `showcase`) — zero churn, they already used `struct {}`
- Repo grep: no `NoArgs`/`NoOptions` references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)