### PR TITLE
Rebuild website to mirror new design

### DIFF
--- a/website/assets/styles.css
+++ b/website/assets/styles.css
@@ -294,5 +294,5 @@ details.repro pre { margin-top: 8px; font-family: var(--mono); font-size: 12.5px
 .tier-table td { padding: 11px 14px; border-bottom: 1px solid var(--border); color: var(--muted); vertical-align: top; }
 .tier-table td.tier { font-family: var(--mono); color: var(--accent); white-space: nowrap; }
 
-.transcript { background: #0a0b0e; border: 1px solid var(--border2); border-radius: 10px; padding: 18px 20px; font-family: var(--mono); font-size: 13px; line-height: 1.85; color: var(--muted); overflow-x: auto; }
+.transcript { background: #0a0b0e; border: 1px solid var(--border2); border-radius: 10px; padding: 18px 20px; font-family: var(--mono); font-size: 13px; line-height: 1.85; color: var(--muted); white-space: pre-wrap; overflow-x: auto; }
 .transcript .t-agent { color: var(--cyan); } .transcript .t-cmd { color: var(--accent); } .transcript .t-ok { color: var(--green); } .transcript .t-you { color: var(--fg); }

--- a/website/assets/styles.css
+++ b/website/assets/styles.css
@@ -164,3 +164,135 @@ footer .meta { color: var(--faint); font-size: 13px; font-family: var(--mono); }
   .nav .gh { padding: 7px 10px; }
   section { padding: 64px 0; }
 }
+
+/* =====================================================================
+   Shared cross-page components (redesign additions).
+   Reuses the existing tokens only — no new colors/fonts introduced.
+   ===================================================================== */
+
+/* measured-claim affordance — small mono tag linking to /why/#numbers */
+.measured {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.04em;
+  color: var(--green); border: 1px solid rgba(87,201,122,0.28);
+  background: rgba(87,201,122,0.08); border-radius: 999px;
+  padding: 2px 9px 2px 7px; white-space: nowrap; transition: border-color .15s, background .15s;
+}
+.measured:hover { border-color: var(--green); background: rgba(87,201,122,0.14); }
+
+/* ---------- folder → CLI interactive mapping (home, signature component) ---------- */
+.foldermap { display: grid; grid-template-columns: 300px 1fr; gap: 0; border: 1px solid var(--border2); border-radius: 12px; overflow: hidden; background: #0a0b0e; }
+.foldermap .fm-tree { padding: 22px 4px; border-right: 1px solid var(--border); }
+.foldermap .fm-tree .fm-head { font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--faint); padding: 0 20px 14px; }
+.fm-row { display: flex; align-items: center; gap: 8px; font-family: var(--mono); font-size: 13.5px; color: var(--muted); padding: 7px 20px; cursor: pointer; border-left: 2px solid transparent; transition: all .12s; }
+.fm-row .fm-indent { display: inline-block; }
+.fm-row:hover, .fm-row.on { color: var(--fg); background: rgba(247,164,29,0.07); border-left-color: var(--accent); }
+.fm-row .fm-dir { color: var(--cyan); }
+.foldermap .fm-term { padding: 22px 24px; }
+.foldermap .fm-term .fm-head { font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--faint); margin-bottom: 14px; }
+.foldermap .fm-term pre { font-family: var(--mono); font-size: 13.5px; line-height: 1.85; color: #cfd3da; min-height: 190px; white-space: pre-wrap; }
+.foldermap .fm-term .c-prompt { color: var(--accent); } .foldermap .fm-term .c-cmd { color: #fff; } .foldermap .fm-term .c-mut { color: var(--faint); }
+.foldermap-caption { display: flex; align-items: center; gap: 10px; margin-top: 18px; color: var(--muted); font-size: 14px; }
+.foldermap-caption svg { width: 16px; height: 16px; color: var(--accent); flex: none; }
+@media (max-width: 780px) { .foldermap { grid-template-columns: 1fr; } .foldermap .fm-tree { border-right: none; border-bottom: 1px solid var(--border); } }
+
+/* ---------- type-safety comptime-error demo ---------- */
+.errdemo { background: #0a0b0e; border: 1px solid rgba(240,105,105,0.3); border-radius: 10px; overflow: hidden; }
+.errdemo .code-head { background: #150f10; border-bottom: 1px solid rgba(240,105,105,0.22); }
+.errdemo pre { margin: 0; padding: 18px; font-family: var(--mono); font-size: 13px; line-height: 1.75; color: #cfd3da; overflow-x: auto; }
+.errdemo .e-file { color: var(--red); } .errdemo .e-line { color: var(--faint); } .errdemo .e-msg { color: var(--red); } .errdemo .e-cmd { color: var(--accent); } .errdemo .e-hint { color: var(--faint); font-style: italic; }
+
+/* ---------- numbers strip (home) ---------- */
+.numstrip { display: flex; flex-wrap: wrap; gap: 0; border: 1px solid var(--border); border-radius: 12px; background: var(--surface); overflow: hidden; }
+.numstrip .ns-item { flex: 1 1 190px; padding: 20px 22px; border-right: 1px solid var(--border); }
+.numstrip .ns-item:last-child { border-right: none; }
+.numstrip .ns-val { font-family: var(--mono); font-size: 20px; font-weight: 600; color: var(--fg); letter-spacing: -0.01em; }
+.numstrip .ns-label { color: var(--muted); font-size: 12.5px; margin-top: 4px; }
+.numstrip .ns-item .measured { margin-top: 10px; }
+
+/* ---------- meta-CLI / AI teaser (home) ---------- */
+.metateaser { display: grid; grid-template-columns: 1fr 1fr; gap: 48px; align-items: center; }
+.metateaser > * { min-width: 0; }
+@media (max-width: 900px) { .metateaser { grid-template-columns: 1fr; } }
+
+/* ---------- comparison teaser mini-cards (home) ---------- */
+.cmp-mini { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+.cmp-mini .card { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 20px 22px; }
+.cmp-mini .card h4 { font-family: var(--mono); font-size: 14px; color: var(--fg); margin-bottom: 8px; }
+.cmp-mini .card p { color: var(--muted); font-size: 13.5px; line-height: 1.55; }
+@media (max-width: 780px) { .cmp-mini { grid-template-columns: 1fr; } }
+
+/* ---------- built-with-zcli (home) ---------- */
+.builtwith { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+.builtwith .bw { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 22px; }
+.builtwith .bw h4 { font-size: 15.5px; margin-bottom: 6px; }
+.builtwith .bw p { color: var(--muted); font-size: 13.5px; }
+.builtwith .bw.add { display: flex; align-items: center; justify-content: center; text-align: center; border-style: dashed; border-color: var(--border2); color: var(--faint); font-family: var(--mono); font-size: 13px; }
+@media (max-width: 780px) { .builtwith { grid-template-columns: 1fr; } }
+
+/* ---------- /why/ page ---------- */
+.why-hero { padding: 72px 0 8px; max-width: 68ch; }
+.why-hero h1 { font-size: clamp(32px, 4.6vw, 48px); }
+.why-hero .lead { margin-top: 18px; font-size: 18px; }
+.why-nav { display: flex; gap: 8px; flex-wrap: wrap; margin: 30px 0 0; }
+.why-nav a { font-family: var(--mono); font-size: 12.5px; color: var(--muted); border: 1px solid var(--border); border-radius: 999px; padding: 7px 14px; transition: all .15s; }
+.why-nav a:hover { color: var(--accent); border-color: var(--accent); }
+
+.cmp-table { width: 100%; border-collapse: collapse; font-size: 14.5px; }
+.cmp-table th { text-align: left; font-family: var(--mono); font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--faint); padding: 0 16px 14px; border-bottom: 1px solid var(--border); font-weight: 500; }
+.cmp-table td { padding: 15px 16px; border-bottom: 1px solid var(--border); vertical-align: top; color: var(--muted); }
+.cmp-table td.hl { color: var(--fg); }
+.cmp-table th.zcli-col, .cmp-table td.zcli-col { background: rgba(247,164,29,0.05); }
+
+.contrast { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-top: 20px; }
+.contrast > * { min-width: 0; }
+@media (max-width: 780px) { .contrast { grid-template-columns: 1fr; } }
+
+.num-table { width: 100%; border-collapse: collapse; font-size: 14.5px; margin-top: 8px; }
+.num-table td { padding: 13px 4px; border-bottom: 1px solid var(--border); }
+.num-table td.metric { color: var(--muted); }
+.num-table td.value { font-family: var(--mono); color: var(--fg); text-align: right; white-space: nowrap; }
+details.repro { margin-top: 4px; }
+details.repro summary { cursor: pointer; font-family: var(--mono); font-size: 11.5px; color: var(--faint); list-style: none; }
+details.repro summary::-webkit-details-marker { display: none; }
+details.repro summary::before { content: "▸ "; color: var(--accent); }
+details.repro[open] summary::before { content: "▾ "; }
+details.repro pre { margin-top: 8px; font-family: var(--mono); font-size: 12.5px; color: var(--muted); background: #0a0b0e; border: 1px solid var(--border); border-radius: 7px; padding: 10px 14px; overflow-x: auto; }
+
+.zig-table { width: 100%; border-collapse: collapse; font-size: 14.5px; margin-top: 8px; }
+.zig-table th { text-align: left; font-family: var(--mono); font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--faint); padding: 0 14px 12px; border-bottom: 1px solid var(--border); font-weight: 500; }
+.zig-table td { padding: 12px 14px; border-bottom: 1px solid var(--border); color: var(--muted); }
+.zig-table td.zcli-v { font-family: var(--mono); color: var(--accent); }
+
+/* ---------- /changelog/ page ---------- */
+.chglog-policy { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 10px 10px 0; padding: 18px 22px; margin-bottom: 8px; color: var(--muted); font-size: 14.5px; line-height: 1.65; }
+.chglog-policy b { color: var(--fg); }
+.release { padding: 40px 0; border-top: 1px solid var(--border); scroll-margin-top: 84px; }
+.release:first-of-type { border-top: none; padding-top: 8px; }
+.release-head { display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap; margin-bottom: 6px; }
+.release-head h2 { font-family: var(--mono); font-size: 22px; color: var(--fg); }
+.release-head .date { color: var(--faint); font-size: 13px; font-family: var(--mono); }
+.release-head .tag { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.08em; text-transform: uppercase; padding: 3px 9px; border-radius: 999px; }
+.release-head .tag.breaking { color: var(--red); background: rgba(240,105,105,0.1); }
+.release-head .tag.minor { color: var(--green); background: rgba(87,201,122,0.1); }
+.release-summary { color: var(--muted); font-size: 15px; margin-bottom: 18px; max-width: 68ch; }
+.release h3 { font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--faint); margin: 20px 0 8px; }
+.release ul { color: var(--muted); font-size: 14.5px; margin-left: 20px; }
+.release li { padding: 5px 0; line-height: 1.6; }
+.release li b { color: var(--fg); }
+.release code { font-family: var(--mono); font-size: 0.88em; background: var(--surface2); border: 1px solid var(--border); border-radius: 5px; padding: 1px 6px; color: var(--accent); }
+
+/* ---------- docs hub additions ---------- */
+.prompt-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+.prompt-grid .pcard { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 16px 18px; }
+.prompt-grid .pcard h4 { font-family: var(--mono); font-size: 13.5px; color: var(--accent); margin-bottom: 6px; }
+.prompt-grid .pcard p { color: var(--muted); font-size: 13px; margin: 0; }
+@media (max-width: 700px) { .prompt-grid { grid-template-columns: 1fr; } }
+
+.tier-table { width: 100%; border-collapse: collapse; font-size: 14px; margin: 8px 0 18px; }
+.tier-table th { text-align: left; font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--faint); padding: 0 14px 10px; border-bottom: 1px solid var(--border); font-weight: 500; }
+.tier-table td { padding: 11px 14px; border-bottom: 1px solid var(--border); color: var(--muted); vertical-align: top; }
+.tier-table td.tier { font-family: var(--mono); color: var(--accent); white-space: nowrap; }
+
+.transcript { background: #0a0b0e; border: 1px solid var(--border2); border-radius: 10px; padding: 18px 20px; font-family: var(--mono); font-size: 13px; line-height: 1.85; color: var(--muted); overflow-x: auto; }
+.transcript .t-agent { color: var(--cyan); } .transcript .t-cmd { color: var(--accent); } .transcript .t-ok { color: var(--green); } .transcript .t-you { color: var(--fg); }

--- a/website/content/blog/index.smd
+++ b/website/content/blog/index.smd
@@ -1,0 +1,7 @@
+---
+.title = "zcli — Blog",
+.description = "zcli release notes and deep-dives. First post: introducing zcli — your folder structure is your CLI.",
+.date = @date("2025-01-01"),
+.author = "Ryan Hair",
+.layout = "blog.shtml",
+---

--- a/website/content/changelog/index.smd
+++ b/website/content/changelog/index.smd
@@ -1,0 +1,7 @@
+---
+.title = "zcli — Changelog",
+.description = "Every zcli release, newest first, with the versioning policy and Zig support table. Rendered from CHANGELOG.md in the repo.",
+.date = @date("2025-01-01"),
+.author = "Ryan Hair",
+.layout = "changelog.shtml",
+---

--- a/website/content/docs/index.smd
+++ b/website/content/docs/index.smd
@@ -1,6 +1,6 @@
 ---
 .title = "zcli — Documentation",
-.description = "Getting started with zcli: scaffold a project with zcli init, then learn commands, args & options, plugins, config, prompts, and progress.",
+.description = "zcli documentation: quick start, commands, prompts, progress & theming, config files, plugins, testing, docs generation, the meta-CLI, and building with AI agents.",
 .date = @date("2025-01-01"),
 .author = "Ryan Hair",
 .layout = "docs.shtml",

--- a/website/content/getting-started/index.smd
+++ b/website/content/getting-started/index.smd
@@ -1,0 +1,7 @@
+---
+.title = "zcli — Getting started",
+.description = "From zero to a working CLI in three commands: install the zcli binary, initialize a project with zcli init, and scaffold commands with zcli add command.",
+.date = @date("2025-01-01"),
+.author = "Ryan Hair",
+.layout = "getting-started.shtml",
+---

--- a/website/content/index.smd
+++ b/website/content/index.smd
@@ -1,6 +1,6 @@
 ---
-.title = "zcli — batteries-included CLI framework for Zig",
-.description = "The filesystem is your command tree. The compiler is your argument parser. Drop a .zig file in commands/ and it becomes a command — help, completions, typo suggestions, and typed parsing generated at compile time.",
+.title = "zcli — your folder structure is your CLI",
+.description = "zcli is a batteries-included framework for command-line tools in Zig. Files become commands, folders become groups, structs become type-checked flags — routing generated at build time.",
 .date = @date("2025-01-01"),
 .author = "Ryan Hair",
 .layout = "home.shtml",

--- a/website/content/why/index.smd
+++ b/website/content/why/index.smd
@@ -1,0 +1,7 @@
+---
+.title = "zcli — Why zcli",
+.description = "Why zcli exists: comptime over runtime, conventions over registration, and the measured numbers behind the batteries-included claim — binary size, dependencies, CI, and Zig version support.",
+.date = @date("2025-01-01"),
+.author = "Ryan Hair",
+.layout = "why.shtml",
+---

--- a/website/layouts/blog.shtml
+++ b/website/layouts/blog.shtml
@@ -1,0 +1,50 @@
+<extend template="base.shtml">
+
+<head id="head">
+<style>
+  .blog-body { max-width: 720px; padding: 64px 0 96px; }
+  .blog-body h1 { font-size: clamp(30px,4vw,42px); }
+  .post-meta { font-family: var(--mono); font-size: 12.5px; color: var(--faint); margin: 10px 0 34px; }
+  .post p { color: var(--muted); font-size: 16.5px; line-height: 1.75; margin-bottom: 18px; }
+  .post h2 { font-size: 24px; margin: 40px 0 12px; }
+  .post code { font-family: var(--mono); font-size: 0.88em; background: var(--surface2); border: 1px solid var(--border); border-radius: 5px; padding: 1px 6px; color: var(--accent); }
+  .post .code { margin: 16px 0 22px; }
+</style>
+</head>
+
+<main id="main">
+<div class="wrap blog-body">
+  <div class="eyebrow" style="display:inline-block;">Blog</div>
+  <h1 style="margin-top:14px;">Introducing zcli: your folder structure is your CLI</h1>
+  <div class="post-meta">2026-07-05 · Ryan Hair</div>
+
+  <article class="post" id="introducing-zcli">
+    <p>I kept writing the same argument-parsing boilerplate for every command-line tool I built in Zig, then re-wiring a registry every time a command moved. zcli is the framework I wanted: drop a <code>.zig</code> file in <code>commands/</code>, and it's a command — discovered at build time, routed with zero runtime cost, and type-checked by the compiler instead of by hand.</p>
+
+    <h2>The idea</h2>
+    <p>A command is one file, up to four exports: <code>meta</code> for help text, <code>Args</code> and <code>Options</code> as plain structs, and an <code>execute</code> function. There's no builder chain to keep in sync, no registry to forget to update — the file <em>is</em> the command.</p>
+    <div class="code">
+      <div class="code-head"><span class="fname">src/commands/deploy.zig</span><span class="lang">zig</span></div>
+<pre><span class="kw">pub const</span> meta = .{ .description = <span class="str">"Deploy your application"</span> };
+<span class="kw">pub const</span> Args = <span class="kw">struct</span> { service: []<span class="kw">const</span> <span class="fn">u8</span> };
+<span class="kw">pub const</span> Options = <span class="kw">struct</span> { env: []<span class="kw">const</span> <span class="fn">u8</span> = <span class="str">"production"</span> };
+
+<span class="kw">pub fn</span> <span class="fn">execute</span>(args: Args, options: Options, context: <span class="kw">anytype</span>) !<span class="kw">void</span> {
+    <span class="kw">try</span> context.<span class="fn">stdout</span>().<span class="fn">print</span>(<span class="str">"Deploying {s} to {s}\n"</span>, .{ args.service, options.env });
+}</pre>
+    </div>
+
+    <h2>What v0.19.0 adds</h2>
+    <p>This release is hardening and tooling: <code>zcli add/rm/mv</code> restructure command files in place via an AST splice engine, <code>zcli guide</code> gives your editor — or your coding agent — a version-matched reference, and the <code>zcli_secrets</code> plugin stores credentials in the OS keychain instead of a plaintext config file. Windows joined the first CI tier, and two audit passes closed 50+ findings across the parse pipeline and the PTY test harness. Full detail in the <a href="$site.page('changelog').link().suffix('#v0-19-0')" style="color:var(--accent);">changelog</a>.</p>
+
+    <h2>Try it</h2>
+    <div class="code">
+      <div class="code-head"><span class="fname">terminal</span><span class="lang">sh</span></div>
+<pre><span class="c-prompt">$</span> <span class="c-cmd">curl</span> -fsSL https://raw.githubusercontent.com/ryanhair/zcli/main/install.sh | sh
+<span class="c-prompt">$</span> <span class="c-cmd">zcli</span> init myapp && <span class="c-cmd">cd</span> myapp && zig build
+<span class="c-prompt">$</span> ./zig-out/bin/myapp hello World</pre>
+    </div>
+    <p>It's MIT licensed, targets stable Zig 0.16.0, and the <a href="$site.page('why').link().suffix('#comparison')" style="color:var(--accent);">comparison to zig-clap and zli</a> is on the site if you're weighing options. Issues and PRs welcome on <a href="https://github.com/ryanhair/zcli" target="_blank" rel="noopener" style="color:var(--accent);">GitHub</a>.</p>
+  </article>
+</div>
+</main>

--- a/website/layouts/changelog.shtml
+++ b/website/layouts/changelog.shtml
@@ -1,0 +1,105 @@
+<extend template="base.shtml">
+
+<head id="head">
+<style>
+  .cl-body { max-width: 800px; padding: 64px 0 96px; }
+  .cl-body h1 { font-size: clamp(30px,4vw,42px); }
+  .cl-body .lead { color: var(--muted); font-size: 17px; margin-top: 14px; max-width: 68ch; }
+</style>
+</head>
+
+<main id="main">
+<div class="wrap cl-body">
+  <div class="eyebrow" style="display:inline-block;">Changelog</div>
+  <h1>Every release, newest first.</h1>
+  <p class="lead">All notable changes to zcli, rendered from <a href="https://github.com/ryanhair/zcli/blob/main/CHANGELOG.md" target="_blank" rel="noopener" style="color:var(--accent);">CHANGELOG.md</a> in the repo — that file stays the single source of truth.</p>
+
+  <div id="versioning" class="chglog-policy" style="margin-top:32px;">
+    <b>Versioning policy</b>
+    zcli follows <a href="https://semver.org" target="_blank" rel="noopener" style="color:var(--accent);">semver</a>. Until 1.0, breaking changes may land in minor versions and are called out below; patch versions are always safe to take. Releases target <b>stable Zig</b> — moving to a new Zig version is at least a minor bump and is stated in the entry. Each release is tagged twice, in lockstep: <code class="mono">vX.Y.Z</code> is the framework library (the tag for your <code class="mono">build.zig.zon</code>), <code class="mono">zcli-vX.Y.Z</code> carries the prebuilt meta-CLI binaries.
+  </div>
+
+  <table class="zig-table" style="margin-top:28px;">
+    <thead><tr><th>zcli</th><th>Zig</th></tr></thead>
+    <tbody>
+      <tr><td class="zcli-v">main, v0.18.0 and later</td><td>0.16.0</td></tr>
+      <tr><td class="zcli-v">v0.14.0 – v0.17.0</td><td>0.15.1</td></tr>
+    </tbody>
+  </table>
+
+  <!-- v0.19.0 -->
+  <article class="release" id="v0-19-0">
+    <div class="release-head">
+      <h2>v0.19.0</h2>
+      <span class="date">2026-07-05</span>
+      <span class="tag minor">stable Zig 0.16.0</span>
+    </div>
+    <p class="release-summary">Hardening and tooling release. Requires Zig 0.16.0.</p>
+
+    <h3>Added</h3>
+    <ul>
+      <li><b>Command-authoring tools in the meta-CLI</b>: <code class="mono">zcli add option/arg/group/plugin</code> and <code class="mono">zcli mv</code>/<code class="mono">zcli rm</code> restructure command files in place via an AST splice engine — no JSON blobs, no regeneration.</li>
+      <li><b><code class="mono">zcli guide</code></b> — version-matched, topic-based reference for the framework's idioms; <code class="mono">zcli init</code> scaffolds an <code class="mono">AGENTS.md</code> that points AI agents at it.</li>
+      <li><b><code class="mono">zcli_secrets</code> plugin</b> — opt-in credential storage in the OS keychain (macOS Keychain, Linux Secret Service, Windows Credential Manager), no plaintext fallback.</li>
+      <li>HTTP client with safe defaults over <code class="mono">std.http.Client</code> (credential headers stripped on cross-origin redirects), plus a canonical <code class="mono">ghauth</code> example showing the secrets + auth idiom.</li>
+      <li>Arena-per-command allocator for <code class="mono">execute()</code>, and <code class="mono">context.fail()</code> for friendly, stack-trace-free command errors.</li>
+      <li>Windows joins the first tier: unit tests and the full e2e suite (interactive tier via a ConPTY backend) run on Windows CI, <code class="mono">upgrade</code> self-replaces correctly on Windows, and the console is put into UTF-8 mode so multibyte I/O round-trips.</li>
+    </ul>
+    <h3>Fixed</h3>
+    <ul>
+      <li>Two full-repo audit passes burned down 50+ findings: memory leaks in the parse pipeline, a PTY-harness deadlock, vterm out-of-bounds on resize, comptime build errors that now name the offending command, config command-scoping applied to TOML/YAML (was JSON-only), and legible errors instead of <code class="mono">exit(1)</code> throughout the build API.</li>
+    </ul>
+    <h3>Changed</h3>
+    <ul>
+      <li><code class="mono">generate()</code>/<code class="mono">generateDocs()</code>/<code class="mono">addCommandTests()</code> take typed configs and derive the zcli module themselves.</li>
+      <li>The 2,460-line registry was split into focused submodules; zcli no longer re-exports all of serde.</li>
+      <li>Releases are gated on the full test suite (including native Windows), and CI actions are pinned to SHAs.</li>
+    </ul>
+  </article>
+
+  <!-- v0.18.0 -->
+  <article class="release" id="v0-18-0">
+    <div class="release-head">
+      <h2>v0.18.0</h2>
+      <span class="date">2026-06-30</span>
+      <span class="tag breaking">breaking</span>
+    </div>
+    <p class="release-summary">The Zig 0.16 release — the largest since the project started. <b>Breaking: requires Zig 0.16.0</b> (the new <code class="mono">std.Io</code> model).</p>
+
+    <h3>Added</h3>
+    <ul>
+      <li><b><code class="mono">zcli dev</code></b> — watches your source and rebuilds on change, with restart-on-change for a running binary (native fs events via kqueue/inotify/FSEvents).</li>
+      <li><b><code class="mono">zcli tree</code></b> — prints the command hierarchy, sharing the framework's own discovery logic.</li>
+      <li>Interactive wizard for <code class="mono">zcli add command</code>, plus declarative flags for scripted use.</li>
+      <li>Interactive prompts (text, confirm, select, multi-select, password, search, number, editor), config file support for TOML and YAML with per-command scoping, and command aliases.</li>
+      <li>Apps can name their generated <code class="mono">Context</code> type for full editor autocomplete in commands.</li>
+      <li>End-to-end test suite for the meta-CLI; docs website; Windows console backend and a libc-free terminal stack (fully static musl builds on Linux).</li>
+    </ul>
+    <h3>Changed</h3>
+    <ul>
+      <li>The monolithic interactive package was split into focused, standalone packages: <code class="mono">zinput</code>, <code class="mono">terminal</code>, <code class="mono">vterm</code>, <code class="mono">zprogress</code>, <code class="mono">ztheme</code>.</li>
+      <li><code class="mono">vterm</code> was removed from zcli's public re-exports — it's a testing tool, available directly.</li>
+      <li><code class="mono">zcli.builtin(.help, .{})</code> shortcut for enabling built-in plugins.</li>
+    </ul>
+  </article>
+
+  <!-- v0.14.0 – v0.17.0 -->
+  <article class="release" id="v0-14-0">
+    <div class="release-head">
+      <h2>v0.14.0 – v0.17.0</h2>
+      <span class="date">2025-10-23 to 2025-11-21</span>
+      <span class="tag minor">stable Zig 0.15.1</span>
+    </div>
+    <p class="release-summary">Zig 0.15.1 era. Windows support landed (v0.15.0), <code class="mono">std.posix.getenv</code> was dropped for portability, repeated short options for array types were fixed, commands gained support for C dependencies and command-specific imports (v0.16.0), and a completions memory leak was fixed.</p>
+  </article>
+
+  <!-- v0.1.0 – v0.13.1 -->
+  <article class="release" id="v0-1-0">
+    <div class="release-head">
+      <h2>v0.1.0 – v0.13.1</h2>
+      <span class="date">2025-10-09 to 2025-10-19</span>
+    </div>
+    <p class="release-summary">The foundation, built in ten days: build-time command discovery and routing, the plugin system (help, version, not-found, completions, config, output, upgrade), shell completions, hidden commands, shared modules, the <code class="mono">zcli</code> meta-CLI with <code class="mono">init</code>/<code class="mono">release</code>/<code class="mono">upgrade</code>, and the <code class="mono">curl | sh</code> install script. The dual-tag release scheme (<code class="mono">v*</code> library / <code class="mono">zcli-v*</code> CLI) was established at v0.11.0.</p>
+  </article>
+</div>
+</main>

--- a/website/layouts/docs.shtml
+++ b/website/layouts/docs.shtml
@@ -3,15 +3,15 @@
 <head id="head">
 <style>
   .layout { display: grid; grid-template-columns: 240px 1fr; gap: 56px; padding: 56px 0 96px; align-items: start; }
-  .layout > * { min-width: 0; }   /* let code blocks scroll instead of widening the page */
-  .toc { position: sticky; top: 84px; font-family: var(--mono); font-size: 13px; }
+  .layout > * { min-width: 0; }
+  .toc { position: sticky; top: 84px; font-family: var(--mono); font-size: 13px; max-height: calc(100vh - 110px); overflow-y: auto; }
   .toc h4 { font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--faint); margin: 20px 0 10px; }
   .toc h4:first-child { margin-top: 0; }
   .toc a { display: block; color: var(--muted); padding: 5px 0 5px 12px; border-left: 1px solid var(--border); transition: all .15s; }
   .toc a:hover, .toc a.active { color: var(--accent); border-left-color: var(--accent); }
 
   .doc { max-width: 760px; }
-  .doc > section { padding: 0 0 56px; border: none; }
+  .doc > section { padding: 0 0 56px; border: none; scroll-margin-top: 84px; }
   .doc h1 { font-size: 40px; margin-bottom: 12px; }
   .doc .sub { color: var(--muted); font-size: 18px; margin-bottom: 8px; }
   .doc h2 { font-size: 26px; margin: 44px 0 14px; padding-top: 12px; }
@@ -40,9 +40,18 @@
   .nextlinks { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 16px; }
   .nextlinks a { display: block; background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 18px 20px; transition: border-color .15s; }
   .nextlinks a:hover { border-color: var(--accent); }
-  .nextlinks .k { font-family: var(--mono); font-size: 12px; color: var(--accent); }
-  .nextlinks .t { color: var(--fg); font-size: 15px; margin-top: 4px; }
-  @media (max-width: 860px) { .layout { grid-template-columns: 1fr; } .toc { display: none; } .nextlinks { grid-template-columns: 1fr; } }
+  .nextlinks .k { display: block; font-family: var(--mono); font-size: 12px; color: var(--accent); }
+  .nextlinks .t { display: block; color: var(--fg); font-size: 15px; margin-top: 4px; }
+  .table-scroll { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+  .ptable { width: 100%; border-collapse: collapse; font-size: 14.5px; margin: 8px 0 8px; }
+  .ptable th { text-align: left; font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--faint); padding: 0 14px 12px; border-bottom: 1px solid var(--border); font-weight: 500; }
+  .ptable td { padding: 13px 14px; border-bottom: 1px solid var(--border); vertical-align: top; }
+  .ptable td.name { font-family: var(--mono); color: var(--accent); white-space: nowrap; }
+  .ptable td.desc { color: var(--muted); }
+  .ptable .badge { font-family: var(--mono); font-size: 11px; padding: 3px 9px; border-radius: 999px; }
+  .ptable .badge.on { background: rgba(87,201,122,0.12); color: var(--green); }
+  .ptable .badge.opt { background: rgba(146,152,164,0.1); color: var(--muted); }
+  @media (max-width: 860px) { .layout { grid-template-columns: 1fr; } .toc { display: none; } .nextlinks, .prompt-grid, .contrast { grid-template-columns: 1fr; } }
 </style>
 </head>
 
@@ -51,44 +60,48 @@
     <div class="layout">
       <aside class="toc">
         <h4>Get started</h4>
-        <a href="#start">Overview</a>
-        <a href="#fast">Fast path · zcli init</a>
-        <a href="#manual">Manual setup</a>
+        <a href="#quick-start">Quick start</a>
         <h4>Guide</h4>
         <a href="#commands">Commands</a>
         <a href="#options">Args & options</a>
         <a href="#context">The context</a>
-        <a href="#plugins">Plugins</a>
-        <a href="#config">Config files</a>
         <a href="#prompts">Prompts</a>
-        <a href="#progress">Progress</a>
+        <a href="#progress">Progress & theming</a>
+        <a href="#config">Config files</a>
+        <h4>Plugins</h4>
+        <a href="#plugins">Using plugins</a>
+        <a href="#writing-plugins">Writing plugins</a>
+        <h4>Testing</h4>
+        <a href="#testing">Testing</a>
+        <h4>Reference</h4>
+        <a href="#docsgen">Docs generation</a>
+        <a href="#the-zcli-cli">The zcli CLI</a>
+        <a href="#ai-agents">AI agents</a>
       </aside>
 
       <article class="doc">
-        <section id="start">
+
+        <!-- ============ QUICK START ============ -->
+        <section id="quick-start">
           <h1>Documentation</h1>
           <p class="sub">A batteries-included framework for building command-line interfaces in Zig. Drop <code>.zig</code> files in a directory and get a fully-featured CLI — with command discovery and routing wired up at compile time for zero-cost dispatch.</p>
           <div class="callout"><b>Requires</b> Zig 0.16.0 or newer. zcli is currently v<span :text="$site.asset('site-data.json').ziggy().get('version')"></span> and MIT licensed.</div>
-        </section>
 
-        <!-- ============ FAST PATH ============ -->
-        <section id="fast">
-          <h2 style="margin-top:8px;">Fast path — <code style="font-size:0.7em;">zcli init</code><span class="recommended">recommended</span></h2>
-          <p>The quickest way to a working CLI: install the <code>zcli</code> tool, then scaffold a project. <code>zcli init</code> writes <code>build.zig</code>, <code>build.zig.zon</code>, <code>src/main.zig</code>, an example command, and fetches the dependency — with the default plugins already wired up.</p>
+          <h2 style="margin-top:36px;">Quick start<span class="recommended">3 commands</span></h2>
+          <p>Install the meta-CLI, scaffold a project, add a command. That's the whole loop.</p>
 
           <div class="step"><span class="n">1</span><h2>Install the zcli CLI</h2></div>
-          <p>Grab the binary (see the <a href="$site.page('install').link()" style="color:var(--accent)">install page</a> for all options):</p>
+          <p>See the <a href="$site.page('install').link()" style="color:var(--accent)">install page</a> for every option, including shell completions.</p>
           <div class="code">
             <div class="code-head"><span class="fname">terminal</span><span class="lang">sh</span></div>
-<pre><span class="c-prompt">$</span> <span class="c-cmd">curl</span> -fsSL https://zcli.sh/install.sh | sh</pre>
+<pre><span class="c-prompt">$</span> <span class="c-cmd">curl</span> -fsSL https://raw.githubusercontent.com/ryanhair/zcli/main/install.sh | sh</pre>
           </div>
 
           <div class="step"><span class="n">2</span><h2>Scaffold a project</h2></div>
-          <p>Create a new project (or pass <code>.</code> to initialize the current directory). Add <code>--description</code> to set your app's tagline.</p>
           <div class="code">
             <div class="code-head"><span class="fname">terminal</span><span class="lang">sh</span></div>
-<pre><span class="c-prompt">$</span> <span class="c-cmd">zcli</span> init my-app <span class="c-flag">--description</span> <span class="str">"My awesome CLI"</span>
-Creating new zcli project: my-app
+<pre><span class="c-prompt">$</span> <span class="c-cmd">zcli</span> init myapp <span class="c-flag">--description</span> <span class="str">"My awesome CLI"</span>
+Creating new zcli project: myapp
   Creating build.zig.zon...
   Creating build.zig...
   Creating src/main.zig...
@@ -96,153 +109,83 @@ Creating new zcli project: my-app
   Creating AGENTS.md...
   Fetching dependencies (this may take a moment)...
 
-<span class="c-ok">✓</span> Project 'my-app' created successfully!</pre>
-          </div>
-          <p>This generates the full structure for you:</p>
-          <div class="code">
-            <div class="code-head"><span class="fname">my-app/</span><span class="lang">tree</span></div>
-<pre style="color:var(--muted);font-family:var(--mono);font-size:13px;line-height:1.85;">my-app/
-├── AGENTS.md             <span style="color:var(--faint);">— points coding agents at zcli guide</span>
-├── build.zig             <span style="color:var(--faint);">— executable + zcli.generate()</span>
-├── build.zig.zon         <span style="color:var(--faint);">— zcli dependency</span>
-└── src/
-    ├── main.zig          <span style="color:var(--faint);">— entry point</span>
-    └── commands/
-        └── hello.zig     <span style="color:var(--accent);">→ my-app hello</span></pre>
+<span class="c-ok">✓</span> Project 'myapp' created successfully!</pre>
           </div>
 
-          <div class="step"><span class="n">3</span><h2>Build & run</h2></div>
+          <div class="step"><span class="n">3</span><h2>Add a command & build</h2></div>
           <div class="code">
             <div class="code-head"><span class="fname">terminal</span><span class="lang">sh</span></div>
-<pre><span class="c-prompt">$</span> <span class="c-cmd">cd</span> my-app
+<pre><span class="c-prompt">$</span> <span class="c-cmd">cd</span> myapp
+<span class="c-prompt">$</span> <span class="c-cmd">zcli</span> add command deploy <span class="c-flag">--description</span> <span class="str">"Deploy your application"</span>
+<span class="c-ok">  ✔</span> Created src/commands/deploy.zig
+
 <span class="c-prompt">$</span> <span class="c-cmd">zig</span> build
-<span class="c-prompt">$</span> ./zig-out/bin/my-app hello World
-Hello, World!
-<span class="c-prompt">$</span> ./zig-out/bin/my-app <span class="c-flag">--help</span>
-<span class="c-mut">USAGE</span>  my-app &lt;command&gt; [options]</pre>
+<span class="c-prompt">$</span> ./zig-out/bin/myapp <span class="c-flag">--help</span>
+<span class="c-mut">USAGE</span>  myapp &lt;command&gt; [options]
+  <span class="c-cmd">deploy</span>   Deploy your application
+  <span class="c-cmd">hello</span>    Say hello</pre>
           </div>
-          <p>That's the whole loop. Add another command by dropping a new <code>.zig</code> file in <code>src/commands/</code> — jump to <a href="#commands" style="color:var(--accent)">Commands</a>.</p>
-        </section>
+          <p>Add more commands the same way — jump to <a href="#commands" style="color:var(--accent)">Commands</a> for the file-path rules, or <a href="#ai-agents" style="color:var(--accent)">AI agents</a> if a coding agent is driving.</p>
 
-        <!-- ============ MANUAL SETUP ============ -->
-        <section id="manual">
-          <h2>Manual setup</h2>
-          <p>Prefer to wire things up yourself, or adding zcli to an existing project? Here's everything <code>zcli init</code> does, by hand.</p>
-
-          <details class="manual">
-            <summary><span class="chev">›</span><span class="lbl">Set up a zcli project from scratch <small>— 4 steps</small></span></summary>
+          <details class="manual" style="margin-top:24px;">
+            <summary><span class="chev">›</span><span class="lbl">Manual setup — wiring build.zig by hand <small>— skip if zcli init worked</small></span></summary>
             <div class="inner">
-
               <div class="step"><span class="n">1</span><h2>Add zcli to build.zig.zon</h2></div>
-              <p>Add the dependency, then run <code>zig build</code> once — it prints the correct hash to paste in.</p>
               <div class="code">
-                <div class="code-head"><span class="fname">build.zig.zon</span><span class="lang">zig</span></div>
-<pre>.dependencies = .{
-    .zcli = .{
-        .url = <span class="str">"https://github.com/ryanhair/zcli/archive/refs/heads/main.tar.gz"</span>,
-        .hash = <span class="str">"..."</span>,  <span class="cm">// zig build will tell you the correct hash</span>
-    },
-},</pre>
+                <div class="code-head"><span class="fname">terminal</span><span class="lang">sh</span></div>
+<pre><span class="c-prompt">$</span> <span class="c-cmd">zig</span> fetch --save https://github.com/ryanhair/zcli/archive/refs/tags/v<span :text="$site.asset('site-data.json').ziggy().get('version')"></span>.tar.gz</pre>
               </div>
-
-              <div class="step"><span class="n">2</span><h2>Set up build.zig</h2></div>
-              <p>Create the executable, import the <code>zcli</code> module, then call <code>zcli.generate</code> to discover commands and produce the routing registry at build time. Turn on the default plugins with the <code>zcli.builtin(.tag, .{})</code> shortcut — no paths to spell out.</p>
+              <div class="step"><span class="n">2</span><h2>Wire up build.zig</h2></div>
               <div class="code">
                 <div class="code-head"><span class="fname">build.zig</span><span class="lang">zig</span></div>
-<pre><span class="kw">const</span> std = <span class="at">@import</span>(<span class="str">"std"</span>);
+<pre><span class="kw">const</span> zcli_dep = b.<span class="fn">dependency</span>(<span class="str">"zcli"</span>, .{ .target = target, .optimize = optimize });
+<span class="kw">const</span> zcli_module = zcli_dep.<span class="fn">module</span>(<span class="str">"zcli"</span>);
+exe.root_module.<span class="fn">addImport</span>(<span class="str">"zcli"</span>, zcli_module);
 
-<span class="kw">pub fn</span> <span class="fn">build</span>(b: *std.Build) <span class="kw">!void</span> {
-    <span class="kw">const</span> target = b.<span class="fn">standardTargetOptions</span>(.{});
-    <span class="kw">const</span> optimize = b.<span class="fn">standardOptimizeOption</span>(.{});
-
-    <span class="kw">const</span> zcli_dep = b.<span class="fn">dependency</span>(<span class="str">"zcli"</span>, .{
-        .target = target,
-        .optimize = optimize,
-    });
-    <span class="kw">const</span> zcli_module = zcli_dep.<span class="fn">module</span>(<span class="str">"zcli"</span>);
-
-    <span class="kw">const</span> exe = b.<span class="fn">addExecutable</span>(.{
-        .name = <span class="str">"myapp"</span>,
-        .root_module = b.<span class="fn">createModule</span>(.{
-            .root_source_file = b.<span class="fn">path</span>(<span class="str">"src/main.zig"</span>),
-            .target = target, .optimize = optimize,
-        }),
-    });
-    exe.root_module.<span class="fn">addImport</span>(<span class="str">"zcli"</span>, zcli_module);
-
-    <span class="kw">const</span> zcli = <span class="at">@import</span>(<span class="str">"zcli"</span>);
-    <span class="kw">const</span> cmd_registry = <span class="kw">try</span> zcli.<span class="fn">generate</span>(b, exe, zcli_dep, zcli_module, .{
-        .commands_dir = <span class="str">"src/commands"</span>,
-        .plugins = &.{
-            zcli.<span class="fn">builtin</span>(.help, .{}),
-            zcli.<span class="fn">builtin</span>(.version, .{}),
-            zcli.<span class="fn">builtin</span>(.not_found, .{}),
-            zcli.<span class="fn">builtin</span>(.completions, .{}),
-        },
-        .app_name = <span class="str">"myapp"</span>,
-        .app_description = <span class="str">"My CLI application"</span>,
-    });
-
-    exe.root_module.<span class="fn">addImport</span>(<span class="str">"command_registry"</span>, cmd_registry);
-    b.<span class="fn">installArtifact</span>(exe);
-}</pre>
+<span class="kw">const</span> zcli = <span class="at">@import</span>(<span class="str">"zcli"</span>);
+<span class="kw">const</span> cmd_registry = zcli.<span class="fn">generate</span>(b, exe, zcli_dep, zcli_module, .{
+    .commands_dir = <span class="str">"src/commands"</span>,
+    .plugins = &.{
+        zcli.<span class="fn">builtin</span>(.help, .{}),
+        zcli.<span class="fn">builtin</span>(.version, .{}),
+        zcli.<span class="fn">builtin</span>(.not_found, .{}),
+    },
+    .app_name = <span class="str">"myapp"</span>,
+});
+exe.root_module.<span class="fn">addImport</span>(<span class="str">"command_registry"</span>, cmd_registry);</pre>
               </div>
-              <div class="callout"><b>Tip</b> Need <code>config</code> or <code>output</code> too? Add <code>zcli.builtin(.config, .{})</code> / <code>zcli.builtin(.output, .{})</code>. For your <em>own</em> plugins, set <code>.plugins_dir = "src/plugins"</code> — see the <a href="$site.page('plugins').link()" style="color:var(--accent)">Plugins guide</a>.</div>
-
-              <div class="step"><span class="n">3</span><h2>Write main.zig</h2></div>
-              <p>zcli uses Zig's structured entry point. <code>main</code> receives a <code>std.process.Init</code> — hand its allocator, I/O, environment, and args to the generated registry.</p>
-              <div class="code">
-                <div class="code-head"><span class="fname">src/main.zig</span><span class="lang">zig</span></div>
-<pre><span class="kw">const</span> std = <span class="at">@import</span>(<span class="str">"std"</span>);
-<span class="kw">const</span> registry = <span class="at">@import</span>(<span class="str">"command_registry"</span>);
-
-<span class="kw">pub fn</span> <span class="fn">main</span>(init: std.process.Init) !<span class="kw">void</span> {
-    <span class="kw">const</span> args = <span class="kw">try</span> init.minimal.args.<span class="fn">toSlice</span>(init.arena.<span class="fn">allocator</span>());
-    <span class="kw">var</span> app = registry.<span class="fn">init</span>();
-    app.<span class="fn">run</span>(init.gpa, init.io, init.environ_map, args) <span class="kw">catch</span> |err| <span class="kw">switch</span> (err) {
-        <span class="kw">error</span>.CommandNotFound =&gt; std.process.<span class="fn">exit</span>(<span class="num">1</span>),
-        <span class="kw">else</span> =&gt; <span class="kw">return</span> err,
-    };
-}</pre>
-              </div>
-
-              <div class="step"><span class="n">4</span><h2>Write your first command</h2></div>
-              <p>Drop a file in <code>src/commands/</code>. The example below maps to <code>myapp hello</code>.</p>
+              <div class="step"><span class="n">3</span><h2>Write main.zig & your first command</h2></div>
               <div class="code">
                 <div class="code-head"><span class="fname">src/commands/hello.zig</span><span class="lang">zig</span></div>
 <pre><span class="kw">const</span> Context = <span class="at">@import</span>(<span class="str">"command_registry"</span>).Context;
 
 <span class="kw">pub const</span> meta = .{ .description = <span class="str">"Say hello"</span> };
-<span class="kw">pub const</span> Args = <span class="kw">struct</span> {
-    name: []<span class="kw">const</span> <span class="fn">u8</span>,
-};
-<span class="kw">pub const</span> Options = <span class="kw">struct</span> {
-    loud: <span class="fn">bool</span> = <span class="num">false</span>,
-};
+<span class="kw">pub const</span> Args = <span class="kw">struct</span> { name: []<span class="kw">const</span> <span class="fn">u8</span> };
+<span class="kw">pub const</span> Options = <span class="kw">struct</span> {};
 
-<span class="kw">pub fn</span> <span class="fn">execute</span>(args: Args, options: Options, context: *Context) !<span class="kw">void</span> {
-    <span class="kw">const</span> greeting = <span class="kw">if</span> (options.loud) <span class="str">"HELLO"</span> <span class="kw">else</span> <span class="str">"Hello"</span>;
-    <span class="kw">try</span> context.<span class="fn">stdout</span>().<span class="fn">print</span>(<span class="str">"{s}, {s}!\n"</span>, .{ greeting, args.name });
+<span class="kw">pub fn</span> <span class="fn">execute</span>(args: Args, _: Options, context: *Context) !<span class="kw">void</span> {
+    <span class="kw">try</span> context.<span class="fn">stdout</span>().<span class="fn">print</span>(<span class="str">"Hello, {s}!\n"</span>, .{args.name});
 }</pre>
-              </div>
-              <div class="code">
-                <div class="code-head"><span class="fname">terminal</span><span class="lang">sh</span></div>
-<pre><span class="c-prompt">$</span> <span class="c-cmd">zig build</span> &amp;&amp; ./zig-out/bin/myapp hello world
-Hello, world!</pre>
               </div>
             </div>
           </details>
+
+          <div class="nextlinks">
+            <a href="#commands"><span class="k">→ commands</span><span class="t">File-based command discovery</span></a>
+            <a href="#ai-agents"><span class="k">→ ai agents</span><span class="t">AGENTS.md and zcli guide</span></a>
+          </div>
         </section>
 
-        <!-- ============ GUIDE ============ -->
+        <!-- ============ COMMANDS ============ -->
         <section id="commands">
-          <h2>Commands</h2>
+          <h2 style="margin-top:0;">Commands</h2>
           <p>Commands are <code>.zig</code> files in your commands directory; the file path becomes the command path. Create folders for subcommands, and add an <code>index.zig</code> to give a directory a description.</p>
           <ul>
             <li><code>init.zig</code> → <code>myapp init</code></li>
             <li><code>users/create.zig</code> → <code>myapp users create</code></li>
             <li><code>users/index.zig</code> → describes the <code>users</code> group (no <code>execute</code> = shows subcommands)</li>
           </ul>
+          <div class="callout"><b>Structure changes</b> Use the scaffolder — <code>zcli add/rm/mv</code> — instead of hand-editing struct fields and meta blocks; it keeps the file, the metadata, and the argument order in sync. Read the current shape any time with <code>zcli tree --show-options</code>.</div>
         </section>
 
         <section id="options">
@@ -254,12 +197,8 @@ Hello, world!</pre>
     .description = <span class="str">"Add files to the index"</span>,
     .examples = &.{ <span class="str">"add file.txt"</span>, <span class="str">"add --all"</span> },
     .options = .{
-        .all = .{
-            .short = <span class="str">'a'</span>,
-            .description = <span class="str">"Add all files"</span>,
-        },
+        .all = .{ .short = <span class="str">'a'</span>, .description = <span class="str">"Add all files"</span> },
     },
-    .aliases = &.{ <span class="str">"a"</span> },
 };
 
 <span class="kw">pub const</span> Args = <span class="kw">struct</span> {
@@ -270,42 +209,81 @@ Hello, world!</pre>
     all: <span class="fn">bool</span> = <span class="num">false</span>,            <span class="cm">// --all / -a (flag)</span>
     output: []<span class="kw">const</span> <span class="fn">u8</span> = <span class="str">"text"</span>,  <span class="cm">// --output &lt;value&gt;</span>
     count: <span class="fn">u32</span> = <span class="num">1</span>,               <span class="cm">// --count &lt;number&gt;</span>
-    verbose: ?<span class="fn">bool</span> = <span class="num">null</span>,        <span class="cm">// optional flag</span>
+    verbose: <span class="fn">bool</span> = <span class="num">false</span>,        <span class="cm">// --verbose (flag)</span>
 };</pre>
           </div>
         </section>
 
         <section id="context">
           <h2>The context</h2>
-          <p>Every command's <code>execute</code> takes a concrete <code>context: *Context</code>, imported from the generated registry: <code>const Context = @import("command_registry").Context;</code>. It's your handle to I/O, the allocator, the active theme, and plugin data — a real type, not <code>anytype</code>, so the compiler checks your usage and your editor can autocomplete it.</p>
+          <p>Every command's <code>execute</code> takes a concrete <code>context: *Context</code>, imported from the generated registry. It's your handle to I/O, a per-command arena allocator, the active theme, and plugin data — a real type, not <code>anytype</code>, so the compiler checks your usage and your editor autocompletes it.</p>
           <div class="code">
             <div class="code-head"><span class="fname">src/commands/whoami.zig</span><span class="lang">zig</span></div>
 <pre><span class="kw">const</span> Context = <span class="at">@import</span>(<span class="str">"command_registry"</span>).Context;
 
 <span class="kw">pub fn</span> <span class="fn">execute</span>(args: Args, options: Options, context: *Context) !<span class="kw">void</span> {
-    <span class="kw">const</span> allocator = context.allocator;     <span class="cm">// per-run allocator</span>
-    <span class="kw">const</span> out = context.<span class="fn">stdout</span>();             <span class="cm">// buffered stdout writer</span>
-    <span class="kw">const</span> in  = context.<span class="fn">stdin</span>();              <span class="cm">// stdin reader (prompts)</span>
-
-    <span class="cm">// Plugin data is namespaced under context.plugins.{plugin_id}</span>
-    <span class="kw">if</span> (context.plugins.zcli_help.help_requested) <span class="kw">return</span>;
-
+    <span class="kw">const</span> allocator = context.allocator;     <span class="cm">// arena, freed after this command</span>
+    <span class="kw">const</span> out = context.<span class="fn">stdout</span>();
+    <span class="kw">if</span> (args.name.len == <span class="num">0</span>) <span class="kw">return</span> context.<span class="fn">fail</span>(<span class="str">"name is required"</span>, .{});
     <span class="kw">try</span> out.<span class="fn">print</span>(<span class="str">"{s}\n"</span>, .{args.name});
 }</pre>
           </div>
-          <div class="callout"><b>Unused params</b> Set unused parameters to <code>_</code> directly in the signature: <code>pub fn execute(_: Args, _: Options, context: *Context) !void</code>. <b>Plugin authors</b> — lifecycle hooks take <code>context: anytype</code>, since a plugin can't import the registry it gets compiled into.</div>
+          <div class="callout"><b>context.fail vs error</b> <code>context.fail("...", .{})</code> prints a clean message and exits — use it for anything the user should just read. A plain <code>return error.X</code> is for unexpected bugs and gets a name + Debug-only trace.</div>
         </section>
 
-        <section id="plugins">
-          <h2>Plugins</h2>
-          <p>zcli ships seven plugins. Three are on by default in a freshly scaffolded project (<code>zcli_help</code>, <code>zcli_version</code>, <code>zcli_not_found</code>); the rest you opt into. Plugins contribute global options and lifecycle hooks, and store data in <code>context.plugins.{plugin_id}</code>.</p>
-          <p>Enable a default with the <code>zcli.builtin(.help, .{})</code> shortcut, or auto-discover your own by pointing <code>.plugins_dir</code> at a folder. Full details — defaults, build-time config, and writing your own — live on the dedicated page:</p>
-          <div class="nextlinks" style="margin-top:8px;">
-            <a href="$site.page('plugins').link()"><span class="k">→ plugins guide</span><span class="t">Defaults, auto-discovery & writing plugins</span></a>
-            <a href="#config"><span class="k">→ config files</span><span class="t">Load defaults from JSON / TOML / YAML</span></a>
+        <!-- ============ PROMPTS ============ -->
+        <section id="prompts">
+          <h2>Interactive prompts</h2>
+          <p>The <code>zinput</code> package provides all 8 prompt types — every one works standalone (no zcli dependency) and falls back to line-based input when stdin isn't a TTY.</p>
+          <div class="prompt-grid">
+            <div class="pcard"><h4>text</h4><p>Free-form input with an optional default.</p></div>
+            <div class="pcard"><h4>confirm</h4><p>Yes/no, defaulting either way.</p></div>
+            <div class="pcard"><h4>select</h4><p>Arrow-key single choice from a list.</p></div>
+            <div class="pcard"><h4>multiSelect</h4><p>Space to toggle, arrows to move, defaults per item.</p></div>
+            <div class="pcard"><h4>password</h4><p>Masked input, no echo to the terminal.</p></div>
+            <div class="pcard"><h4>search</h4><p>Type-to-filter over a long list.</p></div>
+            <div class="pcard"><h4>number</h4><p>Range-validated numeric input.</p></div>
+            <div class="pcard"><h4>editor</h4><p>Opens <code>$EDITOR</code> for longer input.</p></div>
+          </div>
+          <div class="code">
+            <div class="code-head"><span class="fname">zinput</span><span class="lang">zig</span></div>
+<pre><span class="kw">const</span> name = <span class="kw">try</span> zinput.<span class="fn">text</span>(writer, reader, allocator, .{
+    .message = <span class="str">"Project name:"</span>, .default = <span class="str">"my-project"</span>,
+});
+<span class="kw">const</span> features = <span class="kw">try</span> zinput.<span class="fn">multiSelect</span>(writer, reader, allocator, .{
+    .message = <span class="str">"Features:"</span>,
+    .choices = &.{ <span class="str">"typescript"</span>, <span class="str">"eslint"</span>, <span class="str">"prettier"</span> },
+    .defaults = &.{ <span class="num">true</span>, <span class="num">true</span>, <span class="num">false</span> },
+});
+<span class="kw">const</span> pw = <span class="kw">try</span> zinput.<span class="fn">password</span>(writer, reader, allocator, .{
+    .message = <span class="str">"Token:"</span>,
+});</pre>
           </div>
         </section>
 
+        <!-- ============ PROGRESS & THEMING ============ -->
+        <section id="progress">
+          <h2>Progress & theming</h2>
+          <p>The <code>zprogress</code> package provides spinners (9 styles) and progress bars with ETA; animations auto-disable when not a TTY.</p>
+          <div class="code">
+            <div class="code-head"><span class="fname">zprogress</span><span class="lang">zig</span></div>
+<pre><span class="kw">var</span> spinner = zprogress.<span class="fn">spinner</span>(io, .{ .style = .dots });
+spinner.<span class="fn">start</span>(<span class="str">"Connecting to server..."</span>);
+spinner.<span class="fn">succeed</span>(<span class="str">"Synced successfully"</span>);  <span class="cm">// or .fail() / .warn() / .info()</span>
+
+<span class="kw">var</span> bar = zprogress.<span class="fn">progressBar</span>(io, .{ .total = items.len, .show_eta = <span class="num">true</span> });
+<span class="kw">for</span> (items, <span class="num">0</span>..) |item, i| { <span class="fn">process</span>(item); bar.<span class="fn">update</span>(i + <span class="num">1</span>, <span class="kw">null</span>); }</pre>
+          </div>
+          <h3>Theming</h3>
+          <p>The <code>ztheme</code> package maps semantic roles — <code>success</code>, <code>err</code>, <code>warning</code>, <code>command</code>, <code>path</code> — to true color, 256 color, 16 color, or no color, and respects <code>NO_COLOR</code>. Commands already have a themed context; standalone use is the same call.</p>
+          <div class="code">
+            <div class="code-head"><span class="fname">ztheme</span><span class="lang">zig</span></div>
+<pre><span class="kw">try</span> ztheme.<span class="fn">theme</span>(<span class="str">"Error"</span>).<span class="fn">red</span>().<span class="fn">bold</span>().<span class="fn">render</span>(writer, &context.theme);
+<span class="kw">try</span> ztheme.<span class="fn">theme</span>(<span class="str">"Synced"</span>).<span class="fn">success</span>().<span class="fn">render</span>(writer, &context.theme);</pre>
+          </div>
+        </section>
+
+        <!-- ============ CONFIG ============ -->
         <section id="config">
           <h2>Config files</h2>
           <p>The <code>zcli_config</code> plugin transparently loads option defaults from a config file — JSON, TOML, or YAML, with no changes to command code. Discovery follows: <code>--config &lt;path&gt;</code>, then <code>./{app}.config.*</code>, then <code>$XDG_CONFIG_HOME/{app}/config.*</code>.</p>
@@ -319,40 +297,181 @@ all = <span class="num">true</span></pre>
           </div>
         </section>
 
-        <section id="prompts">
-          <h2>Interactive prompts</h2>
-          <p>The <code>zinput</code> package provides 8 prompt types — text, confirm, select, multi-select, password, search, number, and editor. It works standalone (no zcli dependency) and falls back to line-based input when stdin isn't a TTY.</p>
+        <!-- ============ PLUGINS: USING ============ -->
+        <section id="plugins">
+          <h2>Using plugins</h2>
+          <p>zcli ships eight plugins. A project scaffolded with <code>zcli init</code> turns on the first three; the rest you opt in to.</p>
+          <div class="table-scroll">
+          <table class="ptable">
+            <thead><tr><th>Plugin</th><th>Provides</th><th>Default</th></tr></thead>
+            <tbody>
+              <tr><td class="name">zcli_help</td><td class="desc"><code>--help</code> / <code>-h</code>, auto-generated help text</td><td><span class="badge on">default</span></td></tr>
+              <tr><td class="name">zcli_version</td><td class="desc"><code>--version</code> / <code>-V</code></td><td><span class="badge on">default</span></td></tr>
+              <tr><td class="name">zcli_not_found</td><td class="desc">"Did you mean?" suggestions for typos</td><td><span class="badge on">default</span></td></tr>
+              <tr><td class="name">zcli_completions</td><td class="desc">Generate & install completions for bash, zsh, fish</td><td><span class="badge opt">optional</span></td></tr>
+              <tr><td class="name">zcli_config</td><td class="desc">Transparent config loading — JSON, TOML, YAML, per-command scoping</td><td><span class="badge opt">optional</span></td></tr>
+              <tr><td class="name">zcli_output</td><td class="desc"><code>--output</code> flag — json, table, plain</td><td><span class="badge opt">optional</span></td></tr>
+              <tr><td class="name">zcli_secrets</td><td class="desc">OS-keychain credential storage — macOS Keychain, Linux Secret Service, Windows Credential Manager</td><td><span class="badge opt">optional</span></td></tr>
+              <tr><td class="name">zcli_github_upgrade</td><td class="desc"><code>upgrade</code> command via GitHub releases</td><td><span class="badge opt">optional</span></td></tr>
+            </tbody>
+          </table>
+          </div>
           <div class="code">
-            <div class="code-head"><span class="fname">zinput</span><span class="lang">zig</span></div>
-<pre><span class="kw">const</span> name = <span class="kw">try</span> zinput.<span class="fn">text</span>(writer, reader, allocator, .{
-    .message = <span class="str">"Project name:"</span>, .default = <span class="str">"my-project"</span>,
-});
-<span class="kw">const</span> features = <span class="kw">try</span> zinput.<span class="fn">multiSelect</span>(writer, reader, allocator, .{
-    .message = <span class="str">"Features:"</span>,
-    .choices = &.{ <span class="str">"typescript"</span>, <span class="str">"eslint"</span>, <span class="str">"prettier"</span> },
-    .defaults = &.{ <span class="num">true</span>, <span class="num">true</span>, <span class="num">false</span> },
-});
-<span class="kw">const</span> port = <span class="kw">try</span> zinput.<span class="fn">number</span>(writer, reader, .{
-    .message = <span class="str">"Port:"</span>,
-    .default = <span class="num">3000</span>,
-    .min = <span class="num">1</span>,
-    .max = <span class="num">65535</span>,
-});</pre>
+            <div class="code-head"><span class="fname">build.zig</span><span class="lang">zig</span></div>
+<pre>.plugins = &.{
+    zcli.<span class="fn">builtin</span>(.help, .{}),
+    zcli.<span class="fn">builtin</span>(.completions, .{}),
+    zcli.<span class="fn">builtin</span>(.secrets, .{}),
+},
+<span class="cm">// or point at your own: .plugins_dir = "src/plugins"</span></pre>
           </div>
         </section>
 
-        <section id="progress">
-          <h2>Progress indicators</h2>
-          <p>The <code>zprogress</code> package provides spinners (9 styles) and progress bars with ETA. Theming uses semantic colors that adapt to terminal capabilities.</p>
+        <!-- ============ PLUGINS: WRITING ============ -->
+        <section id="writing-plugins">
+          <h2>Writing plugins</h2>
+          <p>A plugin is a Zig file exporting a <code>plugin_id</code> plus any lifecycle hooks, global options, context data, or commands it needs. Auto-discovery scans <code>.plugins_dir</code>: a lone <code>name.zig</code> is a single-file plugin; a folder with a <code>plugin.zig</code> entry point is a multi-file plugin.</p>
           <div class="code">
-            <div class="code-head"><span class="fname">zprogress</span><span class="lang">zig</span></div>
-<pre><span class="kw">var</span> bar = zprogress.<span class="fn">progressBar</span>(.{ .total = <span class="num">100</span>, .show_eta = <span class="num">true</span> });
-<span class="kw">var</span> spinner = zprogress.<span class="fn">spinner</span>(.{ .style = .dots });
-spinner.<span class="fn">start</span>(<span class="str">"Loading..."</span>);
-spinner.<span class="fn">succeed</span>(<span class="str">"Done!"</span>);   <span class="cm">// ✔ Done!</span></pre>
+            <div class="code-head"><span class="fname">src/plugins/timing.zig</span><span class="lang">zig</span></div>
+<pre><span class="kw">pub const</span> plugin_id = <span class="str">"timing"</span>;
+
+<span class="kw">pub const</span> ContextData = <span class="kw">struct</span> { started_ns: <span class="fn">i128</span> = <span class="num">0</span> };
+
+<span class="kw">pub const</span> global_options = [_]zcli.GlobalOption{
+    zcli.<span class="fn">option</span>(<span class="str">"time"</span>, <span class="fn">bool</span>, .{ .short = <span class="str">'t'</span>, .default = <span class="num">false</span> }),
+};
+
+<span class="kw">pub fn</span> <span class="fn">postExecute</span>(context: <span class="kw">anytype</span>) !<span class="kw">void</span> {
+    <span class="kw">const</span> start = context.plugins.timing.started_ns;
+    <span class="kw">if</span> (start != <span class="num">0</span>) {
+        <span class="kw">const</span> ms = <span class="at">@divTrunc</span>(std.time.<span class="fn">nanoTimestamp</span>() - start, <span class="num">1_000_000</span>);
+        <span class="kw">try</span> context.<span class="fn">stderr</span>().<span class="fn">print</span>(<span class="str">"⏱  {d}ms\n"</span>, .{ms});
+    }
+}</pre>
           </div>
+          <p>Hooks take <code>context: anytype</code> — a plugin is compiled <em>into</em> the registry, so it can't name the concrete <code>Context</code> type your commands import. Full hook list, build-time config, and plugin-provided commands: see the full <a href="$site.page('plugins').link()" style="color:var(--accent);">plugins guide</a>.</p>
+        </section>
+
+        <!-- ============ TESTING ============ -->
+        <section id="testing">
+          <h2>Testing</h2>
+          <p>Three tiers, each suited to a different verification need — use them together for coverage without slow feedback loops.</p>
+          <table class="tier-table">
+            <thead><tr><th>Tier</th><th>Tests</th><th>Speed</th></tr></thead>
+            <tbody>
+              <tr><td class="tier">Unit</td><td>Command logic in isolation — <code>execute()</code> only</td><td>Fast, in-process</td></tr>
+              <tr><td class="tier">Integration</td><td>The full CLI binary via subprocess — arg parsing, routing, output</td><td>Medium</td></tr>
+              <tr><td class="tier">E2E</td><td>Interactive terminal behavior — prompts, signals, TTY output</td><td>Slow</td></tr>
+            </tbody>
+          </table>
+          <p>Unit tests run against a real virtual terminal (<code>vterm</code>) that parses ANSI output — assert on colors and formatting, not raw escape codes:</p>
+          <div class="code">
+            <div class="code-head"><span class="fname">deploy_test.zig</span><span class="lang">zig</span></div>
+<pre><span class="kw">test</span> <span class="str">"deploy command"</span> {
+    <span class="kw">var</span> result = <span class="kw">try</span> testing.<span class="fn">runCommand</span>(DeployCommand, .{
+        .args = .{ .service = <span class="str">"api"</span> },
+        .options = .{ .env = <span class="str">"staging"</span> },
+    });
+    <span class="kw">defer</span> result.<span class="fn">deinit</span>();
+
+    <span class="kw">try</span> std.testing.<span class="fn">expectEqualStrings</span>(<span class="str">"Deploying api to staging\n"</span>, result.stdout);
+    <span class="kw">try</span> std.testing.<span class="fn">expect</span>(result.term.<span class="fn">containsText</span>(<span class="str">"Deploying"</span>));
+    <span class="kw">try</span> std.testing.<span class="fn">expect</span>(result.term.<span class="fn">hasAttribute</span>(<span class="num">0</span>, <span class="num">0</span>, .bold));</pre>
+          </div>
+          <p><code>result.term</code> is a real ANSI-parsing terminal emulator — assert a cell is bold at row 0, check a foreground color, or match a wildcard pattern across the rendered screen. No other Zig CLI library ships this. Full API and the integration/e2e tiers: see <a href="https://github.com/ryanhair/zcli/blob/main/docs/TESTING.md" target="_blank" rel="noopener" style="color:var(--accent);">docs/TESTING.md</a>.</p>
+        </section>
+
+        <!-- ============ DOCS GENERATION ============ -->
+        <section id="docsgen">
+          <h2>Docs generation</h2>
+          <p>Generate markdown, man pages, or HTML documentation from your command metadata — automatically on every build, so docs can't drift from the commands they describe.</p>
+          <div class="code">
+            <div class="code-head"><span class="fname">build.zig — after generate()</span><span class="lang">zig</span></div>
+<pre>zcli.<span class="fn">generateDocs</span>(b, cmd_registry, zcli_dep, .{
+    .formats = &.{ <span class="str">"markdown"</span>, <span class="str">"man"</span>, <span class="str">"html"</span> },
+    .output_dir = <span class="str">"docs"</span>,
+});</pre>
+          </div>
+          <p>The HTML output is a styled, dark-mode-aware static site with navigation — this documentation page is generated the same way.</p>
+        </section>
+
+        <!-- ============ THE ZCLI CLI ============ -->
+        <section id="the-zcli-cli">
+          <h2>The zcli CLI</h2>
+          <p>The meta-CLI you install with <code>curl | sh</code> is itself a zcli app — <code>init</code>, <code>add</code>, <code>gh</code>, <code>mv</code>, <code>rm</code>, <code>tree</code>, <code>dev</code>, <code>guide</code>, and <code>release</code> are files in its own <code>commands/</code> directory, running on the framework's own <code>help</code>, <code>completions</code>, "did you mean?", and GitHub self-upgrade plugins. If the meta-CLI's own commands look like a well-formed zcli project, that's because they are one.</p>
+          <div class="code">
+            <div class="code-head"><span class="fname">zcli tree</span><span class="lang">sh</span></div>
+<pre><span class="c-prompt">$</span> <span class="c-cmd">zcli</span> tree
+zcli
+<span class="c-mut">├──</span> <span class="c-cmd">add</span> <span class="c-flag">(group)</span> <span class="c-mut">[Add commands and plugins to your zcli project]</span>
+<span class="c-mut">│   ├──</span> <span class="c-cmd">arg</span> <span class="c-mut">[Add a positional argument to an existing command]</span>
+<span class="c-mut">│   ├──</span> <span class="c-cmd">command</span> <span class="c-mut">[Add a new command to your zcli project]</span>
+<span class="c-mut">│   ├──</span> <span class="c-cmd">group</span> <span class="c-mut">[Add a command group (a directory of subcommands) to your project]</span>
+<span class="c-mut">│   ├──</span> <span class="c-cmd">option</span> <span class="c-mut">[Add an option to an existing command]</span>
+<span class="c-mut">│   └──</span> <span class="c-cmd">plugin</span> <span class="c-mut">[Add a local plugin to your zcli project]</span>
+<span class="c-mut">├──</span> <span class="c-cmd">dev</span> <span class="c-mut">[Watch src/ and rebuild on change (optionally run a command)]</span>
+<span class="c-mut">├──</span> <span class="c-cmd">gh</span> <span class="c-flag">(group)</span> <span class="c-mut">[Add GitHub-related features and workflows]</span>
+<span class="c-mut">│   └──</span> <span class="c-cmd">add</span> <span class="c-flag">(group)</span>
+<span class="c-mut">│       └──</span> <span class="c-cmd">workflow</span> <span class="c-flag">(group)</span>
+<span class="c-mut">│           └──</span> <span class="c-cmd">release</span> <span class="c-mut">[Add GitHub Actions workflow for building and releasing binaries]</span>
+<span class="c-mut">├──</span> <span class="c-cmd">guide</span> <span class="c-mut">[Version-matched reference and worked examples for building with zcli]</span>
+<span class="c-mut">├──</span> <span class="c-cmd">init</span> <span class="c-mut">[Initialize a new zcli project]</span>
+<span class="c-mut">├──</span> <span class="c-cmd">mv</span> <span class="c-mut">[Move or rename a command file, tidying up empty groups]</span>
+<span class="c-mut">├──</span> <span class="c-cmd">release</span> <span class="c-mut">[Create and manage project releases]</span>
+<span class="c-mut">├──</span> <span class="c-cmd">rm</span> <span class="c-flag">(group)</span> <span class="c-mut">[Remove args and options from an existing command]</span>
+<span class="c-mut">│   ├──</span> <span class="c-cmd">arg</span> <span class="c-mut">[Remove one or more positional arguments from an existing command]</span>
+<span class="c-mut">│   ├──</span> <span class="c-cmd">command</span> <span class="c-mut">[Remove a whole command file from your project]</span>
+<span class="c-mut">│   └──</span> <span class="c-cmd">option</span> <span class="c-mut">[Remove one or more options from an existing command]</span>
+<span class="c-mut">└──</span> <span class="c-cmd">tree</span> <span class="c-mut">[Show the command tree discovered from src/commands]</span></pre>
+          </div>
+          <p><code>zcli add option/arg/group/plugin</code> and <code>zcli mv</code>/<code>zcli rm</code> restructure command files in place via an AST splice engine — struct field, meta entry, and argument order all edited together, correctly, instead of by hand.</p>
+        </section>
+
+        <!-- ============ AI AGENTS ============ -->
+        <section id="ai-agents">
+          <h2>AI agents</h2>
+          <p>AI coding agents are good at Zig, but they hallucinate stale APIs the moment a framework changes — a `Context` field that got renamed, a plugin config shape that moved. zcli's answer is version-matched: the reference an agent reads is generated from the exact zcli it's compiling against, not a training-data snapshot.</p>
+
+          <h3>AGENTS.md</h3>
+          <p><code>zcli init</code> scaffolds an <code>AGENTS.md</code> in every new project — a thin, frozen file that points an agent at <code>zcli guide</code> rather than duplicating framework docs that would drift. Re-running <code>init</code> on an existing project appends or refreshes just the zcli section, never clobbering the rest of your <code>AGENTS.md</code>.</p>
+
+          <h3>zcli guide</h3>
+          <p>A topic-based reference, matched to the zcli version in your <code>build.zig.zon</code>. Each topic is a worked example, not prose:</p>
+          <ul>
+            <li><code>structure</code> — files, commands, groups, plugins</li>
+            <li><code>sharing</code> — reusing a helper module across commands</li>
+            <li><code>storage</code>, <code>arena</code> — allocator lifetimes</li>
+            <li><code>output</code>, <code>prompts</code>, <code>http</code>, <code>secrets</code> — the terminal & network toolkit</li>
+            <li><code>plugins</code>, <code>testing</code> — extending and verifying a project</li>
+          </ul>
+          <div class="code">
+            <div class="code-head"><span class="fname">terminal</span><span class="lang">sh</span></div>
+<pre><span class="c-prompt">$</span> <span class="c-cmd">zcli</span> guide structure
+structure — a zcli project is its files
+
+File path = command path:
+  src/commands/deploy.zig        → app deploy
+  src/commands/users/create.zig  → app users create
+  src/commands/users/index.zig   → the "users" group landing
+
+Change structure with the scaffolder, not by hand:
+  zcli add command &lt;path&gt;    zcli rm command &lt;path&gt;    zcli mv &lt;from&gt; &lt;to&gt;</pre>
+          </div>
+
+          <h3>An agent adding a command, first try</h3>
+          <p>The loop <code>zcli guide</code> teaches an agent: read what exists, change structure with the scaffolder, write logic freeform, verify with <code>zig build test</code>.</p>
+          <div class="transcript">
+<span class="t-you">you:</span> add a "users create" command that takes a name and an --admin flag
+<span class="t-agent">agent:</span> <span class="t-cmd">zcli tree --show-options</span>
+<span class="t-agent">agent:</span> <span class="t-cmd">zcli add command users/create --arg '{"name":"name","type":"[]const u8"}' --option '{"name":"admin","type":"bool","short":"a"}'</span>
+<span class="t-ok">  ✔</span> Created src/commands/users/create.zig
+<span class="t-agent">agent:</span> <span class="t-mut">writes execute() body freeform</span>
+<span class="t-agent">agent:</span> <span class="t-cmd">zig build test</span>
+<span class="t-ok">  ✓</span> All tests passed
+          </div>
+
           <div class="nextlinks">
-            <a href="$site.page('plugins').link()"><span class="k">→ plugins</span><span class="t">Defaults & writing your own</span></a>
+            <a href="#the-zcli-cli"><span class="k">→ the zcli cli</span><span class="t">The meta-CLI, dogfooded</span></a>
             <a href="https://github.com/ryanhair/zcli" target="_blank" rel="noopener"><span class="k">→ github</span><span class="t">Source, issues & releases</span></a>
           </div>
         </section>

--- a/website/layouts/docs.shtml
+++ b/website/layouts/docs.shtml
@@ -463,8 +463,12 @@ Change structure with the scaffolder, not by hand:
           <div class="transcript">
 <span class="t-you">you:</span> add a "users create" command that takes a name and an --admin flag
 <span class="t-agent">agent:</span> <span class="t-cmd">zcli tree --show-options</span>
-<span class="t-agent">agent:</span> <span class="t-cmd">zcli add command users/create --arg '{"name":"name","type":"[]const u8"}' --option '{"name":"admin","type":"bool","short":"a"}'</span>
+<span class="t-agent">agent:</span> <span class="t-cmd">zcli add command users/create --description "Create a user"</span>
 <span class="t-ok">  ✔</span> Created src/commands/users/create.zig
+<span class="t-agent">agent:</span> <span class="t-cmd">zcli add arg users/create name --type []const u8</span>
+<span class="t-ok">  ✔</span> Added argument 'name' to src/commands/users/create.zig
+<span class="t-agent">agent:</span> <span class="t-cmd">zcli add option users/create admin --type bool --default false --short a</span>
+<span class="t-ok">  ✔</span> Added option --admin to src/commands/users/create.zig
 <span class="t-agent">agent:</span> <span class="t-mut">writes execute() body freeform</span>
 <span class="t-agent">agent:</span> <span class="t-cmd">zig build test</span>
 <span class="t-ok">  ✓</span> All tests passed

--- a/website/layouts/getting-started.shtml
+++ b/website/layouts/getting-started.shtml
@@ -1,0 +1,443 @@
+<extend template="base.shtml">
+
+<head id="head">
+<style>
+  /* ---------- page header ---------- */
+  .gs-head { padding: 72px 0 40px; }
+  .gs-head h1 { font-size: clamp(34px, 5vw, 56px); max-width: 16ch; }
+  .gs-head h1 .amber { color: var(--accent); }
+  .gs-head .lead { margin-top: 20px; font-size: 19px; }
+  .gs-head .meta-row { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 26px; }
+  .gs-head .chip { font-family: var(--mono); font-size: 12px; color: var(--muted); border: 1px solid var(--border); border-radius: 999px; padding: 5px 12px; }
+  .gs-head .chip b { color: var(--accent); font-weight: 600; }
+
+  /* ---------- sticky step rail ---------- */
+  .steprail { position: sticky; top: 60px; z-index: 40; background: rgba(12,13,16,0.82); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border-top: 1px solid var(--border); border-bottom: 1px solid var(--border); }
+  .steprail .wrap { display: flex; gap: 6px; height: 56px; align-items: center; overflow-x: auto; scrollbar-width: none; }
+  .steprail .wrap::-webkit-scrollbar { display: none; }
+  .steprail a { display: inline-flex; align-items: baseline; gap: 9px; white-space: nowrap; font-family: var(--mono); font-size: 13px; color: var(--muted); padding: 8px 14px; border-radius: 8px; transition: color .15s, background .15s; }
+  .steprail a .n { color: var(--faint); font-size: 11px; letter-spacing: 0.08em; }
+  .steprail a:hover { color: var(--fg); }
+  .steprail a.active { color: var(--accent); background: rgba(247,164,29,0.08); }
+  .steprail a.active .n { color: var(--accent); }
+
+  /* ---------- steps ---------- */
+  .step { padding: 88px 0; border-top: 1px solid var(--border); scroll-margin-top: 128px; }
+  .step:first-of-type { border-top: none; }
+  .step-head { display: grid; grid-template-columns: auto 1fr; gap: 26px; align-items: start; max-width: 72ch; margin-bottom: 44px; }
+  .step-n { font-family: var(--mono); font-size: 15px; font-weight: 700; color: #1a1205; background: var(--accent); width: 46px; height: 46px; border-radius: 11px; display: grid; place-items: center; box-shadow: 0 6px 22px rgba(247,164,29,0.28); }
+  .step-head h2 { font-size: clamp(26px, 3.4vw, 36px); margin-bottom: 12px; }
+  .step-head .what { color: var(--muted); font-size: 17px; line-height: 1.55; }
+  .step-head .what b { color: var(--fg); font-weight: 600; }
+
+  /* command box (reused pattern from install page) */
+  .cmdbox { display: flex; align-items: stretch; background: #0a0b0e; border: 1px solid var(--border2); border-radius: 10px; overflow: hidden; margin: 0 0 6px; }
+  .cmdbox pre { flex: 1; font-family: var(--mono); font-size: 14px; color: #cfd3da; padding: 15px 18px; overflow-x: auto; white-space: pre; }
+  .cmdbox .pr { color: var(--accent); }
+  .cmdbox .fl { color: var(--cyan); }
+  .cmdbox button { border: none; border-left: 1px solid var(--border); background: var(--surface); color: var(--muted); font-family: var(--mono); font-size: 12px; padding: 0 18px; cursor: pointer; transition: color .15s; }
+  .cmdbox button:hover { color: var(--accent); }
+
+  /* two-column body: command/terminal on one side, result on the other */
+  .duo { display: grid; grid-template-columns: 1fr 1fr; gap: 26px; align-items: start; }
+  .duo > * { min-width: 0; }
+  .col-label { font-family: var(--mono); font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--faint); margin: 0 0 12px; }
+  .stack > * + * { margin-top: 22px; }
+
+  .note { color: var(--muted); font-size: 14px; line-height: 1.6; margin-top: 12px; }
+  .note code, .step p code, .what code { font-family: var(--mono); font-size: 0.88em; color: var(--accent); background: rgba(247,164,29,0.08); padding: 1px 6px; border-radius: 5px; }
+
+  /* "what you get" file tree */
+  .tree { font-family: var(--mono); font-size: 13px; line-height: 1.95; color: var(--muted); white-space: pre; overflow-x: auto; }
+  .tree .dir { color: var(--cyan); } .tree .arrow { color: var(--faint); } .tree .cmd { color: var(--accent); } .tree .an { color: var(--faint); font-style: italic; }
+
+  /* callout */
+  .callout { display: flex; gap: 14px; background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 10px 10px 0; padding: 16px 18px; margin-top: 26px; }
+  .callout svg { width: 18px; height: 18px; color: var(--accent); flex: none; margin-top: 2px; }
+  .callout p { color: var(--muted); font-size: 14px; line-height: 1.6; margin: 0; }
+  .callout b { color: var(--fg); }
+
+  /* alt / secondary block (from source) */
+  .alt { margin-top: 22px; border: 1px dashed var(--border2); border-radius: 10px; padding: 18px 20px; }
+  .alt h4 { font-size: 14px; margin-bottom: 4px; }
+  .alt p { color: var(--muted); font-size: 13.5px; margin-bottom: 14px; }
+
+  /* end CTA */
+  .endcta { text-align: center; padding: 96px 0 104px; border-top: 1px solid var(--border); }
+  .endcta .eyebrow { display: inline-block; }
+  .endcta h2 { font-size: clamp(28px, 4vw, 42px); margin-bottom: 16px; }
+  .endcta p { color: var(--muted); font-size: 18px; max-width: 52ch; margin: 0 auto 28px; }
+  .endcta .cta { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; }
+
+  @media (max-width: 820px) {
+    .duo { grid-template-columns: 1fr; gap: 30px; }
+  }
+  @media (max-width: 560px) {
+    .step-head { grid-template-columns: 1fr; gap: 16px; }
+    .step { padding: 64px 0; }
+  }
+</style>
+</head>
+
+<main id="main">
+
+<!-- HEADER -->
+<div class="wrap">
+  <div class="gs-head">
+    <div class="eyebrow" style="display:inline-block;">Getting started</div>
+    <h1>From zero to a working CLI in <span class="amber">three commands</span>.</h1>
+    <p class="lead">Install the <code class="mono" style="color:var(--accent)">zcli</code> binary, scaffold a project with <code class="mono" style="color:var(--accent)">zcli&nbsp;init</code>, then grow it one file at a time with <code class="mono" style="color:var(--accent)">zcli&nbsp;add&nbsp;command</code>. Each step below shows exactly what runs and what lands on disk.</p>
+    <div class="meta-row">
+      <span class="chip">Requires <b>Zig 0.16+</b></span>
+      <span class="chip"><b>4</b> plugins wired in on init</span>
+      <span class="chip"><b>MIT</b> licensed</span>
+    </div>
+  </div>
+</div>
+
+<!-- STICKY STEP RAIL -->
+<div class="steprail" role="navigation" aria-label="Getting started steps">
+  <div class="wrap">
+    <a href="#step-install" data-step="step-install"><span class="n">01</span> Install the binary</a>
+    <a href="#step-init" data-step="step-init"><span class="n">02</span> Initialize a project</a>
+    <a href="#step-add" data-step="step-add"><span class="n">03</span> Add a command</a>
+  </div>
+</div>
+
+<div class="wrap">
+
+  <!-- STEP 1 — INSTALL -->
+  <article class="step" id="step-install">
+    <div class="step-head">
+      <span class="step-n">01</span>
+      <div>
+        <h2>Install the zcli binary</h2>
+        <p class="what">One line downloads the latest release for your OS and drops the <b>zcli scaffolding tool</b> into <code>~/.local/bin</code>. This is the meta-CLI you'll use to create projects and generate commands — it is <b>not</b> a dependency your app ships with.</p>
+      </div>
+    </div>
+
+    <div class="duo">
+      <div class="stack">
+        <div>
+          <p class="col-label">Run</p>
+          <div class="cmdbox">
+            <pre><span class="pr">$</span> curl -fsSL https://raw.githubusercontent.com/ryanhair/zcli/main/install.sh | sh</pre>
+            <button onclick="cp(this,'curl -fsSL https://raw.githubusercontent.com/ryanhair/zcli/main/install.sh | sh')">copy</button>
+          </div>
+          <p class="note">The script detects your platform, pulls the matching binary from the latest GitHub release, verifies the checksum when available, and marks it executable.</p>
+        </div>
+
+        <div class="alt">
+          <h4>Prefer building from source?</h4>
+          <p>Clone and build with Zig directly — artifacts land in <code class="mono" style="color:var(--accent)">zig-out/bin/</code>.</p>
+          <div class="cmdbox">
+            <pre><span class="pr">$</span> git clone https://github.com/ryanhair/zcli.git
+<span class="pr">$</span> cd zcli && zig build</pre>
+            <button onclick="cp(this,'git clone https://github.com/ryanhair/zcli.git && cd zcli && zig build')">copy</button>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <p class="col-label">What happens</p>
+        <div class="term">
+          <div class="term-bar">
+            <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+            <span class="ttl">install — zsh</span>
+          </div>
+          <div class="term-body">
+<pre><span class="c-prompt">$</span> <span class="c-cmd">curl</span> -fsSL <span class="c-mut">…/install.sh</span> | sh
+<span class="c-flag">==></span> Detecting platform… macos / aarch64
+<span class="c-flag">==></span> Fetching latest release… zcli v0.18.0
+<span class="c-flag">==></span> Downloading binary…
+<span class="c-flag">==></span> Verifying checksum…
+<span class="c-ok">  ✓</span> Installed zcli to ~/.local/bin/zcli
+
+<span class="c-prompt">$</span> <span class="c-cmd">zcli</span> --version
+zcli 0.18.0
+
+<span class="c-prompt">$</span> <span class="c-cmd">zcli</span> --help
+<span class="c-mut">Build beautiful CLIs with zcli — scaffold</span>
+<span class="c-mut">projects, add commands, and more.</span>
+
+<span class="c-mut">COMMANDS</span>
+  <span class="c-cmd">init</span>   Initialize a new zcli project
+  <span class="c-cmd">add</span>    Add commands and plugins
+  <span class="c-cmd">tree</span>   Visualize your command structure<span class="cursor"></span></pre>
+          </div>
+        </div>
+        <div class="callout">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><circle cx="12" cy="12" r="9"/><path d="M12 8v5"/><path d="M12 16h.01"/></svg>
+          <p>If <b>zcli</b> isn't found afterward, make sure <code style="color:inherit;background:none;padding:0;">~/.local/bin</code> is on your <b>PATH</b>.</p>
+        </div>
+      </div>
+    </div>
+  </article>
+
+  <!-- STEP 2 — INIT -->
+  <article class="step" id="step-init">
+    <div class="step-head">
+      <span class="step-n">02</span>
+      <div>
+        <h2>Initialize a new project</h2>
+        <p class="what"><code>zcli init</code> scaffolds a complete, buildable project: a <b>build.zig.zon</b> that pulls in zcli, a <b>build.zig</b> that wires up <code>zcli.generate</code> with the built-in plugins, an entrypoint, and one working example command. It fetches dependencies so <code>zig build</code> works immediately.</p>
+      </div>
+    </div>
+
+    <div>
+      <p class="col-label">Run</p>
+      <div class="cmdbox">
+        <pre><span class="pr">$</span> zcli init myapp <span class="fl">--description</span> "My awesome CLI"</pre>
+        <button onclick="cp(this,'zcli init myapp --description &quot;My awesome CLI&quot;')">copy</button>
+      </div>
+      <p class="note">Pass <code>.</code> instead of a name to initialize in the current directory (it must be empty). <code>--version</code> sets the starting version; both options are optional.</p>
+    </div>
+
+    <div class="duo" style="margin-top:26px;">
+      <div>
+        <p class="col-label">What happens</p>
+        <div class="term">
+          <div class="term-bar">
+            <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+            <span class="ttl">myapp — zsh</span>
+          </div>
+          <div class="term-body">
+<pre><span class="c-prompt">$</span> <span class="c-cmd">zcli</span> init myapp
+Creating new zcli project: myapp
+  Creating build.zig.zon…
+  Creating build.zig…
+  Creating src/main.zig…
+  Creating example command (hello)…
+  Fetching dependencies…
+
+<span class="c-ok">✓</span> Project 'myapp' created successfully!
+
+<span class="c-mut">Next steps:</span>
+  cd myapp
+  zig build
+  ./zig-out/bin/myapp hello World
+  ./zig-out/bin/myapp --help<span class="cursor"></span></pre>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <p class="col-label">What you get</p>
+        <div class="code">
+          <div class="code-head"><span class="fname">myapp/</span><span class="lang">scaffold</span></div>
+          <pre class="tree">myapp/
+├── build.zig.zon     <span class="an"># project + zcli dependency</span>
+├── build.zig         <span class="an"># zcli.generate + builtin plugins</span>
+└── src/
+    ├── main.zig      <span class="an"># generated entrypoint</span>
+    └── commands/
+        └── hello.zig <span class="arrow">→</span> <span class="cmd">myapp hello</span></pre>
+        </div>
+        <div class="callout">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M4 7l9-4 9 4-9 4-9-4z"/><path d="M4 12l9 4 9-4"/></svg>
+          <p><b>build.zig</b> already registers the <b>help</b>, <b>version</b>, <b>not-found</b>, and <b>completions</b> plugins — you get <code style="color:inherit;background:none;padding:0;">--help</code> and "did you mean?" for free.</p>
+        </div>
+      </div>
+    </div>
+
+    <div style="margin-top:30px;">
+      <p class="col-label">Build it &amp; run the example</p>
+      <div class="term">
+        <div class="term-bar">
+          <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+          <span class="ttl">myapp — zsh</span>
+        </div>
+        <div class="term-body">
+<pre><span class="c-prompt">$</span> <span class="c-cmd">cd</span> myapp && zig build
+<span class="c-prompt">$</span> <span class="c-cmd">./zig-out/bin/myapp</span> hello World
+Hello, World!
+<span class="c-prompt">$</span> <span class="c-cmd">./zig-out/bin/myapp</span> hello Alice <span class="c-flag">--loud</span>
+HELLO, Alice!<span class="cursor"></span></pre>
+        </div>
+      </div>
+      <p class="note">That output comes from the generated <code>src/commands/hello.zig</code> — a real command with a typed <code>name</code> argument and a <code>--loud</code> flag. Open it to see the shape every command follows.</p>
+    </div>
+  </article>
+
+  <!-- STEP 3 — ADD COMMAND -->
+  <article class="step" id="step-add">
+    <div class="step-head">
+      <span class="step-n">03</span>
+      <div>
+        <h2>Add a new command</h2>
+        <p class="what"><code>zcli add command</code> writes a ready-to-edit command file at the right path under <code>src/commands/</code> — with <b>meta</b>, <b>Args</b>, <b>Options</b>, and an <b>execute()</b> stub already filled in. Nested paths like <code>users/create</code> create the folders for you. Run it from your project root (where <code>build.zig</code> lives).</p>
+      </div>
+    </div>
+
+    <div>
+      <p class="col-label">Run</p>
+      <div class="cmdbox">
+        <pre><span class="pr">$</span> zcli add command deploy <span class="fl">--description</span> "Deploy your application"</pre>
+        <button onclick="cp(this,'zcli add command deploy --description &quot;Deploy your application&quot;')">copy</button>
+      </div>
+      <p class="note">Because the path becomes the command, <code>zcli add command users/create</code> produces <code>myapp users create</code> and creates the <code>users/</code> namespace automatically.</p>
+    </div>
+
+    <div class="duo" style="margin-top:26px;">
+      <div>
+        <p class="col-label">What happens</p>
+        <div class="term">
+          <div class="term-bar">
+            <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+            <span class="ttl">myapp — zsh</span>
+          </div>
+          <div class="term-body">
+<pre><span class="c-prompt">$</span> <span class="c-cmd">zcli</span> add command deploy \
+    <span class="c-flag">--description</span> "Deploy your application"
+
+<span class="c-ok">  ✔</span> Created src/commands/deploy.zig
+
+<span class="c-mut">  Next steps</span>
+    1. Implement execute() in
+       src/commands/deploy.zig
+    2. zig build
+    3. ./zig-out/bin/myapp deploy <span class="c-flag">--help</span><span class="cursor"></span></pre>
+          </div>
+        </div>
+        <div class="callout">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M12 9v4"/><path d="M12 17h.01"/><path d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z"/></svg>
+          <p>Run it <b>outside</b> a project and it stops with <code style="color:inherit;background:none;padding:0;">Not in a zcli project directory</code> — no stray files.</p>
+        </div>
+      </div>
+
+      <div>
+        <p class="col-label">The file it generates</p>
+        <div class="code">
+          <div class="code-head"><span class="fname">src/commands/deploy.zig</span><span class="lang">zig</span></div>
+<pre><span class="kw">const</span> std = <span class="at">@import</span>(<span class="str">"std"</span>);
+<span class="kw">const</span> zcli = <span class="at">@import</span>(<span class="str">"zcli"</span>);
+<span class="kw">const</span> Context = <span class="at">@import</span>(<span class="str">"command_registry"</span>).Context;
+
+<span class="kw">pub const</span> meta = .{
+    .description = <span class="str">"Deploy your application"</span>,
+    .examples = &.{
+        <span class="str">"deploy"</span>,
+    },
+};
+
+<span class="kw">pub const</span> Args = <span class="kw">struct</span> {};
+<span class="kw">pub const</span> Options = <span class="kw">struct</span> {};
+
+<span class="kw">pub fn</span> <span class="fn">execute</span>(args: Args, options: Options, context: *Context) !<span class="kw">void</span> {
+    _ = args;
+    _ = options;
+    <span class="kw">const</span> stdout = context.<span class="fn">stdout</span>();
+    <span class="kw">try</span> stdout.<span class="fn">print</span>(<span class="str">"TODO: Implement deploy\n"</span>, .{});
+}</pre>
+        </div>
+        <p class="note">Fill in <code>execute()</code>, then <code>zig build</code> — routing regenerates and <code>myapp deploy</code> is live with auto-generated <code>--help</code>.</p>
+      </div>
+    </div>
+
+    <div class="alt" style="margin-top:30px;">
+      <h4>Scaffold args &amp; options in one shot</h4>
+      <p>Skip the stub editing — describe the arguments and options inline and zcli generates the full typed structs for you.</p>
+      <div class="cmdbox">
+        <pre><span class="pr">$</span> zcli add command deploy \
+    <span class="fl">--arg</span> '{"name":"service","type":"[]const u8"}' \
+    <span class="fl">--option</span> '{"name":"env","type":"[]const u8","short":"e","default":"production"}'</pre>
+        <button onclick="cp(this,'zcli add command deploy --arg \'{&quot;name&quot;:&quot;service&quot;,&quot;type&quot;:&quot;[]const u8&quot;}\' --option \'{&quot;name&quot;:&quot;env&quot;,&quot;type&quot;:&quot;[]const u8&quot;,&quot;short&quot;:&quot;e&quot;,&quot;default&quot;:&quot;production&quot;}\'')">copy</button>
+      </div>
+    </div>
+  </article>
+
+  <!-- BONUS — TREE -->
+  <article class="step" id="step-tree">
+    <div class="step-head">
+      <span class="step-n" style="background:var(--surface2);color:var(--accent);box-shadow:none;border:1px solid var(--border2);">+</span>
+      <div>
+        <h2>See your whole CLI at a glance</h2>
+        <p class="what"><code>zcli tree</code> reads <code>src/commands/</code> and prints the structure it discovered — <b>no build required</b>. Add <code>--show-options</code> to include each command's arguments and options.</p>
+      </div>
+    </div>
+
+    <div class="duo">
+      <div>
+        <p class="col-label">Run</p>
+        <div class="cmdbox">
+          <pre><span class="pr">$</span> zcli tree</pre>
+          <button onclick="cp(this,'zcli tree')">copy</button>
+        </div>
+        <p class="note">Discovery reuses the same scan the build runs, so the tree always reflects what's actually on disk — folders show as <code>(group)</code> namespaces.</p>
+      </div>
+      <div>
+        <p class="col-label">What happens</p>
+        <div class="term">
+          <div class="term-bar">
+            <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+            <span class="ttl">myapp — zsh</span>
+          </div>
+          <div class="term-body">
+<pre><span class="c-prompt">$</span> <span class="c-cmd">zcli</span> tree
+<span class="c-mut">├──</span> <span class="c-cmd">deploy</span> <span class="c-mut">[Deploy your application]</span>
+<span class="c-mut">└──</span> <span class="c-cmd">hello</span> <span class="c-mut">[Say hello to someone]</span>
+
+<span class="c-prompt">$</span> <span class="c-cmd">zcli</span> tree <span class="c-flag">--show-options</span>
+<span class="c-mut">├──</span> <span class="c-cmd">deploy</span> <span class="c-mut">[Deploy your application]</span>
+<span class="c-mut">└──</span> <span class="c-cmd">hello</span> <span class="c-mut">[Say hello to someone]</span>
+    <span class="c-mut">args:</span>    <span class="c-flag">&lt;name:[]const u8&gt;</span>
+    <span class="c-mut">options:</span> <span class="c-flag">--loud</span><span class="cursor"></span></pre>
+          </div>
+        </div>
+      </div>
+    </div>
+  </article>
+
+</div>
+
+<!-- END CTA -->
+<section class="endcta">
+  <div class="wrap">
+    <div class="eyebrow">That's the whole loop</div>
+    <h2>Install · init · add. Ship the rest.</h2>
+    <p>You now have a buildable CLI and a one-liner to grow it. Next: wire up options, add plugins, and generate docs from your command metadata.</p>
+    <div class="cta">
+      <a class="btn primary" href="$site.page('docs').link()">Read the full docs →</a>
+      <a class="btn ghost" href="$site.page('plugins').link()">Explore plugins</a>
+    </div>
+  </div>
+</section>
+
+<script>
+  /* copy-to-clipboard for command boxes */
+  function cp(btn, text) {
+    navigator.clipboard.writeText(text).then(function () {
+      var old = btn.textContent; btn.textContent = 'copied ✓'; btn.style.color = 'var(--green)';
+      setTimeout(function () { btn.textContent = old; btn.style.color = ''; }, 1600);
+    });
+  }
+
+  /* scroll-spy: highlight the active step in the sticky rail */
+  (function () {
+    var links = Array.prototype.slice.call(document.querySelectorAll('.steprail a'));
+    var byId = {};
+    links.forEach(function (a) { byId[a.dataset.step] = a; });
+    var steps = links.map(function (a) { return document.getElementById(a.dataset.step); });
+
+    function setActive(id) {
+      links.forEach(function (a) { a.classList.toggle('active', a.dataset.step === id); });
+    }
+
+    if ('IntersectionObserver' in window) {
+      var visible = {};
+      var io = new IntersectionObserver(function (entries) {
+        entries.forEach(function (e) { visible[e.target.id] = e.isIntersecting ? e.intersectionRatio : 0; });
+        var best = null, bestRatio = 0;
+        steps.forEach(function (s) {
+          var r = visible[s.id] || 0;
+          if (r >= bestRatio) { bestRatio = r; best = s.id; }
+        });
+        if (best) setActive(best);
+      }, { rootMargin: '-140px 0px -55% 0px', threshold: [0, 0.15, 0.4, 0.75, 1] });
+      steps.forEach(function (s) { io.observe(s); });
+    }
+    setActive('step-install');
+  })();
+</script>
+
+</main>

--- a/website/layouts/getting-started.shtml
+++ b/website/layouts/getting-started.shtml
@@ -335,13 +335,12 @@ HELLO, Alice!<span class="cursor"></span></pre>
     </div>
 
     <div class="alt" style="margin-top:30px;">
-      <h4>Scaffold args &amp; options in one shot</h4>
-      <p>Skip the stub editing — describe the arguments and options inline and zcli generates the full typed structs for you.</p>
+      <h4>Add args &amp; options to a command</h4>
+      <p>Args and options are their own scaffolders — <code>zcli add arg</code> and <code>zcli add option</code> splice a typed field into an existing command's struct in place, so you don't hand-edit the boilerplate.</p>
       <div class="cmdbox">
-        <pre><span class="pr">$</span> zcli add command deploy \
-    <span class="fl">--arg</span> '{"name":"service","type":"[]const u8"}' \
-    <span class="fl">--option</span> '{"name":"env","type":"[]const u8","short":"e","default":"production"}'</pre>
-        <button onclick="cp(this,'zcli add command deploy --arg \'{&quot;name&quot;:&quot;service&quot;,&quot;type&quot;:&quot;[]const u8&quot;}\' --option \'{&quot;name&quot;:&quot;env&quot;,&quot;type&quot;:&quot;[]const u8&quot;,&quot;short&quot;:&quot;e&quot;,&quot;default&quot;:&quot;production&quot;}\'')">copy</button>
+        <pre><span class="pr">$</span> zcli add arg deploy service <span class="fl">--type</span> []const u8
+<span class="pr">$</span> zcli add option deploy env <span class="fl">--type</span> []const u8 <span class="fl">--short</span> e <span class="fl">--nullable</span></pre>
+        <button onclick="cp(this,'zcli add arg deploy service --type []const u8\nzcli add option deploy env --type []const u8 --short e --nullable')">copy</button>
       </div>
     </div>
   </article>

--- a/website/layouts/home.shtml
+++ b/website/layouts/home.shtml
@@ -2,8 +2,8 @@
 
 <head id="head">
 <style>
-  /* ---- home page ---- */
-  .hero { padding: 84px 0 96px; position: relative; overflow: hidden; }
+  /* ---- page-specific ---- */
+  .hero { padding: 84px 0 88px; position: relative; overflow: hidden; }
   .hero::before {
     content: ""; position: absolute; top: -200px; left: 50%; transform: translateX(-50%);
     width: 900px; height: 520px; pointer-events: none;
@@ -11,7 +11,7 @@
     filter: blur(8px);
   }
   .hero .wrap { position: relative; display: grid; grid-template-columns: 1.05fr 1fr; gap: 56px; align-items: center; }
-  .hero h1 { font-size: clamp(38px, 5.4vw, 62px); }
+  .hero h1 { font-size: clamp(36px, 4.7vw, 52px); text-wrap: balance; }
   .hero h1 .amber { color: var(--accent); }
   .hero .lead { margin: 22px 0 30px; font-size: 19px; }
   .hero .cta { display: flex; gap: 12px; flex-wrap: wrap; align-items: center; }
@@ -29,66 +29,63 @@
   .chip { font-family: var(--mono); font-size: 12px; color: var(--muted); border: 1px solid var(--border); border-radius: 999px; padding: 5px 12px; }
   .chip b { color: var(--accent); font-weight: 600; }
 
-  /* demo recording */
-  .demo-term { max-width: 880px; margin: 0 auto; }
-  .demo-gif { display: block; width: 100%; height: auto; border-radius: 0 0 12px 12px; }
-
   /* feature grid */
   .features { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1px; background: var(--border); border: 1px solid var(--border); border-radius: 14px; overflow: hidden; }
-  .feat { background: var(--surface); padding: 28px 26px; }
-  .feat .ic { width: 34px; height: 34px; color: var(--accent); margin-bottom: 16px; }
-  .feat h3 { font-size: 17px; margin-bottom: 8px; }
-  .feat p { color: var(--muted); font-size: 14.5px; line-height: 1.6; }
+  .feat { background: var(--surface); padding: 26px 24px; display: block; transition: background .15s; }
+  a.feat:hover { background: var(--surface2); }
+  .feat .ic { width: 32px; height: 32px; color: var(--accent); margin-bottom: 14px; }
+  .feat h3 { font-size: 16.5px; margin-bottom: 8px; }
+  .feat p { color: var(--muted); font-size: 14px; line-height: 1.6; margin-bottom: 10px; }
+  .feat .goto { font-family: var(--mono); font-size: 12px; color: var(--faint); }
+  a.feat:hover .goto { color: var(--accent); }
 
-  /* two-col explainer */
-  .split { display: grid; grid-template-columns: 1fr 1fr; gap: 48px; align-items: center; }
-  .split + .split { margin-top: 72px; }
-  .split h3 { font-size: 24px; margin-bottom: 12px; }
-  .split p { color: var(--muted); margin-bottom: 14px; }
-  .split ul { list-style: none; }
-  .split li { color: var(--muted); font-size: 15px; padding: 6px 0 6px 24px; position: relative; }
-  .split li::before { content: "→"; position: absolute; left: 0; color: var(--accent); font-family: var(--mono); }
+  .sec-head { max-width: 62ch; margin-bottom: 44px; }
 
-  /* file tree */
-  .tree { font-family: var(--mono); font-size: 13px; line-height: 1.85; color: var(--muted); }
-  .tree .dir { color: var(--cyan); } .tree .arrow { color: var(--faint); } .tree .cmd { color: var(--accent); }
-
-  /* plugins table */
-  .ptable { width: 100%; border-collapse: collapse; font-size: 14.5px; }
-  .ptable th { text-align: left; font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--faint); padding: 0 16px 14px; border-bottom: 1px solid var(--border); font-weight: 500; }
-  .ptable td { padding: 15px 16px; border-bottom: 1px solid var(--border); vertical-align: top; }
-  .ptable td.name { font-family: var(--mono); color: var(--accent); white-space: nowrap; }
-  .ptable td.desc { color: var(--muted); }
-  .ptable .badge { font-family: var(--mono); font-size: 11px; padding: 3px 9px; border-radius: 999px; }
-  .ptable .badge.on { background: rgba(87,201,122,0.12); color: var(--green); }
-  .ptable .badge.opt { background: rgba(146,152,164,0.1); color: var(--muted); }
-
-  /* showcase cards */
-  .show { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
-  .show .card { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 4px; }
-  .show .card h4 { font-family: var(--mono); font-size: 13px; color: var(--fg); padding: 14px 16px 6px; }
-  .show .card p { color: var(--muted); font-size: 13px; padding: 0 16px 12px; }
-
-  /* big CTA */
+  /* end CTA (class referenced by the design but not defined in the shared sheet) */
   .endcta { text-align: center; }
   .endcta h2 { font-size: clamp(30px, 4.5vw, 46px); margin-bottom: 18px; }
   .endcta p { color: var(--muted); font-size: 18px; max-width: 52ch; margin: 0 auto 30px; }
   .endcta .cta { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; }
 
-  /* Let grid children shrink so inner code blocks scroll instead of
-     pushing the page wider than the viewport. */
-  .hero .wrap > *, .split > *, .show .card { min-width: 0; }
+  /* recording frame (see-it-run) */
+  .recframe { background: #0a0b0e; border: 1px solid var(--border2); border-radius: 12px; overflow: hidden; box-shadow: 0 24px 60px rgba(0,0,0,0.5); }
+  .recframe .term-bar { display: flex; align-items: center; gap: 8px; padding: 12px 14px; background: #111318; border-bottom: 1px solid var(--border); }
+  .recframe .term-bar .dot { width: 11px; height: 11px; border-radius: 50%; }
+  .recframe .term-bar .dot.r { background: #ff5f57; } .recframe .term-bar .dot.y { background: #febc2e; } .recframe .term-bar .dot.g { background: #28c840; }
+  .recframe .term-bar .ttl { margin-left: 8px; font-family: var(--mono); font-size: 12px; color: var(--faint); }
+  .recframe .demo-gif { display: block; width: 100%; height: auto; }
+  .rec-caption { display: flex; align-items: center; gap: 10px; margin-top: 16px; color: var(--muted); font-size: 14px; }
+  .rec-caption svg { width: 16px; height: 16px; color: var(--accent); flex: none; }
+  .rec-caption a { color: var(--accent); }
+
+  /* see-it-run: folder tree ↔ recording, side by side */
+  .runmap { display: grid; grid-template-columns: minmax(230px, 300px) 1fr; gap: 20px; align-items: start; }
+  .runmap > * { min-width: 0; }
+  .runmap .tree { white-space: pre; overflow-x: auto; line-height: 1.85; color: var(--muted); }
+  .runmap .tree .dir { color: var(--cyan); }
+  .runmap .tree .hl { color: var(--accent); }
+  @media (max-width: 820px) { .runmap { grid-template-columns: 1fr; } }
+
+  /* inline code — match the docs page pill styling */
+  code.mono { font-size: 0.88em; background: var(--surface2); border: 1px solid var(--border); border-radius: 5px; padding: 1px 6px; color: var(--accent); }
+
+  /* numbers strip — bottom-align the measured chips across the row */
+  .numstrip .ns-item { display: flex; flex-direction: column; align-items: flex-start; }
+  .numstrip .ns-item .ns-label { margin-bottom: 12px; }
+  .numstrip .ns-item .measured { margin-top: auto; }
+
+  /* Let grid children shrink so inner code blocks scroll instead of widening the page. */
+  .hero .wrap > *, .metateaser > *, .contrast > * { min-width: 0; }
   .code, .term { max-width: 100%; }
   .table-scroll { overflow-x: auto; -webkit-overflow-scrolling: touch; }
 
   @media (max-width: 900px) {
-    .hero .wrap, .split, .show { grid-template-columns: 1fr; }
+    .hero .wrap { grid-template-columns: 1fr; }
     .features { grid-template-columns: 1fr 1fr; }
   }
   @media (max-width: 600px) {
     .features { grid-template-columns: 1fr; }
     .install-pill { flex-wrap: wrap; }
-    .ptable { min-width: 460px; }
   }
 </style>
 </head>
@@ -101,20 +98,20 @@
     <div>
       <div class="eyebrow">CLI framework · Zig 0.16+</div>
       <h1>Your folder structure <span class="amber">is</span> your CLI.</h1>
-      <p class="lead">The compiler is your argument parser. zcli is a batteries-included framework for building polished command-line apps in Zig: drop a <code class="mono">.zig</code> file in <code class="mono">commands/</code> and it becomes a command — help text, shell completions, "did you mean?", and typed argument parsing generated at compile time. One dependency, one self-contained binary.</p>
+      <p class="lead">Files become commands. Folders become subcommand groups. Structs become type-checked flags. Help text, completions, "did you mean?", prompts, progress bars, and docs — wired up at compile time for zero-cost dispatch.</p>
       <div class="cta">
         <a class="btn primary" href="$site.page('docs').link()">Get started →</a>
         <a class="btn ghost" href="https://github.com/ryanhair/zcli" target="_blank" rel="noopener">Star on GitHub</a>
       </div>
       <div class="install-pill">
-        <span><span class="dollar">$</span> curl -fsSL https://zcli.sh/install.sh | sh</span>
+        <span><span class="dollar">$</span> curl -fsSL zcli.sh/install.sh | sh</span>
         <button class="copy" onclick="copyInstall(this)">copy</button>
       </div>
       <div class="chips">
         <span class="chip"><b>0</b> runtime reflection</span>
         <span class="chip"><b><span :text="$site.asset('site-data.json').ziggy().get('plugin_count')"></span></b> built-in plugins</span>
         <span class="chip"><b>8</b> prompt types</span>
-        <span class="chip">MIT licensed</span>
+        <span class="chip"><b>215 KB</b> hello-world</span>
       </div>
     </div>
 
@@ -141,20 +138,122 @@ Deploying api to staging
   </div>
 </section>
 
-<!-- DEMO -->
-<section id="demo">
+<!-- SIGNATURE COMPONENT: folder → CLI mapping -->
+<section id="mapping">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="eyebrow">How it actually works</div>
+      <h2>No routing table. No registration calls.</h2>
+      <p>Hover a file to see the command it becomes. Dispatch is generated Zig code — there's no runtime filesystem scan, no reflection, nothing to register by hand.</p>
+    </div>
+
+    <div class="foldermap" id="fm">
+      <div class="fm-tree">
+        <div class="fm-head">src/commands/</div>
+        <div class="fm-row on" data-cmd="deploy">
+          <span>├── <span class="fm-dir"></span>deploy.zig</span>
+        </div>
+        <div class="fm-row" data-cmd="init">
+          <span>├── init.zig</span>
+        </div>
+        <div class="fm-row" data-cmd="users">
+          <span>└── <span class="fm-dir">users/</span></span>
+        </div>
+        <div class="fm-row" data-cmd="users" style="padding-left:32px;">
+          <span>&nbsp;&nbsp;&nbsp;&nbsp;├── index.zig</span>
+        </div>
+        <div class="fm-row" data-cmd="create" style="padding-left:32px;">
+          <span>&nbsp;&nbsp;&nbsp;&nbsp;├── create.zig</span>
+        </div>
+        <div class="fm-row" data-cmd="list" style="padding-left:32px;">
+          <span>&nbsp;&nbsp;&nbsp;&nbsp;└── list.zig</span>
+        </div>
+      </div>
+      <div class="fm-term">
+        <div class="fm-head">resulting CLI</div>
+        <pre id="fm-out"><span class="c-prompt">$</span> <span class="c-cmd">myapp</span> deploy api <span class="c-flag">--env</span> staging
+Deploying api to staging<span class="cursor"></span></pre>
+      </div>
+    </div>
+    <div class="foldermap-caption">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M4 17l6-6-6-6"/><path d="M12 19h8"/></svg>
+      No routing table. No registration calls. Dispatch is generated Zig code.
+    </div>
+  </div>
+</section>
+
+<!-- SEE IT RUN -->
+<section id="run">
   <div class="wrap">
     <div class="sec-head">
       <div class="eyebrow">See it run</div>
       <h2>A real recording, not a mockup.</h2>
-      <p>The <a href="https://github.com/ryanhair/zcli/tree/main/examples/showcase" target="_blank" rel="noopener">showcase task tracker</a> — interactive prompts, a colored table, live search, and a spinner — captured from a real terminal with VHS.</p>
+      <p>Every file in the <a href="https://github.com/ryanhair/zcli/tree/main/examples/showcase" target="_blank" rel="noopener">showcase task tracker</a> on the left is a command — the recording on the right is that exact CLI running, with interactive prompts, a colored table, live search, and a spinner, captured from a real terminal with VHS. The <span class="mono" style="color:var(--accent)">highlighted</span> files are the ones you see run.</p>
     </div>
-    <div class="term demo-term">
-      <div class="term-bar">
-        <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
-        <span class="ttl">tasks — recorded with vhs</span>
+    <div class="runmap">
+      <div class="code">
+        <div class="code-head"><span class="fname">tasks/src/commands/</span><span class="lang">tree</span></div>
+<pre class="tree">src/commands/
+├── <span class="hl">add.zig</span>
+├── config.zig
+├── done.zig
+├── edit.zig
+├── import.zig
+├── init.zig
+├── <span class="hl">list.zig</span>
+├── remove.zig
+├── <span class="hl">search.zig</span>
+├── show.zig
+├── <span class="hl">sync.zig</span>
+└── <span class="dir">sprint/</span>
+    ├── index.zig
+    ├── close.zig
+    ├── create.zig
+    └── list.zig</pre>
       </div>
-      <img class="demo-gif" src="$site.asset('demo.gif').link()" alt="Recording of a zcli app: interactive prompts, a colored task table, live search filtering, and a spinner" width="900" height="560">
+      <div class="recframe">
+        <div class="term-bar">
+          <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+          <span class="ttl">tasks — recorded with vhs</span>
+        </div>
+        <img class="demo-gif" src="$site.asset('demo.gif').link()" alt="Recording of the tasks showcase CLI: interactive prompts, a colored task table, live search filtering, and a spinner" width="900" height="560">
+      </div>
+    </div>
+    <div class="rec-caption">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><circle cx="12" cy="12" r="9"/><path d="M12 8v5"/><path d="M12 16h.01"/></svg>
+      Every frame is a real capture — the showcase lives in <a href="https://github.com/ryanhair/zcli/tree/main/examples/showcase" target="_blank" rel="noopener">examples/showcase</a>.
+    </div>
+  </div>
+</section>
+
+<!-- TYPE SAFETY -->
+<section id="typesafe">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="eyebrow">Type safety, demonstrated</div>
+      <h2>Wrong types never compile.</h2>
+      <p>Args and Options are plain Zig structs. Typo a field or reach for one that doesn't exist, and the build fails — naming the exact command file, not a runtime stack trace.</p>
+    </div>
+    <div class="contrast">
+      <div class="code">
+        <div class="code-head"><span class="fname">src/commands/deploy.zig</span><span class="lang">zig</span></div>
+<pre><span class="kw">pub const</span> Options = <span class="kw">struct</span> {
+    env: []<span class="kw">const</span> <span class="fn">u8</span> = <span class="str">"production"</span>,
+};
+
+<span class="kw">pub fn</span> <span class="fn">execute</span>(args: Args, options: Options, context: *Context) !<span class="kw">void</span> {
+    <span class="kw">try</span> context.<span class="fn">stdout</span>().<span class="fn">print</span>(
+        <span class="str">"target: {s}\n"</span>, .{ options.envv });
+}</pre>
+      </div>
+      <div class="errdemo">
+        <div class="code-head"><span class="fname">zig build</span><span class="lang">error</span></div>
+<pre><span class="e-file">commands/deploy.zig:6:52</span>: <span class="e-msg">error: no field named 'envv' in struct 'commands.deploy.Options'</span>
+    try context.stdout().print("target: {s}\n", .{options.envv});
+                                                           <span class="e-msg">^~~~</span>
+<span class="e-line">commands/deploy.zig:2:16</span>: <span class="e-hint">note: struct declared here</span>
+<span class="e-hint">note: did you mean 'env'?</span></pre>
+      </div>
     </div>
   </div>
 </section>
@@ -168,176 +267,157 @@ Deploying api to staging
       <p>The boring-but-essential parts of a command-line tool, generated for you and type-checked at compile time.</p>
     </div>
     <div class="features">
-      <div class="feat">
+      <a class="feat" href="$site.page('docs').link().suffix('#commands')">
         <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M3 7l9-4 9 4-9 4-9-4z"/><path d="M3 12l9 4 9-4M3 17l9 4 9-4"/></svg>
         <h3>File-based commands</h3>
         <p>Create files in <code class="mono">commands/</code> to add commands; nest folders for subcommands. The path becomes the command.</p>
-      </div>
-      <div class="feat">
+        <span class="goto">→ docs</span>
+      </a>
+      <a class="feat" href="$site.page('docs').link().suffix('#options')">
         <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M4 17l6-6-6-6"/><path d="M12 19h8"/></svg>
         <h3>Type-safe parsing</h3>
         <p>Define args & options as Zig structs. Parsing is checked via comptime introspection — wrong types never compile.</p>
-      </div>
-      <div class="feat">
+        <span class="goto">→ docs</span>
+      </a>
+      <a class="feat" href="$site.page('docs').link().suffix('#plugins')">
         <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg>
         <h3>Did-you-mean</h3>
         <p>Auto-generated <code class="mono">--help</code>, <code class="mono">--version</code>, shell completions, and typo suggestions out of the box.</p>
-      </div>
-      <div class="feat">
+        <span class="goto">→ docs</span>
+      </a>
+      <a class="feat" href="$site.page('docs').link().suffix('#prompts')">
         <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M12 4v16M6 9l6-5 6 5"/><rect x="4" y="16" width="16" height="4" rx="1"/></svg>
         <h3>Interactive prompts</h3>
         <p>Text, confirm, select, multi-select, password, search, number, and editor — all falling back gracefully without a TTY.</p>
-      </div>
-      <div class="feat">
+        <span class="goto">→ docs</span>
+      </a>
+      <a class="feat" href="$site.page('docs').link().suffix('#progress')">
         <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 3"/></svg>
         <h3>Progress & spinners</h3>
         <p>Nine spinner styles plus progress bars with ETA. Semantic colors adapt to your terminal's capabilities.</p>
-      </div>
-      <div class="feat">
+        <span class="goto">→ docs</span>
+      </a>
+      <a class="feat" href="$site.page('docs').link().suffix('#docsgen')">
         <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M4 4h11l5 5v11H4z"/><path d="M14 4v5h5M8 13h8M8 17h8"/></svg>
         <h3>Docs generation</h3>
         <p>Emit markdown, man pages, and HTML straight from command metadata. Config loads transparently from JSON, TOML, or YAML.</p>
+        <span class="goto">→ docs</span>
+      </a>
+    </div>
+  </div>
+</section>
+
+<!-- NUMBERS STRIP -->
+<section id="numbers">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="eyebrow">Numbers, not adjectives</div>
+      <h2>What "batteries-included" costs you.</h2>
+    </div>
+    <div class="numstrip">
+      <div class="ns-item">
+        <div class="ns-val">215 KB</div>
+        <div class="ns-label">ReleaseSmall hello-world</div>
+        <a class="measured" href="$site.page('why').link().suffix('#numbers')">✓ v0.19.0</a>
+      </div>
+      <div class="ns-item">
+        <div class="ns-val">195 KB</div>
+        <div class="ns-label">static musl binary</div>
+        <a class="measured" href="$site.page('why').link().suffix('#numbers')">✓ v0.19.0</a>
+      </div>
+      <div class="ns-item">
+        <div class="ns-val">libSystem</div>
+        <div class="ns-label">only macOS runtime dep</div>
+        <a class="measured" href="$site.page('why').link().suffix('#numbers')">✓ v0.19.0</a>
+      </div>
+      <div class="ns-item">
+        <div class="ns-val">0</div>
+        <div class="ns-label">ANSI escapes with NO_COLOR set</div>
+        <a class="measured" href="$site.page('why').link().suffix('#numbers')">✓ v0.19.0</a>
+      </div>
+      <div class="ns-item">
+        <div class="ns-val">3 OSes</div>
+        <div class="ns-label">CI, every commit</div>
+        <a class="measured" href="$site.page('why').link().suffix('#numbers')">✓ v0.19.0</a>
       </div>
     </div>
   </div>
 </section>
 
-<!-- HOW IT WORKS -->
-<section id="how">
+<!-- META-CLI / AI TEASER -->
+<section id="meta">
   <div class="wrap">
-    <div class="sec-head">
-      <div class="eyebrow">How it works</div>
-      <h2>Commands are <em style="font-style:normal;color:var(--accent)">discovered</em>, not registered.</h2>
-      <p>No registries to maintain, no macros to memorize. Commands are discovered and routing is generated at build time — there's no runtime filesystem scanning or reflection.</p>
-    </div>
-
-    <div class="split">
+    <div class="metateaser">
       <div>
-        <h3>1 · Lay out your commands</h3>
-        <p>Each <code class="mono">.zig</code> file maps to a command path. Add an <code class="mono">index.zig</code> to describe a group.</p>
-        <ul>
-          <li>Folders become subcommand namespaces</li>
-          <li>Variadic args, flags, typed numbers — all from struct fields</li>
-          <li>Aliases & examples live in command metadata</li>
-        </ul>
+        <div class="eyebrow">The meta-CLI</div>
+        <h2 style="font-size:clamp(26px,3.4vw,36px);margin-bottom:14px;">The tool that scaffolds your CLI is itself a zcli app.</h2>
+        <p style="color:var(--muted);font-size:16px;line-height:1.65;margin-bottom:14px;"><code class="mono">zcli init</code>, <code class="mono">zcli add command</code>, and <code class="mono">zcli dev</code> restructure your project without hand-editing struct fields or meta blocks. The same scaffolder writes an <code class="mono">AGENTS.md</code> for you — a version-matched reference at <code class="mono">zcli guide</code> that keeps AI coding agents from hallucinating stale APIs.</p>
+        <a class="btn ghost" href="$site.page('docs').link().suffix('#ai-agents')">AI agents & AGENTS.md →</a>
       </div>
-      <div class="code">
-        <div class="code-head"><span class="fname">src/commands/</span><span class="lang">tree</span></div>
-        <pre class="tree">src/commands/
-├── init.zig              <span class="arrow">→</span> <span class="cmd">myapp init</span>
-├── deploy.zig            <span class="arrow">→</span> <span class="cmd">myapp deploy</span>
-└── users/
-    ├── index.zig         <span class="arrow">→</span> <span class="cmd">myapp users</span>
-    ├── create.zig        <span class="arrow">→</span> <span class="cmd">myapp users create</span>
-    └── list.zig          <span class="arrow">→</span> <span class="cmd">myapp users list</span></pre>
-      </div>
-    </div>
+      <div class="term">
+        <div class="term-bar">
+          <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+          <span class="ttl">myapp — zsh</span>
+        </div>
+        <div class="term-body">
+<pre><span class="c-prompt">$</span> <span class="c-cmd">zcli</span> init myapp
+<span class="c-ok">✓</span> Project 'myapp' created successfully!
 
-    <div class="split">
-      <div class="code">
-        <div class="code-head"><span class="fname">src/commands/deploy.zig</span><span class="lang">zig</span></div>
-<pre><span class="kw">const</span> Context = <span class="at">@import</span>(<span class="str">"command_registry"</span>).Context;
+<span class="c-prompt">$</span> <span class="c-cmd">zcli</span> add command users/create
+<span class="c-ok">  ✔</span> Created src/commands/users/create.zig
 
-<span class="kw">pub const</span> meta = .{
-    .description = <span class="str">"Deploy your application"</span>,
-    .options = .{
-        .env = .{
-            .short = <span class="str">'e'</span>,
-            .description = <span class="str">"Target environment"</span>,
-        },
-    },
-};
-
-<span class="kw">pub const</span> Args = <span class="kw">struct</span> {
-    service: []<span class="kw">const</span> <span class="fn">u8</span>,
-};
-
-<span class="kw">pub const</span> Options = <span class="kw">struct</span> {
-    env: []<span class="kw">const</span> <span class="fn">u8</span> = <span class="str">"production"</span>,
-};
-
-<span class="kw">pub fn</span> <span class="fn">execute</span>(args: Args, options: Options, context: *Context) !<span class="kw">void</span> {
-    <span class="kw">try</span> context.<span class="fn">stdout</span>().<span class="fn">print</span>(
-        <span class="str">"Deploying {s} to {s}\n"</span>, .{ args.service, options.env });
-}</pre>
-      </div>
-      <div>
-        <h3>2 · Write the command</h3>
-        <p>Up to four exports: <code class="mono">meta</code>, <code class="mono">Args</code>, <code class="mono">Options</code>, and <code class="mono">execute</code>. The <code class="mono">context</code> hands you stdout/stderr, an allocator, the active theme, and plugin data.</p>
-        <ul>
-          <li>Defaults on struct fields become option defaults</li>
-          <li><code class="mono">?bool</code> for optional flags, <code class="mono">[]const []const u8</code> for variadic</li>
-          <li>Dispatch is generated — zero-cost at runtime</li>
-        </ul>
-      </div>
-    </div>
-  </div>
-</section>
-
-<!-- PLUGINS -->
-<section id="plugins">
-  <div class="wrap">
-    <div class="sec-head">
-      <div class="eyebrow">Plugins</div>
-      <h2>Seven plugins ship in the box.</h2>
-      <p>Add them in <code class="mono">build.zig</code>. Plugins contribute global options, lifecycle hooks, and build-time config — store state in <code class="mono">context.plugins.{id}</code>.</p>
-    </div>
-    <div class="table-scroll">
-    <table class="ptable">
-      <thead><tr><th>Plugin</th><th>Provides</th><th>Default</th></tr></thead>
-      <tbody>
-        <tr><td class="name">zcli_help</td><td class="desc"><code class="mono">--help</code> / <code class="mono">-h</code>, auto-generated help text</td><td><span class="badge on">default</span></td></tr>
-        <tr><td class="name">zcli_version</td><td class="desc"><code class="mono">--version</code> / <code class="mono">-V</code></td><td><span class="badge on">default</span></td></tr>
-        <tr><td class="name">zcli_not_found</td><td class="desc">"Did you mean?" suggestions for typos</td><td><span class="badge on">default</span></td></tr>
-        <tr><td class="name">zcli_completions</td><td class="desc">Generate & install completions for bash, zsh, fish</td><td><span class="badge opt">optional</span></td></tr>
-        <tr><td class="name">zcli_config</td><td class="desc">Transparent config loading — JSON, TOML, YAML, per-command scoping</td><td><span class="badge opt">optional</span></td></tr>
-        <tr><td class="name">zcli_output</td><td class="desc"><code class="mono">--output</code> flag — json, table, plain</td><td><span class="badge opt">optional</span></td></tr>
-        <tr><td class="name">zcli_github_upgrade</td><td class="desc"><code class="mono">upgrade</code> command via GitHub releases</td><td><span class="badge opt">optional</span></td></tr>
-      </tbody>
-    </table>
-    </div>
-    <div style="margin-top:28px;">
-      <a class="btn ghost" href="$site.page('plugins').link()">Plugins guide — defaults, auto-discovery & writing your own →</a>
-    </div>
-  </div>
-</section>
-
-<!-- SHOWCASE -->
-<section>
-  <div class="wrap">
-    <div class="sec-head">
-      <div class="eyebrow">Standalone packages</div>
-      <h2>Prompts and progress you can use anywhere.</h2>
-      <p><code class="mono">zinput</code> and <code class="mono">zprogress</code> work with or without the rest of zcli — no framework dependency required.</p>
-    </div>
-    <div class="show">
-      <div class="card">
-        <h4>zinput — interactive prompts</h4>
-        <p>Eight prompt types. Configurable prefix; line-based fallback when stdin isn't a TTY.</p>
-        <div class="code" style="border-radius:9px;">
-          <div class="code-head"><span class="fname">select + confirm</span><span class="lang">zig</span></div>
-<pre><span class="kw">const</span> idx = <span class="kw">try</span> zinput.<span class="fn">select</span>(writer, reader, .{
-    .message = <span class="str">"Framework:"</span>,
-    .choices = &.{ <span class="str">"express"</span>, <span class="str">"fastify"</span>, <span class="str">"koa"</span> },
-});
-<span class="kw">const</span> ok = <span class="kw">try</span> zinput.<span class="fn">confirm</span>(writer, reader, .{
-    .message = <span class="str">"Continue?"</span>, .default = <span class="num">true</span>,
-});</pre>
+<span class="c-prompt">$</span> <span class="c-cmd">zcli</span> dev
+<span class="c-mut">watching src/ — rebuild on change…</span><span class="cursor"></span></pre>
         </div>
       </div>
+    </div>
+  </div>
+</section>
+
+<!-- COMPARISON TEASER -->
+<section id="compare">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="eyebrow">Why not zig-clap, or zli?</div>
+      <h2>Three tools, three different jobs.</h2>
+    </div>
+    <div class="cmp-mini">
       <div class="card">
-        <h4>zprogress — spinners & bars</h4>
-        <p>Nine spinner styles, progress bars with ETA, and semantic status states.</p>
-        <div class="code" style="border-radius:9px;">
-          <div class="code-head"><span class="fname">spinner</span><span class="lang">zig</span></div>
-<pre><span class="kw">var</span> spinner = zprogress.<span class="fn">spinner</span>(.{ .style = .dots });
-spinner.<span class="fn">start</span>(<span class="str">"Loading..."</span>);
-<span class="cm">// ... do work, spinner.tick() in a loop ...</span>
-spinner.<span class="fn">succeed</span>(<span class="str">"Done!"</span>);   <span class="cm">// ✔ Done!</span>
-spinner.<span class="fn">fail</span>(<span class="str">"Failed"</span>);    <span class="cm">// ✖ Failed</span>
-spinner.<span class="fn">warn</span>(<span class="str">"Warning"</span>);   <span class="cm">// ⚠ Warning</span></pre>
-        </div>
+        <h4>zig-clap</h4>
+        <p>An argument parser, and the lightest of the three. If flag parsing is all you need, it's a great choice.</p>
       </div>
+      <div class="card">
+        <h4>zli</h4>
+        <p>A batteries-included framework built around a runtime builder — commands assembled with <code class="mono">Command.init()</code> as the program starts.</p>
+      </div>
+      <div class="card">
+        <h4>zcli</h4>
+        <p>The directory tree <em>is</em> the command tree, discovered at build time. Batteries extend past parsing into the whole terminal experience.</p>
+      </div>
+    </div>
+    <div style="margin-top:22px;">
+      <a class="btn ghost" href="$site.page('why').link().suffix('#comparison')">Full comparison →</a>
+    </div>
+  </div>
+</section>
+
+<!-- BUILT WITH ZCLI -->
+<section id="builtwith-sec">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="eyebrow">Built with zcli</div>
+      <h2>Dogfooded, not just demoed.</h2>
+    </div>
+    <div class="builtwith">
+      <div class="bw">
+        <h4>zcli — the meta-CLI</h4>
+        <p><code class="mono">init</code>, <code class="mono">add</code>, <code class="mono">mv</code>, <code class="mono">rm</code>, <code class="mono">tree</code>, <code class="mono">dev</code>, <code class="mono">guide</code>, and <code class="mono">release</code> are files in its own <code class="mono">commands/</code> directory, running on the framework's own plugins.</p>
+      </div>
+      <div class="bw">
+        <h4>tasks — showcase app</h4>
+        <p>A fully functional task tracker: 14 commands, nested groups, every prompt type, themed output, config files, and doc generation.</p>
+      </div>
+      <div class="bw add">Your project here — open a PR</div>
     </div>
   </div>
 </section>
@@ -357,11 +437,32 @@ spinner.<span class="fn">warn</span>(<span class="str">"Warning"</span>);   <spa
 
 <script>
   function copyInstall(btn) {
-    navigator.clipboard.writeText("curl -fsSL https://zcli.sh/install.sh | sh").then(function () {
+    navigator.clipboard.writeText("curl -fsSL https://raw.githubusercontent.com/ryanhair/zcli/main/install.sh | sh").then(function () {
       var old = btn.textContent; btn.textContent = "copied ✓"; btn.style.color = "var(--green)"; btn.style.borderColor = "var(--green)";
       setTimeout(function () { btn.textContent = old; btn.style.color = ""; btn.style.borderColor = ""; }, 1600);
     });
   }
+
+  /* folder → CLI mapping: hover a file, see the resulting CLI */
+  (function () {
+    var outputs = {
+      deploy: '<span class="c-prompt">$</span> <span class="c-cmd">myapp</span> deploy api <span class="c-flag">--env</span> staging\nDeploying api to staging<span class="cursor"></span>',
+      init: '<span class="c-prompt">$</span> <span class="c-cmd">myapp</span> init\nScaffolding new project…<span class="cursor"></span>',
+      users: '<span class="c-prompt">$</span> <span class="c-cmd">myapp</span> users\n<span class="c-mut">USAGE</span>  myapp users &lt;command&gt;\n  <span class="c-cmd">create</span>   Create a user\n  <span class="c-cmd">list</span>     List users<span class="c-mut"> · no execute() = shows subcommands</span><span class="cursor"></span>',
+      create: '<span class="c-prompt">$</span> <span class="c-cmd">myapp</span> users create alice <span class="c-flag">--admin</span>\nCreated user alice (admin)<span class="cursor"></span>',
+      list: '<span class="c-prompt">$</span> <span class="c-cmd">myapp</span> users list\nalice   admin\nbob     member<span class="cursor"></span>'
+    };
+    var rows = document.querySelectorAll('#fm .fm-row');
+    var out = document.getElementById('fm-out');
+    rows.forEach(function (row) {
+      row.addEventListener('mouseenter', function () {
+        rows.forEach(function (r) { r.classList.remove('on'); });
+        row.classList.add('on');
+        var key = row.dataset.cmd;
+        if (outputs[key]) out.innerHTML = outputs[key];
+      });
+    });
+  })();
 </script>
 
 </main>

--- a/website/layouts/install.shtml
+++ b/website/layouts/install.shtml
@@ -47,6 +47,7 @@
       <button class="tab" role="tab" aria-selected="true" data-t="script">Install script</button>
       <button class="tab" role="tab" aria-selected="false" data-t="pkg">Zig package</button>
       <button class="tab" role="tab" aria-selected="false" data-t="src">From source</button>
+      <button class="tab" role="tab" aria-selected="false" data-t="completions">Shell completions</button>
     </div>
 
     <div class="panels">
@@ -55,8 +56,8 @@
         <h3>Install script</h3>
         <p>Downloads the latest release binary for your platform and drops it in your install dir.</p>
         <div class="cmdbox">
-          <pre><span class="pr">$</span> curl -fsSL https://zcli.sh/install.sh | sh</pre>
-          <button onclick="cp(this,'curl -fsSL https://zcli.sh/install.sh | sh')">copy</button>
+          <pre><span class="pr">$</span> curl -fsSL https://raw.githubusercontent.com/ryanhair/zcli/main/install.sh | sh</pre>
+          <button onclick="cp(this,'curl -fsSL https://raw.githubusercontent.com/ryanhair/zcli/main/install.sh | sh')">copy</button>
         </div>
         <p style="font-size:13.5px;">Requires <code class="mono" style="color:var(--accent)">curl</code>. The script reads the latest release from GitHub, verifies the checksum when available, and makes the binary executable.</p>
       </div>
@@ -74,7 +75,7 @@
 },</pre>
           <button onclick="cp(this,'.zcli = .{ .url = &quot;https://github.com/ryanhair/zcli/archive/refs/heads/main.tar.gz&quot;, .hash = &quot;...&quot; },')">copy</button>
         </div>
-        <p style="font-size:13.5px;">Then follow steps 2 & 3 in the <a href="$site.page('docs').link().suffix('#manual')" style="color:var(--accent)">docs</a> to wire up <code class="mono">zcli.generate</code>.</p>
+        <p style="font-size:13.5px;">Then follow steps 2 & 3 in the <a href="$site.page('docs').link().suffix('#quick-start')" style="color:var(--accent)">docs</a> to wire up <code class="mono">zcli.generate</code>.</p>
       </div>
 
       <!-- SOURCE -->
@@ -87,6 +88,17 @@
           <button onclick="cp(this,'git clone https://github.com/ryanhair/zcli.git && cd zcli && zig build')">copy</button>
         </div>
         <p style="font-size:13.5px;">Built artifacts land in <code class="mono">zig-out/bin/</code>. Requires Zig 0.16.0+.</p>
+      </div>
+
+      <!-- COMPLETIONS -->
+      <div class="panel" id="p-completions">
+        <h3>Shell completions</h3>
+        <p>Usually the first thing people want right after install — tab-complete commands, subcommands, and flags in bash, zsh, or fish.</p>
+        <div class="cmdbox">
+          <pre><span class="pr">$</span> myapp completions install</pre>
+          <button onclick="cp(this,'myapp completions install')">copy</button>
+        </div>
+        <p style="font-size:13.5px;">Detects your shell, writes the completion script to the right location, and prints the one line to add to your shell profile if it can't do it automatically. Requires the <code class="mono" style="color:var(--accent)">zcli_completions</code> plugin — on by default in a project scaffolded with <code class="mono" style="color:var(--accent)">zcli init</code>.</p>
       </div>
     </div>
 
@@ -103,7 +115,7 @@
     </div>
 
     <div style="text-align:center;margin:56px 0 96px;">
-      <a class="btn primary" href="$site.page('docs').link()">Read the getting-started guide →</a>
+      <a class="btn primary" href="$site.page('getting-started').link()">Read the getting-started guide →</a>
     </div>
   </div>
 

--- a/website/layouts/plugins.shtml
+++ b/website/layouts/plugins.shtml
@@ -48,8 +48,8 @@
   .nextlinks { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 16px; }
   .nextlinks a { display: block; background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 18px 20px; transition: border-color .15s; }
   .nextlinks a:hover { border-color: var(--accent); }
-  .nextlinks .k { font-family: var(--mono); font-size: 12px; color: var(--accent); }
-  .nextlinks .t { color: var(--fg); font-size: 15px; margin-top: 4px; }
+  .nextlinks .k { display: block; font-family: var(--mono); font-size: 12px; color: var(--accent); }
+  .nextlinks .t { display: block; color: var(--fg); font-size: 15px; margin-top: 4px; }
   @media (max-width: 860px) { .layout { grid-template-columns: 1fr; } .toc { display: none; } .two, .nextlinks { grid-template-columns: 1fr; } }
 </style>
 </head>
@@ -91,7 +91,7 @@
               <tr><td class="name">zcli_completions</td><td class="desc">Generate & install completions for bash, zsh, fish</td><td><span class="badge opt">optional</span></td></tr>
               <tr><td class="name">zcli_config</td><td class="desc">Transparent config loading — JSON, TOML, YAML, per-command scoping</td><td><span class="badge opt">optional</span></td></tr>
               <tr><td class="name">zcli_output</td><td class="desc"><code>--output</code> flag — json, table, plain</td><td><span class="badge opt">optional</span></td></tr>
-              <tr><td class="name">zcli_secrets</td><td class="desc">Opt-in credential storage in the OS keychain — get, set, delete</td><td><span class="badge opt">optional</span></td></tr>
+              <tr><td class="name">zcli_secrets</td><td class="desc">OS-keychain credential storage — macOS Keychain, Linux Secret Service, Windows Credential Manager</td><td><span class="badge opt">optional</span></td></tr>
               <tr><td class="name">zcli_github_upgrade</td><td class="desc"><code>upgrade</code> command via GitHub releases</td><td><span class="badge opt">optional</span></td></tr>
             </tbody>
           </table>
@@ -120,7 +120,7 @@
           </div>
           <div class="code">
             <div class="code-head"><span class="fname">build.zig — all three together</span><span class="lang">zig</span></div>
-<pre><span class="kw">const</span> cmd_registry = <span class="kw">try</span> zcli.<span class="fn">generate</span>(b, exe, zcli_dep, zcli_module, .{
+<pre><span class="kw">const</span> cmd_registry = zcli.<span class="fn">generate</span>(b, exe, zcli_dep, zcli_module, .{
     .commands_dir = <span class="str">"src/commands"</span>,
 
     <span class="cm">// Auto-discover everything in your own plugins folder</span>

--- a/website/layouts/templates/base.shtml
+++ b/website/layouts/templates/base.shtml
@@ -21,15 +21,15 @@
             <span class="glyph">z</span> zcli <span class="ver mono">v<span :text="$site.asset('site-data.json').ziggy().get('version')"></span></span>
         </a>
         <nav>
-            <a href="$site.page('').link().suffix('#features')">Features</a>
-            <a href="$site.page('').link().suffix('#how')">How it works</a>
-            <a href="$site.page('plugins').link()">Plugins</a>
             <a href="$site.page('docs').link()">Docs</a>
-            <a href="$site.page('install').link()">Install</a>
+            <a href="$site.page('why').link()">Why zcli</a>
+            <a href="$site.page('changelog').link()">Changelog</a>
+            <a href="$site.page('blog').link()">Blog</a>
             <a class="gh" href="https://github.com/ryanhair/zcli" target="_blank" rel="noopener">
                 <svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
                 GitHub
             </a>
+            <a class="btn primary" style="padding:7px 16px;font-size:13px;" href="$site.page('install').link()">Install →</a>
         </nav>
     </div>
 </header>
@@ -40,27 +40,28 @@
     <div class="wrap">
         <div>
             <a class="brand" href="$site.page('').link()"><span class="glyph">z</span> zcli</a>
-            <p class="meta" style="margin-top:14px;">MIT · © 2025 Ryan Hair<br>Built with Zig 0.16+</p>
+            <p class="meta" style="margin-top:14px;">MIT · © 2025–2026 Ryan Hair<br>Built with Zig 0.16+</p>
         </div>
         <div class="cols">
             <div class="col">
                 <h4>Docs</h4>
-                <a href="$site.page('docs').link().suffix('#fast')">Getting started</a>
+                <a href="$site.page('docs').link().suffix('#quick-start')">Quick start</a>
                 <a href="$site.page('docs').link().suffix('#commands')">Commands</a>
-                <a href="$site.page('plugins').link()">Plugins</a>
+                <a href="$site.page('docs').link().suffix('#ai-agents')">AI agents</a>
                 <a href="$site.page('install').link()">Install</a>
             </div>
             <div class="col">
                 <h4>Project</h4>
+                <a href="$site.page('why').link()">Why zcli</a>
+                <a href="$site.page('changelog').link()">Changelog</a>
+                <a href="$site.page('blog').link()">Blog</a>
                 <a href="https://github.com/ryanhair/zcli" target="_blank" rel="noopener">GitHub</a>
-                <a href="https://github.com/ryanhair/zcli/issues" target="_blank" rel="noopener">Issues</a>
-                <a href="https://github.com/ryanhair/zcli/blob/main/LICENSE" target="_blank" rel="noopener">License (MIT)</a>
             </div>
             <div class="col">
                 <h4>Packages</h4>
                 <a href="$site.page('docs').link().suffix('#prompts')">zinput</a>
                 <a href="$site.page('docs').link().suffix('#progress')">zprogress</a>
-                <a href="https://github.com/ryanhair/zcli" target="_blank" rel="noopener">zcli core</a>
+                <a href="https://github.com/ryanhair/zcli/blob/main/LICENSE" target="_blank" rel="noopener">License (MIT)</a>
             </div>
         </div>
     </div>

--- a/website/layouts/why.shtml
+++ b/website/layouts/why.shtml
@@ -1,0 +1,156 @@
+<extend template="base.shtml">
+
+<head id="head">
+<style>
+  .why-body { padding-bottom: 24px; }
+  .why-body section { max-width: 880px; }
+  .why-body h2 { font-size: 28px; margin-bottom: 14px; }
+  .why-body p.p { color: var(--muted); font-size: 16px; line-height: 1.7; margin-bottom: 16px; max-width: 72ch; }
+  .why-body p.p b { color: var(--fg); font-weight: 600; }
+  .why-body h3 { font-size: 18px; margin: 30px 0 10px; }
+  .table-scroll { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+</style>
+</head>
+
+<main id="main">
+<div class="wrap why-body">
+  <div class="why-hero">
+    <div class="eyebrow" style="display:inline-block;">Why zcli</div>
+    <h1>Comptime over runtime. Conventions over registration.</h1>
+    <p class="lead">Zig already has good CLI libraries — the difference is the level they operate at. Here's the philosophy, an honest comparison, and every measured number behind the "batteries-included" claim.</p>
+    <div class="why-nav">
+      <a href="#philosophy">Philosophy</a>
+      <a href="#comparison">Comparison</a>
+      <a href="#numbers">Numbers</a>
+      <a href="#stability">Stability</a>
+    </div>
+  </div>
+
+  <!-- PHILOSOPHY -->
+  <section id="philosophy" style="padding-top:64px;">
+    <h2>Philosophy</h2>
+    <p class="p"><b>Comptime over runtime.</b> The command tree, the argument parser, and the routing table are all generated at build time from your files and your structs. There's no filesystem scan at startup, no reflection, no registry object built on every run — the binary that ships already knows its own shape.</p>
+    <p class="p"><b>Conventions over registration.</b> A file in <code class="mono">commands/</code> is a command. A folder is a group. There's no <code class="mono">addCommand()</code> call to forget, no builder chain to keep in sync with the file that implements it — the two can't drift apart because they're the same artifact.</p>
+    <p class="p"><b>Batteries with opt-out.</b> Every package — <code class="mono">zinput</code>, <code class="mono">zprogress</code>, <code class="mono">ztheme</code>, <code class="mono">terminal</code>, <code class="mono">vterm</code> — works standalone, with no dependency on the framework. Use the whole thing, or take one package and leave the rest.</p>
+    <p class="p"><b>Stable Zig only.</b> zcli targets Zig 0.16.0 — the current stable release, no nightly required. That's a deliberate constraint: a framework you can't build tomorrow because it tracked a moving target isn't actually batteries-included.</p>
+  </section>
+
+  <!-- COMPARISON -->
+  <section id="comparison" style="padding-top:64px;border-top:1px solid var(--border);">
+    <h2>Comparison</h2>
+    <p class="p"><a href="https://github.com/Hejsil/zig-clap" target="_blank" rel="noopener" style="color:var(--accent);">zig-clap</a> is an argument parser, and the lightest of the three: describe flags in a comptime help-text DSL, get typed results back, build the rest of the CLI yourself. <b>If flag parsing is all you need, it's a great choice.</b> <a href="https://github.com/xcaeser/zli" target="_blank" rel="noopener" style="color:var(--accent);">zli</a> is a batteries-included framework built around a runtime builder: commands are constructed with <code class="mono">Command.init(...)</code>, wired up with <code class="mono">addCommand</code>, flags registered with <code class="mono">addFlag</code> and read by name.</p>
+    <p class="p">zcli moves that work to the filesystem and the compiler. The directory tree <em>is</em> the command tree, discovered at build time with routing generated as ordinary Zig code. And the batteries extend past parsing into the whole terminal experience.</p>
+
+    <div class="table-scroll">
+    <table class="cmp-table">
+      <thead><tr><th>&nbsp;</th><th>zig-clap</th><th>zli</th><th class="zcli-col">zcli</th></tr></thead>
+      <tbody>
+        <tr><td class="hl">Scope</td><td>argument parser</td><td>CLI framework</td><td class="zcli-col hl">CLI framework</td></tr>
+        <tr><td class="hl">Commands defined by</td><td>manual dispatch</td><td>runtime builder</td><td class="zcli-col hl">files on disk, discovered at build time</td></tr>
+        <tr><td class="hl">Flags are</td><td>comptime DSL → typed result</td><td>registered at runtime, read by name</td><td class="zcli-col hl">struct fields, checked at compile time</td></tr>
+        <tr><td class="hl">Beyond parsing</td><td>help text</td><td>help, version, spinners</td><td class="zcli-col hl">help, completions, prompts, progress, theming, config files, plugins, testing tools</td></tr>
+      </tbody>
+    </table>
+    </div>
+
+    <h3>At the code level</h3>
+    <p class="p">The difference isn't abstract — it shows up in how you read an option value.</p>
+    <div class="contrast">
+      <div class="code">
+        <div class="code-head"><span class="fname">zli — runtime lookup</span><span class="lang">zig</span></div>
+<pre><span class="kw">const</span> verbose = ctx.<span class="fn">flag</span>(<span class="str">"verbose"</span>, <span class="fn">bool</span>);
+<span class="cm">// string key, looked up at runtime;</span>
+<span class="cm">// a typo compiles and returns a default</span></pre>
+      </div>
+      <div class="code" style="border-color:rgba(247,164,29,0.28);">
+        <div class="code-head"><span class="fname">zcli — struct field</span><span class="lang">zig</span></div>
+<pre><span class="kw">pub const</span> Options = <span class="kw">struct</span> {
+    verbose: <span class="fn">bool</span> = <span class="num">false</span>,
+};
+<span class="cm">// options.verbose — a typo is a</span>
+<span class="cm">// compile error, not a silent default</span></pre>
+      </div>
+    </div>
+  </section>
+
+  <!-- NUMBERS -->
+  <section id="numbers" style="padding-top:64px;border-top:1px solid var(--border);">
+    <h2>Numbers</h2>
+    <p class="p">Every figure below is measured against zcli v0.19.0, built from the <a href="https://github.com/ryanhair/zcli/tree/main/examples/showcase" target="_blank" rel="noopener" style="color:var(--accent);">showcase</a> and a minimal hello-world command. Expand a row for the exact commands used.</p>
+
+    <table class="num-table">
+      <tbody>
+        <tr>
+          <td class="metric">Hello-world binary, <code class="mono">ReleaseSmall</code></td>
+          <td class="value">215 KB</td>
+        </tr>
+        <tr><td colspan="2" style="border:none;padding:0 0 14px;">
+          <details class="repro"><summary>reproduce</summary>
+<pre>$ zcli init hello --description "hello world"
+$ cd hello && zig build -Doptimize=ReleaseSmall
+$ ls -la zig-out/bin/hello</pre>
+          </details>
+        </td></tr>
+
+        <tr>
+          <td class="metric">Static musl binary, same command, <code class="mono">x86_64-linux-musl</code></td>
+          <td class="value">195 KB</td>
+        </tr>
+        <tr><td colspan="2" style="border:none;padding:0 0 14px;">
+          <details class="repro"><summary>reproduce</summary>
+<pre>$ zig build -Dtarget=x86_64-linux-musl -Doptimize=ReleaseSmall
+$ file zig-out/bin/hello   # statically linked</pre>
+          </details>
+        </td></tr>
+
+        <tr>
+          <td class="metric">macOS runtime dependencies</td>
+          <td class="value">libSystem only</td>
+        </tr>
+        <tr><td colspan="2" style="border:none;padding:0 0 14px;">
+          <details class="repro"><summary>reproduce</summary>
+<pre>$ otool -L zig-out/bin/hello</pre>
+          </details>
+        </td></tr>
+
+        <tr>
+          <td class="metric">ANSI escape sequences emitted with <code class="mono">NO_COLOR=1</code></td>
+          <td class="value">0</td>
+        </tr>
+        <tr><td colspan="2" style="border:none;padding:0 0 14px;">
+          <details class="repro"><summary>reproduce</summary>
+<pre>$ NO_COLOR=1 zig-out/bin/hello --help | grep -c $'\x1b'</pre>
+          </details>
+        </td></tr>
+
+        <tr>
+          <td class="metric">CI matrix</td>
+          <td class="value">3 OSes, every commit</td>
+        </tr>
+        <tr><td colspan="2" style="border:none;padding:0;">
+          <details class="repro"><summary>reproduce</summary>
+<pre>Linux, macOS, and Windows — unit tests + full e2e suite,
+including the interactive tier via a ConPTY backend on Windows.
+See .github/workflows/ci.yml</pre>
+          </details>
+        </td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <!-- STABILITY -->
+  <section id="stability" style="padding-top:64px;border-top:1px solid var(--border);padding-bottom:80px;">
+    <h2>Stability</h2>
+    <p class="p">zcli targets <b>stable Zig</b> — no nightly required. <code class="mono">main</code> and the latest release are built and tested against the current stable Zig on Linux, macOS, and Windows in CI on every commit.</p>
+    <table class="zig-table">
+      <thead><tr><th>zcli</th><th>Zig</th></tr></thead>
+      <tbody>
+        <tr><td class="zcli-v">main, v0.18.0 and later</td><td>0.16.0</td></tr>
+        <tr><td class="zcli-v">v0.14.0 – v0.17.0</td><td>0.15.1</td></tr>
+      </tbody>
+    </table>
+    <p class="p" style="margin-top:20px;">Each release is tagged twice: <code class="mono">vX.Y.Z</code> is the framework library — the tag for your <code class="mono">build.zig.zon</code> — and <code class="mono">zcli-vX.Y.Z</code> carries the prebuilt meta-CLI binaries that <code class="mono">install.sh</code> downloads. The two ship in lockstep, tags are immutable once cut, and CI enforces the version pin doesn't drift silently between them.</p>
+    <a class="btn ghost" href="$site.page('changelog').link().suffix('#versioning')" style="margin-top:6px;display:inline-flex;">Versioning policy →</a>
+  </section>
+</div>
+</main>


### PR DESCRIPTION
Rebuilds the Zine (`website/`) site to mirror the redesigned mockups, and folds in the follow-up polish for the home and docs pages.

## Structure
- New shared stylesheet (`assets/styles.css` ← redesign `site.css`), nav, and 3-column footer in `base.shtml`.
- Reworked **home**, **docs**, **plugins**, **install** layouts; four new pages — **why**, **changelog**, **blog**, **getting-started** (each a layout + `content/*/index.smd` stub).
- Internal links use Zine routing (`$site.page(...).link()`); `version` and `plugin_count` stay wired to the generated `site-data.json`.

## Home page
- **Folder→CLI map fixed** — `index.zig` now shows the same group listing as the `users/` folder; `create.zig` shows `myapp users create alice --admin` (was showing `users list`). `data-cmd` keys renamed to match their files.
- **"See it run"** now pairs the real `tasks/src/commands/` tree (left) with the demo GIF (right); the four commands the recording runs — `add`, `list`, `search`, `sync` — are highlighted.
- **Numbers strip** — the `✓ v0.19.0` chips bottom-align across the row, even under the two-line label.
- **Inline code** adopts the docs page pill styling.
- Also styled the home end-CTA (the design referenced `.endcta` but never defined it).

## Docs page
- **nextlinks** key/title now stack (`→ commands` above the title) instead of colliding on one line — fixed on the plugins page too.
- **Args & options** uses `verbose: bool = false` (was `?bool = null`).
- **"Using plugins"** renders as a real table — the `.ptable` styles were missing from the shared sheet, so it had been rendering unstyled.
- The **`zcli tree`** block now shows the actual meta-CLI tree, captured from a real `zcli tree` run in `projects/zcli` (real descriptions, `(group)` markers, `add`/`rm`/`gh` subtrees); prose updated to include `gh`.

## Verification
`zine release` builds all 8 pages cleanly; each change was checked in a browser (rendered links resolve, dynamic version/plugin_count render, tables/trees/chips display correctly).

Note: building requires the gitignored `./website/zine` binary (CI fetches its own copy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)