### PR TITLE
feat(website): active state on current nav link

### DIFF
--- a/website/assets/styles.css
+++ b/website/assets/styles.css
@@ -82,7 +82,7 @@ a { color: inherit; text-decoration: none; }
 .brand .ver { font-size: 11px; color: var(--faint); font-weight: 500; letter-spacing: 0.04em; padding-top: 2px; }
 .nav nav { display: flex; gap: 22px; margin-left: auto; align-items: center; }
 .nav nav a { font-size: 14px; color: var(--muted); transition: color .15s; }
-.nav nav a:hover { color: var(--fg); }
+.nav nav a:hover, .nav nav a.active { color: var(--fg); }
 .nav .gh {
   display: inline-flex; align-items: center; gap: 7px;
   border: 1px solid var(--border2); border-radius: 7px; padding: 7px 12px;

--- a/website/layouts/templates/base.shtml
+++ b/website/layouts/templates/base.shtml
@@ -21,10 +21,10 @@
             <span class="glyph">z</span> zcli <span class="ver mono">v<span :text="$site.asset('site-data.json').ziggy().get('version')"></span></span>
         </a>
         <nav>
-            <a href="$site.page('docs').link()">Docs</a>
-            <a href="$site.page('why').link()">Why zcli</a>
-            <a href="$site.page('changelog').link()">Changelog</a>
-            <a href="$site.page('blog').link()">Blog</a>
+            <a class="$site.page('docs').isCurrent().then('active')" href="$site.page('docs').link()">Docs</a>
+            <a class="$site.page('why').isCurrent().then('active')" href="$site.page('why').link()">Why zcli</a>
+            <a class="$site.page('changelog').isCurrent().then('active')" href="$site.page('changelog').link()">Changelog</a>
+            <a class="$site.page('blog').isCurrent().then('active')" href="$site.page('blog').link()">Blog</a>
             <a class="gh" href="https://github.com/ryanhair/zcli" target="_blank" rel="noopener">
                 <svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
                 GitHub


### PR DESCRIPTION
## Summary

- Adds `class="active"` to the nav link matching the current page, using Zine's built-in `$site.page('...').isCurrent().then('active')` expression
- Adds `.nav nav a.active { color: var(--fg) }` to the hover rule in `styles.css` so the active link is visually distinct from muted siblings

## Test plan

- [ ] Build with `zine release` and confirm `<a class="active">` appears only on the matching page's nav link
- [ ] Visit Docs, Why zcli, Changelog, and Blog pages and confirm each highlights the correct link

🤖 Generated with [Claude Code](https://claude.com/claude-code)