### PR TITLE
fix(website): create content/changelog/ in sync script; cosmetic cleanups

### DIFF
--- a/website/assets/styles.css
+++ b/website/assets/styles.css
@@ -34,6 +34,8 @@ body {
   background-size: 56px 56px;
 }
 a { color: inherit; text-decoration: none; }
+/* prose links (paragraphs + the changelog policy box) read as accent by default */
+p a, .chglog-policy a { color: var(--accent); }
 ::selection { background: var(--accent); color: #1a1205; }
 
 /* Visible keyboard focus on every interactive element (WCAG 2.4.7 / 2.4.13). */

--- a/website/content/docs/index.smd
+++ b/website/content/docs/index.smd
@@ -1,7 +1,7 @@
 ---
 .title = "zcli — Documentation",
 .description = "zcli documentation: quick start, commands, prompts, progress & theming, config files, plugins, testing, docs generation, the meta-CLI, and building with AI agents.",
-.date = @date("2025-01-01"),
+.date = @date("2026-07-05"),
 .author = "Ryan Hair",
 .layout = "docs.shtml",
 ---

--- a/website/content/getting-started/index.smd
+++ b/website/content/getting-started/index.smd
@@ -1,7 +1,7 @@
 ---
 .title = "zcli — Getting started",
 .description = "From zero to a working CLI in three commands: install the zcli binary, initialize a project with zcli init, and scaffold commands with zcli add command.",
-.date = @date("2025-01-01"),
+.date = @date("2026-07-05"),
 .author = "Ryan Hair",
 .layout = "getting-started.shtml",
 ---

--- a/website/content/index.smd
+++ b/website/content/index.smd
@@ -1,7 +1,7 @@
 ---
 .title = "zcli — your folder structure is your CLI",
 .description = "zcli is a batteries-included framework for command-line tools in Zig. Files become commands, folders become groups, structs become type-checked flags — routing generated at build time.",
-.date = @date("2025-01-01"),
+.date = @date("2026-07-05"),
 .author = "Ryan Hair",
 .layout = "home.shtml",
 ---

--- a/website/content/install/index.smd
+++ b/website/content/install/index.smd
@@ -1,7 +1,7 @@
 ---
 .title = "zcli — Install",
 .description = "Install zcli with the install script, or add it as a Zig package dependency in build.zig.zon.",
-.date = @date("2025-01-01"),
+.date = @date("2026-07-05"),
 .author = "Ryan Hair",
 .layout = "install.shtml",
 ---

--- a/website/content/plugins/index.smd
+++ b/website/content/plugins/index.smd
@@ -1,7 +1,7 @@
 ---
 .title = "zcli — Plugins",
 .description = "zcli plugins: the built-in defaults, enabling them, auto-discovery with plugins_dir, build-time configuration, and writing your own plugins.",
-.date = @date("2025-01-01"),
+.date = @date("2026-07-05"),
 .author = "Ryan Hair",
 .layout = "plugins.shtml",
 ---

--- a/website/content/why/index.smd
+++ b/website/content/why/index.smd
@@ -1,7 +1,7 @@
 ---
 .title = "zcli — Why zcli",
 .description = "Why zcli exists: comptime over runtime, conventions over registration, and the measured numbers behind the batteries-included claim — binary size, dependencies, CI, and Zig version support.",
-.date = @date("2025-01-01"),
+.date = @date("2026-07-05"),
 .author = "Ryan Hair",
 .layout = "why.shtml",
 ---

--- a/website/layouts/changelog.shtml
+++ b/website/layouts/changelog.shtml
@@ -12,11 +12,11 @@
 <div class="wrap cl-body">
   <div class="eyebrow" style="display:inline-block;">Changelog</div>
   <h1>Every release, newest first.</h1>
-  <p class="lead">All notable changes to zcli, rendered from <a href="https://github.com/ryanhair/zcli/blob/main/CHANGELOG.md" target="_blank" rel="noopener" style="color:var(--accent);">CHANGELOG.md</a> in the repo — that file stays the single source of truth.</p>
+  <p class="lead">All notable changes to zcli, rendered from <a href="https://github.com/ryanhair/zcli/blob/main/CHANGELOG.md" target="_blank" rel="noopener">CHANGELOG.md</a> in the repo — that file stays the single source of truth.</p>
 
   <div id="versioning" class="chglog-policy" style="margin-top:32px;">
     <b>Versioning policy</b>
-    zcli follows <a href="https://semver.org" target="_blank" rel="noopener" style="color:var(--accent);">semver</a>. Until 1.0, breaking changes may land in minor versions and are called out below; patch versions are always safe to take. Releases target <b>stable Zig</b> — moving to a new Zig version is at least a minor bump and is stated in the entry. Each release is tagged twice, in lockstep: <code class="mono">vX.Y.Z</code> is the framework library (the tag for your <code class="mono">build.zig.zon</code>), <code class="mono">zcli-vX.Y.Z</code> carries the prebuilt meta-CLI binaries.
+    zcli follows <a href="https://semver.org" target="_blank" rel="noopener">semver</a>. Until 1.0, breaking changes may land in minor versions and are called out below; patch versions are always safe to take. Releases target <b>stable Zig</b> — moving to a new Zig version is at least a minor bump and is stated in the entry. Each release is tagged twice, in lockstep: <code class="mono">vX.Y.Z</code> is the framework library (the tag for your <code class="mono">build.zig.zon</code>), <code class="mono">zcli-vX.Y.Z</code> carries the prebuilt meta-CLI binaries.
   </div>
 
   <table class="zig-table" style="margin-top:28px;">

--- a/website/layouts/docs.shtml
+++ b/website/layouts/docs.shtml
@@ -91,7 +91,7 @@
           <p>Install the meta-CLI, scaffold a project, add a command. That's the whole loop.</p>
 
           <div class="step"><span class="n">1</span><h2>Install the zcli CLI</h2></div>
-          <p>See the <a href="$site.page('install').link()" style="color:var(--accent)">install page</a> for every option, including shell completions.</p>
+          <p>See the <a href="$site.page('install').link()">install page</a> for every option, including shell completions.</p>
           <div class="code">
             <div class="code-head"><span class="fname">terminal</span><span class="lang">sh</span></div>
 <pre><span class="c-prompt">$</span> <span class="c-cmd">curl</span> -fsSL https://raw.githubusercontent.com/ryanhair/zcli/main/install.sh | sh</pre>
@@ -125,7 +125,7 @@ Creating new zcli project: myapp
   <span class="c-cmd">deploy</span>   Deploy your application
   <span class="c-cmd">hello</span>    Say hello</pre>
           </div>
-          <p>Add more commands the same way — jump to <a href="#commands" style="color:var(--accent)">Commands</a> for the file-path rules, or <a href="#ai-agents" style="color:var(--accent)">AI agents</a> if a coding agent is driving.</p>
+          <p>Add more commands the same way — jump to <a href="#commands">Commands</a> for the file-path rules, or <a href="#ai-agents">AI agents</a> if a coding agent is driving.</p>
 
           <details class="manual" style="margin-top:24px;">
             <summary><span class="chev">›</span><span class="lbl">Manual setup — wiring build.zig by hand <small>— skip if zcli init worked</small></span></summary>
@@ -349,7 +349,7 @@ all = <span class="num">true</span></pre>
     }
 }</pre>
           </div>
-          <p>Hooks take <code>context: anytype</code> — a plugin is compiled <em>into</em> the registry, so it can't name the concrete <code>Context</code> type your commands import. Full hook list, build-time config, and plugin-provided commands: see the full <a href="$site.page('plugins').link()" style="color:var(--accent);">plugins guide</a>.</p>
+          <p>Hooks take <code>context: anytype</code> — a plugin is compiled <em>into</em> the registry, so it can't name the concrete <code>Context</code> type your commands import. Full hook list, build-time config, and plugin-provided commands: see the full <a href="$site.page('plugins').link()">plugins guide</a>.</p>
         </section>
 
         <!-- ============ TESTING ============ -->
@@ -378,7 +378,7 @@ all = <span class="num">true</span></pre>
     <span class="kw">try</span> std.testing.<span class="fn">expect</span>(result.term.<span class="fn">containsText</span>(<span class="str">"Deploying"</span>));
     <span class="kw">try</span> std.testing.<span class="fn">expect</span>(result.term.<span class="fn">hasAttribute</span>(<span class="num">0</span>, <span class="num">0</span>, .bold));</pre>
           </div>
-          <p><code>result.term</code> is a real ANSI-parsing terminal emulator — assert a cell is bold at row 0, check a foreground color, or match a wildcard pattern across the rendered screen. No other Zig CLI library ships this. Full API and the integration/e2e tiers: see <a href="https://github.com/ryanhair/zcli/blob/main/docs/TESTING.md" target="_blank" rel="noopener" style="color:var(--accent);">docs/TESTING.md</a>.</p>
+          <p><code>result.term</code> is a real ANSI-parsing terminal emulator — assert a cell is bold at row 0, check a foreground color, or match a wildcard pattern across the rendered screen. No other Zig CLI library ships this. Full API and the integration/e2e tiers: see <a href="https://github.com/ryanhair/zcli/blob/main/docs/TESTING.md" target="_blank" rel="noopener">docs/TESTING.md</a>.</p>
         </section>
 
         <!-- ============ DOCS GENERATION ============ -->

--- a/website/layouts/install.shtml
+++ b/website/layouts/install.shtml
@@ -75,7 +75,7 @@
 },</pre>
           <button onclick="cp(this,'.zcli = .{ .url = &quot;https://github.com/ryanhair/zcli/archive/refs/heads/main.tar.gz&quot;, .hash = &quot;...&quot; },')">copy</button>
         </div>
-        <p style="font-size:13.5px;">Then follow steps 2 & 3 in the <a href="$site.page('docs').link().suffix('#quick-start')" style="color:var(--accent)">docs</a> to wire up <code class="mono">zcli.generate</code>.</p>
+        <p style="font-size:13.5px;">Then follow steps 2 & 3 in the <a href="$site.page('docs').link().suffix('#quick-start')">docs</a> to wire up <code class="mono">zcli.generate</code>.</p>
       </div>
 
       <!-- SOURCE -->

--- a/website/layouts/why.shtml
+++ b/website/layouts/why.shtml
@@ -38,7 +38,7 @@
   <!-- COMPARISON -->
   <section id="comparison" style="padding-top:64px;border-top:1px solid var(--border);">
     <h2>Comparison</h2>
-    <p class="p"><a href="https://github.com/Hejsil/zig-clap" target="_blank" rel="noopener" style="color:var(--accent);">zig-clap</a> is an argument parser, and the lightest of the three: describe flags in a comptime help-text DSL, get typed results back, build the rest of the CLI yourself. <b>If flag parsing is all you need, it's a great choice.</b> <a href="https://github.com/xcaeser/zli" target="_blank" rel="noopener" style="color:var(--accent);">zli</a> is a batteries-included framework built around a runtime builder: commands are constructed with <code class="mono">Command.init(...)</code>, wired up with <code class="mono">addCommand</code>, flags registered with <code class="mono">addFlag</code> and read by name.</p>
+    <p class="p"><a href="https://github.com/Hejsil/zig-clap" target="_blank" rel="noopener">zig-clap</a> is an argument parser, and the lightest of the three: describe flags in a comptime help-text DSL, get typed results back, build the rest of the CLI yourself. <b>If flag parsing is all you need, it's a great choice.</b> <a href="https://github.com/xcaeser/zli" target="_blank" rel="noopener">zli</a> is a batteries-included framework built around a runtime builder: commands are constructed with <code class="mono">Command.init(...)</code>, wired up with <code class="mono">addCommand</code>, flags registered with <code class="mono">addFlag</code> and read by name.</p>
     <p class="p">zcli moves that work to the filesystem and the compiler. The directory tree <em>is</em> the command tree, discovered at build time with routing generated as ordinary Zig code. And the batteries extend past parsing into the whole terminal experience.</p>
 
     <div class="table-scroll">
@@ -76,7 +76,7 @@
   <!-- NUMBERS -->
   <section id="numbers" style="padding-top:64px;border-top:1px solid var(--border);">
     <h2>Numbers</h2>
-    <p class="p">Every figure below is measured against zcli v0.19.0, built from the <a href="https://github.com/ryanhair/zcli/tree/main/examples/showcase" target="_blank" rel="noopener" style="color:var(--accent);">showcase</a> and a minimal hello-world command. Expand a row for the exact commands used.</p>
+    <p class="p">Every figure below is measured against zcli v0.19.0, built from the <a href="https://github.com/ryanhair/zcli/tree/main/examples/showcase" target="_blank" rel="noopener">showcase</a> and a minimal hello-world command. Expand a row for the exact commands used.</p>
 
     <table class="num-table">
       <tbody>

--- a/website/sync-site-data.sh
+++ b/website/sync-site-data.sh
@@ -66,6 +66,10 @@ if [ -z "$latest_date" ]; then
   exit 1
 fi
 
+# The directory may not exist on a fresh checkout: the generated index.smd is
+# the only thing in it, and git doesn't track empty directories.
+mkdir -p "$(dirname "$changelog_out")"
+
 cat > "$changelog_out" <<EOF
 ---
 .title = "zcli — Changelog",


### PR DESCRIPTION
## What

**Fixes the red deploy on main.** The changelog generation from #152 fails on any fresh checkout: `content/changelog/` contains only the generated (gitignored) `index.smd`, git doesn't track empty directories, so `sync-site-data.sh`'s output redirect hits a missing directory — which is exactly how the post-merge deploy run failed. The script now `mkdir -p`'s the directory before writing. Merging this re-runs the deploy and unblocks the site (still serving the #151 build meanwhile, so nothing user-visible broke).

Plus the two cosmetic leftovers from the site-structure review:

- The six layout-authored pages had placeholder `@date("2025-01-01")` frontmatter; now dated to the redesign. (Blog and changelog already carry real dates.)
- Prose links are styled once in CSS (`p a, .chglog-policy a { color: var(--accent) }`) instead of `style="color:var(--accent)"` repeated on ~10 anchors across five layouts. Inline accents on `code.mono`/`span` tokens are deliberate one-offs and left alone.

## Verification

`cd website && zig build release` passes from this branch after deleting `content/changelog/` (reproduces the CI condition). Rendered output checked: no `<a>` retains an inline accent style, the new CSS rule is in the shipped stylesheet, and changelog anchors are intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)