### PR TITLE
ci(website): scope docs deploy to doc-relevant paths

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,6 +3,11 @@ name: Deploy Documentation
 on:
   push:
     branches: [main]
+    paths:
+      - "website/**"
+      - "CHANGELOG.md"
+      - "install.sh"
+      - "build.zig.zon"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## What

Adds a `paths` filter to the **Deploy Documentation** workflow so it only runs on `main` when its actual inputs change.

## Why

Every merge to `main` fired two workflow runs — **CI** and **Deploy Documentation** — even for changes that don't touch the docs site. The docs deploy only needs to run when its inputs change.

## Scope

Deploy now triggers on pushes touching:
- `website/**`
- `CHANGELOG.md` — feeds the generated changelog page
- `install.sh` — published at the site root (`zcli.dev/install.sh`)
- `build.zig.zon` — root file only; read by `sync-site-data.sh` for site version data

`workflow_dispatch` is retained for manual redeploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)