### PR TITLE
fix(website): blog readability pass + cosmetic cleanups

### DIFF
--- a/website/assets/favicon.svg
+++ b/website/assets/favicon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><rect width="64" height="64" rx="14" fill="#f7a41d"/><text x="32" y="47" font-family="'JetBrains Mono',Menlo,ui-monospace,monospace" font-size="44" font-weight="800" text-anchor="middle" fill="#1a1205">z</text></svg>

--- a/website/assets/styles.css
+++ b/website/assets/styles.css
@@ -4,6 +4,7 @@
   --surface:  #14161b;
   --surface2: #1a1d24;
   --fg:       #e7e9ee;
+  --fg-soft:  #c9cdd6;   /* long-form body copy — brighter than --muted so articles don't read washed out */
   --muted:    #9298a4;
   --faint:    #838b98;   /* lifted from #646a76 to clear 4.5:1 on --bg for small labels */
   --border:   rgba(255, 255, 255, 0.08);

--- a/website/assets/styles.css
+++ b/website/assets/styles.css
@@ -34,6 +34,8 @@ body {
   background-size: 56px 56px;
 }
 a { color: inherit; text-decoration: none; }
+/* prose links (paragraphs + the changelog policy box) read as accent by default */
+p a, .chglog-policy a { color: var(--accent); }
 ::selection { background: var(--accent); color: #1a1205; }
 
 /* Visible keyboard focus on every interactive element (WCAG 2.4.7 / 2.4.13). */

--- a/website/content/blog/introducing-zcli.smd
+++ b/website/content/blog/introducing-zcli.smd
@@ -41,7 +41,7 @@ pub fn execute(args: Args, options: Options, context: anytype) !void {
 }
 ```
 
-## Enabling LLM generation
+## [Enabling LLM generation]($heading.id('enabling-llm-generation'))
 
 One of my recent goals was to make it easier for LLM generation of CLIs. I understand people have _very strong opinions_ on this, and while I respect that, I want to make it easy for those who have a need for a CLI to be able to generate one cleanly. The benefit to following "one way to do things" _also_ leads to LLMs being able to more easily reason about and iterate on CLI code. Overall, zcli makes it surprisingly easy to get a small, portable CLI that does what you need, without disk space and memory bloat, and with about as snappy performance as possible.
 

--- a/website/content/docs/index.smd
+++ b/website/content/docs/index.smd
@@ -1,7 +1,7 @@
 ---
 .title = "zcli — Documentation",
 .description = "zcli documentation: quick start, commands, prompts, progress & theming, config files, plugins, testing, docs generation, the meta-CLI, and building with AI agents.",
-.date = @date("2025-01-01"),
+.date = @date("2026-07-05"),
 .author = "Ryan Hair",
 .layout = "docs.shtml",
 ---

--- a/website/content/getting-started/index.smd
+++ b/website/content/getting-started/index.smd
@@ -1,7 +1,7 @@
 ---
 .title = "zcli — Getting started",
 .description = "From zero to a working CLI in three commands: install the zcli binary, initialize a project with zcli init, and scaffold commands with zcli add command.",
-.date = @date("2025-01-01"),
+.date = @date("2026-07-05"),
 .author = "Ryan Hair",
 .layout = "getting-started.shtml",
 ---

--- a/website/content/index.smd
+++ b/website/content/index.smd
@@ -1,7 +1,7 @@
 ---
 .title = "zcli — your folder structure is your CLI",
 .description = "zcli is a batteries-included framework for command-line tools in Zig. Files become commands, folders become groups, structs become type-checked flags — routing generated at build time.",
-.date = @date("2025-01-01"),
+.date = @date("2026-07-05"),
 .author = "Ryan Hair",
 .layout = "home.shtml",
 ---

--- a/website/content/install/index.smd
+++ b/website/content/install/index.smd
@@ -1,7 +1,7 @@
 ---
 .title = "zcli — Install",
 .description = "Install zcli with the install script, or add it as a Zig package dependency in build.zig.zon.",
-.date = @date("2025-01-01"),
+.date = @date("2026-07-05"),
 .author = "Ryan Hair",
 .layout = "install.shtml",
 ---

--- a/website/content/plugins/index.smd
+++ b/website/content/plugins/index.smd
@@ -1,7 +1,7 @@
 ---
 .title = "zcli — Plugins",
 .description = "zcli plugins: the built-in defaults, enabling them, auto-discovery with plugins_dir, build-time configuration, and writing your own plugins.",
-.date = @date("2025-01-01"),
+.date = @date("2026-07-05"),
 .author = "Ryan Hair",
 .layout = "plugins.shtml",
 ---

--- a/website/content/why/index.smd
+++ b/website/content/why/index.smd
@@ -1,7 +1,7 @@
 ---
 .title = "zcli — Why zcli",
 .description = "Why zcli exists: comptime over runtime, conventions over registration, and the measured numbers behind the batteries-included claim — binary size, dependencies, CI, and Zig version support.",
-.date = @date("2025-01-01"),
+.date = @date("2026-07-05"),
 .author = "Ryan Hair",
 .layout = "why.shtml",
 ---

--- a/website/layouts/changelog.shtml
+++ b/website/layouts/changelog.shtml
@@ -12,11 +12,11 @@
 <div class="wrap cl-body">
   <div class="eyebrow" style="display:inline-block;">Changelog</div>
   <h1>Every release, newest first.</h1>
-  <p class="lead">All notable changes to zcli, rendered from <a href="https://github.com/ryanhair/zcli/blob/main/CHANGELOG.md" target="_blank" rel="noopener" style="color:var(--accent);">CHANGELOG.md</a> in the repo — that file stays the single source of truth.</p>
+  <p class="lead">All notable changes to zcli, rendered from <a href="https://github.com/ryanhair/zcli/blob/main/CHANGELOG.md" target="_blank" rel="noopener">CHANGELOG.md</a> in the repo — that file stays the single source of truth.</p>
 
   <div id="versioning" class="chglog-policy" style="margin-top:32px;">
     <b>Versioning policy</b>
-    zcli follows <a href="https://semver.org" target="_blank" rel="noopener" style="color:var(--accent);">semver</a>. Until 1.0, breaking changes may land in minor versions and are called out below; patch versions are always safe to take. Releases target <b>stable Zig</b> — moving to a new Zig version is at least a minor bump and is stated in the entry. Each release is tagged twice, in lockstep: <code class="mono">vX.Y.Z</code> is the framework library (the tag for your <code class="mono">build.zig.zon</code>), <code class="mono">zcli-vX.Y.Z</code> carries the prebuilt meta-CLI binaries.
+    zcli follows <a href="https://semver.org" target="_blank" rel="noopener">semver</a>. Until 1.0, breaking changes may land in minor versions and are called out below; patch versions are always safe to take. Releases target <b>stable Zig</b> — moving to a new Zig version is at least a minor bump and is stated in the entry. Each release is tagged twice, in lockstep: <code class="mono">vX.Y.Z</code> is the framework library (the tag for your <code class="mono">build.zig.zon</code>), <code class="mono">zcli-vX.Y.Z</code> carries the prebuilt meta-CLI binaries.
   </div>
 
   <table class="zig-table" style="margin-top:28px;">

--- a/website/layouts/docs.shtml
+++ b/website/layouts/docs.shtml
@@ -91,7 +91,7 @@
           <p>Install the meta-CLI, scaffold a project, add a command. That's the whole loop.</p>
 
           <div class="step"><span class="n">1</span><h2>Install the zcli CLI</h2></div>
-          <p>See the <a href="$site.page('install').link()" style="color:var(--accent)">install page</a> for every option, including shell completions.</p>
+          <p>See the <a href="$site.page('install').link()">install page</a> for every option, including shell completions.</p>
           <div class="code">
             <div class="code-head"><span class="fname">terminal</span><span class="lang">sh</span></div>
 <pre><span class="c-prompt">$</span> <span class="c-cmd">curl</span> -fsSL https://raw.githubusercontent.com/ryanhair/zcli/main/install.sh | sh</pre>
@@ -125,7 +125,7 @@ Creating new zcli project: myapp
   <span class="c-cmd">deploy</span>   Deploy your application
   <span class="c-cmd">hello</span>    Say hello</pre>
           </div>
-          <p>Add more commands the same way — jump to <a href="#commands" style="color:var(--accent)">Commands</a> for the file-path rules, or <a href="#ai-agents" style="color:var(--accent)">AI agents</a> if a coding agent is driving.</p>
+          <p>Add more commands the same way — jump to <a href="#commands">Commands</a> for the file-path rules, or <a href="#ai-agents">AI agents</a> if a coding agent is driving.</p>
 
           <details class="manual" style="margin-top:24px;">
             <summary><span class="chev">›</span><span class="lbl">Manual setup — wiring build.zig by hand <small>— skip if zcli init worked</small></span></summary>
@@ -349,7 +349,7 @@ all = <span class="num">true</span></pre>
     }
 }</pre>
           </div>
-          <p>Hooks take <code>context: anytype</code> — a plugin is compiled <em>into</em> the registry, so it can't name the concrete <code>Context</code> type your commands import. Full hook list, build-time config, and plugin-provided commands: see the full <a href="$site.page('plugins').link()" style="color:var(--accent);">plugins guide</a>.</p>
+          <p>Hooks take <code>context: anytype</code> — a plugin is compiled <em>into</em> the registry, so it can't name the concrete <code>Context</code> type your commands import. Full hook list, build-time config, and plugin-provided commands: see the full <a href="$site.page('plugins').link()">plugins guide</a>.</p>
         </section>
 
         <!-- ============ TESTING ============ -->
@@ -378,7 +378,7 @@ all = <span class="num">true</span></pre>
     <span class="kw">try</span> std.testing.<span class="fn">expect</span>(result.term.<span class="fn">containsText</span>(<span class="str">"Deploying"</span>));
     <span class="kw">try</span> std.testing.<span class="fn">expect</span>(result.term.<span class="fn">hasAttribute</span>(<span class="num">0</span>, <span class="num">0</span>, .bold));</pre>
           </div>
-          <p><code>result.term</code> is a real ANSI-parsing terminal emulator — assert a cell is bold at row 0, check a foreground color, or match a wildcard pattern across the rendered screen. No other Zig CLI library ships this. Full API and the integration/e2e tiers: see <a href="https://github.com/ryanhair/zcli/blob/main/docs/TESTING.md" target="_blank" rel="noopener" style="color:var(--accent);">docs/TESTING.md</a>.</p>
+          <p><code>result.term</code> is a real ANSI-parsing terminal emulator — assert a cell is bold at row 0, check a foreground color, or match a wildcard pattern across the rendered screen. No other Zig CLI library ships this. Full API and the integration/e2e tiers: see <a href="https://github.com/ryanhair/zcli/blob/main/docs/TESTING.md" target="_blank" rel="noopener">docs/TESTING.md</a>.</p>
         </section>
 
         <!-- ============ DOCS GENERATION ============ -->

--- a/website/layouts/install.shtml
+++ b/website/layouts/install.shtml
@@ -75,7 +75,7 @@
 },</pre>
           <button onclick="cp(this,'.zcli = .{ .url = &quot;https://github.com/ryanhair/zcli/archive/refs/heads/main.tar.gz&quot;, .hash = &quot;...&quot; },')">copy</button>
         </div>
-        <p style="font-size:13.5px;">Then follow steps 2 & 3 in the <a href="$site.page('docs').link().suffix('#quick-start')" style="color:var(--accent)">docs</a> to wire up <code class="mono">zcli.generate</code>.</p>
+        <p style="font-size:13.5px;">Then follow steps 2 & 3 in the <a href="$site.page('docs').link().suffix('#quick-start')">docs</a> to wire up <code class="mono">zcli.generate</code>.</p>
       </div>
 
       <!-- SOURCE -->

--- a/website/layouts/post.shtml
+++ b/website/layouts/post.shtml
@@ -2,19 +2,28 @@
 
 <head id="head">
 	<style>
-		.blog-body { max-width: 720px; padding: 64px 0 96px; }
-		.blog-body h1 { font-size: clamp(30px,4vw,42px); }
+		/* ~640px at 17px text keeps the measure near 75ch — long-form reading width. */
+		.blog-body { max-width: 640px; padding: 64px 0 96px; }
+		.blog-body h1 { font-size: clamp(27px,3.2vw,36px); line-height: 1.18; }
 		.post-meta { font-family: var(--mono); font-size: 12.5px; color: var(--faint); margin: 10px 0 34px; }
-		.post p { color: var(--muted); font-size: 16.5px; line-height: 1.75; margin-bottom: 18px; }
-		.post ul { margin-bottom: 18px; }
-		.post ul li { font-weight: bold; }
-		.post h2 { font-size: 24px; margin: 40px 0 12px; }
-		.post a { color: var(--accent); }
+		.post p { color: var(--fg-soft); font-size: 17px; line-height: 1.75; margin-bottom: 20px; }
+		.post ul, .post ol { color: var(--fg-soft); font-size: 17px; line-height: 1.75; margin-bottom: 20px; padding-left: 26px; }
+		.post li { margin: 6px 0; }
+		.post strong, .post b { color: var(--fg); }
+		.post h2 { font-size: 24px; margin: 40px 0 12px; scroll-margin-top: 84px; }
+		.post h3 { font-size: 19px; margin: 32px 0 10px; scroll-margin-top: 84px; }
+		.post a { color: var(--accent); text-decoration: underline; text-decoration-color: rgba(247,164,29,0.4); text-underline-offset: 3px; }
+		.post a:hover { text-decoration-color: var(--accent); }
+		.post blockquote { border-left: 3px solid var(--accent); padding: 2px 0 2px 18px; margin: 0 0 20px; color: var(--muted); }
+		.post blockquote p:last-child { margin-bottom: 0; }
+		.post img { max-width: 100%; border-radius: 10px; }
+		.post hr { border: none; border-top: 1px solid var(--border); margin: 32px 0; }
 		.post code { font-family: var(--mono); font-size: 0.88em; background: var(--surface2); border: 1px solid var(--border); border-radius: 5px; padding: 1px 6px; color: var(--accent); }
 		.post pre { margin: 16px 0 22px; padding: 18px; background: #0d0e12; border: 1px solid var(--border); border-radius: 10px; overflow-x: auto; }
 		.post pre code { background: none; border: none; padding: 0; font-size: 13px; line-height: 1.7; color: #cfd3da; }
 		.post-nav { display: flex; justify-content: space-between; gap: 16px; margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--border); font-family: var(--mono); font-size: 13px; }
 		.post-nav a { color: var(--accent); }
+		.post-nav:not(:has(a)) { display: none; }   /* no prev/next yet — don't render a stray rule */
 	</style>
 </head>
 

--- a/website/layouts/templates/base.shtml
+++ b/website/layouts/templates/base.shtml
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <link rel="icon" type="image/svg+xml" href="$site.asset('favicon.svg').link()">
     <link rel="stylesheet" href="$site.asset('styles.css').link()">
     <link rel="alternate" type="application/rss+xml" title="zcli blog" href="$site.page('blog').alternative('rss').link()">
     <super>

--- a/website/layouts/why.shtml
+++ b/website/layouts/why.shtml
@@ -38,7 +38,7 @@
   <!-- COMPARISON -->
   <section id="comparison" style="padding-top:64px;border-top:1px solid var(--border);">
     <h2>Comparison</h2>
-    <p class="p"><a href="https://github.com/Hejsil/zig-clap" target="_blank" rel="noopener" style="color:var(--accent);">zig-clap</a> is an argument parser, and the lightest of the three: describe flags in a comptime help-text DSL, get typed results back, build the rest of the CLI yourself. <b>If flag parsing is all you need, it's a great choice.</b> <a href="https://github.com/xcaeser/zli" target="_blank" rel="noopener" style="color:var(--accent);">zli</a> is a batteries-included framework built around a runtime builder: commands are constructed with <code class="mono">Command.init(...)</code>, wired up with <code class="mono">addCommand</code>, flags registered with <code class="mono">addFlag</code> and read by name.</p>
+    <p class="p"><a href="https://github.com/Hejsil/zig-clap" target="_blank" rel="noopener">zig-clap</a> is an argument parser, and the lightest of the three: describe flags in a comptime help-text DSL, get typed results back, build the rest of the CLI yourself. <b>If flag parsing is all you need, it's a great choice.</b> <a href="https://github.com/xcaeser/zli" target="_blank" rel="noopener">zli</a> is a batteries-included framework built around a runtime builder: commands are constructed with <code class="mono">Command.init(...)</code>, wired up with <code class="mono">addCommand</code>, flags registered with <code class="mono">addFlag</code> and read by name.</p>
     <p class="p">zcli moves that work to the filesystem and the compiler. The directory tree <em>is</em> the command tree, discovered at build time with routing generated as ordinary Zig code. And the batteries extend past parsing into the whole terminal experience.</p>
 
     <div class="table-scroll">
@@ -76,7 +76,7 @@
   <!-- NUMBERS -->
   <section id="numbers" style="padding-top:64px;border-top:1px solid var(--border);">
     <h2>Numbers</h2>
-    <p class="p">Every figure below is measured against zcli v0.19.0, built from the <a href="https://github.com/ryanhair/zcli/tree/main/examples/showcase" target="_blank" rel="noopener" style="color:var(--accent);">showcase</a> and a minimal hello-world command. Expand a row for the exact commands used.</p>
+    <p class="p">Every figure below is measured against zcli v0.19.0, built from the <a href="https://github.com/ryanhair/zcli/tree/main/examples/showcase" target="_blank" rel="noopener">showcase</a> and a minimal hello-world command. Expand a row for the exact commands used.</p>
 
     <table class="num-table">
       <tbody>

--- a/website/sync-site-data.sh
+++ b/website/sync-site-data.sh
@@ -66,6 +66,10 @@ if [ -z "$latest_date" ]; then
   exit 1
 fi
 
+# The directory may not exist on a fresh checkout: the generated index.smd is
+# the only thing in it, and git doesn't track empty directories.
+mkdir -p "$(dirname "$changelog_out")"
+
 cat > "$changelog_out" <<EOF
 ---
 .title = "zcli — Changelog",


### PR DESCRIPTION
## Summary

UX audit of the blog (layout/style, not content) turned up several readability issues on the post page; this fixes all of them, plus the earlier cosmetic cleanups already on this branch.

**Readability**
- Post body was ~93 chars/line in `--muted` gray — now a ~75ch measure (640px @ 17px) set in a new `--fg-soft` token (11.7:1 contrast), so articles read like articles instead of captions
- `strong`/`b` inherited the muted body color — now `--fg`, so the design-principles emphasis actually reads
- Prose links were color-only (amber vs gray is ~1.4:1, failing WCAG 1.4.1's 3:1 rule for undecorated links) — now underlined with a softened decoration color
- Post h1 resized for the narrower column (36px cap; the index keeps 42px)

**Structure / landmines**
- Removed the leftover `.post ul li { font-weight: bold }` test rule, and added missing `.post` styles for `ul`/`ol` (the global reset zeroed list padding, so markers would have hung outside the column), `h3`, `blockquote`, `img`, and `hr` — the first post using any of these would have rendered broken
- Empty prev/next nav rendered as a stray hairline above the footer — hidden via `:has()` until there's a second post
- The post h2 now has an anchor id (`$heading.id()`) plus `scroll-margin-top` so the sticky nav doesn't cover anchored headings
- Added an SVG favicon — every page previously 404'd on `/favicon.ico`

## Verification

Rebuilt with `zig build release` and verified in a real browser at 1440px and 390px: measured computed styles (body color, chars/line, underlines, nav hidden, anchor id + scroll margin, favicon load) and eyeballed full-page screenshots before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)