### PR TITLE
feat(blog): final editorial pass on the introducing-zcli launch post

### DIFF
--- a/website/content/blog/introducing-zcli.smd
+++ b/website/content/blog/introducing-zcli.smd
@@ -1,48 +1,75 @@
 ---
-.title = "Introducing zcli: fast, slim and typesafe command-line tools in Zig",
-.description = "Why zcli exists: drop a .zig file in commands/ and it's a command — discovered at build time, routed with zero runtime cost, type-checked by the compiler.",
+.title = "Introducing zcli: fast, slim, and type-safe command-line tools in Zig",
+.description = "Why zcli exists: drop a .zig file in commands/ and it's a command - discovered at build time, routed with zero runtime cost, type-checked by the compiler.",
 .date = @date("2026-07-07"),
 .author = "Ryan Hair",
 .layout = "post.shtml",
 ---
 
-I've always loved building command-line tools. I have often joined developer experience teams because I love creating great developer tooling. I love crafting a really great user experience for customers, but I think my _favorite_ customers are other developers. Developer tooling has always been a passion of mine, and I've always looked for ways to improve the developer experience. With most of the companies I've worked for, I have found that there are common utilities that are spread across different repos, random collections of scripts scattered between codebases, or even scripts that live directly on developer machines, which get shared organically, copied from one user's machine to another. One of my passions has been to collect those tools, dig in to figure out what problem the scripts are trying to _solve_, and build a CLI shaped around the very best solutions, tailored to the products and processes of the company.
+zcli is a CLI framework for Zig: drop a `.zig` file into `commands/` and it's a command - discovered at build time, routed with no runtime cost, and type-checked by the compiler. Batteries-included means you get theming, common components, and a solid testing story out of the box. It's MIT-licensed and available today. This post dives into why I built it.
 
-Along the way, I've tried a lot of different CLI frameworks. I built a company-wide CLI in Node using Pastel and Ink. We had a lot of frontend engineers, and the idea that they could possibly contribute, since Ink uses React, was appealing. I really loved the simplicity that came from building a CLI from a folder structure: to me, it was an elegant mapping that made sense. Create a folder, add a JS file with a function as the default export, and that function returns a React component. To me, it was incredibly elegant. It was also very heavy.
+## The JS tax
 
-I've always held a strong belief that we've accepted too much bloat for the simplicity that a high-level language like JS affords us. I get it. JavaScript and TypeScript are two of my most loved languages, and I've probably spent more time with them than any other. It hurts, though, when I see that we've accepted that 40MB is the _floor_ on the size of a CLI built with JS. It makes sense, we're packaging an entire _runtime_, one that is built to do all _sorts_ of things, and we package it up to run a set of scripts. Most have dependencies, and in the JS ecosystem that means _transitive_ dependencies. Honestly, most CLIs don't need this.
+I've always loved building command-line tools. I have often joined developer experience teams because I love creating great developer tooling. I love crafting a really great user experience for customers, but I think my favorite customers are other developers.
 
-It also hurts _speed_. Having to load an entire JS runtime, then have that runtime parse JS files, takes _time_. Yes, we're only talking hundreds of milliseconds, but I've learned that perceived time in a CLI _matters_. There's a thin line between a CLI not feeling responsive, and it doesn't take long to cross that line.
+With most of the companies I've worked for, I have found that there are common utilities that are spread across different repos, random collections of scripts scattered between codebases, or even scripts that live directly on developer machines, which get shared organically, copied from one user's machine to another. One of my passions has been to collect those tools, dig in to figure out what problem the scripts are trying to solve, and build a CLI shaped around the very best solutions, tailored to the products and processes of the company.
 
-It feels like we've accepted this. A _lot_ of AI tooling, especially CLIs, are being written in JS. Again, I understand when there are so many fantastic libraries and frameworks already built, but they come at a cost: bloated binaries, slower load times, and, for long-lived tasks, high memory usage.
+Along the way, I've tried a lot of different CLI frameworks. I built a company-wide CLI in Node using Pastel and Ink. We had a lot of frontend engineers, and the idea that they could possibly contribute, since Ink uses React, was appealing. I really loved the simplicity that came from building a CLI from a folder structure: create a folder, add a JS file with a function as the default export, and that function returns a React component. To me, it was incredibly elegant. It was also very heavy.
 
-I have had a dream, for quite a while, of building a CLI framework to solve a lot of these issues. I've really enjoyed watching Zig grow, and have felt for a long time that it sits right at the intersection of simplicity and performance. After a lot of iterating on design and UX, `zcli` was born.
+I've always held a strong belief that we've accepted too much bloat for the simplicity that a high-level language like JS affords us. I get it. JavaScript and TypeScript are two of my most loved languages, and I've probably spent more time with them than any other. It hurts, though, when I see that we've accepted that 40MB is the floor on the size of a CLI built with JS. It makes sense: we're packaging an entire _runtime_, one that is built to do all sorts of things, and we package it up to run a set of scripts. Most JS-based CLIs have dependencies, and in the JS ecosystem that means transitive dependencies. Honestly, most CLIs don't need this.
+
+It also hurts speed. Having to load an entire JS runtime, then have that runtime parse JS files, takes time. Yes, we're only talking hundreds of milliseconds, but I've learned that perceived time in a CLI matters. There's a thin line between a CLI that feels responsive and a CLI that feels laggy, and it doesn't take much to cross that line.
+
+It feels like we've accepted this. A lot of AI tooling, especially CLIs, are being written in JS. Again, I understand why: there are many fantastic libraries and frameworks already built. A complex CLI can be built quickly, but that convenience comes at a cost: bloated binaries, slower load times, and, for long-lived tasks, high memory usage.
+
+For a long time, I've dreamed of building a CLI framework to solve these issues. I've really enjoyed watching Zig grow, and have felt for a long time that it sits right at the intersection of simplicity and performance. `zcli` is the result of a long time iterating on these problems. Instead of >40MB binaries, you can build <1MB binaries. Instead of >150ms startup time (>300ms with any real content), you get <10ms on a command that **loads a file from disk**. [See the numbers here]($link.page('why').unsafeRef('numbers')).
+
+## Two principles
 
 There were two core design principles I decided on when architecting `zcli`:
 
 1. **Wherever possible, have only one way to do things**, and
-2. **Everything that _can_ be done at compile time _should_ be**.
+2. **Everything that _can_ be done at compile time should be**.
 
-Zig was a perfect language for this. Users can define a command tree, as complex as they want, and the router for it is automatically built, at comptime. This means a router doesn't need to be built and loaded when the CLI starts up. Arg and option parsing is determined at comptime. When an option is passed, it goes to machinery that was optimized at comptime exactly _for that option_. Using structs to define the inputs (args and options), we could specify _exactly_ what we want from the user, layering on top of Zig's powerful type system.
+Zig was a perfect language for this. You define a command tree, as complex as you want, and the router is automatically built at comptime. This means no router loading at runtime. Arg and option parsing is determined at comptime. When an option is passed, it goes to machinery that was optimized at comptime exactly for that option. No hash maps, no string dispatch - instead you get exact parsing code for the type you defined. Using structs to define the inputs (args and options), you can specify exactly what you want from your user, layering on top of Zig's powerful type system. Instead of diving deep here, I'll talk about this more in a follow-up post.
 
-Following the principle of a single way to do things led to choices that some may not agree with. That's fine, I completely understand, there were certain features I had to actively decide _against_ in order to keep the zcli patterns simple. For example, `Args` and `Options` must be defined if you define the `execute` function. If you don't it's not a runtime error, it's a _compile time_ error (core principle 2). To some, that may seem a bit heavy-handed, not being able to just import and use a struct from another file. (side note - you can still do that, you just have to specify `pub const Args = YourExternalType` so it's defined in your file). The benefits, to me, outweigh the slight cons. Having a structure that is followed consistently means less guessing. Errors are also much easier to design and can cleanly inform the user when something is wrong.
+Following the principle of a single way to do things led to choices that some may not agree with. That's fine, I completely understand: there were certain features I had to actively decide _against_ in order to keep the zcli patterns simple.
 
-I'm pretty happy with the result. I'm sure it's going to have some growing pains: being a batteries-included framework means there's a _lot_ of surface area, and with a lot of surface area, there will be issues. I feel confident in the structure, and building the `zcli` CLI on _top_ of this, as the first use case of the framework itself, has made me more confident.
+For example, `Args` and `Options` must be defined if you define the `execute` function. If you don't, it's not a runtime error, it's a _compile time_ error (core principle 2). To some, that may seem a bit heavy-handed, not being able to just import and use a struct from another file. (You can still do that, you just have to specify `pub const Args = YourExternalType` so it's defined in your file). The benefits, to me, outweigh the cost. Having a structure that is followed consistently means less guessing. Errors are also much easier to design and can cleanly inform the user when something is wrong.
 
-So, what does this look like in practice? Here's an example file:
+So, what does this look like in practice? Here's `src/commands/deploy.zig`:
 
 ```zig
+const Context = @import("command_registry").Context;
+
 pub const meta = .{ .description = "Deploy your application" };
+
 pub const Args = struct { service: []const u8 };
 pub const Options = struct { env: []const u8 = "development" };
 
-pub fn execute(args: Args, options: Options, context: anytype) !void {
+pub fn execute(args: Args, options: Options, context: *Context) !void {
     try context.stdout().print("Deploying {s} to {s}\n", .{ args.service, options.env });
 }
 ```
 
+Then run the following:
+
+```sh
+> zig build
+...
+> cd zig-out/bin
+> myapp deploy api --env production
+Deploying api to production
+```
+
+No registration, no router config, and `--help` comes free.
+
+I'm pretty happy with the result. I'm sure it's going to have some growing pains: being a batteries-included framework means there's a _lot_ of surface area, and with a lot of surface area, there will be issues. I feel confident in the structure, and building the `zcli` CLI on top of this, as the first use case of the framework itself, has made me more confident.
+
 ## [Enabling LLM generation]($heading.id('enabling-llm-generation'))
 
-One of my recent goals was to make it easier for LLM generation of CLIs. I understand people have _very strong opinions_ on this, and while I respect that, I want to make it easy for those who have a need for a CLI to be able to generate one cleanly. The benefit to following "one way to do things" _also_ leads to LLMs being able to more easily reason about and iterate on CLI code. Overall, zcli makes it surprisingly easy to get a small, portable CLI that does what you need, without disk space and memory bloat, and with about as snappy performance as possible.
+One of my recent goals was to make LLM generation of CLIs easier. People have very strong opinions here, and that's fine. I want to make it easy for those who have a need for a CLI to be able to generate one cleanly. The benefit to following "one way to do things" also leads to LLMs being able to more easily reason about and iterate on CLI code. For example, if the model hallucinates a field name, it's a build error, not a runtime surprise. I also gave LLMs _deterministic_ tooling to add, remove, and change args and options, which strengthens the external contract. When changes to args and options are guaranteed to be correct, and problems with the use of those args and options are a compile time problem, the agent can iterate quickly.
 
-zcli is MIT licensed, targets stable Zig 0.16.0, and the [comparison to zig-clap and zli]($link.page('why').unsafeRef('comparison')) is on the site if you're weighing options. Issues and PRs welcome on [GitHub](https://github.com/ryanhair/zcli).
+Overall, zcli makes it surprisingly easy to get a small, portable CLI that does what you need, without disk space and memory bloat, and about as snappy as possible.
+
+If this sounds interesting to you, [please try it!]($link.page('install')) zcli is MIT licensed, targets stable Zig 0.16.0, and the [comparison to zig-clap and zli]($link.page('why').unsafeRef('comparison')) is on the site if you're weighing options. Issues and PRs welcome on [GitHub](https://github.com/ryanhair/zcli).


### PR DESCRIPTION
## Summary

Editorial restructure of the launch post based on a full content review:

- **Cold open** — the post now says what zcli is (and that it's available today) before the personal history, reusing the folder-structure pitch from the meta description
- **Section headings** — "The JS tax" and "Two principles" break up the essay so it scans
- **Evidence** — real measured numbers (<1MB binaries vs >40MB, <10ms startup vs >150ms) with a link to /why/#numbers
- **Complete demo** — the code example now shows the filename (`src/commands/deploy.zig`), the canonical `command_registry` Context import, the invocation with its output, and the "no registration, no router config, `--help` comes free" payoff
- **LLM section substantiated** — hallucinated field names are build errors not runtime surprises; deterministic arg/option tooling keeps the external contract stable so agents can iterate
- **Install CTA** at the close, plus grammar/emphasis cleanup throughout

## Verification

- The code snippet was tested character-for-character: pasted into a fresh `zcli init myapp` scaffold, `zig build` succeeds, `myapp deploy api --env production` prints exactly the output shown in the post, and `myapp deploy --help` produces the generated help page
- `zig build release` in `website/` builds clean; spot-checked the rendered page

🤖 Generated with [Claude Code](https://claude.com/claude-code)