### PR TITLE
fix(theme)!: single default palette + writer-based style rendering

### DIFF
--- a/packages/progress/src/progress.zig
+++ b/packages/progress/src/progress.zig
@@ -213,9 +213,10 @@ pub fn Spinner(comptime WriterType: type) type {
             self.writer.writeAll(data) catch {};
         }
 
-        fn colorSequence(color: theme.Color) []const u8 {
+        /// Write the color's escape sequence; returns true if one was written
+        fn writeColor(self: *Self, color: theme.Color) bool {
             const style = theme.Style{ .foreground = color };
-            return style.sequenceForCapability(.ansi_16);
+            return style.writeSequence(self.writer, .ansi_16) catch false;
         }
 
         fn finishWithColor(self: *Self, symbol: []const u8, color: theme.Color, message: []const u8) void {
@@ -223,12 +224,9 @@ pub fn Spinner(comptime WriterType: type) type {
 
             if (self.is_tty) {
                 self.writeAll("\r\x1b[K"); // Clear line
-                const seq = colorSequence(color);
-                if (seq.len > 0) {
-                    self.writeAll(seq);
-                }
+                const wrote_color = self.writeColor(color);
                 self.writeAll(symbol);
-                if (seq.len > 0) {
+                if (wrote_color) {
                     self.writeAll("\x1b[0m");
                 }
                 self.writeAll(" ");
@@ -303,12 +301,9 @@ pub fn Spinner(comptime WriterType: type) type {
             self.writeAll(self.config.prefix);
 
             // Write colored spinner frame
-            const color_seq = colorSequence(self.config.color);
-            if (color_seq.len > 0) {
-                self.writeAll(color_seq);
-            }
+            const wrote_color = self.writeColor(self.config.color);
             self.writeAll(frame);
-            if (color_seq.len > 0) {
+            if (wrote_color) {
                 self.writeAll("\x1b[0m");
             }
 

--- a/packages/theme/src/adaptive/palettes.zig
+++ b/packages/theme/src/adaptive/palettes.zig
@@ -29,7 +29,8 @@ pub const RGB = struct {
     /// Convert to basic 16-color ANSI code (approximated)
     fn toAnsi16(comptime self: RGB) []const u8 {
         const ansi_code = comptime approximateRgbToAnsi16(self.r, self.g, self.b);
-        return comptime std.fmt.comptimePrint("\x1b[{d}m", .{30 + (ansi_code % 8)});
+        const sgr_code = if (ansi_code < 8) 30 + @as(u16, ansi_code) else 90 + @as(u16, ansi_code - 8);
+        return comptime std.fmt.comptimePrint("\x1b[{d}m", .{sgr_code});
     }
 
     /// Convert to 256-color ANSI code (approximated)
@@ -127,45 +128,28 @@ pub const SemanticPalette = struct {
     }
 };
 
-/// Get the color for a semantic role using our carefully designed palette
+/// Get the color for a semantic role using the default palette
 pub fn getSemanticColor(role: SemanticRole) Color {
     const rgb = getSemanticRGB(role);
     return rgb.toColor();
 }
 
-/// Get the RGB color for a semantic role using our carefully designed palette
+/// Get the RGB color for a semantic role using the default palette
 pub fn getSemanticRGB(role: SemanticRole) RGB {
-    return getPaletteColor(role);
-}
-
-/// Our carefully designed semantic color palette
-/// These colors are chosen to be vibrant, distinctive, and accessible
-fn getPaletteColor(role: SemanticRole) RGB {
-    return switch (role) {
-        // Core 5 - High contrast, WCAG AA compliant colors
-        .success => RGB{ .r = 76, .g = 217, .b = 100 }, // Bright green - universally recognized for success
-        .err => RGB{ .r = 255, .g = 105, .b = 97 }, // Bright coral red - stands out for errors
-        .warning => RGB{ .r = 255, .g = 206, .b = 84 }, // Bright amber - perfect for warnings
-        .info => RGB{ .r = 116, .g = 169, .b = 250 }, // Light blue - calm and informative
-        .muted => RGB{ .r = 156, .g = 163, .b = 175 }, // Subtle gray - for less important text
-
-        // CLI-specific roles
-        .command => RGB{ .r = 64, .g = 224, .b = 208 }, // Turquoise - distinctive for commands
-        .flag => RGB{ .r = 218, .g = 112, .b = 214 }, // Orchid - stands out for flags
-        .path => RGB{ .r = 100, .g = 221, .b = 221 }, // Light cyan - classic for file paths
-        .value => RGB{ .r = 124, .g = 252, .b = 0 }, // Lawn green - emphasizes values
-        .code => RGB{ .r = 168, .g = 136, .b = 248 }, // Purple - inline code snippets
-        .header => RGB{ .r = 255, .g = 255, .b = 255 }, // White - clean headers
-        .link => RGB{ .r = 135, .g = 206, .b = 250 }, // Light sky blue - traditional link color
-
-        // Hierarchy
-        .primary => RGB{ .r = 255, .g = 255, .b = 255 }, // White - primary content
-        .secondary => RGB{ .r = 189, .g = 189, .b = 189 }, // Light gray - secondary content
-        .accent => RGB{ .r = 0, .g = 255, .b = 255 }, // Cyan - brand/accent color
-    };
+    return (SemanticPalette{}).getColor(role);
 }
 
 const testing = std.testing;
+
+test "RGB toAnsi16 preserves bright colors" {
+    // Regression test: bright approximations (8-15) used to be folded back
+    // into the dim 30-37 range, losing the bright bit.
+    const bright = comptime (RGB{ .r = 76, .g = 217, .b = 100 }).toAnsi16(); // bright green
+    try testing.expectEqualStrings("\x1b[92m", bright);
+
+    const dim = comptime (RGB{ .r = 0, .g = 100, .b = 0 }).toAnsi16(); // dark green
+    try testing.expectEqualStrings("\x1b[32m", dim);
+}
 
 test "semantic color palette" {
     // Test semantic colors

--- a/packages/theme/src/adaptive/semantic.zig
+++ b/packages/theme/src/adaptive/semantic.zig
@@ -1,5 +1,3 @@
-const Color = @import("../core/color.zig").Color;
-
 /// Semantic roles for theming
 pub const SemanticRole = enum {
     // Core 5 - Most common CLI use cases
@@ -22,30 +20,6 @@ pub const SemanticRole = enum {
     primary, // Main content, most important
     secondary, // Supporting text, descriptions
     accent, // Brand highlights, emphasis
-
-    /// Get the default color for this semantic role
-    /// This is a simple mapping for now, will become adaptive later
-    pub fn getDefaultColor(self: SemanticRole) Color {
-        return switch (self) {
-            .success => .green,
-            .err => .red,
-            .warning => .yellow,
-            .info => .blue,
-            .muted => .bright_black, // Gray
-
-            .command => .bright_cyan,
-            .flag => .bright_magenta,
-            .path => .cyan,
-            .value => .bright_green,
-            .code => .bright_magenta,
-            .header => .bright_white,
-            .link => .bright_blue,
-
-            .primary => .white,
-            .secondary => .bright_white,
-            .accent => .bright_cyan,
-        };
-    }
 
     /// Get the style attributes for this semantic role
     /// Some roles may want bold, italic, etc. by default

--- a/packages/theme/src/api/fluent.zig
+++ b/packages/theme/src/api/fluent.zig
@@ -343,16 +343,8 @@ pub fn Themed(comptime T: type) type {
                 effective_style.foreground = palettes.getSemanticColor(role);
             }
 
-            // Generate appropriate escape sequence for terminal capability
-            const start_seq = effective_style.sequenceForCapability(capability);
-
-            // Debug: check what sequence we got
-            // std.debug.print("Start sequence: '{s}' (len={})\n", .{ start_seq, start_seq.len });
-
             // Apply starting style if any
-            if (start_seq.len > 0) {
-                try writer.writeAll(start_seq);
-            }
+            const wrote_style = try effective_style.writeSequence(writer, capability);
 
             // Write the actual content
             const ContentType = @TypeOf(self.content);
@@ -373,7 +365,7 @@ pub fn Themed(comptime T: type) type {
             }
 
             // Reset styling if we applied any
-            if (start_seq.len > 0) {
+            if (wrote_style) {
                 try writer.writeAll("\x1B[0m");
             }
         }
@@ -416,10 +408,10 @@ pub fn Themed(comptime T: type) type {
 
         /// Get the styled content as a string (requires allocator)
         pub fn toString(self: Self, allocator: std.mem.Allocator, theme_ctx: *const Theme) ![]u8 {
-            var list: std.ArrayList(u8) = .empty;
-            var aw_render: std.Io.Writer.Allocating = .init(allocator);
-            try self.render(&aw_render.writer, theme_ctx);
-            return list.toOwnedSlice(allocator);
+            var aw: std.Io.Writer.Allocating = .init(allocator);
+            defer aw.deinit();
+            try self.render(&aw.writer, theme_ctx);
+            return allocator.dupe(u8, aw.written());
         }
 
         /// Create a copy with different content but same styling
@@ -532,6 +524,17 @@ test "fluent API basics" {
     try theme("test").render(&aw.writer, &theme_ctx);
 
     try testing.expect(aw.writer.end >= 4); // At least "test"
+}
+
+test "toString returns the styled content" {
+    const testing = std.testing;
+
+    // Regression test: toString used to render into one writer but return the
+    // owned slice of a different, empty list — always producing "".
+    const theme_ctx = Theme{ .capability = .ansi_16, .is_tty = true, .color_enabled = true };
+    const result = try theme("hello").red().toString(testing.allocator, &theme_ctx);
+    defer testing.allocator.free(result);
+    try testing.expectEqualStrings("\x1B[31mhello\x1B[0m", result);
 }
 
 test "comprehensive color methods" {

--- a/packages/theme/src/core/style.zig
+++ b/packages/theme/src/core/style.zig
@@ -1,7 +1,7 @@
 //! Style definitions and ANSI escape sequence generation
 //!
 //! Combines colors and text decorations into complete styles that can
-//! generate optimal escape sequences at compile-time.
+//! generate escape sequences at runtime or compile-time.
 
 const std = @import("std");
 const Color = @import("color.zig").Color;
@@ -10,8 +10,9 @@ const toAnsi256 = @import("color.zig").toAnsi256;
 const parseHex = @import("color.zig").parseHex;
 const approximateRgbToAnsi16 = @import("color.zig").approximateRgbToAnsi16;
 const SemanticRole = @import("../adaptive/semantic.zig").SemanticRole;
+const TerminalCapability = @import("../detection/capability.zig").TerminalCapability;
 
-// Create runtime version of toAnsi16 for this module
+// Runtime version of toAnsi16 (color.zig's version requires comptime for hex parsing)
 fn toAnsi16Runtime(color: Color) u8 {
     return switch (color) {
         .black => 0,
@@ -39,8 +40,6 @@ fn toAnsi16Runtime(color: Color) u8 {
     };
 }
 
-const TerminalCapability = @import("../detection/capability.zig").TerminalCapability;
-
 /// Complete text styling information
 pub const Style = struct {
     // Core styling
@@ -54,20 +53,10 @@ pub const Style = struct {
     reverse: bool = false,
     semantic_role: ?SemanticRole = null, // For adaptive color adjustment
 
-    // Legacy aliases for backward compatibility
-    pub fn fg(self: Style) ?Color {
-        return self.foreground;
-    }
-
-    pub fn bg(self: Style) ?Color {
-        return self.background;
-    }
-
     /// Create a new style with the given modifications
     pub fn with(self: @This(), modifications: anytype) Style {
         var result = self;
 
-        // Simple approach for now - will make more sophisticated in Task 3
         const ModType = @TypeOf(modifications);
         const mod_info = @typeInfo(ModType);
 
@@ -82,66 +71,50 @@ pub const Style = struct {
         return result;
     }
 
-    /// Generate ANSI escape sequence for 16-color terminals (default)
-    pub fn sequence(self: @This()) []const u8 {
-        return self.sequenceForCapability(.ansi_16);
+    /// Whether this style emits any escape codes at the given capability
+    pub fn isVisible(self: @This(), capability: TerminalCapability) bool {
+        if (capability == .no_color) return false;
+        return self.bold or self.dim or self.italic or self.underline or
+            self.strikethrough or self.reverse or
+            self.foreground != null or self.background != null;
     }
 
-    /// Generate ANSI escape sequence for specific terminal capability
-    pub fn sequenceForCapability(self: @This(), capability: TerminalCapability) []const u8 {
-        if (capability == .no_color) {
-            return ""; // No color support
+    /// Write the ANSI escape sequence for this style to `writer`.
+    /// Returns true if a sequence was written, so callers know whether a
+    /// reset is needed after the styled content.
+    pub fn writeSequence(self: @This(), writer: anytype, capability: TerminalCapability) !bool {
+        if (!self.isVisible(capability)) return false;
+
+        try writer.writeAll("\x1B[");
+        var first = true;
+
+        const decorations = [_]struct { enabled: bool, code: []const u8 }{
+            .{ .enabled = self.bold, .code = "1" },
+            .{ .enabled = self.dim, .code = "2" },
+            .{ .enabled = self.italic, .code = "3" },
+            .{ .enabled = self.underline, .code = "4" },
+            .{ .enabled = self.strikethrough, .code = "9" },
+            .{ .enabled = self.reverse, .code = "7" },
+        };
+        for (decorations) |decoration| {
+            if (!decoration.enabled) continue;
+            if (!first) try writer.writeAll(";");
+            try writer.writeAll(decoration.code);
+            first = false;
         }
 
-        // Build sequence components
-        var seq_parts: [8][]const u8 = undefined;
-        var part_count: usize = 0;
-
-        // Add style codes first
-        if (self.bold) {
-            seq_parts[part_count] = "1";
-            part_count += 1;
+        if (self.foreground) |color| {
+            if (!first) try writer.writeAll(";");
+            try writeColorCode(writer, color, capability, true);
+            first = false;
         }
-        if (self.dim) {
-            seq_parts[part_count] = "2";
-            part_count += 1;
-        }
-        if (self.italic) {
-            seq_parts[part_count] = "3";
-            part_count += 1;
-        }
-        if (self.underline) {
-            seq_parts[part_count] = "4";
-            part_count += 1;
-        }
-        if (self.strikethrough) {
-            seq_parts[part_count] = "9";
-            part_count += 1;
-        }
-        if (self.reverse) {
-            seq_parts[part_count] = "7";
-            part_count += 1;
+        if (self.background) |color| {
+            if (!first) try writer.writeAll(";");
+            try writeColorCode(writer, color, capability, false);
         }
 
-        // Add foreground color
-        if (self.foreground) |fg_color| {
-            seq_parts[part_count] = generateColorCode(fg_color, capability, true);
-            part_count += 1;
-        }
-
-        // Add background color
-        if (self.background) |bg_color| {
-            seq_parts[part_count] = generateColorCode(bg_color, capability, false);
-            part_count += 1;
-        }
-
-        // If no styles, return empty
-        if (part_count == 0) {
-            return "";
-        }
-
-        // Build the complete sequence
-        return buildEscapeSequence(seq_parts[0..part_count]);
+        try writer.writeAll("m");
+        return true;
     }
 
     /// Generate compile-time optimized sequence (when style is known at compile-time)
@@ -202,39 +175,35 @@ pub const Style = struct {
     }
 };
 
-/// Generate ANSI color code for runtime use
-fn generateColorCode(color: Color, capability: TerminalCapability, is_foreground: bool) []const u8 {
-    const base_offset: u8 = if (is_foreground) 30 else 40;
-
+/// Write the ANSI color code (without the CSI prefix or trailing 'm') for `color`
+fn writeColorCode(writer: anytype, color: Color, capability: TerminalCapability, is_foreground: bool) !void {
     switch (capability) {
-        .no_color => return "",
+        .no_color => {},
         .ansi_16 => {
-            const color_idx = toAnsi16Runtime(color);
-            if (color_idx < 8) {
-                return formatU8(base_offset + color_idx);
+            const idx = toAnsi16Runtime(color);
+            if (idx < 8) {
+                const base: u8 = if (is_foreground) 30 else 40;
+                try writer.print("{d}", .{base + idx});
             } else {
                 // Bright colors use different codes
-                const bright_offset: u8 = if (is_foreground) 90 else 100;
-                return formatU8(bright_offset + (color_idx - 8));
+                const base: u8 = if (is_foreground) 90 else 100;
+                try writer.print("{d}", .{base + (idx - 8)});
             }
         },
         .ansi_256 => {
-            const color_idx = toAnsi256(color);
-            const color_type: u8 = if (is_foreground) 38 else 48;
-            return formatColorCode256(color_type, color_idx);
+            const selector: u8 = if (is_foreground) 38 else 48;
+            try writer.print("{d};5;{d}", .{ selector, toAnsi256(color) });
         },
         .true_color => {
+            const selector: u8 = if (is_foreground) 38 else 48;
             switch (color) {
-                .rgb => |rgb| {
-                    const color_type: u8 = if (is_foreground) 38 else 48;
-                    return formatColorCodeRgb(color_type, rgb.r, rgb.g, rgb.b);
+                .rgb => |rgb| try writer.print("{d};2;{d};{d};{d}", .{ selector, rgb.r, rgb.g, rgb.b }),
+                .hex => |hex_str| {
+                    const rgb = parseHex(hex_str);
+                    try writer.print("{d};2;{d};{d};{d}", .{ selector, rgb.r, rgb.g, rgb.b });
                 },
-                else => {
-                    // Fall back to 256-color for non-RGB colors
-                    const color_idx = toAnsi256(color);
-                    const color_type: u8 = if (is_foreground) 38 else 48;
-                    return formatColorCode256(color_type, color_idx);
-                },
+                // Fall back to 256-color for palette-based colors
+                else => try writer.print("{d};5;{d}", .{ selector, toAnsi256(color) }),
             }
         },
     }
@@ -250,229 +219,54 @@ fn generateColorCodeComptime(comptime color: Color, comptime capability: Termina
             .ansi_16 => {
                 const color_idx = toAnsi16(color);
                 if (color_idx < 8) {
-                    return formatU8Comptime(base_offset + color_idx);
+                    return std.fmt.comptimePrint("{d}", .{base_offset + color_idx});
                 } else {
                     // Bright colors use different codes
                     const bright_offset: u8 = if (is_foreground) 90 else 100;
-                    return formatU8Comptime(bright_offset + (color_idx - 8));
+                    return std.fmt.comptimePrint("{d}", .{bright_offset + (color_idx - 8)});
                 }
             },
             .ansi_256 => {
                 const color_idx = toAnsi256(color);
                 const color_type: u8 = if (is_foreground) 38 else 48;
-                return formatColorCode256Comptime(color_type, color_idx);
+                return std.fmt.comptimePrint("{d};5;{d}", .{ color_type, color_idx });
             },
             .true_color => {
+                const color_type: u8 = if (is_foreground) 38 else 48;
                 switch (color) {
-                    .rgb => |rgb| {
-                        const color_type: u8 = if (is_foreground) 38 else 48;
-                        return formatColorCodeRgbComptime(color_type, rgb.r, rgb.g, rgb.b);
+                    .rgb => |rgb| return std.fmt.comptimePrint("{d};2;{d};{d};{d}", .{ color_type, rgb.r, rgb.g, rgb.b }),
+                    .hex => |hex_str| {
+                        const rgb = parseHex(hex_str);
+                        return std.fmt.comptimePrint("{d};2;{d};{d};{d}", .{ color_type, rgb.r, rgb.g, rgb.b });
                     },
+                    // Fall back to 256-color for palette-based colors
                     else => {
-                        // Fall back to 256-color for non-RGB colors
                         const color_idx = toAnsi256(color);
-                        const color_type: u8 = if (is_foreground) 38 else 48;
-                        return formatColorCode256Comptime(color_type, color_idx);
+                        return std.fmt.comptimePrint("{d};5;{d}", .{ color_type, color_idx });
                     },
                 }
             },
         }
     }
-}
-
-// Thread-local static buffer for building sequences at runtime
-threadlocal var sequence_buffer: [64]u8 = undefined;
-
-/// Build complete escape sequence from parts (runtime)
-fn buildEscapeSequence(parts: []const []const u8) []const u8 {
-    if (parts.len == 0) return "";
-
-    // Calculate total length needed: "\x1B[" + parts with ";" + "m"
-    var total_len: usize = 3; // "\x1B[" (2) + "m" (1)
-    for (parts, 0..) |part, i| {
-        total_len += part.len;
-        if (i < parts.len - 1) total_len += 1; // semicolon
-    }
-
-    if (total_len > sequence_buffer.len) {
-        // Fallback for very long sequences
-        return "";
-    }
-
-    // Build the sequence in the thread-local buffer
-    sequence_buffer[0] = '\x1B';
-    sequence_buffer[1] = '[';
-    var pos: usize = 2;
-
-    for (parts, 0..) |part, i| {
-        // Copy the part
-        for (part) |c| {
-            sequence_buffer[pos] = c;
-            pos += 1;
-        }
-        // Add semicolon if not the last part
-        if (i < parts.len - 1) {
-            sequence_buffer[pos] = ';';
-            pos += 1;
-        }
-    }
-
-    sequence_buffer[pos] = 'm';
-    pos += 1;
-
-    // Return a slice of our thread-local buffer
-    return sequence_buffer[0..pos];
 }
 
 /// Build complete escape sequence from parts at compile-time
 fn buildEscapeSequenceComptime(comptime parts: []const []const u8) []const u8 {
     comptime {
         if (parts.len == 0) return "";
-        if (parts.len == 1) return "\x1B[" ++ parts[0] ++ "m";
-        if (parts.len == 2) return "\x1B[" ++ parts[0] ++ ";" ++ parts[1] ++ "m";
-        if (parts.len == 3) return "\x1B[" ++ parts[0] ++ ";" ++ parts[1] ++ ";" ++ parts[2] ++ "m";
 
-        // For more parts, just use the first three for now
-        return "\x1B[" ++ parts[0] ++ ";" ++ parts[1] ++ ";" ++ parts[2] ++ "m";
+        var seq: []const u8 = "\x1B[" ++ parts[0];
+        for (parts[1..]) |part| {
+            seq = seq ++ ";" ++ part;
+        }
+        return seq ++ "m";
     }
 }
 
-/// Format u8 as string (runtime - simplified with hardcoded values)
-fn formatU8(value: u8) []const u8 {
-    // Return hardcoded strings for common values
-    return switch (value) {
-        30 => "30",
-        31 => "31",
-        32 => "32",
-        33 => "33",
-        34 => "34",
-        35 => "35",
-        36 => "36",
-        37 => "37",
-        40 => "40",
-        41 => "41",
-        42 => "42",
-        43 => "43",
-        44 => "44",
-        45 => "45",
-        46 => "46",
-        47 => "47",
-        90 => "90",
-        91 => "91",
-        92 => "92",
-        93 => "93",
-        94 => "94",
-        95 => "95",
-        96 => "96",
-        97 => "97",
-        100 => "100",
-        101 => "101",
-        102 => "102",
-        103 => "103",
-        104 => "104",
-        105 => "105",
-        106 => "106",
-        107 => "107",
-        1 => "1",
-        2 => "2",
-        3 => "3",
-        4 => "4",
-        7 => "7",
-        9 => "9",
-        else => "0", // fallback
-    };
-}
-
-/// Format u8 as string at compile-time
-fn formatU8Comptime(comptime value: u8) []const u8 {
-    return comptime std.fmt.comptimePrint("{d}", .{value});
-}
-
-/// Format 256-color code (runtime)
-fn formatColorCode256(color_type: u8, color_idx: u8) []const u8 {
-    // Use hardcoded patterns for common cases to avoid allocation
-    return switch (color_type) {
-        38 => switch (color_idx) { // Foreground
-            0 => "38;5;0",
-            1 => "38;5;1",
-            2 => "38;5;2",
-            3 => "38;5;3",
-            4 => "38;5;4",
-            5 => "38;5;5",
-            6 => "38;5;6",
-            7 => "38;5;7",
-            8 => "38;5;8",
-            9 => "38;5;9",
-            10 => "38;5;10",
-            11 => "38;5;11",
-            12 => "38;5;12",
-            13 => "38;5;13",
-            14 => "38;5;14",
-            15 => "38;5;15",
-            16 => "38;5;16",
-            17 => "38;5;17",
-            18 => "38;5;18",
-            19 => "38;5;19",
-            20 => "38;5;20",
-            21 => "38;5;21",
-            42 => "38;5;42",
-            46 => "38;5;46",
-            93 => "38;5;93",
-            129 => "38;5;129",
-            196 => "38;5;196",
-            226 => "38;5;226",
-            else => "38;5;15", // Default to bright white
-        },
-        48 => switch (color_idx) { // Background
-            0 => "48;5;0",
-            1 => "48;5;1",
-            2 => "48;5;2",
-            3 => "48;5;3",
-            4 => "48;5;4",
-            5 => "48;5;5",
-            6 => "48;5;6",
-            7 => "48;5;7",
-            8 => "48;5;8",
-            9 => "48;5;9",
-            10 => "48;5;10",
-            11 => "48;5;11",
-            12 => "48;5;12",
-            13 => "48;5;13",
-            14 => "48;5;14",
-            15 => "48;5;15",
-            42 => "48;5;42",
-            46 => "48;5;46",
-            196 => "48;5;196",
-            226 => "48;5;226",
-            else => "48;5;0", // Default to black
-        },
-        else => "38;5;15", // Default fallback
-    };
-}
-
-/// Format 256-color code at compile-time
-fn formatColorCode256Comptime(comptime color_type: u8, comptime color_idx: u8) []const u8 {
-    return comptime std.fmt.comptimePrint("{d};5;{d}", .{ color_type, color_idx });
-}
-
-// Thread-local buffer for RGB color codes
-threadlocal var rgb_buffer: [20]u8 = undefined; // Enough for "38;2;255;255;255"
-
-/// Format RGB color code (runtime)
-fn formatColorCodeRgb(color_type: u8, r: u8, g: u8, b: u8) []const u8 {
-    // Build the RGB sequence dynamically in the thread-local buffer
-    const bytes_written = std.fmt.bufPrint(&rgb_buffer, "{d};2;{d};{d};{d}", .{ color_type, r, g, b }) catch |err| switch (err) {
-        error.NoSpaceLeft => {
-            // Fallback for very long sequences (should not happen)
-            return if (color_type == 38) "38;2;255;255;255" else "48;2;0;0;0";
-        },
-    };
-    return rgb_buffer[0..bytes_written.len];
-}
-
-/// Format RGB color code at compile-time
-fn formatColorCodeRgbComptime(comptime color_type: u8, comptime r: u8, comptime g: u8, comptime b: u8) []const u8 {
-    return comptime std.fmt.comptimePrint("{d};2;{d};{d};{d}", .{ color_type, r, g, b });
+fn sequenceToBuf(style: Style, capability: TerminalCapability, buf: []u8) ![]const u8 {
+    var writer: std.Io.Writer = .fixed(buf);
+    _ = try style.writeSequence(&writer, capability);
+    return writer.buffered();
 }
 
 test "style creation and modification" {
@@ -495,31 +289,57 @@ test "style creation and modification" {
 
 test "ANSI sequence generation for different capabilities" {
     const testing = std.testing;
+    var buf: [64]u8 = undefined;
 
     // Test basic bold style
     const bold_style = Style{ .bold = true };
-    try testing.expect(std.mem.eql(u8, bold_style.sequenceForCapability(.ansi_16), "\x1B[1m"));
-    try testing.expect(std.mem.eql(u8, bold_style.sequenceForCapability(.no_color), ""));
+    try testing.expectEqualStrings("\x1B[1m", try sequenceToBuf(bold_style, .ansi_16, &buf));
+    try testing.expectEqualStrings("", try sequenceToBuf(bold_style, .no_color, &buf));
 
     // Test red foreground
     const red_style = Style{ .foreground = Color.red };
-    try testing.expect(std.mem.eql(u8, red_style.sequenceForCapability(.ansi_16), "\x1B[31m"));
+    try testing.expectEqualStrings("\x1B[31m", try sequenceToBuf(red_style, .ansi_16, &buf));
 
     // Test bright red (should use 90+ codes)
     const bright_red_style = Style{ .foreground = Color.bright_red };
-    try testing.expect(std.mem.eql(u8, bright_red_style.sequenceForCapability(.ansi_16), "\x1B[91m"));
+    try testing.expectEqualStrings("\x1B[91m", try sequenceToBuf(bright_red_style, .ansi_16, &buf));
 
     // Test background color
     const bg_blue_style = Style{ .background = Color.blue };
-    try testing.expect(std.mem.eql(u8, bg_blue_style.sequenceForCapability(.ansi_16), "\x1B[44m"));
+    try testing.expectEqualStrings("\x1B[44m", try sequenceToBuf(bg_blue_style, .ansi_16, &buf));
 
     // Test combined styles
     const complex_style = Style{ .foreground = Color.red, .bold = true, .underline = true };
-    const seq = complex_style.sequenceForCapability(.ansi_16);
-    // Should contain all components: bold (1), underline (4), red (31)
-    try testing.expect(std.mem.indexOf(u8, seq, "1") != null);
-    try testing.expect(std.mem.indexOf(u8, seq, "4") != null);
-    try testing.expect(std.mem.indexOf(u8, seq, "31") != null);
+    try testing.expectEqualStrings("\x1B[1;4;31m", try sequenceToBuf(complex_style, .ansi_16, &buf));
+}
+
+test "writeSequence returns whether anything was written" {
+    const testing = std.testing;
+    var buf: [64]u8 = undefined;
+
+    const styled = Style{ .foreground = Color.red };
+    const plain = Style{};
+
+    var writer: std.Io.Writer = .fixed(&buf);
+    try testing.expect(try styled.writeSequence(&writer, .ansi_16));
+    try testing.expect(!try styled.writeSequence(&writer, .no_color));
+    try testing.expect(!try plain.writeSequence(&writer, .ansi_16));
+}
+
+test "sequential writes do not clobber each other" {
+    const testing = std.testing;
+
+    // Regression test: the old implementation returned slices of a shared
+    // threadlocal buffer, so a second call invalidated the first result.
+    var buf: [128]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buf);
+
+    const first = Style{ .foreground = Color{ .rgb = .{ .r = 1, .g = 2, .b = 3 } } };
+    const second = Style{ .foreground = Color{ .rgb = .{ .r = 4, .g = 5, .b = 6 } } };
+    _ = try first.writeSequence(&writer, .true_color);
+    _ = try second.writeSequence(&writer, .true_color);
+
+    try testing.expectEqualStrings("\x1B[38;2;1;2;3m\x1B[38;2;4;5;6m", writer.buffered());
 }
 
 test "compile-time sequence generation" {
@@ -528,35 +348,53 @@ test "compile-time sequence generation" {
     // Test compile-time generation
     const red_bold = Style{ .foreground = Color.red, .bold = true };
     const comptime_seq = comptime red_bold.sequenceComptime(.ansi_16);
+    try testing.expectEqualStrings("\x1B[1;31m", comptime_seq);
+}
 
-    // Should be a valid ANSI sequence
-    try testing.expect(std.mem.startsWith(u8, comptime_seq, "\x1B["));
-    try testing.expect(std.mem.endsWith(u8, comptime_seq, "m"));
-    try testing.expect(std.mem.indexOf(u8, comptime_seq, "1") != null); // bold
-    try testing.expect(std.mem.indexOf(u8, comptime_seq, "31") != null); // red
+test "compile-time sequence includes more than three parts" {
+    const testing = std.testing;
+
+    // Regression test: the old implementation silently dropped everything
+    // past the third part, losing e.g. the background color here.
+    const style = Style{ .foreground = Color.red, .background = Color.blue, .bold = true, .underline = true };
+    const seq = comptime style.sequenceComptime(.ansi_16);
+    try testing.expectEqualStrings("\x1B[1;4;31;44m", seq);
 }
 
 test "RGB and 256-color sequence generation" {
     const testing = std.testing;
+    var buf: [64]u8 = undefined;
 
     // Test RGB color in true color mode
     const rgb_style = Style{ .foreground = Color{ .rgb = .{ .r = 255, .g = 128, .b = 64 } } };
-    const rgb_seq = rgb_style.sequenceForCapability(.true_color);
-
-    // Should contain RGB values
-    try testing.expect(std.mem.indexOf(u8, rgb_seq, "255") != null);
-    try testing.expect(std.mem.indexOf(u8, rgb_seq, "128") != null);
-    try testing.expect(std.mem.indexOf(u8, rgb_seq, "64") != null);
-    try testing.expect(std.mem.indexOf(u8, rgb_seq, "38;2") != null); // True color foreground
+    try testing.expectEqualStrings("\x1B[38;2;255;128;64m", try sequenceToBuf(rgb_style, .true_color, &buf));
 
     // Test 256-color mode
-    const indexed_style = Style{ .foreground = Color{ .indexed = 196 } }; // Bright red in 256-color
-    const color256_seq = indexed_style.sequenceForCapability(.ansi_256);
-    try testing.expect(std.mem.indexOf(u8, color256_seq, "38;5;196") != null);
+    const indexed_style = Style{ .foreground = Color{ .indexed = 196 } };
+    try testing.expectEqualStrings("\x1B[38;5;196m", try sequenceToBuf(indexed_style, .ansi_256, &buf));
+
+    // Regression test: the old implementation only knew a hardcoded subset of
+    // indices and silently rendered everything else as bright white.
+    const arbitrary_indexed = Style{ .foreground = Color{ .indexed = 123 } };
+    try testing.expectEqualStrings("\x1B[38;5;123m", try sequenceToBuf(arbitrary_indexed, .ansi_256, &buf));
+    const arbitrary_indexed_bg = Style{ .background = Color{ .indexed = 201 } };
+    try testing.expectEqualStrings("\x1B[48;5;201m", try sequenceToBuf(arbitrary_indexed_bg, .ansi_256, &buf));
+}
+
+test "hex colors render as exact RGB in true color mode" {
+    const testing = std.testing;
+    var buf: [64]u8 = undefined;
+
+    const hex_style = Style{ .foreground = Color{ .hex = "#FF8040" } };
+    try testing.expectEqualStrings("\x1B[38;2;255;128;64m", try sequenceToBuf(hex_style, .true_color, &buf));
+
+    const comptime_seq = comptime (Style{ .foreground = Color{ .hex = "#FF8040" } }).sequenceComptime(.true_color);
+    try testing.expectEqualStrings("\x1B[38;2;255;128;64m", comptime_seq);
 }
 
 test "multiple text decorations" {
     const testing = std.testing;
+    var buf: [64]u8 = undefined;
 
     // Test all decorations together
     const decorated_style = Style{
@@ -566,13 +404,5 @@ test "multiple text decorations" {
         .strikethrough = true,
         .dim = true,
     };
-
-    const seq = decorated_style.sequenceForCapability(.ansi_16);
-
-    // Should contain all decoration codes
-    try testing.expect(std.mem.indexOf(u8, seq, "1") != null); // bold
-    try testing.expect(std.mem.indexOf(u8, seq, "2") != null); // dim
-    try testing.expect(std.mem.indexOf(u8, seq, "3") != null); // italic
-    try testing.expect(std.mem.indexOf(u8, seq, "4") != null); // underline
-    try testing.expect(std.mem.indexOf(u8, seq, "9") != null); // strikethrough
+    try testing.expectEqualStrings("\x1B[1;2;3;4;9m", try sequenceToBuf(decorated_style, .ansi_16, &buf));
 }


### PR DESCRIPTION
First PR of the theme-system plan (see analysis: theme is a text styler whose semantic layer has the theme hardcoded; this PR cleans the foundation before introducing a real `Theme` type).

## Bugs fixed
- **`Themed.toString` always returned `""`** — it rendered into one writer but returned the owned slice of a different, empty list.
- **Comptime sequences dropped parts past three** — `bold+underline+fg+bg` silently lost the background color.
- **Runtime 256-color table was partial** — unknown indices silently rendered as bright white.
- **Threadlocal-buffer aliasing** — runtime sequences were slices of a shared buffer; the next call invalidated the previous result.
- **`RGB.toAnsi16` lost the bright bit** — bright approximations (8–15) were folded back into the dim 30–37 range. Help output at `ansi_16` now uses bright variants where the palette color is bright.
- **Hex colors at `true_color`** now render as exact RGB instead of a 256-color approximation.

## Dedup / API cleanup (breaking)
- The default semantic colors were defined **three times** (`SemanticPalette` field defaults, `getPaletteColor`, `SemanticRole.getDefaultColor`). `SemanticPalette` field defaults are now the single source of truth; the other two are deleted (`getDefaultColor` had zero callers).
- `Style.sequence()`/`sequenceForCapability()` → `Style.writeSequence(writer, capability) -> bool`, which writes directly and reports whether a reset is needed. Threadlocal buffers and hardcoded lookup tables are gone. `sequenceComptime` stays (fixed).
- Removed the unused legacy `fg()`/`bg()` aliases.
- `progress` (the only external caller) migrated to `writeSequence`.

## Testing
- Regression tests added for every bug above (theme: 51 pass).
- Full sweep green: markdown 75, progress 10, prompts 56, core 1080, terminal 37, vterm 116, testing 39, zcli 58 unit + 28 e2e; tasks + vterm examples build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)