### PR TITLE
feat(help): themed help output from the app's zcli_theme palette

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -220,7 +220,7 @@ pub const Context = struct {
     allocator: std.mem.Allocator,        // arena-per-command (ADR-0001)
     io: std.Io,                          // the explicit-I/O entry point
     environ: *const std.process.Environ.Map,
-    theme: zcli.theme.Theme,            // capability-detected theming
+    theme: zcli.theme.ThemeContext,      // app theme + detected terminal capabilities
 
     // App metadata (filled by the registry)
     app_name: []const u8,

--- a/docs/adr/0012-theme-system.md
+++ b/docs/adr/0012-theme-system.md
@@ -1,0 +1,68 @@
+# Theme system: one app-level theme applied everywhere
+
+Status: accepted
+
+The `theme` package started as a text styler: a fluent API (`.red().bold()`),
+terminal capability detection, and a set of semantic roles (`success`,
+`command`, `flag`, ...) — but the palette behind those roles was hardcoded.
+`SemanticPalette` was a customizable struct that nothing accepted; the fluent
+API and the markdown formatter both resolved roles through a private default.
+Meanwhile prompts hardcoded its own ANSI colors (with no NO_COLOR support) and
+progress hardcoded `.ansi_16`. A CLI author had no way to say "my app's brand
+color is amber" and have help, prompts, and their own output follow.
+
+## Decision
+
+**A CLI declares one `Theme`, and every render path resolves through it.**
+
+The token hierarchy follows design-system practice:
+
+- **`Palette`** maps every semantic role to a complete `Style` — color *and*
+  attributes (errors are bold, links italic, muted is dim). The palette field
+  defaults are the single source of truth for the default look.
+- **`StyleRef`** is either a role reference or a literal style. Component
+  tokens — `PromptTheme` (cursor, selected, marker, hint) and `ProgressTheme`
+  (spinner, bar fill/empty) — default to role references, so one palette edit
+  flows through every component, while any single token can still be pinned.
+- **`Theme`** aggregates `{ palette, prompts, progress }`. **`ThemeContext`**
+  pairs a `*const Theme` with detected `Capabilities` (the struct previously
+  misnamed `Theme`) and is the one value render paths consume: it answers both
+  "what does this role look like" and "what can this terminal display".
+
+**Apps declare the theme in their root source file**, the `std_options` idiom:
+
+```zig
+pub const zcli_theme: zcli.Theme = .{
+    .palette = .{ .command = .{ .foreground = .{ .rgb = .{ .r = 255, .g = 179, .b = 71 } } } },
+};
+```
+
+`zcli.appTheme()` resolves it via `@import("root")` + `@hasDecl` with a default
+fallback. This needs no build wiring and no codegen serialization, and the
+theme is comptime-known — which preserves the zero-runtime-cost help pipeline:
+the help plugin hands the app's palette to the markdown formatter, which still
+compiles all four capability variants (no_color/16/256/truecolor) of every
+format string at comptime and selects one at runtime.
+
+**Semantic styling is resolved at render time, not at tag time.** The fluent
+API's `.success()` only tags a role; `render(writer, ctx)` resolves the role
+through the active palette and merges any explicit fluent settings on top
+(explicit settings win regardless of chain order). This is what makes a custom
+palette apply to code written before the theme existed.
+
+## Consequences
+
+- Help output is themed by the app palette (section headers render via the
+  `header` role; command/flag/argument names via their roles). Verified e2e:
+  a scaffolded project with a root `zcli_theme` renders help under a PTY in
+  the custom color, stays plain when piped, and honors NO_COLOR.
+- Prompts and progress adopt their component tokens in follow-up changes;
+  the schema ships with the Theme so the contract is stable.
+- Runtime theme *switching* (config file, `--theme` flag) is deliberately out
+  of scope: a comptime theme is what keeps help compilation zero-cost. If
+  demand appears, help rendering can move to the runtime formatting path.
+- Light/dark background adaptation (OSC 11) is future work; the palette
+  defaults assume a dark background, except `header`, which is attribute-only
+  (bold, no color) so it stays readable on any background.
+- The roles `primary`/`secondary` were dropped (unused, ambiguous); `accent`
+  is the brand hook component tokens reference by default.

--- a/examples/tasks/src/main.zig
+++ b/examples/tasks/src/main.zig
@@ -1,8 +1,18 @@
 const std = @import("std");
+const zcli = @import("zcli");
 const registry = @import("command_registry");
 
 pub const std_options: std.Options = .{
     .log_level = .warn,
+};
+
+/// The tasks brand: a warm amber for command names and highlights, applied
+/// everywhere — help output, prompts, and semantic styles.
+pub const zcli_theme: zcli.Theme = .{
+    .palette = .{
+        .command = .{ .foreground = .{ .rgb = .{ .r = 255, .g = 179, .b = 71 } } },
+        .accent = .{ .foreground = .{ .rgb = .{ .r = 255, .g = 179, .b = 71 } } },
+    },
 };
 
 pub fn main(init: std.process.Init) !void {

--- a/packages/core/src/plugins/zcli_help/plugin.zig
+++ b/packages/core/src/plugins/zcli_help/plugin.zig
@@ -2,6 +2,10 @@ const std = @import("std");
 const zcli = @import("zcli");
 const md = zcli.markdown;
 
+// The app's palette, resolved at comptime from the root `zcli_theme`
+// declaration, so help text compiles to the app's themed escape sequences.
+const app_palette = zcli.appTheme().palette;
+
 /// zcli-help Plugin
 ///
 /// Provides help functionality for CLI applications using the lifecycle hook plugin system.
@@ -138,7 +142,7 @@ pub fn onError(
 /// Unified help display function that handles all help scenarios
 fn showHelp(context: anytype, help_type: HelpType) !void {
     var writer = context.stderr();
-    var fmt = md.capabilityFormatter(writer, context.theme.capability());
+    var fmt = md.capabilityFormatterWithPalette(writer, context.theme.capability(), app_palette);
     const app_name = context.app_name;
     const app_version = context.app_version;
     const app_description = context.app_description;
@@ -172,7 +176,7 @@ fn showHelp(context: anytype, help_type: HelpType) !void {
     }
 
     // Show usage
-    try fmt.write("**USAGE:**\n", .{});
+    try fmt.write("<header>USAGE:</header>\n", .{});
     switch (help_type) {
         .app, .root => {
             if (help_type == .root) {
@@ -203,7 +207,7 @@ fn showHelp(context: anytype, help_type: HelpType) !void {
             if (module_info.has_args) {
                 if (generateArgsHelp(module_info, context) catch null) |args_help| {
                     defer context.allocator.free(args_help);
-                    try fmt.write("**ARGUMENTS:**\n", .{});
+                    try fmt.write("<header>ARGUMENTS:</header>\n", .{});
                     try writer.writeAll(args_help);
                     try writer.writeAll("\n");
                 }
@@ -217,7 +221,7 @@ fn showHelp(context: anytype, help_type: HelpType) !void {
             if (module_info.has_options) {
                 if (generateOptionsHelp(module_info, context) catch null) |options_help| {
                     defer context.allocator.free(options_help);
-                    try fmt.write("**OPTIONS:**\n", .{});
+                    try fmt.write("<header>OPTIONS:</header>\n", .{});
                     try writer.writeAll(options_help);
                     try fmt.write("    <flag>--help</flag>, <flag>-h</flag>{s:<6} Show this help message\n\n", .{""});
                 }
@@ -241,7 +245,7 @@ fn showHelp(context: anytype, help_type: HelpType) !void {
 
     // Show options (for non-root commands)
     if (help_type == .command) {
-        try fmt.write("**OPTIONS:**\n", .{});
+        try fmt.write("<header>OPTIONS:</header>\n", .{});
         if (context.command_module_info) |module_info| {
             if (module_info.has_options) {
                 if (generateOptionsHelp(module_info, context) catch null) |options_help| {
@@ -257,7 +261,7 @@ fn showHelp(context: anytype, help_type: HelpType) !void {
     if (help_type == .app or help_type == .root) {
         const global_opts = context.getGlobalOptions();
         if (global_opts.len > 0) {
-            try fmt.write("\n**GLOBAL OPTIONS:**\n", .{});
+            try fmt.write("\n<header>GLOBAL OPTIONS:</header>\n", .{});
             for (global_opts) |opt| {
                 if (opt.short) |short| {
                     try fmt.write("    <flag>-{c}</flag>, <flag>--{s}</flag>", .{ short, opt.name });
@@ -291,7 +295,7 @@ fn showHelp(context: anytype, help_type: HelpType) !void {
     // Show examples if available
     if ((help_type == .command or help_type == .root) and context.command_meta != null) {
         if (context.command_meta.?.examples) |examples| {
-            try fmt.write("\n**EXAMPLES:**\n", .{});
+            try fmt.write("\n<header>EXAMPLES:</header>\n", .{});
             for (examples) |example| {
                 try writer.print("    {s}\n", .{example});
             }
@@ -337,9 +341,9 @@ fn isAlias(name: []const u8, aliases: []const []const u8) bool {
 /// Show a list of commands (used by unified help function)
 fn showCommandList(context: anytype, fmt: anytype, list_type: CommandListType) !void {
     if (list_type == .top_level) {
-        try fmt.write("**COMMANDS:**\n", .{});
+        try fmt.write("<header>COMMANDS:</header>\n", .{});
     } else {
-        try fmt.write("**SUBCOMMANDS:**\n", .{});
+        try fmt.write("<header>SUBCOMMANDS:</header>\n", .{});
     }
 
     const command_infos = context.getAvailableCommandInfo();
@@ -530,7 +534,7 @@ fn generateUsage(context: anytype) ![]const u8 {
     var aw: std.Io.Writer.Allocating = .init(context.allocator);
     errdefer aw.deinit();
     const buf_writer = &aw.writer;
-    var fmt = md.capabilityFormatter(buf_writer, context.theme.capability());
+    var fmt = md.capabilityFormatterWithPalette(buf_writer, context.theme.capability(), app_palette);
 
     // Start with app name and command path
     try fmt.write("<command>{s}</command>", .{context.app_name});
@@ -642,7 +646,7 @@ fn showSubcommands(context: anytype, fmt: anytype) !void {
                 try displayed_names.append(context.allocator, display_name);
 
                 if (!has_commands) {
-                    try fmt.write("**COMMANDS:**\n", .{});
+                    try fmt.write("<header>COMMANDS:</header>\n", .{});
                     has_commands = true;
                 }
 
@@ -713,7 +717,7 @@ fn generateArgsHelp(module_info: zcli.CommandModuleInfo, context: anytype) !?[]u
     var aw: std.Io.Writer.Allocating = .init(context.allocator);
     errdefer aw.deinit();
     const buf_writer = &aw.writer;
-    var buf_fmt = md.capabilityFormatter(buf_writer, context.theme.capability());
+    var buf_fmt = md.capabilityFormatterWithPalette(buf_writer, context.theme.capability(), app_palette);
 
     // Generate basic help from field names
     for (module_info.args_fields) |field_info| {
@@ -732,7 +736,7 @@ fn generateOptionsHelp(module_info: zcli.CommandModuleInfo, context: anytype) !?
     var aw: std.Io.Writer.Allocating = .init(context.allocator);
     errdefer aw.deinit();
     const buf_writer = &aw.writer;
-    var buf_fmt = md.capabilityFormatter(buf_writer, context.theme.capability());
+    var buf_fmt = md.capabilityFormatterWithPalette(buf_writer, context.theme.capability(), app_palette);
 
     // Generate help from field info with metadata
     for (module_info.options_fields) |field_info| {

--- a/packages/markdown/src/renderers.zig
+++ b/packages/markdown/src/renderers.zig
@@ -261,8 +261,8 @@ test "render header" {
     const palette = semantic.Palette{};
     const result = comptime renderHeader(1, "Hello", palette, .true_color);
     try std.testing.expect(std.mem.indexOf(u8, result, "Hello") != null);
-    // The header role's full style (bold + white) is applied as one sequence
-    try std.testing.expect(std.mem.indexOf(u8, result, "\x1b[1;38;2;255;255;255m") != null);
+    // The header role's style (attribute-only bold by default) is applied
+    try std.testing.expect(std.mem.indexOf(u8, result, "\x1b[1m") != null);
 }
 
 test "render code block" {

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -1,293 +1,154 @@
 # theme
 
-A powerful, zero-cost CLI theming system for Zig. The `theme` package provides compile-time style generation, runtime terminal capability detection, and an intuitive fluent API for creating beautiful CLI output.
+A CLI design system for Zig. Define a `Theme` once — a palette mapping
+semantic roles to styles, plus component tokens — and every render path
+(help output, prompts, progress, your own commands) follows it, degrading
+gracefully from true color down to plain text.
 
 ## Features
 
-- **Fluent API**: Intuitive method chaining like `.red().bold().underline()`
-- **Zero-Cost Abstractions**: Styling computed at compile-time where possible
-- **Terminal Capability Detection**: Automatic detection of color support (16-color, 256-color, true color)
-- **Graceful Degradation**: Colors downgrade automatically for limited terminals
-- **Semantic Theming**: Meaningful roles like `.success()`, `.error()`, `.warning()` with accessible colors
-- **Type-Safe**: Generic `Themed(T)` interface works with any content type
-- **Cross-Platform**: Windows, macOS, and Linux terminal detection
+- **Semantic roles**: style by meaning — `.success()`, `.command()`, `.err()` —
+  and let the active palette decide what that looks like
+- **One theme, applied everywhere**: a zcli app declares `pub const zcli_theme`
+  in its root file; help, prompts, and progress pick it up automatically
+- **Component tokens**: prompt cursor, selection highlight, spinner color —
+  all reference palette roles by default, all individually overridable
+- **Terminal capability detection**: NO_COLOR, COLORTERM, TERM, and platform
+  signals; colors degrade true color → 256 → 16 → plain automatically
+- **Fluent API**: `styled("text").red().bold().underline()`
+- **Cross-platform**: Windows, macOS, and Linux terminal detection
 
-## Installation
+## Theming a zcli app
 
-Add theme to your `build.zig.zon`:
+Declare a theme in your app's root source file (next to `main`), the same way
+`std_options` works:
 
 ```zig
-.dependencies = .{
-    .theme = .{
-        .path = "path/to/theme",
+const zcli = @import("zcli");
+
+pub const zcli_theme: zcli.Theme = .{
+    .palette = .{
+        // Brand your CLI: command names in help, highlights, etc.
+        .command = .{ .foreground = .{ .rgb = .{ .r = 255, .g = 179, .b = 71 } } },
+        .accent = .{ .foreground = .{ .rgb = .{ .r = 255, .g = 179, .b = 71 } } },
     },
-},
+};
 ```
 
-In your `build.zig`:
+That's the whole integration: `--help` renders command names in your color,
+and every semantic style in your commands resolves through your palette.
+Inside a command, the ready-to-use handle is `context.theme`:
 
 ```zig
-const theme = b.dependency("theme", .{
-    .target = target,
-    .optimize = optimize,
-});
-exe.root_module.addImport("theme", theme.module("theme"));
-```
+const styled = zcli.theme.styled;
 
-## Quick Start
-
-```zig
-const std = @import("std");
-const theme = @import("theme");
-
-pub fn main(init: std.process.Init) !void {
-    const io = init.io;
-
-    var stdout_buf: [4096]u8 = undefined;
-    var stdout_writer = std.Io.File.stdout().writer(io, &stdout_buf);
-    const stdout = &stdout_writer.interface;
-
-    // Initialize theme context with automatic detection
-    const theme_ctx = theme.Theme.init(init.environ_map, io);
-
-    // Basic coloring
-    try theme.theme("Error: ").red().bold().render(stdout, &theme_ctx);
-    try stdout.print("Something went wrong\n", .{});
-
-    // Semantic styling
-    try theme.theme("Success!").success().render(stdout, &theme_ctx);
-    try stdout.writeAll("\n");
-
-    // RGB colors (true color terminals)
-    try theme.theme("Custom color").rgb(255, 100, 50).render(stdout, &theme_ctx);
-    try stdout.writeAll("\n");
-
-    // Background colors
-    try theme.theme("Highlighted").onYellow().black().render(stdout, &theme_ctx);
-    try stdout.writeAll("\n");
-
-    // Writers are buffered in Zig 0.16 — flush before exit.
-    try stdout.flush();
+pub fn execute(args: Args, options: Options, context: *Context) !void {
+    const out = context.stdout();
+    try styled("deploy complete").success().render(out, &context.theme);
+    try styled(args.host).value().render(out, &context.theme);
 }
 ```
 
-## API Reference
+## The pieces
 
-### Creating Themed Content
+### Palette: role → style
 
-```zig
-const styled = theme.theme("Your text");
-```
+Every semantic role maps to a full `Style` — color *and* attributes. The
+defaults are accessible colors on a dark background; `header` is
+attribute-only (bold) so it reads on any background.
 
-The `theme()` function accepts any content type and returns a `Themed(T)` wrapper.
+| Role | Default | | Role | Default |
+|------|---------|-|------|---------|
+| `success` | green, bold | | `command` | turquoise |
+| `err` | coral, bold | | `flag` | orchid |
+| `warning` | amber, bold | | `path` | light cyan |
+| `info` | blue, bold | | `value` | lawn green |
+| `muted` | gray, dim | | `code` | purple |
+| `header` | bold (no color) | | `link` | sky blue, italic |
+| `accent` | cyan | | | |
 
-### Foreground Colors
+### Component tokens
 
-**Basic Colors (ANSI 16)**
-```zig
-.black()    .red()      .green()    .yellow()
-.blue()     .magenta()  .cyan()     .white()
-```
-
-**Bright Colors**
-```zig
-.brightBlack()    .brightRed()      .brightGreen()    .brightYellow()
-.brightBlue()     .brightMagenta()  .brightCyan()     .brightWhite()
-```
-
-**Convenience Aliases**
-```zig
-.gray()   // Same as .brightBlack()
-.grey()   // Same as .brightBlack()
-```
-
-**Advanced Colors**
-```zig
-.rgb(255, 128, 64)    // True color RGB
-.hex("#FF8040")       // Hex color (compile-time only)
-.color256(196)        // 256-color palette index
-```
-
-### Background Colors
-
-All foreground colors have background equivalents prefixed with `on`:
+`Theme.prompts` and `Theme.progress` hold `StyleRef` tokens — each is either a
+role reference (the default) or a literal style:
 
 ```zig
-.onBlack()    .onRed()      .onGreen()    .onYellow()
-.onBlue()     .onMagenta()  .onCyan()     .onWhite()
-.onBrightBlack()  .onBrightRed()  // ... etc
-
-.onRgb(100, 150, 200)   // RGB background
-.onHex("#FF8040")       // Hex background (compile-time only)
-.onColor256(42)         // 256-color background
+pub const zcli_theme: zcli.Theme = .{
+    .palette = .{ .accent = .{ .foreground = .cyan } },
+    .prompts = .{
+        // Defaults shown: cursor/selected follow accent, marker follows
+        // success, hint follows muted. Pin any one independently:
+        .selected = .{ .style = .{ .foreground = .yellow, .bold = true } },
+    },
+};
 ```
 
-### Text Styles
+### ThemeContext: what render paths consume
+
+`ThemeContext` pairs the theme with detected terminal capabilities. zcli
+builds it for you as `context.theme`; standalone users build their own:
 
 ```zig
-.bold()           // Bold text
-.dim()            // Dimmed/faint text
-.italic()         // Italic text
-.underline()      // Underlined text
-.strikethrough()  // Strikethrough text
+const theme = @import("theme");
+
+const caps = theme.Capabilities.init(&environ_map, io);
+const ctx = theme.ThemeContext{ .caps = caps }; // default theme
+try theme.styled("ok").success().render(writer, &ctx);
 ```
 
-### Semantic Styling
+`Capabilities.init` honors `NO_COLOR`, `COLORTERM`, `TERM`, TTY-ness, and
+platform-specific signals (Windows Terminal, iTerm, Apple Terminal, VS Code).
 
-The `theme` package includes carefully designed semantic colors for common CLI patterns:
-
-**Core Roles**
-```zig
-.success()   // Green - successful operations
-.err()       // Red - errors and failures
-.warning()   // Yellow - warnings and cautions
-.info()      // Blue - informational messages
-.muted()     // Gray - less important text
-```
-
-**CLI-Specific Roles**
-```zig
-.command()   // Turquoise - command names
-.flag()      // Orchid - flags and options
-.path()      // Cyan - file paths
-.value()     // Green - user input/values
-.header()    // White - section headers
-.link()      // Light blue - URLs
-```
-
-### Rendering
-
-**Runtime Rendering**
-```zig
-// Render to any writer
-try styled.render(writer, &theme_ctx);
-
-// Get as allocated string
-const str = try styled.toString(allocator, &theme_ctx);
-defer allocator.free(str);
-```
-
-**Compile-Time Rendering**
-```zig
-const styled = comptime theme.theme("Optimized").red().bold();
-try styled.renderComptime(writer, .ansi_16);
-```
-
-### Method Chaining
-
-All methods return a new `Themed` instance, enabling fluent chaining:
+## Fluent styling
 
 ```zig
-const styled = theme.theme("Critical Error!")
-    .brightRed()
-    .onWhite()
-    .bold()
-    .underline();
+const styled = theme.styled;
+
+// Colors and attributes
+try styled("Error").red().bold().render(w, &ctx);
+try styled("Custom").rgb(255, 100, 50).underline().render(w, &ctx);
+try styled("Warning").onYellow().black().render(w, &ctx);
+
+// Semantic roles — resolved through ctx's palette at render time
+try styled("Build passed").success().render(w, &ctx);
+try styled("git commit").command().render(w, &ctx);
+
+// Roles and explicit settings compose; explicit wins
+try styled("important").err().underline().render(w, &ctx);
+
+// Any content type
+try styled(@as(u32, 42)).value().render(w, &ctx);
 ```
 
-### Utility Methods
+Semantic methods only *tag* the value with a role; the role is resolved
+against the active palette when `render` runs. That's what lets one theme
+restyle code that was written long before the theme existed.
+
+## Degradation
+
+A palette color is emitted at the terminal's actual capability:
+
+| Capability | `rgb(255, 105, 97)` renders as |
+|------------|--------------------------------|
+| `true_color` | `38;2;255;105;97` (exact) |
+| `ansi_256` | nearest 256-palette index |
+| `ansi_16` | nearest of the 16 ANSI colors |
+| `no_color` | nothing (plain text) |
+
+## Standalone installation
+
+The package is self-contained (it ships inside zcli but has no dependency on
+it). Add it to `build.zig.zon` and import module `theme`:
 
 ```zig
-.reset()                    // Remove all styling
-.hasStyle()                 // Check if any styling is applied
-.clone()                    // Clone the styled content
-.withContent(new_content)   // New content with same styling
+.dependencies = .{
+    .theme = .{ .path = "path/to/packages/theme" },
+},
 ```
 
-## Terminal Capability Detection
+## Design notes
 
-The `theme` package automatically detects terminal capabilities:
-
-In a zcli command you already have one: `context.theme`. Standalone:
-
-```zig
-const theme_ctx = theme.Theme.init(init.environ_map, io);
-
-// Check capabilities
-if (theme_ctx.supportsColor()) { ... }
-if (theme_ctx.supports256Color()) { ... }
-if (theme_ctx.supportsTrueColor()) { ... }
-
-// Get capability as string (for debugging)
-std.debug.print("Terminal: {s}\n", .{theme_ctx.capabilityString()});
-```
-
-### Capability Levels
-
-| Level | Description | Colors |
-|-------|-------------|--------|
-| `no_color` | No color support | Plain text only |
-| `ansi_16` | Basic ANSI | 16 colors |
-| `ansi_256` | Extended palette | 256 colors |
-| `true_color` | Full RGB | 16.7 million colors |
-
-### Manual Capability Override
-
-```zig
-// Force specific capability
-const theme_ctx = theme.Theme.initWithCapability(.true_color, io);
-
-// Force color output (override TTY detection)
-const theme_ctx = theme.Theme.initForced(init.environ_map, io, true);
-```
-
-### Environment Detection
-
-The `theme` package respects standard environment variables:
-
-- `NO_COLOR` - Disables all color output
-- `COLORTERM=truecolor` or `COLORTERM=24bit` - Enables true color
-- `TERM` - Terminal type detection (xterm-256color, etc.)
-- `TERM_PROGRAM` - Specific terminal detection (iTerm2, VS Code, etc.)
-- `WT_SESSION` - Windows Terminal detection
-
-## Color Conversion
-
-The `theme` package automatically converts colors for terminal capability:
-
-- True color terminals: Full RGB values
-- 256-color terminals: Nearest palette match
-- 16-color terminals: Smart approximation to closest ANSI color
-
-```zig
-// This RGB color will automatically adapt:
-// - True color: exact RGB(255, 100, 50)
-// - 256-color: closest palette index
-// - 16-color: approximated to red or yellow
-try theme.theme("Adaptive").rgb(255, 100, 50).render(writer, &theme_ctx);
-```
-
-## Semantic Color Palette
-
-The semantic colors use carefully designed RGB values for accessibility:
-
-| Role | RGB | Description |
-|------|-----|-------------|
-| success | `76, 217, 100` | Bright green |
-| err | `255, 105, 97` | Coral red |
-| warning | `255, 206, 84` | Bright amber |
-| info | `116, 169, 250` | Light blue |
-| muted | `156, 163, 175` | Subtle gray |
-| command | `64, 224, 208` | Turquoise |
-| flag | `218, 112, 214` | Orchid |
-| path | `100, 221, 221` | Light cyan |
-| value | `124, 252, 0` | Lawn green |
-| header | `255, 255, 255` | White |
-| link | `135, 206, 250` | Light sky blue |
-
-## Testing
-
-Run the test suite:
-
-```bash
-cd packages/theme
-zig build test
-```
-
-## Examples
-
-See [examples/tasks](../../examples/tasks/) — its commands use theme's semantic roles throughout (via `context.theme`).
-
-## License
-
-MIT License - See LICENSE file for details.
+See `docs/adr/0012-theme-system.md` in the repository root for the full
+rationale: the token hierarchy, the root-declaration idiom, why the theme is
+comptime-known (zero-cost themed help), and what's deliberately deferred
+(runtime theme switching, light/dark adaptation).

--- a/packages/theme/src/definition.zig
+++ b/packages/theme/src/definition.zig
@@ -46,7 +46,9 @@ pub const Palette = struct {
     path: Style = .{ .foreground = .{ .rgb = .{ .r = 100, .g = 221, .b = 221 } } },
     value: Style = .{ .foreground = .{ .rgb = .{ .r = 124, .g = 252, .b = 0 } } },
     code: Style = .{ .foreground = .{ .rgb = .{ .r = 168, .g = 136, .b = 248 } } },
-    header: Style = .{ .foreground = .{ .rgb = .{ .r = 255, .g = 255, .b = 255 } }, .bold = true },
+    // Attribute-only (no foreground): headers stay readable on light and dark
+    // backgrounds alike, matching how plain bold section headers behave.
+    header: Style = .{ .bold = true },
     link: Style = .{ .foreground = .{ .rgb = .{ .r = 135, .g = 206, .b = 250 } }, .italic = true },
     accent: Style = .{ .foreground = .{ .rgb = .{ .r = 0, .g = 255, .b = 255 } } },
 
@@ -128,7 +130,7 @@ test "palette get returns the field for every role" {
         const role = @field(SemanticRole, field.name);
         const style = palette.get(role);
         try testing.expect(std.meta.eql(style, @field(palette, field.name)));
-        try testing.expect(style.foreground != null);
+        try testing.expect(style.isVisible(.true_color));
     }
 }
 

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -1031,6 +1031,11 @@ test "root zcli_theme declaration themes help output" {
         try testing.expect(std.mem.indexOf(u8, r.stderr, "\x1b[") == null);
     }
 
+    // The PTY harness needs an absolute binary path: ConPTY's CreateProcessW
+    // resolves a relative command-line path against the parent's cwd, not the
+    // child's `cwd`.
+    const demo_abs = try std.fs.path.join(a, &.{ proj_abs, "zig-out", "bin", "demo" ++ exe_ext });
+
     // Under a PTY in a truecolor-capable environment, help renders command
     // names in the custom palette color.
     {
@@ -1039,6 +1044,10 @@ test "root zcli_theme declaration themes help output" {
         try env.put("TERM", "xterm-256color");
         try env.put("COLORTERM", "truecolor"); // truecolor signal (POSIX)
         try env.put("WT_SESSION", "1"); // truecolor signal (Windows/ConPTY)
+        // A replaced environment must still carry SystemRoot on Windows —
+        // process startup and console plumbing consult it, and dropping it is
+        // a classic source of child-process failures.
+        if (builtin.os.tag == .windows) try env.put("SystemRoot", "C:\\Windows");
 
         var script = harness.InteractiveScript.init(testing.allocator);
         defer script.deinit();
@@ -1047,7 +1056,7 @@ test "root zcli_theme declaration themes help output" {
         var result = harness.runInteractive(
             testing.allocator,
             io,
-            &.{ demo_bin, "--help" },
+            &.{ demo_abs, "--help" },
             script,
             .{ .cwd = proj_abs, .allocate_pty = true, .total_timeout_ms = 20000, .env = env },
         ) catch |err| switch (err) {
@@ -1072,6 +1081,7 @@ test "root zcli_theme declaration themes help output" {
         try env.put("COLORTERM", "truecolor");
         try env.put("WT_SESSION", "1");
         try env.put("NO_COLOR", "1");
+        if (builtin.os.tag == .windows) try env.put("SystemRoot", "C:\\Windows");
 
         var script = harness.InteractiveScript.init(testing.allocator);
         defer script.deinit();
@@ -1080,7 +1090,7 @@ test "root zcli_theme declaration themes help output" {
         var result = harness.runInteractive(
             testing.allocator,
             io,
-            &.{ demo_bin, "--help" },
+            &.{ demo_abs, "--help" },
             script,
             .{ .cwd = proj_abs, .allocate_pty = true, .total_timeout_ms = 20000, .env = env },
         ) catch |err| switch (err) {

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -984,6 +984,117 @@ test "scaffolded project builds, runs, and round-trips add command" {
     }
 }
 
+test "root zcli_theme declaration themes help output" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    {
+        var r = try run(tmp.dir, &.{ zcli_exe, "init", "demo" });
+        defer r.deinit();
+        try expectOk(r);
+    }
+
+    var proj = try tmp.dir.openDir(io, "demo", .{});
+    defer proj.close(io);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const proj_abs = try tmpSubdirAbs(a, tmp, "demo");
+    try pointDependencyAtLocalTree(proj, proj_abs);
+
+    // Declare a custom theme in the app root — the std_options-style hook.
+    // Command names in help should render in this color (tomato, 255;99;71).
+    try replaceInFile(proj, a, "src/main.zig",
+        \\const registry = @import("command_registry");
+    ,
+        \\const registry = @import("command_registry");
+        \\const zcli = @import("zcli");
+        \\
+        \\pub const zcli_theme: zcli.Theme = .{
+        \\    .palette = .{ .command = .{ .foreground = .{ .rgb = .{ .r = 255, .g = 99, .b = 71 } } } },
+        \\};
+    );
+
+    {
+        var r = try run(proj, &.{ "zig", "build" });
+        defer r.deinit();
+        try expectOk(r);
+    }
+
+    // Piped (non-TTY) output stays completely plain.
+    {
+        var r = try run(proj, &.{ demo_bin, "--help" });
+        defer r.deinit();
+        try expectOk(r);
+        try expectContains(r.stderr, "hello");
+        try testing.expect(std.mem.indexOf(u8, r.stderr, "\x1b[") == null);
+    }
+
+    // Under a PTY in a truecolor-capable environment, help renders command
+    // names in the custom palette color.
+    {
+        var env = std.process.Environ.Map.init(testing.allocator);
+        defer env.deinit();
+        try env.put("TERM", "xterm-256color");
+        try env.put("COLORTERM", "truecolor"); // truecolor signal (POSIX)
+        try env.put("WT_SESSION", "1"); // truecolor signal (Windows/ConPTY)
+
+        var script = harness.InteractiveScript.init(testing.allocator);
+        defer script.deinit();
+        _ = script.expect("USAGE:");
+
+        var result = harness.runInteractive(
+            testing.allocator,
+            io,
+            &.{ demo_bin, "--help" },
+            script,
+            .{ .cwd = proj_abs, .allocate_pty = true, .total_timeout_ms = 20000, .env = env },
+        ) catch |err| switch (err) {
+            // PTY allocation can be denied in some sandboxes; skip rather than
+            // fail (CI greps the log for this line and fails if the tier
+            // silently skipped).
+            error.PtyAllocationFailed => {
+                std.debug.print("runInteractive unavailable: {any}\n", .{err});
+                return;
+            },
+            else => return err,
+        };
+        defer result.deinit();
+        try expectContains(result.output, "38;2;255;99;71");
+    }
+
+    // NO_COLOR wins even on a color-capable PTY.
+    {
+        var env = std.process.Environ.Map.init(testing.allocator);
+        defer env.deinit();
+        try env.put("TERM", "xterm-256color");
+        try env.put("COLORTERM", "truecolor");
+        try env.put("WT_SESSION", "1");
+        try env.put("NO_COLOR", "1");
+
+        var script = harness.InteractiveScript.init(testing.allocator);
+        defer script.deinit();
+        _ = script.expect("USAGE:");
+
+        var result = harness.runInteractive(
+            testing.allocator,
+            io,
+            &.{ demo_bin, "--help" },
+            script,
+            .{ .cwd = proj_abs, .allocate_pty = true, .total_timeout_ms = 20000, .env = env },
+        ) catch |err| switch (err) {
+            error.PtyAllocationFailed => {
+                std.debug.print("runInteractive unavailable: {any}\n", .{err});
+                return;
+            },
+            else => return err,
+        };
+        defer result.deinit();
+        try testing.expect(std.mem.indexOf(u8, result.output, "\x1b[") == null);
+    }
+}
+
 test "scaffolded commands are unit-testable via zig build test" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -1101,7 +1101,11 @@ test "root zcli_theme declaration themes help output" {
             else => return err,
         };
         defer result.deinit();
-        try testing.expect(std.mem.indexOf(u8, result.output, "\x1b[") == null);
+        // Assert the theme's color is gone, not that the stream has zero
+        // escapes: ConPTY re-renders child output as VT screen-diff frames
+        // (cursor, positioning, resets), so escape-free PTY output is
+        // impossible on Windows even when the child writes plain text.
+        try testing.expect(std.mem.indexOf(u8, result.output, "38;2;255;99;71") == null);
     }
 }
 


### PR DESCRIPTION
PR 3 of the theme-system plan: the app-level theme flows into help output, completing the "define a theme once, applied everywhere" loop for help.

## Changes
- **Help plugin** resolves the app palette at comptime (`zcli.appTheme().palette`) and hands it to `capabilityFormatterWithPalette` — help text still compiles all four capability variants at comptime, now in the app's colors.
- **Section headers** switch from raw `**bold**` markdown to `<header>` tags so `palette.header` governs them. The `header` role default becomes **attribute-only** (bold, no foreground): identical to the old look, and readable on light *and* dark backgrounds.
- **Dogfood**: the tasks example declares a `zcli_theme` (warm amber command/accent) — its `--help` renders amber command names over the default orchid flags:

  Verified under a PTY: `38;2;255;179;71` on every command name, default turquoise absent, headers `\x1b[1m`.
- **e2e** (new slow-tier test): scaffolds a project, injects a root `zcli_theme` via `replaceInFile`, builds it, and asserts:
  - help under a truecolor PTY contains the exact custom color bytes (`38;2;255;99;71`)
  - piped output has zero escape codes
  - `NO_COLOR` wins even on a color-capable PTY

  Works on both the POSIX PTY and Windows ConPTY harnesses (truecolor signaled via `COLORTERM` + `WT_SESSION`).
- **Docs**: ADR-0012 (token hierarchy, root-declaration idiom, why comptime, deferred work), theme README rewritten for the design-system API, DESIGN.md context sketch synced.

## Testing
Full sweep green: theme 43, markdown 75, core 1080, prompts 56, progress 10, terminal 37, vterm 116, testing 39; zcli 58 unit + **29 e2e** (28 + new themed-help test, PTY tier confirmed running, not skipped); tasks + vterm examples build.

Next: PR 4 routes prompts through `PromptTheme` tokens (which also gives prompts NO_COLOR/capability handling for free).

🤖 Generated with [Claude Code](https://claude.com/claude-code)