### PR TITLE
feat(prompts): style prompts through the theme's component tokens

### DIFF
--- a/examples/tasks/src/commands/add.zig
+++ b/examples/tasks/src/commands/add.zig
@@ -57,6 +57,7 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         const priority_idx = try prompts.select(writer, reader, .{
             .message = "Priority:",
             .choices = &.{ "low", "medium", "high", "critical" },
+            .theme = context.theme,
         });
         priority = switch (priority_idx) {
             0 => .low,

--- a/examples/tasks/src/commands/config.zig
+++ b/examples/tasks/src/commands/config.zig
@@ -59,6 +59,7 @@ pub fn execute(_: Args, _: Options, context: *Context) !void {
     const priority_idx = try prompts.select(writer, reader, .{
         .message = "Default priority for new tasks:",
         .choices = &priorities,
+        .theme = context.theme,
     });
 
     const points = try prompts.number(writer, reader, .{

--- a/examples/tasks/src/commands/init.zig
+++ b/examples/tasks/src/commands/init.zig
@@ -42,6 +42,7 @@ pub fn execute(_: Args, _: Options, context: *Context) !void {
     const method_idx = try prompts.select(writer, reader, .{
         .message = "Methodology:",
         .choices = &.{ "Kanban", "Scrum", "None" },
+        .theme = context.theme,
     });
     _ = method_idx;
 

--- a/examples/tasks/src/commands/sprint/close.zig
+++ b/examples/tasks/src/commands/sprint/close.zig
@@ -30,6 +30,7 @@ pub fn execute(_: Args, _: Options, context: *Context) !void {
     const idx = try prompts.select(writer, reader, .{
         .message = "Close which sprint?",
         .choices = data.sprints,
+        .theme = context.theme,
     });
 
     const name = data.sprints[idx];

--- a/packages/prompts/src/editor.zig
+++ b/packages/prompts/src/editor.zig
@@ -11,6 +11,8 @@ pub const EditorConfig = struct {
     prefix: []const u8 = "? ",
     editor_cmd: []const u8 = "vi",
     io: std.Io,
+    /// Theme + terminal capabilities for styling; zcli commands pass `context.theme`.
+    theme: prompts.theme.ThemeContext = prompts.default_style,
 };
 
 /// Launch the user's editor for multiline input. Returns owned string.
@@ -34,7 +36,9 @@ pub fn editor(writer: anytype, reader: anytype, allocator: std.mem.Allocator, co
         return try buf.toOwnedSlice(allocator);
     }
 
-    try writer.writeAll(" \x1b[2m(press Enter to open editor)\x1b[0m ");
+    var obuf: [64]u8 = undefined;
+    const open = prompts.openSeq(&obuf, config.theme, config.theme.promptTokens().hint);
+    try writer.print(" {s}(press Enter to open editor){s} ", .{ open, prompts.closeSeq(open) });
     prompts.flushWriter(writer);
 
     // Wait for Enter in raw mode

--- a/packages/prompts/src/multi_select.zig
+++ b/packages/prompts/src/multi_select.zig
@@ -11,6 +11,8 @@ pub const MultiSelectConfig = struct {
     defaults: ?[]const bool = null,
     prefix: []const u8 = "? ",
     unicode: bool = true,
+    /// Theme + terminal capabilities for styling; zcli commands pass `context.theme`.
+    theme: prompts.theme.ThemeContext = prompts.default_style,
 };
 
 /// Prompt to select multiple items. Returns owned slice of selected indices.
@@ -102,7 +104,9 @@ pub fn multiSelect(writer: anytype, reader: anytype, allocator: std.mem.Allocato
                     try lr.eraseRegion(writer, rows);
                     // Show summary
                     var first = true;
-                    try writer.writeAll("  \x1b[36m");
+                    var obuf: [64]u8 = undefined;
+                    const open = prompts.openSeq(&obuf, config.theme, config.theme.promptTokens().selected);
+                    try writer.print("  {s}", .{open});
                     for (config.choices, 0..) |choice, i| {
                         if (selected[i]) {
                             if (!first) try writer.writeAll(", ");
@@ -110,7 +114,7 @@ pub fn multiSelect(writer: anytype, reader: anytype, allocator: std.mem.Allocato
                             first = false;
                         }
                     }
-                    try writer.writeAll("\x1b[0m\r\n");
+                    try writer.print("{s}\r\n", .{prompts.closeSeq(open)});
 
                     // Collect selected indices
                     var result = std.ArrayList(usize).empty;
@@ -186,19 +190,26 @@ pub fn renderList(
     const list_budget = @max((height -| 1) -| rows, 1);
     const win = lr.viewport(config.choices.len, cursor, list_budget, &counter, Counter.at);
 
+    const tokens = config.theme.promptTokens();
     for (win.start..win.end) |i| {
         const marker = if (selected[i]) sel_sym else unsel_sym;
-        var pbuf: [64]u8 = undefined;
-        const style: lr.ItemStyle = if (i == cursor)
-            .{
-                .first_prefix = std.fmt.bufPrint(&pbuf, "  \x1b[36m{s}\x1b[0m \x1b[32m{s}\x1b[0m ", .{ cursor_sym, marker }) catch "  ",
-                .prefix_w = prefix_w,
-            }
-        else
-            .{
-                .first_prefix = std.fmt.bufPrint(&pbuf, "    {s} ", .{marker}) catch "    ",
+        var pbuf: [192]u8 = undefined;
+        var cbuf: [64]u8 = undefined;
+        var mbuf: [64]u8 = undefined;
+        const style: lr.ItemStyle = if (i == cursor) blk: {
+            const cur_open = prompts.openSeq(&cbuf, config.theme, tokens.cursor);
+            const mark_open = prompts.openSeq(&mbuf, config.theme, tokens.marker);
+            break :blk .{
+                .first_prefix = std.fmt.bufPrint(&pbuf, "  {s}{s}{s} {s}{s}{s} ", .{
+                    cur_open,  cursor_sym, prompts.closeSeq(cur_open),
+                    mark_open, marker,     prompts.closeSeq(mark_open),
+                }) catch "  ",
                 .prefix_w = prefix_w,
             };
+        } else .{
+            .first_prefix = std.fmt.bufPrint(&pbuf, "    {s} ", .{marker}) catch "    ",
+            .prefix_w = prefix_w,
+        };
         rows += try lr.renderItem(writer, &first_line, style, config.choices[i], avail);
     }
 
@@ -313,6 +324,32 @@ test "renderList: a wrapping option counts as multiple physical rows" {
     // Row count must equal the number of CRLF-separated lines actually emitted.
     const lines = std.mem.count(u8, r.text, "\r\n") + 1;
     try std.testing.expectEqual(lines, r.rows);
+}
+
+test "renderList: cursor row styles through the cursor and marker tokens" {
+    var buf: [1024]u8 = undefined;
+    const custom = prompts.theme.Theme{
+        .prompts = .{
+            .cursor = .{ .style = .{ .foreground = .{ .rgb = .{ .r = 9, .g = 8, .b = 7 } } } },
+            .marker = .{ .style = .{ .foreground = .{ .rgb = .{ .r = 4, .g = 5, .b = 6 } } } },
+        },
+    };
+    const ctx = prompts.theme.ThemeContext{
+        .theme = &custom,
+        .caps = .{ .capability = .true_color, .is_tty = true, .color_enabled = true },
+    };
+    const r = try renderToBuf(&buf, .{ .message = "Pick", .choices = &.{ "a", "b" }, .theme = ctx }, &.{ true, false }, 0, .{ .row = 24, .col = 80 });
+    try std.testing.expect(std.mem.indexOf(u8, r.text, "38;2;9;8;7") != null); // cursor glyph
+    try std.testing.expect(std.mem.indexOf(u8, r.text, "38;2;4;5;6") != null); // marker
+}
+
+test "renderList: no_color renders without any escapes" {
+    var buf: [1024]u8 = undefined;
+    const ctx = prompts.theme.ThemeContext{
+        .caps = .{ .capability = .no_color, .is_tty = true, .color_enabled = false },
+    };
+    const r = try renderToBuf(&buf, .{ .message = "Pick", .choices = &.{ "a", "b" }, .theme = ctx }, &.{ true, false }, 0, .{ .row = 24, .col = 80 });
+    try std.testing.expect(std.mem.indexOf(u8, r.text, "\x1b[") == null);
 }
 
 test "renderList: continuation lines hang-indent under the option text" {

--- a/packages/prompts/src/prompts.zig
+++ b/packages/prompts/src/prompts.zig
@@ -13,6 +13,29 @@
 
 const std = @import("std");
 pub const terminal = @import("terminal");
+pub const theme = @import("theme");
+
+/// Style context used when the caller doesn't pass one: the default theme at
+/// ANSI-16, matching the package's historical fixed colors. zcli applications
+/// pass `context.theme` instead, which carries the app's theme and the
+/// detected terminal capabilities (including NO_COLOR).
+pub const default_style: theme.ThemeContext = .{
+    .caps = .{ .capability = .ansi_16, .is_tty = true, .color_enabled = true },
+};
+
+/// Render `ref`'s opening escape sequence into `buf`, returning the (possibly
+/// empty) slice. Pair every non-empty result with `closeSeq`.
+pub fn openSeq(buf: []u8, ctx: theme.ThemeContext, ref: theme.StyleRef) []const u8 {
+    var w: std.Io.Writer = .fixed(buf);
+    const style = ctx.resolveRef(ref);
+    const wrote = style.writeSequence(&w, ctx.capability()) catch false;
+    return if (wrote) w.buffered() else "";
+}
+
+/// The reset matching a sequence produced by `openSeq` ("" when nothing was opened).
+pub fn closeSeq(open: []const u8) []const u8 {
+    return if (open.len > 0) "\x1b[0m" else "";
+}
 
 /// Shared rendering machinery for the list-style prompts (wrapping, viewport,
 /// resize-safe erase).

--- a/packages/prompts/src/search.zig
+++ b/packages/prompts/src/search.zig
@@ -10,6 +10,8 @@ pub const SearchConfig = struct {
     choices: []const []const u8,
     prefix: []const u8 = "? ",
     unicode: bool = true,
+    /// Theme + terminal capabilities for styling; zcli commands pass `context.theme`.
+    theme: prompts.theme.ThemeContext = prompts.default_style,
 };
 
 /// Prompt with search filtering. Returns the index of the selected item in the original choices array.
@@ -74,7 +76,9 @@ pub fn search(writer: anytype, reader: anytype, allocator: std.mem.Allocator, co
                     if (filtered.len > 0) {
                         const selected_idx = filtered[cursor];
                         try lr.eraseRegion(writer, rows);
-                        try writer.print("  \x1b[36m{s}\x1b[0m\r\n", .{config.choices[selected_idx]});
+                        var obuf: [64]u8 = undefined;
+                        const open = prompts.openSeq(&obuf, config.theme, config.theme.promptTokens().selected);
+                        try writer.print("  {s}{s}{s}\r\n", .{ open, config.choices[selected_idx], prompts.closeSeq(open) });
                         return selected_idx;
                     }
                 },
@@ -158,19 +162,39 @@ pub fn renderSearch(
 
     var rows: usize = 0;
     var first_line = true;
+    const tokens = config.theme.promptTokens();
 
     // Header line.
     const hprefix_w = terminal.displayWidth(config.prefix);
     rows += try lr.renderItem(writer, &first_line, .{ .first_prefix = config.prefix, .prefix_w = hprefix_w }, config.message, @max(usable -| hprefix_w, 1));
 
-    // Search-input line: "  Search: <query>".
+    // Search-input line: "  Search: <query>". The hint style rides in the
+    // prefix (emitted verbatim), not the label: the wrapper drops escapes at
+    // the edges of labels (it measures them as zero-width and slices lines
+    // from the first visible grapheme).
     const search_prefix = "  Search: ";
     const search_prefix_w = terminal.displayWidth(search_prefix);
-    const query_label = if (query.len > 0) query else "\x1b[2mtype to filter\x1b[0m";
-    rows += try lr.renderItem(writer, &first_line, .{ .first_prefix = search_prefix, .prefix_w = search_prefix_w }, query_label, @max(usable -| search_prefix_w, 1));
+    var hint_open_buf: [64]u8 = undefined;
+    var hint_prefix_buf: [96]u8 = undefined;
+    const hint_open = prompts.openSeq(&hint_open_buf, config.theme, tokens.hint);
+    if (query.len > 0) {
+        rows += try lr.renderItem(writer, &first_line, .{ .first_prefix = search_prefix, .prefix_w = search_prefix_w }, query, @max(usable -| search_prefix_w, 1));
+    } else {
+        const styled_prefix = std.fmt.bufPrint(&hint_prefix_buf, "{s}{s}", .{ search_prefix, hint_open }) catch search_prefix;
+        rows += try lr.renderItem(writer, &first_line, .{
+            .first_prefix = styled_prefix,
+            .prefix_w = search_prefix_w,
+            .line_close = prompts.closeSeq(hint_open),
+        }, "type to filter", @max(usable -| search_prefix_w, 1));
+    }
 
     if (filtered.len == 0) {
-        rows += try lr.renderItem(writer, &first_line, .{ .first_prefix = "  ", .prefix_w = 2 }, "\x1b[2mno matches\x1b[0m", avail);
+        const nm_prefix = std.fmt.bufPrint(&hint_prefix_buf, "  {s}", .{hint_open}) catch "  ";
+        rows += try lr.renderItem(writer, &first_line, .{
+            .first_prefix = nm_prefix,
+            .prefix_w = 2,
+            .line_close = prompts.closeSeq(hint_open),
+        }, "no matches", avail);
         return rows;
     }
 
@@ -190,15 +214,16 @@ pub fn renderSearch(
     for (win.start..win.end) |i| {
         const choice = config.choices[filtered[i]];
         var pbuf: [32]u8 = undefined;
-        const style: lr.ItemStyle = if (i == cursor)
-            .{
-                .line_open = "\x1b[36m",
+        var obuf: [64]u8 = undefined;
+        const style: lr.ItemStyle = if (i == cursor) blk: {
+            const open = prompts.openSeq(&obuf, config.theme, tokens.selected);
+            break :blk .{
+                .line_open = open,
                 .first_prefix = std.fmt.bufPrint(&pbuf, "  {s} ", .{cursor_sym}) catch "  ",
                 .prefix_w = prefix_w,
-                .line_close = "\x1b[0m",
-            }
-        else
-            .{ .first_prefix = "    ", .prefix_w = prefix_w };
+                .line_close = prompts.closeSeq(open),
+            };
+        } else .{ .first_prefix = "    ", .prefix_w = prefix_w };
         rows += try lr.renderItem(writer, &first_line, style, choice, avail);
     }
 
@@ -260,6 +285,30 @@ test "renderSearch: header + search line + results, row count matches lines" {
     try std.testing.expectEqual(@as(usize, 5), r.rows);
     const lines = std.mem.count(u8, r.text, "\r\n") + 1;
     try std.testing.expectEqual(lines, r.rows);
+}
+
+test "renderSearch: placeholder styles through the hint token; no_color is escape-free" {
+    var buf: [4096]u8 = undefined;
+    const filtered = [_]usize{ 0, 1 };
+
+    // Custom hint color flows into the placeholder
+    const custom = prompts.theme.Theme{
+        .prompts = .{ .hint = .{ .style = .{ .foreground = .{ .rgb = .{ .r = 7, .g = 7, .b = 7 } } } } },
+    };
+    const color_ctx = prompts.theme.ThemeContext{
+        .theme = &custom,
+        .caps = .{ .capability = .true_color, .is_tty = true, .color_enabled = true },
+    };
+    const r = try renderToBuf(&buf, .{ .message = "Pick", .choices = &.{ "a", "b" }, .theme = color_ctx }, "", &filtered, 0, .{ .row = 24, .col = 80 });
+    try std.testing.expect(std.mem.indexOf(u8, r.text, "38;2;7;7;7") != null);
+
+    // no_color renders the placeholder and cursor row without escapes
+    const plain_ctx = prompts.theme.ThemeContext{
+        .caps = .{ .capability = .no_color, .is_tty = true, .color_enabled = false },
+    };
+    const p = try renderToBuf(&buf, .{ .message = "Pick", .choices = &.{ "a", "b" }, .theme = plain_ctx }, "", &filtered, 0, .{ .row = 24, .col = 80 });
+    try std.testing.expect(std.mem.indexOf(u8, p.text, "type to filter") != null);
+    try std.testing.expect(std.mem.indexOf(u8, p.text, "\x1b[") == null);
 }
 
 test "renderSearch: no matches renders a message row" {

--- a/packages/prompts/src/select.zig
+++ b/packages/prompts/src/select.zig
@@ -13,6 +13,8 @@ pub const SelectConfig = struct {
     /// Keys the prompt should not handle itself: pressing one aborts the prompt
     /// with `error.Interrupted`. Empty = handle/ignore all keys.
     interrupt_keys: []const terminal.Key = &.{},
+    /// Theme + terminal capabilities for styling; zcli commands pass `context.theme`.
+    theme: prompts.theme.ThemeContext = prompts.default_style,
 };
 
 /// Prompt to select one item from a list. Returns the chosen index, or
@@ -76,7 +78,9 @@ pub fn select(writer: anytype, reader: anytype, config: SelectConfig) !usize {
                     },
                     .enter => {
                         try lr.eraseRegion(writer, rows);
-                        try writer.print("  \x1b[36m{s}\x1b[0m\r\n", .{config.choices[cursor]});
+                        var obuf: [64]u8 = undefined;
+                        const open = prompts.openSeq(&obuf, config.theme, config.theme.promptTokens().selected);
+                        try writer.print("  {s}{s}{s}\r\n", .{ open, config.choices[cursor], prompts.closeSeq(open) });
                         return cursor;
                     },
                     .ctrl => |c| {
@@ -122,17 +126,19 @@ pub fn renderList(writer: anytype, config: SelectConfig, cursor: usize, ws: term
     const list_budget = @max((height -| 1) -| rows, 1);
     const win = lr.viewport(config.choices.len, cursor, list_budget, &counter, Counter.at);
 
+    const tokens = config.theme.promptTokens();
     for (win.start..win.end) |i| {
         var pbuf: [32]u8 = undefined;
-        const style: lr.ItemStyle = if (i == cursor)
-            .{
-                .line_open = "\x1b[36m",
+        var obuf: [64]u8 = undefined;
+        const style: lr.ItemStyle = if (i == cursor) blk: {
+            const open = prompts.openSeq(&obuf, config.theme, tokens.selected);
+            break :blk .{
+                .line_open = open,
                 .first_prefix = std.fmt.bufPrint(&pbuf, "  {s} ", .{cursor_sym}) catch "  ",
                 .prefix_w = prefix_w,
-                .line_close = "\x1b[0m",
-            }
-        else
-            .{ .first_prefix = "    ", .prefix_w = prefix_w };
+                .line_close = prompts.closeSeq(open),
+            };
+        } else .{ .first_prefix = "    ", .prefix_w = prefix_w };
         rows += try lr.renderItem(writer, &first_line, style, config.choices[i], avail);
     }
 
@@ -214,6 +220,28 @@ test "renderList: short options are one row each" {
     var buf: [1024]u8 = undefined;
     const r = try renderToBuf(&buf, .{ .message = "Pick", .choices = &.{ "a", "b", "c" } }, 0, .{ .row = 24, .col = 80 });
     try std.testing.expectEqual(@as(usize, 4), r.rows); // header + 3
+}
+
+test "renderList: selected row styles through the theme's selected token" {
+    var buf: [1024]u8 = undefined;
+    const custom = prompts.theme.Theme{
+        .palette = .{ .accent = .{ .foreground = .{ .rgb = .{ .r = 1, .g = 2, .b = 3 } } } },
+    };
+    const ctx = prompts.theme.ThemeContext{
+        .theme = &custom,
+        .caps = .{ .capability = .true_color, .is_tty = true, .color_enabled = true },
+    };
+    const r = try renderToBuf(&buf, .{ .message = "Pick", .choices = &.{ "a", "b" }, .theme = ctx }, 0, .{ .row = 24, .col = 80 });
+    try std.testing.expect(std.mem.indexOf(u8, r.text, "38;2;1;2;3") != null);
+}
+
+test "renderList: no_color renders without any escapes" {
+    var buf: [1024]u8 = undefined;
+    const ctx = prompts.theme.ThemeContext{
+        .caps = .{ .capability = .no_color, .is_tty = true, .color_enabled = false },
+    };
+    const r = try renderToBuf(&buf, .{ .message = "Pick", .choices = &.{ "a", "b" }, .theme = ctx }, 0, .{ .row = 24, .col = 80 });
+    try std.testing.expect(std.mem.indexOf(u8, r.text, "\x1b[") == null);
 }
 
 test "renderList: wrapped option reports true physical row count" {

--- a/packages/theme/src/definition.zig
+++ b/packages/theme/src/definition.zig
@@ -116,6 +116,16 @@ pub const ThemeContext = struct {
         return self.theme.palette.get(role);
     }
 
+    /// Resolve a style reference (role or literal) through the active palette
+    pub fn resolveRef(self: ThemeContext, ref: StyleRef) Style {
+        return ref.resolve(self.theme.palette);
+    }
+
+    /// The active theme's prompt component tokens
+    pub fn promptTokens(self: ThemeContext) PromptTheme {
+        return self.theme.prompts;
+    }
+
     /// The effective terminal capability (no_color when color is disabled)
     pub fn capability(self: ThemeContext) TerminalCapability {
         return self.caps.getCapability();

--- a/projects/zcli/src/commands/add/_wizard.zig
+++ b/projects/zcli/src/commands/add/_wizard.zig
@@ -96,7 +96,7 @@ fn runWizardOnce(
     // Step 5 — review, then choose what to do.
     while (true) {
         try review(arena, w, theme, path.parts, file_path, description, args_list.items, opts_list.items);
-        const action = try prompts.select(w, r, .{ .message = "What next?", .choices = &.{
+        const action = try prompts.select(w, r, .{ .message = "What next?", .theme = theme.*, .choices = &.{
             "Create it",
             "Add another argument",
             "Add another option",
@@ -266,7 +266,7 @@ fn gatherOneArg(
             step = .type;
         },
         .type => {
-            kind = selectArgKind(w, r) catch |e| {
+            kind = selectArgKind(w, r, theme) catch |e| {
                 if (e == error.Interrupted) {
                     step = .description;
                     continue;
@@ -320,10 +320,11 @@ fn gatherOneArg(
     };
 }
 
-fn selectArgKind(w: *std.Io.Writer, r: *std.Io.Reader) !ArgKind {
+fn selectArgKind(w: *std.Io.Writer, r: *std.Io.Reader, theme: *const ThemeContext) !ArgKind {
     const idx = try prompts.select(w, r, .{
         .message = "  Type:",
         .interrupt_keys = back_keys,
+        .theme = theme.*,
         .choices = &.{
             "Text          ([]const u8)",
             "Integer       (i64)",

--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -154,6 +154,7 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         .message = "Select built-in plugins to include:",
         .choices = &choices,
         .defaults = &defaults,
+        .theme = context.theme,
     });
     defer allocator.free(selected);
 


### PR DESCRIPTION
PR 4 of the theme-system plan: prompts stop hardcoding ANSI colors and resolve their visuals through `PromptTheme` tokens — a CLI's `zcli_theme` now restyles its prompts along with help and user output.

## Token wiring
- **select / search**: cursor row + enter-confirmation line → `selected`
- **multi_select**: cursor glyph → `cursor`, check marker → `marker`, summary → `selected`
- **search** placeholders ("type to filter", "no matches") and the **editor** hint → `hint`

## API
- Every themed prompt config gains `theme: ThemeContext`, defaulting to `prompts.default_style` (default theme at ANSI-16 — the historical standalone look, so plain library users see no change).
- zcli call sites (`zcli init` plugin picker, the add-command wizard, tasks example) pass `context.theme` — which also brings **NO_COLOR support and capability degradation to prompts for the first time**.
- `prompts.openSeq`/`closeSeq` render a `StyleRef` into a caller buffer for the `ItemStyle` channels; `ThemeContext` gains `resolveRef()` and `promptTokens()`.

## Bug found along the way
The old hardcoded `\x1b[2m` placeholder dim **never actually rendered**: the wrap machinery measures escapes as zero-width and slices lines from the first visible grapheme, dropping label-edge escapes. Hint styles now ride in the item prefix (emitted verbatim), with a comment explaining why.

## Verification
- PTY smoke: the tasks example's `zcli_theme` accent (`38;2;255;179;71`) renders in the interactive select cursor row — app theme → context → prompt tokens, end to end.
- New render tests: custom `selected`/`cursor`/`marker`/`hint` token colors appear at true-color; `no_color` renders escape-free.
- Full sweep green: theme 43, markdown 75, core 1080, prompts **61** (was 56), progress 10, terminal 37, vterm 116, testing 39; zcli 58 unit + 29 e2e; examples build.

Next (final planned PR): progress through `ProgressTheme` tokens — spinner/bar styles, result symbols via palette roles, and killing the hardcoded `.ansi_16`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)