### PR TITLE
feat(prompts)!: instance API — Prompts struct bundles writer/reader/allocator/theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,17 +181,24 @@ Eight prompt types with arrow-key navigation, live filtering, and unicode-correc
 ```zig
 const prompts = zcli.prompts;  // or standalone: @import("prompts")
 
-const name = try prompts.text(writer, reader, allocator, .{
+const p: prompts.Prompts = .{
+    .writer = context.stdout(),
+    .reader = context.stdin(),
+    .allocator = context.allocator,
+    .theme = context.theme,
+};
+
+const name = try p.text(.{
     .message = "Project name:",
     .default = "my-project",
 });
 
-const idx = try prompts.select(writer, reader, .{
+const idx = try p.select(.{
     .message = "Framework:",
     .choices = &.{ "express", "fastify", "koa" },
 });
 
-const pw = try prompts.password(writer, reader, allocator, .{
+const pw = try p.password(.{
     .message = "Token:",
 });
 ```

--- a/README.md
+++ b/README.md
@@ -179,14 +179,9 @@ If you want one dependency that covers the whole terminal experience, that's the
 Eight prompt types with arrow-key navigation, live filtering, and unicode-correct editing. Every prompt falls back to plain line input when stdin isn't a TTY, so scripts and pipes keep working.
 
 ```zig
-const prompts = zcli.prompts;  // or standalone: @import("prompts")
-
-const p: prompts.Prompts = .{
-    .writer = context.stdout(),
-    .reader = context.stdin(),
-    .allocator = context.allocator,
-    .theme = context.theme,
-};
+// In a zcli command — pre-wired to the command's streams, allocator, and theme.
+// Standalone: `const Prompts = @import("prompts");` and fill the fields yourself.
+const p = context.prompts();
 
 const name = try p.text(.{
     .message = "Project name:",

--- a/examples/tasks/src/commands/add.zig
+++ b/examples/tasks/src/commands/add.zig
@@ -46,18 +46,21 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         priority = store.priorityFromString(options.priority) orelse .medium;
     } else {
         // Interactive mode
-        const writer = context.stdout();
-        const reader = context.stdin();
+        const p: prompts.Prompts = .{
+            .writer = context.stdout(),
+            .reader = context.stdin(),
+            .allocator = allocator,
+            .theme = context.theme,
+        };
 
-        title_owned = try prompts.text(writer, reader, allocator, .{
+        title_owned = try p.text(.{
             .message = "Task title:",
         });
         title = title_owned.?;
 
-        const priority_idx = try prompts.select(writer, reader, .{
+        const priority_idx = try p.select(.{
             .message = "Priority:",
             .choices = &.{ "low", "medium", "high", "critical" },
-            .theme = context.theme,
         });
         priority = switch (priority_idx) {
             0 => .low,
@@ -67,7 +70,7 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
             else => .medium,
         };
 
-        const pts = try prompts.number(writer, reader, .{
+        const pts = try p.number(.{
             .message = "Story points:",
             .default = 1,
             .min = 0,

--- a/examples/tasks/src/commands/add.zig
+++ b/examples/tasks/src/commands/add.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 const zcli = @import("zcli");
 const Context = @import("command_registry").Context;
 const store = @import("store");
-const prompts = zcli.prompts;
 const themed = zcli.theme.styled;
 
 pub const meta = .{
@@ -46,12 +45,7 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         priority = store.priorityFromString(options.priority) orelse .medium;
     } else {
         // Interactive mode
-        const p: prompts.Prompts = .{
-            .writer = context.stdout(),
-            .reader = context.stdin(),
-            .allocator = allocator,
-            .theme = context.theme,
-        };
+        const p = context.prompts();
 
         title_owned = try p.text(.{
             .message = "Task title:",

--- a/examples/tasks/src/commands/config.zig
+++ b/examples/tasks/src/commands/config.zig
@@ -35,10 +35,17 @@ pub fn execute(_: Args, _: Options, context: *Context) !void {
     const writer = context.stdout();
     const reader = context.stdin();
 
+    const p: prompts.Prompts = .{
+        .writer = writer,
+        .reader = reader,
+        .allocator = allocator,
+        .theme = context.theme,
+    };
+
     // Load the current config so prompts can show existing values as defaults.
     // Keep `parsed` alive until after we write, so its strings stay valid.
     var parsed: ?std.json.Parsed(Config) = null;
-    defer if (parsed) |p| p.deinit();
+    defer if (parsed) |loaded| loaded.deinit();
     var current = Config{};
     const cwd = std.Io.Dir.cwd();
     if (cwd.readFileAlloc(context.io, CONFIG_FILE, allocator, .limited(1024 * 1024))) |content| {
@@ -46,9 +53,9 @@ pub fn execute(_: Args, _: Options, context: *Context) !void {
         if (std.json.parseFromSlice(Config, allocator, content, .{
             .allocate = .alloc_always,
             .ignore_unknown_fields = true,
-        })) |p| {
-            parsed = p;
-            current = p.value;
+        })) |loaded| {
+            parsed = loaded;
+            current = loaded.value;
         } else |_| {}
     } else |_| {}
 
@@ -56,20 +63,19 @@ pub fn execute(_: Args, _: Options, context: *Context) !void {
     try themed("Settings").bold().render(writer, &context.theme);
     try writer.writeAll("\r\n\r\n");
 
-    const priority_idx = try prompts.select(writer, reader, .{
+    const priority_idx = try p.select(.{
         .message = "Default priority for new tasks:",
         .choices = &priorities,
-        .theme = context.theme,
     });
 
-    const points = try prompts.number(writer, reader, .{
+    const points = try p.number(.{
         .message = "Default story points:",
         .default = current.add.points,
         .min = 0,
         .max = 100,
     });
 
-    const show_done = try prompts.confirm(writer, reader, .{
+    const show_done = try p.confirm(.{
         .message = "Show completed tasks in 'list' by default?",
         .default = current.list.all,
     });

--- a/examples/tasks/src/commands/config.zig
+++ b/examples/tasks/src/commands/config.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const zcli = @import("zcli");
 const Context = @import("command_registry").Context;
-const prompts = zcli.prompts;
 const themed = zcli.theme.styled;
 
 pub const meta = .{
@@ -33,14 +32,8 @@ const priorities = [_][]const u8{ "low", "medium", "high", "critical" };
 pub fn execute(_: Args, _: Options, context: *Context) !void {
     const allocator = context.allocator;
     const writer = context.stdout();
-    const reader = context.stdin();
 
-    const p: prompts.Prompts = .{
-        .writer = writer,
-        .reader = reader,
-        .allocator = allocator,
-        .theme = context.theme,
-    };
+    const p = context.prompts();
 
     // Load the current config so prompts can show existing values as defaults.
     // Keep `parsed` alive until after we write, so its strings stay valid.

--- a/examples/tasks/src/commands/edit.zig
+++ b/examples/tasks/src/commands/edit.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 const zcli = @import("zcli");
 const Context = @import("command_registry").Context;
 const store = @import("store");
-const prompts = zcli.prompts;
 const themed = zcli.theme.styled;
 
 pub const meta = .{
@@ -23,12 +22,7 @@ pub fn execute(args: Args, _: Options, context: *Context) !void {
     for (data.tasks) |*task| {
         if (task.id != args.id) continue;
 
-        const p: prompts.Prompts = .{
-            .writer = context.stdout(),
-            .reader = context.stdin(),
-            .allocator = allocator,
-            .theme = context.theme,
-        };
+        const p = context.prompts();
 
         // Git-commit-style buffer: first line is title, blank line, then description.
         // Lines starting with '#' are comments and get stripped.

--- a/examples/tasks/src/commands/edit.zig
+++ b/examples/tasks/src/commands/edit.zig
@@ -23,8 +23,12 @@ pub fn execute(args: Args, _: Options, context: *Context) !void {
     for (data.tasks) |*task| {
         if (task.id != args.id) continue;
 
-        const writer = context.stdout();
-        const reader = context.stdin();
+        const p: prompts.Prompts = .{
+            .writer = context.stdout(),
+            .reader = context.stdin(),
+            .allocator = allocator,
+            .theme = context.theme,
+        };
 
         // Git-commit-style buffer: first line is title, blank line, then description.
         // Lines starting with '#' are comments and get stripped.
@@ -44,7 +48,7 @@ pub fn execute(args: Args, _: Options, context: *Context) !void {
         const msg = try std.fmt.allocPrint(allocator, "Edit task #{d}:", .{task.id});
         defer allocator.free(msg);
 
-        const content = try prompts.editor(writer, reader, allocator, .{
+        const content = try p.editor(.{
             .message = msg,
             .io = context.io,
             .default = initial,

--- a/examples/tasks/src/commands/init.zig
+++ b/examples/tasks/src/commands/init.zig
@@ -28,25 +28,31 @@ pub fn execute(_: Args, _: Options, context: *Context) !void {
     try themed("Project Setup").bold().render(writer, &context.theme);
     try writer.writeAll("\r\n\r\n");
 
-    const name = try prompts.text(writer, reader, allocator, .{
+    const p: prompts.Prompts = .{
+        .writer = writer,
+        .reader = reader,
+        .allocator = allocator,
+        .theme = context.theme,
+    };
+
+    const name = try p.text(.{
         .message = "Project name:",
         .default = "my-project",
     });
     defer allocator.free(name);
 
-    const description = try prompts.text(writer, reader, allocator, .{
+    const description = try p.text(.{
         .message = "Description:",
     });
     defer allocator.free(description);
 
-    const method_idx = try prompts.select(writer, reader, .{
+    const method_idx = try p.select(.{
         .message = "Methodology:",
         .choices = &.{ "Kanban", "Scrum", "None" },
-        .theme = context.theme,
     });
     _ = method_idx;
 
-    const create_samples = try prompts.confirm(writer, reader, .{
+    const create_samples = try p.confirm(.{
         .message = "Create sample tasks?",
         .default = true,
     });

--- a/examples/tasks/src/commands/init.zig
+++ b/examples/tasks/src/commands/init.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 const zcli = @import("zcli");
 const Context = @import("command_registry").Context;
 const store = @import("store");
-const prompts = zcli.prompts;
 const themed = zcli.theme.styled;
 
 pub const meta = .{
@@ -16,7 +15,6 @@ pub const Options = struct {};
 pub fn execute(_: Args, _: Options, context: *Context) !void {
     const allocator = context.allocator;
     const writer = context.stdout();
-    const reader = context.stdin();
 
     // Check if already initialized
     if (std.Io.Dir.cwd().access(context.io, "tasks.json", .{})) |_| {
@@ -28,12 +26,7 @@ pub fn execute(_: Args, _: Options, context: *Context) !void {
     try themed("Project Setup").bold().render(writer, &context.theme);
     try writer.writeAll("\r\n\r\n");
 
-    const p: prompts.Prompts = .{
-        .writer = writer,
-        .reader = reader,
-        .allocator = allocator,
-        .theme = context.theme,
-    };
+    const p = context.prompts();
 
     const name = try p.text(.{
         .message = "Project name:",

--- a/examples/tasks/src/commands/remove.zig
+++ b/examples/tasks/src/commands/remove.zig
@@ -26,13 +26,17 @@ pub fn execute(args: Args, _: Options, context: *Context) !void {
         return;
     };
 
-    const writer = context.stdout();
-    const reader = context.stdin();
+    const p: prompts.Prompts = .{
+        .writer = context.stdout(),
+        .reader = context.stdin(),
+        .allocator = allocator,
+        .theme = context.theme,
+    };
 
     const msg = try std.fmt.allocPrint(allocator, "Remove task #{d}: {s}?", .{ task.id, task.title });
     defer allocator.free(msg);
 
-    const confirmed = prompts.confirm(writer, reader, .{
+    const confirmed = p.confirm(.{
         .message = msg,
         .default = false,
     }) catch true; // Default to yes on non-interactive

--- a/examples/tasks/src/commands/remove.zig
+++ b/examples/tasks/src/commands/remove.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 const zcli = @import("zcli");
 const Context = @import("command_registry").Context;
 const store = @import("store");
-const prompts = zcli.prompts;
 const themed = zcli.theme.styled;
 
 pub const meta = .{
@@ -26,12 +25,7 @@ pub fn execute(args: Args, _: Options, context: *Context) !void {
         return;
     };
 
-    const p: prompts.Prompts = .{
-        .writer = context.stdout(),
-        .reader = context.stdin(),
-        .allocator = allocator,
-        .theme = context.theme,
-    };
+    const p = context.prompts();
 
     const msg = try std.fmt.allocPrint(allocator, "Remove task #{d}: {s}?", .{ task.id, task.title });
     defer allocator.free(msg);

--- a/examples/tasks/src/commands/search.zig
+++ b/examples/tasks/src/commands/search.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 const zcli = @import("zcli");
 const Context = @import("command_registry").Context;
 const store = @import("store");
-const prompts = zcli.prompts;
 const themed = zcli.theme.styled;
 
 pub const meta = .{
@@ -33,12 +32,7 @@ pub fn execute(_: Args, _: Options, context: *Context) !void {
     }
     defer for (titles.items) |t| allocator.free(t);
 
-    const p: prompts.Prompts = .{
-        .writer = context.stdout(),
-        .reader = context.stdin(),
-        .allocator = allocator,
-        .theme = context.theme,
-    };
+    const p = context.prompts();
 
     const idx = try p.search(.{
         .message = "Search tasks:",

--- a/examples/tasks/src/commands/search.zig
+++ b/examples/tasks/src/commands/search.zig
@@ -33,10 +33,14 @@ pub fn execute(_: Args, _: Options, context: *Context) !void {
     }
     defer for (titles.items) |t| allocator.free(t);
 
-    const writer = context.stdout();
-    const reader = context.stdin();
+    const p: prompts.Prompts = .{
+        .writer = context.stdout(),
+        .reader = context.stdin(),
+        .allocator = allocator,
+        .theme = context.theme,
+    };
 
-    const idx = try prompts.search(writer, reader, allocator, .{
+    const idx = try p.search(.{
         .message = "Search tasks:",
         .choices = titles.items,
     });

--- a/examples/tasks/src/commands/sprint/close.zig
+++ b/examples/tasks/src/commands/sprint/close.zig
@@ -24,13 +24,16 @@ pub fn execute(_: Args, _: Options, context: *Context) !void {
         return;
     }
 
-    const writer = context.stdout();
-    const reader = context.stdin();
+    const p: prompts.Prompts = .{
+        .writer = context.stdout(),
+        .reader = context.stdin(),
+        .allocator = allocator,
+        .theme = context.theme,
+    };
 
-    const idx = try prompts.select(writer, reader, .{
+    const idx = try p.select(.{
         .message = "Close which sprint?",
         .choices = data.sprints,
-        .theme = context.theme,
     });
 
     const name = data.sprints[idx];

--- a/examples/tasks/src/commands/sprint/close.zig
+++ b/examples/tasks/src/commands/sprint/close.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 const zcli = @import("zcli");
 const Context = @import("command_registry").Context;
 const store = @import("store");
-const prompts = zcli.prompts;
 const themed = zcli.theme.styled;
 
 pub const meta = .{
@@ -24,12 +23,7 @@ pub fn execute(_: Args, _: Options, context: *Context) !void {
         return;
     }
 
-    const p: prompts.Prompts = .{
-        .writer = context.stdout(),
-        .reader = context.stdin(),
-        .allocator = allocator,
-        .theme = context.theme,
-    };
+    const p = context.prompts();
 
     const idx = try p.select(.{
         .message = "Close which sprint?",

--- a/examples/tasks/src/commands/sprint/create.zig
+++ b/examples/tasks/src/commands/sprint/create.zig
@@ -23,9 +23,13 @@ pub fn execute(args: Args, _: Options, context: *Context) !void {
     var data = parsed.value;
 
     const name = if (args.name) |n| n else blk: {
-        const writer = context.stdout();
-        const reader = context.stdin();
-        break :blk try prompts.text(writer, reader, allocator, .{
+        const p: prompts.Prompts = .{
+            .writer = context.stdout(),
+            .reader = context.stdin(),
+            .allocator = allocator,
+            .theme = context.theme,
+        };
+        break :blk try p.text(.{
             .message = "Sprint name:",
             .default = try std.fmt.allocPrint(allocator, "Sprint {d}", .{data.sprints.len + 1}),
         });

--- a/examples/tasks/src/commands/sprint/create.zig
+++ b/examples/tasks/src/commands/sprint/create.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 const zcli = @import("zcli");
 const Context = @import("command_registry").Context;
 const store = @import("store");
-const prompts = zcli.prompts;
 const themed = zcli.theme.styled;
 
 pub const meta = .{
@@ -23,12 +22,7 @@ pub fn execute(args: Args, _: Options, context: *Context) !void {
     var data = parsed.value;
 
     const name = if (args.name) |n| n else blk: {
-        const p: prompts.Prompts = .{
-            .writer = context.stdout(),
-            .reader = context.stdin(),
-            .allocator = allocator,
-            .theme = context.theme,
-        };
+        const p = context.prompts();
         break :blk try p.text(.{
             .message = "Sprint name:",
             .default = try std.fmt.allocPrint(allocator, "Sprint {d}", .{data.sprints.len + 1}),

--- a/packages/core/src/context.zig
+++ b/packages/core/src/context.zig
@@ -154,6 +154,18 @@ pub fn ContextFor(comptime plugins: []const type) type {
             return self.stdio.stdin();
         }
 
+        /// A `Prompts` instance pre-wired to this command's environment:
+        /// stdout, stdin, the arena-per-command allocator, and the app theme.
+        /// Override a field before use if you need to (e.g. a scratch allocator).
+        pub fn prompts(self: *Self) zcli.Prompts {
+            return .{
+                .writer = self.stdout(),
+                .reader = self.stdin(),
+                .allocator = self.allocator,
+                .theme = self.theme,
+            };
+        }
+
         /// Get command description by path (for plugins)
         pub fn getCommandDescription(self: *Self, command_path_query: []const []const u8) ?[]const u8 {
             for (self.plugin_command_info) |cmd_info| {

--- a/packages/core/src/zcli.zig
+++ b/packages/core/src/zcli.zig
@@ -9,7 +9,11 @@ const option_utils = @import("options/utils.zig");
 pub const theme = @import("theme");
 pub const markdown = @import("markdown");
 pub const progress = @import("progress");
-pub const prompts = @import("prompts");
+
+/// Interactive prompts. The import IS the type: build one instance carrying
+/// writer/reader/allocator/theme and every prompt is a method on it. In a
+/// command, prefer `context.prompts()`, which returns a pre-wired instance.
+pub const Prompts = @import("prompts");
 
 /// A complete CLI theme; apps declare `pub const zcli_theme: zcli.Theme` in
 /// their root source file to customize how the CLI looks everywhere.

--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -31,10 +31,11 @@ exe.root_module.addImport("prompts", prompts_dep.module("prompts"));
 ## Quick start
 
 ```zig
-const prompts = @import("prompts");
+// The import IS the type: one instance carries the environment,
+// and every prompt is a method on it.
+const Prompts = @import("prompts");
 
-// Build one instance carrying the environment; every prompt is a method on it.
-const p: prompts.Prompts = .{
+const p: Prompts = .{
     .writer = writer,
     .reader = reader,
     .allocator = allocator,
@@ -75,20 +76,20 @@ app theme and the detected terminal capabilities (including `NO_COLOR`) — ever
 prompt made through that instance is themed:
 
 ```zig
-// In a zcli command — the context already carries the app theme:
-const p: prompts.Prompts = .{
-    .writer = context.stdout(),
-    .reader = context.stdin(),
-    .allocator = context.allocator,
-    .theme = context.theme,
-};
+// In a zcli command, context.prompts() returns an instance already carrying
+// the app theme:
+const p = context.prompts();
 const idx = try p.select(.{
     .message = "Pick:",
     .choices = &.{ "a", "b" },
 });
 ```
 
-Left unset, the default (`prompts.default_style`) is the default theme at
+Standalone, build a style context from the re-exported theming types
+(`Prompts.Theme`, `Prompts.ThemeContext`, `Prompts.Capabilities`) and set
+`.theme` on the instance.
+
+Left unset, the default (`Prompts.default_style`) is the default theme at
 ANSI-16 — the package's historical fixed colors. Tokens and their defaults
 (`cursor`/`selected` → accent, `marker` → success, `hint` → muted) are defined
 in [`theme`](../theme/)'s `PromptTheme`.

--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -33,20 +33,27 @@ exe.root_module.addImport("prompts", prompts_dep.module("prompts"));
 ```zig
 const prompts = @import("prompts");
 
+// Build one instance carrying the environment; every prompt is a method on it.
+const p: prompts.Prompts = .{
+    .writer = writer,
+    .reader = reader,
+    .allocator = allocator,
+};
+
 // Free-form text (returns an owned []u8 — caller frees; empty submit returns
 // the default if set, otherwise an empty string)
-const title = try prompts.text(writer, reader, allocator, .{
+const title = try p.text(.{
     .message = "Task title:",
 });
 
 // Pick one from a list (returns the chosen index)
-const priority_idx = try prompts.select(writer, reader, .{
+const priority_idx = try p.select(.{
     .message = "Priority:",
     .choices = &.{ "low", "medium", "high", "critical" },
 });
 
 // Number with range validation (returns i64)
-const points = try prompts.number(writer, reader, .{
+const points = try p.number(.{
     .message = "Story points:",
     .default = 1,
     .min = 0,
@@ -54,7 +61,7 @@ const points = try prompts.number(writer, reader, .{
 });
 
 // Yes/no (returns bool)
-const sure = try prompts.confirm(writer, reader, .{ .message = "Create it?" });
+const sure = try p.confirm(.{ .message = "Create it?" });
 ```
 
 The other prompt types follow the same shape: `password` (masked input), `multiSelect` (space toggles, returns owned indices), `search` (type-to-filter a list), and `editor` (opens `$EDITOR` for multiline text).
@@ -63,19 +70,25 @@ The other prompt types follow the same shape: `password` (masked input), `multiS
 
 The list prompts (`select`, `multiSelect`, `search`) and `editor` style their
 cursor, selected row, check marker, and hint text through the theme's
-`prompts` component tokens. Pass a `ThemeContext` to follow an app theme and
-the detected terminal capabilities (including `NO_COLOR`):
+`prompts` component tokens. Set `theme` on the `Prompts` instance to follow an
+app theme and the detected terminal capabilities (including `NO_COLOR`) — every
+prompt made through that instance is themed:
 
 ```zig
 // In a zcli command — the context already carries the app theme:
-const idx = try prompts.select(writer, reader, .{
+const p: prompts.Prompts = .{
+    .writer = context.stdout(),
+    .reader = context.stdin(),
+    .allocator = context.allocator,
+    .theme = context.theme,
+};
+const idx = try p.select(.{
     .message = "Pick:",
     .choices = &.{ "a", "b" },
-    .theme = context.theme,
 });
 ```
 
-Standalone, the default (`prompts.default_style`) is the default theme at
+Left unset, the default (`prompts.default_style`) is the default theme at
 ANSI-16 — the package's historical fixed colors. Tokens and their defaults
 (`cursor`/`selected` → accent, `marker` → success, `hint` → muted) are defined
 in [`theme`](../theme/)'s `PromptTheme`.

--- a/packages/prompts/build.zig
+++ b/packages/prompts/build.zig
@@ -8,7 +8,7 @@ pub fn build(b: *std.Build) void {
     const theme_dep = b.dependency("theme", .{ .target = target, .optimize = optimize });
 
     const prompts_mod = b.addModule("prompts", .{
-        .root_source_file = b.path("src/prompts.zig"),
+        .root_source_file = b.path("src/Prompts.zig"),
         .target = target,
         .optimize = optimize,
     });
@@ -17,7 +17,7 @@ pub fn build(b: *std.Build) void {
 
     const test_step = b.step("test", "Run prompts tests");
     const test_mod = b.addModule("test-prompts", .{
-        .root_source_file = b.path("src/prompts.zig"),
+        .root_source_file = b.path("src/Prompts.zig"),
         .target = target,
         .optimize = optimize,
     });

--- a/packages/prompts/examples/confirm.zig
+++ b/packages/prompts/examples/confirm.zig
@@ -1,4 +1,4 @@
-//! `prompts.confirm` — a yes/no question with a default (Enter accepts it).
+//! `Prompts.confirm` — a yes/no question with a default (Enter accepts it).
 
 const std = @import("std");
 const prompts = @import("prompts");
@@ -9,7 +9,9 @@ pub fn main(init: std.process.Init) !void {
     t.init(init.io);
     defer t.flush();
 
-    const ok = prompts.confirm(t.w(), t.r(), .{
+    const p: prompts.Prompts = .{ .writer = t.w(), .reader = t.r(), .allocator = init.gpa };
+
+    const ok = p.confirm(.{
         .message = "Deploy to production?",
         .default = false,
     }) catch |err| {

--- a/packages/prompts/examples/confirm.zig
+++ b/packages/prompts/examples/confirm.zig
@@ -1,7 +1,7 @@
 //! `Prompts.confirm` — a yes/no question with a default (Enter accepts it).
 
 const std = @import("std");
-const prompts = @import("prompts");
+const Prompts = @import("prompts");
 const common = @import("common.zig");
 
 pub fn main(init: std.process.Init) !void {
@@ -9,7 +9,7 @@ pub fn main(init: std.process.Init) !void {
     t.init(init.io);
     defer t.flush();
 
-    const p: prompts.Prompts = .{ .writer = t.w(), .reader = t.r(), .allocator = init.gpa };
+    const p: Prompts = .{ .writer = t.w(), .reader = t.r(), .allocator = init.gpa };
 
     const ok = p.confirm(.{
         .message = "Deploy to production?",

--- a/packages/prompts/examples/editor.zig
+++ b/packages/prompts/examples/editor.zig
@@ -1,4 +1,4 @@
-//! `prompts.editor` — capture multi-line input by launching an external editor.
+//! `Prompts.editor` — capture multi-line input by launching an external editor.
 //!
 //! Pressing Enter opens the editor (`editor_cmd`, default `vi`) on a temporary
 //! file seeded with `default`; whatever is saved is returned.
@@ -12,7 +12,9 @@ pub fn main(init: std.process.Init) !void {
     t.init(init.io);
     defer t.flush();
 
-    const message = prompts.editor(t.w(), t.r(), init.gpa, .{
+    const p: prompts.Prompts = .{ .writer = t.w(), .reader = t.r(), .allocator = init.gpa };
+
+    const message = p.editor(.{
         .message = "Write a commit message",
         .default = "Summary line\n\nDetails go here.\n",
         .extension = ".md",

--- a/packages/prompts/examples/editor.zig
+++ b/packages/prompts/examples/editor.zig
@@ -4,7 +4,7 @@
 //! file seeded with `default`; whatever is saved is returned.
 
 const std = @import("std");
-const prompts = @import("prompts");
+const Prompts = @import("prompts");
 const common = @import("common.zig");
 
 pub fn main(init: std.process.Init) !void {
@@ -12,7 +12,7 @@ pub fn main(init: std.process.Init) !void {
     t.init(init.io);
     defer t.flush();
 
-    const p: prompts.Prompts = .{ .writer = t.w(), .reader = t.r(), .allocator = init.gpa };
+    const p: Prompts = .{ .writer = t.w(), .reader = t.r(), .allocator = init.gpa };
 
     const message = p.editor(.{
         .message = "Write a commit message",

--- a/packages/prompts/examples/multi_select.zig
+++ b/packages/prompts/examples/multi_select.zig
@@ -1,4 +1,4 @@
-//! `prompts.multiSelect` — toggle several items with Space, confirm with Enter.
+//! `Prompts.multiSelect` — toggle several items with Space, confirm with Enter.
 
 const std = @import("std");
 const prompts = @import("prompts");
@@ -9,9 +9,11 @@ pub fn main(init: std.process.Init) !void {
     t.init(init.io);
     defer t.flush();
 
+    const p: prompts.Prompts = .{ .writer = t.w(), .reader = t.r(), .allocator = init.gpa };
+
     const toppings = [_][]const u8{ "Cheese", "Pepperoni", "Mushrooms", "Onions", "Pineapple" };
 
-    const picks = prompts.multiSelect(t.w(), t.r(), init.gpa, .{
+    const picks = p.multiSelect(.{
         .message = "Choose your toppings:",
         .choices = &toppings,
         .defaults = &.{ true, false, false, false, false },

--- a/packages/prompts/examples/multi_select.zig
+++ b/packages/prompts/examples/multi_select.zig
@@ -1,7 +1,7 @@
 //! `Prompts.multiSelect` — toggle several items with Space, confirm with Enter.
 
 const std = @import("std");
-const prompts = @import("prompts");
+const Prompts = @import("prompts");
 const common = @import("common.zig");
 
 pub fn main(init: std.process.Init) !void {
@@ -9,7 +9,7 @@ pub fn main(init: std.process.Init) !void {
     t.init(init.io);
     defer t.flush();
 
-    const p: prompts.Prompts = .{ .writer = t.w(), .reader = t.r(), .allocator = init.gpa };
+    const p: Prompts = .{ .writer = t.w(), .reader = t.r(), .allocator = init.gpa };
 
     const toppings = [_][]const u8{ "Cheese", "Pepperoni", "Mushrooms", "Onions", "Pineapple" };
 

--- a/packages/prompts/examples/number.zig
+++ b/packages/prompts/examples/number.zig
@@ -1,4 +1,4 @@
-//! `prompts.number` — integer input with an optional default and min/max bounds.
+//! `Prompts.number` — integer input with an optional default and min/max bounds.
 
 const std = @import("std");
 const prompts = @import("prompts");
@@ -9,7 +9,9 @@ pub fn main(init: std.process.Init) !void {
     t.init(init.io);
     defer t.flush();
 
-    const n = prompts.number(t.w(), t.r(), .{
+    const p: prompts.Prompts = .{ .writer = t.w(), .reader = t.r(), .allocator = init.gpa };
+
+    const n = p.number(.{
         .message = "Pick a number",
         .default = 42,
         .min = 1,

--- a/packages/prompts/examples/number.zig
+++ b/packages/prompts/examples/number.zig
@@ -1,7 +1,7 @@
 //! `Prompts.number` — integer input with an optional default and min/max bounds.
 
 const std = @import("std");
-const prompts = @import("prompts");
+const Prompts = @import("prompts");
 const common = @import("common.zig");
 
 pub fn main(init: std.process.Init) !void {
@@ -9,7 +9,7 @@ pub fn main(init: std.process.Init) !void {
     t.init(init.io);
     defer t.flush();
 
-    const p: prompts.Prompts = .{ .writer = t.w(), .reader = t.r(), .allocator = init.gpa };
+    const p: Prompts = .{ .writer = t.w(), .reader = t.r(), .allocator = init.gpa };
 
     const n = p.number(.{
         .message = "Pick a number",

--- a/packages/prompts/examples/password.zig
+++ b/packages/prompts/examples/password.zig
@@ -1,4 +1,4 @@
-//! `prompts.password` — masked input; the typed characters are never echoed.
+//! `Prompts.password` — masked input; the typed characters are never echoed.
 
 const std = @import("std");
 const prompts = @import("prompts");
@@ -9,7 +9,9 @@ pub fn main(init: std.process.Init) !void {
     t.init(init.io);
     defer t.flush();
 
-    const secret = prompts.password(t.w(), t.r(), init.gpa, .{
+    const p: prompts.Prompts = .{ .writer = t.w(), .reader = t.r(), .allocator = init.gpa };
+
+    const secret = p.password(.{
         .message = "Enter a password:",
         .mask = '*',
     }) catch |err| {

--- a/packages/prompts/examples/password.zig
+++ b/packages/prompts/examples/password.zig
@@ -1,7 +1,7 @@
 //! `Prompts.password` — masked input; the typed characters are never echoed.
 
 const std = @import("std");
-const prompts = @import("prompts");
+const Prompts = @import("prompts");
 const common = @import("common.zig");
 
 pub fn main(init: std.process.Init) !void {
@@ -9,7 +9,7 @@ pub fn main(init: std.process.Init) !void {
     t.init(init.io);
     defer t.flush();
 
-    const p: prompts.Prompts = .{ .writer = t.w(), .reader = t.r(), .allocator = init.gpa };
+    const p: Prompts = .{ .writer = t.w(), .reader = t.r(), .allocator = init.gpa };
 
     const secret = p.password(.{
         .message = "Enter a password:",

--- a/packages/prompts/examples/search.zig
+++ b/packages/prompts/examples/search.zig
@@ -1,4 +1,4 @@
-//! `prompts.search` — type to fuzzy-filter a list, arrow keys to pick, Enter to select.
+//! `Prompts.search` — type to fuzzy-filter a list, arrow keys to pick, Enter to select.
 
 const std = @import("std");
 const prompts = @import("prompts");
@@ -9,12 +9,14 @@ pub fn main(init: std.process.Init) !void {
     t.init(init.io);
     defer t.flush();
 
+    const p: prompts.Prompts = .{ .writer = t.w(), .reader = t.r(), .allocator = init.gpa };
+
     const languages = [_][]const u8{
         "Zig",    "Rust",       "Go",         "C",       "C++",
         "Python", "JavaScript", "TypeScript", "Haskell", "OCaml",
     };
 
-    const idx = prompts.search(t.w(), t.r(), init.gpa, .{
+    const idx = p.search(.{
         .message = "Search languages (type to filter):",
         .choices = &languages,
     }) catch |err| {

--- a/packages/prompts/examples/search.zig
+++ b/packages/prompts/examples/search.zig
@@ -1,7 +1,7 @@
 //! `Prompts.search` — type to fuzzy-filter a list, arrow keys to pick, Enter to select.
 
 const std = @import("std");
-const prompts = @import("prompts");
+const Prompts = @import("prompts");
 const common = @import("common.zig");
 
 pub fn main(init: std.process.Init) !void {
@@ -9,7 +9,7 @@ pub fn main(init: std.process.Init) !void {
     t.init(init.io);
     defer t.flush();
 
-    const p: prompts.Prompts = .{ .writer = t.w(), .reader = t.r(), .allocator = init.gpa };
+    const p: Prompts = .{ .writer = t.w(), .reader = t.r(), .allocator = init.gpa };
 
     const languages = [_][]const u8{
         "Zig",    "Rust",       "Go",         "C",       "C++",

--- a/packages/prompts/examples/select.zig
+++ b/packages/prompts/examples/select.zig
@@ -1,7 +1,7 @@
 //! `Prompts.select` — choose one item from a list with the arrow keys and Enter.
 
 const std = @import("std");
-const prompts = @import("prompts");
+const Prompts = @import("prompts");
 const common = @import("common.zig");
 
 pub fn main(init: std.process.Init) !void {
@@ -9,7 +9,7 @@ pub fn main(init: std.process.Init) !void {
     t.init(init.io);
     defer t.flush();
 
-    const p: prompts.Prompts = .{ .writer = t.w(), .reader = t.r(), .allocator = init.gpa };
+    const p: Prompts = .{ .writer = t.w(), .reader = t.r(), .allocator = init.gpa };
 
     const fruits = [_][]const u8{ "Apple", "Banana", "Cherry", "Dragonfruit", "Elderberry" };
 

--- a/packages/prompts/examples/select.zig
+++ b/packages/prompts/examples/select.zig
@@ -1,4 +1,4 @@
-//! `prompts.select` — choose one item from a list with the arrow keys and Enter.
+//! `Prompts.select` — choose one item from a list with the arrow keys and Enter.
 
 const std = @import("std");
 const prompts = @import("prompts");
@@ -9,9 +9,11 @@ pub fn main(init: std.process.Init) !void {
     t.init(init.io);
     defer t.flush();
 
+    const p: prompts.Prompts = .{ .writer = t.w(), .reader = t.r(), .allocator = init.gpa };
+
     const fruits = [_][]const u8{ "Apple", "Banana", "Cherry", "Dragonfruit", "Elderberry" };
 
-    const idx = prompts.select(t.w(), t.r(), .{
+    const idx = p.select(.{
         .message = "Pick a fruit:",
         .choices = &fruits,
     }) catch |err| {

--- a/packages/prompts/examples/text.zig
+++ b/packages/prompts/examples/text.zig
@@ -1,4 +1,4 @@
-//! `prompts.text` — free-form single-line text input with an optional default.
+//! `Prompts.text` — free-form single-line text input with an optional default.
 
 const std = @import("std");
 const prompts = @import("prompts");
@@ -9,7 +9,9 @@ pub fn main(init: std.process.Init) !void {
     t.init(init.io);
     defer t.flush();
 
-    const name = prompts.text(t.w(), t.r(), init.gpa, .{
+    const p: prompts.Prompts = .{ .writer = t.w(), .reader = t.r(), .allocator = init.gpa };
+
+    const name = p.text(.{
         .message = "What's your name?",
         .default = "Anonymous",
     }) catch |err| {

--- a/packages/prompts/examples/text.zig
+++ b/packages/prompts/examples/text.zig
@@ -1,7 +1,7 @@
 //! `Prompts.text` — free-form single-line text input with an optional default.
 
 const std = @import("std");
-const prompts = @import("prompts");
+const Prompts = @import("prompts");
 const common = @import("common.zig");
 
 pub fn main(init: std.process.Init) !void {
@@ -9,7 +9,7 @@ pub fn main(init: std.process.Init) !void {
     t.init(init.io);
     defer t.flush();
 
-    const p: prompts.Prompts = .{ .writer = t.w(), .reader = t.r(), .allocator = init.gpa };
+    const p: Prompts = .{ .writer = t.w(), .reader = t.r(), .allocator = init.gpa };
 
     const name = p.text(.{
         .message = "What's your name?",

--- a/packages/prompts/src/Prompts.zig
+++ b/packages/prompts/src/Prompts.zig
@@ -1,33 +1,64 @@
-//! prompts — Interactive terminal prompts for CLI applications.
+//! Prompts — interactive terminal prompts for CLI applications.
 //!
-//! Standalone library: works with any writer/reader, no zcli dependency required.
-//! Falls back to line-based input when stdin is not a TTY.
+//! This file is the type: `@import("prompts")` returns a struct bundling the
+//! environment every prompt needs — writer, reader, allocator, and theme —
+//! and each of the eight prompts is a method on it. Standalone library: no
+//! zcli dependency required; falls back to line-based input when stdin is
+//! not a TTY.
 //!
 //! ```zig
-//! const prompts = @import("prompts");
+//! const Prompts = @import("prompts");
 //!
-//! const p: prompts.Prompts = .{ .writer = writer, .reader = reader, .allocator = allocator };
+//! const p: Prompts = .{ .writer = writer, .reader = reader, .allocator = allocator };
 //!
 //! const name = try p.text(.{ .message = "Name:" });
 //! const ok = try p.confirm(.{ .message = "Continue?" });
 //! const idx = try p.select(.{ .message = "Pick:", .choices = &.{"a", "b"} });
 //! ```
+//!
+//! In a zcli command, `context.prompts()` returns an instance pre-wired to the
+//! command's streams, allocator, and theme.
+
+writer: *std.Io.Writer,
+reader: *std.Io.Reader,
+/// Owns every string a prompt returns (`text`, `password`, `editor`) and
+/// the index slice from `multiSelect`.
+allocator: std.mem.Allocator,
+/// Theme + terminal capabilities for styling; zcli commands carry this in
+/// `context.theme` (`context.prompts()` wires it up).
+theme: ThemeContext = default_style,
+
+pub const text = text_prompt.text;
+pub const confirm = confirm_prompt.confirm;
+pub const select = select_prompt.select;
+pub const multiSelect = multi_select_prompt.multiSelect;
+pub const password = password_prompt.password;
+pub const search = search_prompt.search;
+pub const number = number_prompt.number;
+pub const editor = editor_prompt.editor;
 
 const std = @import("std");
+const theme_pkg = @import("theme");
 pub const terminal = @import("terminal");
-pub const theme = @import("theme");
 
-const ThemeContext = theme.ThemeContext;
+const Prompts = @This();
 
-/// Style context used when a `Prompts` instance doesn't set one: the default
-/// theme at ANSI-16, matching the package's historical fixed colors. zcli
-/// applications set `.theme = context.theme` instead, which carries the app's
-/// theme and the detected terminal capabilities (including NO_COLOR).
-pub const default_style: theme.ThemeContext = .fallback;
+/// Theming re-exports, so standalone users can build a custom style context
+/// without depending on the `theme` package directly (it's transitive here).
+pub const Theme = theme_pkg.Theme;
+pub const ThemeContext = theme_pkg.ThemeContext;
+pub const Capabilities = theme_pkg.Capabilities;
+pub const StyleRef = theme_pkg.StyleRef;
+
+/// Style context used when an instance doesn't set one: the default theme at
+/// ANSI-16, matching the package's historical fixed colors. zcli applications
+/// set `.theme = context.theme` instead, which carries the app's theme and the
+/// detected terminal capabilities (including NO_COLOR).
+pub const default_style: ThemeContext = .fallback;
 
 /// Render `ref`'s opening escape sequence into `buf`, returning the (possibly
 /// empty) slice. Pair every non-empty result with `closeSeq`.
-pub fn openSeq(buf: []u8, ctx: theme.ThemeContext, ref: theme.StyleRef) []const u8 {
+pub fn openSeq(buf: []u8, ctx: ThemeContext, ref: StyleRef) []const u8 {
     var w: std.Io.Writer = .fixed(buf);
     const style = ctx.resolveRef(ref);
     const wrote = style.writeSequence(&w, ctx.capability()) catch false;
@@ -51,38 +82,6 @@ pub const password_prompt = @import("password.zig");
 pub const search_prompt = @import("search.zig");
 pub const number_prompt = @import("number.zig");
 pub const editor_prompt = @import("editor.zig");
-
-/// The prompts API. An instance bundles the environment every prompt needs —
-/// writer, reader, allocator, and theme — so call sites only say what's
-/// specific to the question being asked:
-///
-/// ```zig
-/// const p: prompts.Prompts = .{
-///     .writer = context.stdout(),
-///     .reader = context.stdin(),
-///     .allocator = context.allocator,
-///     .theme = context.theme,
-/// };
-/// const points = try p.number(.{ .message = "Story points:", .min = 0, .max = 100 });
-/// ```
-pub const Prompts = struct {
-    writer: *std.Io.Writer,
-    reader: *std.Io.Reader,
-    /// Owns every string a prompt returns (`text`, `password`, `editor`) and
-    /// the index slice from `multiSelect`.
-    allocator: std.mem.Allocator,
-    /// Theme + terminal capabilities for styling; zcli commands pass `context.theme`.
-    theme: ThemeContext = default_style,
-
-    pub const text = text_prompt.text;
-    pub const confirm = confirm_prompt.confirm;
-    pub const select = select_prompt.select;
-    pub const multiSelect = multi_select_prompt.multiSelect;
-    pub const password = password_prompt.password;
-    pub const search = search_prompt.search;
-    pub const number = number_prompt.number;
-    pub const editor = editor_prompt.editor;
-};
 
 /// Returned by a prompt when the user presses one of the caller's
 /// `interrupt_keys`. The prompt stays domain-agnostic — the caller decides what

--- a/packages/prompts/src/confirm.zig
+++ b/packages/prompts/src/confirm.zig
@@ -15,7 +15,9 @@ pub const ConfirmConfig = struct {
 
 /// Prompt for yes/no confirmation. Returns the answer, or `error.Interrupted`
 /// if the user presses one of `config.interrupt_keys`.
-pub fn confirm(writer: anytype, reader: anytype, config: ConfirmConfig) !bool {
+pub fn confirm(p: prompts.Prompts, config: ConfirmConfig) !bool {
+    const writer = p.writer;
+    const reader = p.reader;
     const is_tty = terminal.isStdinTty();
 
     const hint = if (config.default) "(Y/n)" else "(y/N)";
@@ -98,7 +100,7 @@ test "non-TTY: y input returns true" {
     var output: [256]u8 = undefined;
     var output_writer: std.Io.Writer = .fixed(&output);
 
-    const result = try confirm(&output_writer, &input_reader, .{
+    const result = try confirm(.{ .writer = &output_writer, .reader = &input_reader, .allocator = std.testing.allocator }, .{
         .message = "Continue?",
         .default = false,
     });
@@ -111,7 +113,7 @@ test "non-TTY: n input returns false" {
     var output: [256]u8 = undefined;
     var output_writer: std.Io.Writer = .fixed(&output);
 
-    const result = try confirm(&output_writer, &input_reader, .{
+    const result = try confirm(.{ .writer = &output_writer, .reader = &input_reader, .allocator = std.testing.allocator }, .{
         .message = "Continue?",
         .default = true,
     });
@@ -124,7 +126,7 @@ test "non-TTY: empty input uses default true" {
     var output: [256]u8 = undefined;
     var output_writer: std.Io.Writer = .fixed(&output);
 
-    const result = try confirm(&output_writer, &input_reader, .{
+    const result = try confirm(.{ .writer = &output_writer, .reader = &input_reader, .allocator = std.testing.allocator }, .{
         .message = "Continue?",
         .default = true,
     });
@@ -137,7 +139,7 @@ test "non-TTY: empty input uses default false" {
     var output: [256]u8 = undefined;
     var output_writer: std.Io.Writer = .fixed(&output);
 
-    const result = try confirm(&output_writer, &input_reader, .{
+    const result = try confirm(.{ .writer = &output_writer, .reader = &input_reader, .allocator = std.testing.allocator }, .{
         .message = "Continue?",
         .default = false,
     });
@@ -150,7 +152,7 @@ test "non-TTY: EOF uses default" {
     var output: [256]u8 = undefined;
     var output_writer: std.Io.Writer = .fixed(&output);
 
-    const result = try confirm(&output_writer, &input_reader, .{
+    const result = try confirm(.{ .writer = &output_writer, .reader = &input_reader, .allocator = std.testing.allocator }, .{
         .message = "Continue?",
         .default = true,
     });
@@ -163,7 +165,7 @@ test "prompt shows Y/n when default is true" {
     var output: [256]u8 = undefined;
     var output_writer: std.Io.Writer = .fixed(&output);
 
-    _ = try confirm(&output_writer, &input_reader, .{
+    _ = try confirm(.{ .writer = &output_writer, .reader = &input_reader, .allocator = std.testing.allocator }, .{
         .message = "Ok?",
         .default = true,
     });
@@ -178,7 +180,7 @@ test "prompt shows y/N when default is false" {
     var output: [256]u8 = undefined;
     var output_writer: std.Io.Writer = .fixed(&output);
 
-    _ = try confirm(&output_writer, &input_reader, .{
+    _ = try confirm(.{ .writer = &output_writer, .reader = &input_reader, .allocator = std.testing.allocator }, .{
         .message = "Ok?",
         .default = false,
     });

--- a/packages/prompts/src/confirm.zig
+++ b/packages/prompts/src/confirm.zig
@@ -2,7 +2,7 @@
 
 const std = @import("std");
 const terminal = @import("terminal");
-const prompts = @import("prompts.zig");
+const Prompts = @import("Prompts.zig");
 
 pub const ConfirmConfig = struct {
     message: []const u8,
@@ -15,7 +15,7 @@ pub const ConfirmConfig = struct {
 
 /// Prompt for yes/no confirmation. Returns the answer, or `error.Interrupted`
 /// if the user presses one of `config.interrupt_keys`.
-pub fn confirm(p: prompts.Prompts, config: ConfirmConfig) !bool {
+pub fn confirm(p: Prompts, config: ConfirmConfig) !bool {
     const writer = p.writer;
     const reader = p.reader;
     const is_tty = terminal.isStdinTty();
@@ -39,20 +39,20 @@ pub fn confirm(p: prompts.Prompts, config: ConfirmConfig) !bool {
     }
 
     // TTY: single keypress
-    prompts.flushWriter(writer);
+    Prompts.flushWriter(writer);
     const raw = terminal.enableRawMode(std.Io.File.stdin().handle) catch return config.default;
     defer {
         raw.disable();
-        prompts.flushWriter(writer);
+        Prompts.flushWriter(writer);
     }
 
     while (true) {
-        prompts.flushWriter(writer);
+        Prompts.flushWriter(writer);
         const k = if (config.interrupt_keys.len > 0)
             try terminal.readKeyOpt(reader, std.Io.File.stdin().handle)
         else
             try terminal.readKey(reader);
-        if (prompts.isInterrupt(k, config.interrupt_keys)) {
+        if (Prompts.isInterrupt(k, config.interrupt_keys)) {
             try writer.writeAll("\r\n");
             return error.Interrupted;
         }

--- a/packages/prompts/src/editor.zig
+++ b/packages/prompts/src/editor.zig
@@ -11,12 +11,13 @@ pub const EditorConfig = struct {
     prefix: []const u8 = "? ",
     editor_cmd: []const u8 = "vi",
     io: std.Io,
-    /// Theme + terminal capabilities for styling; zcli commands pass `context.theme`.
-    theme: prompts.theme.ThemeContext = prompts.default_style,
 };
 
 /// Launch the user's editor for multiline input. Returns owned string.
-pub fn editor(writer: anytype, reader: anytype, allocator: std.mem.Allocator, config: EditorConfig) ![]u8 {
+pub fn editor(p: prompts.Prompts, config: EditorConfig) ![]u8 {
+    const writer = p.writer;
+    const reader = p.reader;
+    const allocator = p.allocator;
     const is_tty = terminal.isStdinTty();
 
     try writer.print("{s}{s}", .{ config.prefix, config.message });
@@ -37,7 +38,7 @@ pub fn editor(writer: anytype, reader: anytype, allocator: std.mem.Allocator, co
     }
 
     var obuf: [64]u8 = undefined;
-    const open = prompts.openSeq(&obuf, config.theme, config.theme.promptTokens().hint);
+    const open = prompts.openSeq(&obuf, p.theme, p.theme.promptTokens().hint);
     try writer.print(" {s}(press Enter to open editor){s} ", .{ open, prompts.closeSeq(open) });
     prompts.flushWriter(writer);
 

--- a/packages/prompts/src/editor.zig
+++ b/packages/prompts/src/editor.zig
@@ -2,7 +2,7 @@
 
 const std = @import("std");
 const terminal = @import("terminal");
-const prompts = @import("prompts.zig");
+const Prompts = @import("Prompts.zig");
 
 pub const EditorConfig = struct {
     message: []const u8,
@@ -14,7 +14,7 @@ pub const EditorConfig = struct {
 };
 
 /// Launch the user's editor for multiline input. Returns owned string.
-pub fn editor(p: prompts.Prompts, config: EditorConfig) ![]u8 {
+pub fn editor(p: Prompts, config: EditorConfig) ![]u8 {
     const writer = p.writer;
     const reader = p.reader;
     const allocator = p.allocator;
@@ -38,9 +38,9 @@ pub fn editor(p: prompts.Prompts, config: EditorConfig) ![]u8 {
     }
 
     var obuf: [64]u8 = undefined;
-    const open = prompts.openSeq(&obuf, p.theme, p.theme.promptTokens().hint);
-    try writer.print(" {s}(press Enter to open editor){s} ", .{ open, prompts.closeSeq(open) });
-    prompts.flushWriter(writer);
+    const open = Prompts.openSeq(&obuf, p.theme, p.theme.promptTokens().hint);
+    try writer.print(" {s}(press Enter to open editor){s} ", .{ open, Prompts.closeSeq(open) });
+    Prompts.flushWriter(writer);
 
     // Wait for Enter in raw mode
     const raw = terminal.enableRawMode(std.Io.File.stdin().handle) catch {
@@ -63,10 +63,10 @@ pub fn editor(p: prompts.Prompts, config: EditorConfig) ![]u8 {
         }
     }
     raw.disable();
-    prompts.flushWriter(writer);
+    Prompts.flushWriter(writer);
 
     try writer.writeAll("\r\n");
-    prompts.flushWriter(writer);
+    Prompts.flushWriter(writer);
 
     // Create temp file and write default content
     const tmp_name = try std.fmt.allocPrint(allocator, "/tmp/prompts_edit{s}", .{config.extension});

--- a/packages/prompts/src/multi_select.zig
+++ b/packages/prompts/src/multi_select.zig
@@ -11,12 +11,13 @@ pub const MultiSelectConfig = struct {
     defaults: ?[]const bool = null,
     prefix: []const u8 = "? ",
     unicode: bool = true,
-    /// Theme + terminal capabilities for styling; zcli commands pass `context.theme`.
-    theme: prompts.theme.ThemeContext = prompts.default_style,
 };
 
 /// Prompt to select multiple items. Returns owned slice of selected indices.
-pub fn multiSelect(writer: anytype, reader: anytype, allocator: std.mem.Allocator, config: MultiSelectConfig) ![]usize {
+pub fn multiSelect(p: prompts.Prompts, config: MultiSelectConfig) ![]usize {
+    const writer = p.writer;
+    const reader = p.reader;
+    const allocator = p.allocator;
     if (config.choices.len == 0) return error.NoChoices;
     const is_tty = terminal.isStdinTty();
 
@@ -73,31 +74,31 @@ pub fn multiSelect(writer: anytype, reader: anytype, allocator: std.mem.Allocato
 
     const stdin = std.Io.File.stdin().handle;
     var cursor: usize = 0;
-    var rows = try renderList(writer, config, selected, cursor, lr.windowSize());
+    var rows = try renderList(writer, p.theme, config, selected, cursor, lr.windowSize());
 
     while (true) {
         prompts.flushWriter(writer);
         switch (try terminal.readEvent(reader, stdin, &watcher)) {
             .resize => {
                 try lr.eraseRegion(writer, rows);
-                rows = try renderList(writer, config, selected, cursor, lr.windowSize());
+                rows = try renderList(writer, p.theme, config, selected, cursor, lr.windowSize());
             },
             .key => |k| switch (k) {
                 .up => {
                     if (cursor > 0) cursor -= 1;
                     try lr.eraseRegion(writer, rows);
-                    rows = try renderList(writer, config, selected, cursor, lr.windowSize());
+                    rows = try renderList(writer, p.theme, config, selected, cursor, lr.windowSize());
                 },
                 .down => {
                     if (cursor < config.choices.len - 1) cursor += 1;
                     try lr.eraseRegion(writer, rows);
-                    rows = try renderList(writer, config, selected, cursor, lr.windowSize());
+                    rows = try renderList(writer, p.theme, config, selected, cursor, lr.windowSize());
                 },
                 .char => |c| {
                     if (c == ' ') {
                         selected[cursor] = !selected[cursor];
                         try lr.eraseRegion(writer, rows);
-                        rows = try renderList(writer, config, selected, cursor, lr.windowSize());
+                        rows = try renderList(writer, p.theme, config, selected, cursor, lr.windowSize());
                     }
                 },
                 .enter => {
@@ -105,7 +106,7 @@ pub fn multiSelect(writer: anytype, reader: anytype, allocator: std.mem.Allocato
                     // Show summary
                     var first = true;
                     var obuf: [64]u8 = undefined;
-                    const open = prompts.openSeq(&obuf, config.theme, config.theme.promptTokens().selected);
+                    const open = prompts.openSeq(&obuf, p.theme, p.theme.promptTokens().selected);
                     try writer.print("  {s}", .{open});
                     for (config.choices, 0..) |choice, i| {
                         if (selected[i]) {
@@ -148,6 +149,7 @@ pub fn multiSelect(writer: anytype, reader: anytype, allocator: std.mem.Allocato
 /// Public for the cross-platform emulator render tests.
 pub fn renderList(
     writer: anytype,
+    ctx: prompts.theme.ThemeContext,
     config: MultiSelectConfig,
     selected: []const bool,
     cursor: usize,
@@ -190,15 +192,15 @@ pub fn renderList(
     const list_budget = @max((height -| 1) -| rows, 1);
     const win = lr.viewport(config.choices.len, cursor, list_budget, &counter, Counter.at);
 
-    const tokens = config.theme.promptTokens();
+    const tokens = ctx.promptTokens();
     for (win.start..win.end) |i| {
         const marker = if (selected[i]) sel_sym else unsel_sym;
         var pbuf: [192]u8 = undefined;
         var cbuf: [64]u8 = undefined;
         var mbuf: [64]u8 = undefined;
         const style: lr.ItemStyle = if (i == cursor) blk: {
-            const cur_open = prompts.openSeq(&cbuf, config.theme, tokens.cursor);
-            const mark_open = prompts.openSeq(&mbuf, config.theme, tokens.marker);
+            const cur_open = prompts.openSeq(&cbuf, ctx, tokens.cursor);
+            const mark_open = prompts.openSeq(&mbuf, ctx, tokens.marker);
             break :blk .{
                 .first_prefix = std.fmt.bufPrint(&pbuf, "  {s}{s}{s} {s}{s}{s} ", .{
                     cur_open,  cursor_sym, prompts.closeSeq(cur_open),
@@ -249,7 +251,7 @@ test "non-TTY: selects by comma-separated numbers" {
     var output: [1024]u8 = undefined;
     var output_writer: std.Io.Writer = .fixed(&output);
 
-    const result = try multiSelect(&output_writer, &input_reader, allocator, .{
+    const result = try multiSelect(.{ .writer = &output_writer, .reader = &input_reader, .allocator = allocator }, .{
         .message = "Pick:",
         .choices = &.{ "a", "b", "c" },
     });
@@ -267,7 +269,7 @@ test "non-TTY: empty input returns defaults" {
     var output: [1024]u8 = undefined;
     var output_writer: std.Io.Writer = .fixed(&output);
 
-    const result = try multiSelect(&output_writer, &input_reader, allocator, .{
+    const result = try multiSelect(.{ .writer = &output_writer, .reader = &input_reader, .allocator = allocator }, .{
         .message = "Pick:",
         .choices = &.{ "a", "b", "c" },
         .defaults = &.{ true, false, true },
@@ -286,7 +288,7 @@ test "non-TTY: no defaults returns empty" {
     var output: [1024]u8 = undefined;
     var output_writer: std.Io.Writer = .fixed(&output);
 
-    const result = try multiSelect(&output_writer, &input_reader, allocator, .{
+    const result = try multiSelect(.{ .writer = &output_writer, .reader = &input_reader, .allocator = allocator }, .{
         .message = "Pick:",
         .choices = &.{ "a", "b" },
     });
@@ -301,15 +303,15 @@ test "non-TTY: no defaults returns empty" {
 // hang-indent under the option text.
 // ---------------------------------------------------------------------------
 
-fn renderToBuf(buf: []u8, config: MultiSelectConfig, selected: []const bool, cursor: usize, ws: terminal.Winsize) !struct { rows: usize, text: []const u8 } {
+fn renderToBuf(buf: []u8, ctx: prompts.theme.ThemeContext, config: MultiSelectConfig, selected: []const bool, cursor: usize, ws: terminal.Winsize) !struct { rows: usize, text: []const u8 } {
     var w: std.Io.Writer = .fixed(buf);
-    const rows = try renderList(&w, config, selected, cursor, ws);
+    const rows = try renderList(&w, ctx, config, selected, cursor, ws);
     return .{ .rows = rows, .text = w.buffered() };
 }
 
 test "renderList: short options are one row each" {
     var buf: [1024]u8 = undefined;
-    const r = try renderToBuf(&buf, .{ .message = "Pick", .choices = &.{ "a", "b", "c" } }, &.{ false, false, false }, 0, .{ .row = 24, .col = 80 });
+    const r = try renderToBuf(&buf, prompts.default_style, .{ .message = "Pick", .choices = &.{ "a", "b", "c" } }, &.{ false, false, false }, 0, .{ .row = 24, .col = 80 });
     // 1 header row + 3 option rows.
     try std.testing.expectEqual(@as(usize, 4), r.rows);
 }
@@ -318,7 +320,7 @@ test "renderList: a wrapping option counts as multiple physical rows" {
     var buf: [4096]u8 = undefined;
     const long = "this is a fairly long option label that will certainly wrap";
     // Narrow terminal forces the long option onto several rows.
-    const r = try renderToBuf(&buf, .{ .message = "Pick", .choices = &.{ "short", long } }, &.{ false, false }, 0, .{ .row = 24, .col = 24 });
+    const r = try renderToBuf(&buf, prompts.default_style, .{ .message = "Pick", .choices = &.{ "short", long } }, &.{ false, false }, 0, .{ .row = 24, .col = 24 });
     // header(1) + short(1) + long(>=3 at width 24) — the key point is it is not 3.
     try std.testing.expect(r.rows > 3);
     // Row count must equal the number of CRLF-separated lines actually emitted.
@@ -338,7 +340,7 @@ test "renderList: cursor row styles through the cursor and marker tokens" {
         .theme = &custom,
         .caps = .{ .capability = .true_color, .is_tty = true, .color_enabled = true },
     };
-    const r = try renderToBuf(&buf, .{ .message = "Pick", .choices = &.{ "a", "b" }, .theme = ctx }, &.{ true, false }, 0, .{ .row = 24, .col = 80 });
+    const r = try renderToBuf(&buf, ctx, .{ .message = "Pick", .choices = &.{ "a", "b" } }, &.{ true, false }, 0, .{ .row = 24, .col = 80 });
     try std.testing.expect(std.mem.indexOf(u8, r.text, "38;2;9;8;7") != null); // cursor glyph
     try std.testing.expect(std.mem.indexOf(u8, r.text, "38;2;4;5;6") != null); // marker
 }
@@ -348,14 +350,14 @@ test "renderList: no_color renders without any escapes" {
     const ctx = prompts.theme.ThemeContext{
         .caps = .{ .capability = .no_color, .is_tty = true, .color_enabled = false },
     };
-    const r = try renderToBuf(&buf, .{ .message = "Pick", .choices = &.{ "a", "b" }, .theme = ctx }, &.{ true, false }, 0, .{ .row = 24, .col = 80 });
+    const r = try renderToBuf(&buf, ctx, .{ .message = "Pick", .choices = &.{ "a", "b" } }, &.{ true, false }, 0, .{ .row = 24, .col = 80 });
     try std.testing.expect(std.mem.indexOf(u8, r.text, "\x1b[") == null);
 }
 
 test "renderList: continuation lines hang-indent under the option text" {
     var buf: [4096]u8 = undefined;
     // unicode=false so the prefix is "    [ ] " = 8 columns.
-    const r = try renderToBuf(&buf, .{ .message = "Pick", .choices = &.{"alpha bravo charlie delta"}, .unicode = false }, &.{false}, 0, .{ .row = 24, .col = 20 });
+    const r = try renderToBuf(&buf, prompts.default_style, .{ .message = "Pick", .choices = &.{"alpha bravo charlie delta"}, .unicode = false }, &.{false}, 0, .{ .row = 24, .col = 20 });
     _ = r;
     // The continuation line is preceded by 8 spaces (prefix width), aligning it
     // under the label text rather than under the bullet.

--- a/packages/prompts/src/multi_select.zig
+++ b/packages/prompts/src/multi_select.zig
@@ -2,7 +2,7 @@
 
 const std = @import("std");
 const terminal = @import("terminal");
-const prompts = @import("prompts.zig");
+const Prompts = @import("Prompts.zig");
 const lr = @import("list_render.zig");
 
 pub const MultiSelectConfig = struct {
@@ -14,7 +14,7 @@ pub const MultiSelectConfig = struct {
 };
 
 /// Prompt to select multiple items. Returns owned slice of selected indices.
-pub fn multiSelect(p: prompts.Prompts, config: MultiSelectConfig) ![]usize {
+pub fn multiSelect(p: Prompts, config: MultiSelectConfig) ![]usize {
     const writer = p.writer;
     const reader = p.reader;
     const allocator = p.allocator;
@@ -49,7 +49,7 @@ pub fn multiSelect(p: prompts.Prompts, config: MultiSelectConfig) ![]usize {
     }
 
     // TTY: interactive multi-select
-    prompts.flushWriter(writer);
+    Prompts.flushWriter(writer);
     const raw = terminal.enableRawMode(std.Io.File.stdin().handle) catch {
         return collectDefaults(allocator, config);
     };
@@ -59,7 +59,7 @@ pub fn multiSelect(p: prompts.Prompts, config: MultiSelectConfig) ![]usize {
         writer.writeAll(terminal.ansi.show_cursor) catch {};
         watcher.deinit();
         raw.disable();
-        prompts.flushWriter(writer);
+        Prompts.flushWriter(writer);
     }
 
     var selected = try allocator.alloc(bool, config.choices.len);
@@ -77,7 +77,7 @@ pub fn multiSelect(p: prompts.Prompts, config: MultiSelectConfig) ![]usize {
     var rows = try renderList(writer, p.theme, config, selected, cursor, lr.windowSize());
 
     while (true) {
-        prompts.flushWriter(writer);
+        Prompts.flushWriter(writer);
         switch (try terminal.readEvent(reader, stdin, &watcher)) {
             .resize => {
                 try lr.eraseRegion(writer, rows);
@@ -106,7 +106,7 @@ pub fn multiSelect(p: prompts.Prompts, config: MultiSelectConfig) ![]usize {
                     // Show summary
                     var first = true;
                     var obuf: [64]u8 = undefined;
-                    const open = prompts.openSeq(&obuf, p.theme, p.theme.promptTokens().selected);
+                    const open = Prompts.openSeq(&obuf, p.theme, p.theme.promptTokens().selected);
                     try writer.print("  {s}", .{open});
                     for (config.choices, 0..) |choice, i| {
                         if (selected[i]) {
@@ -115,7 +115,7 @@ pub fn multiSelect(p: prompts.Prompts, config: MultiSelectConfig) ![]usize {
                             first = false;
                         }
                     }
-                    try writer.print("{s}\r\n", .{prompts.closeSeq(open)});
+                    try writer.print("{s}\r\n", .{Prompts.closeSeq(open)});
 
                     // Collect selected indices
                     var result = std.ArrayList(usize).empty;
@@ -149,7 +149,7 @@ pub fn multiSelect(p: prompts.Prompts, config: MultiSelectConfig) ![]usize {
 /// Public for the cross-platform emulator render tests.
 pub fn renderList(
     writer: anytype,
-    ctx: prompts.theme.ThemeContext,
+    ctx: Prompts.ThemeContext,
     config: MultiSelectConfig,
     selected: []const bool,
     cursor: usize,
@@ -199,12 +199,12 @@ pub fn renderList(
         var cbuf: [64]u8 = undefined;
         var mbuf: [64]u8 = undefined;
         const style: lr.ItemStyle = if (i == cursor) blk: {
-            const cur_open = prompts.openSeq(&cbuf, ctx, tokens.cursor);
-            const mark_open = prompts.openSeq(&mbuf, ctx, tokens.marker);
+            const cur_open = Prompts.openSeq(&cbuf, ctx, tokens.cursor);
+            const mark_open = Prompts.openSeq(&mbuf, ctx, tokens.marker);
             break :blk .{
                 .first_prefix = std.fmt.bufPrint(&pbuf, "  {s}{s}{s} {s}{s}{s} ", .{
-                    cur_open,  cursor_sym, prompts.closeSeq(cur_open),
-                    mark_open, marker,     prompts.closeSeq(mark_open),
+                    cur_open,  cursor_sym, Prompts.closeSeq(cur_open),
+                    mark_open, marker,     Prompts.closeSeq(mark_open),
                 }) catch "  ",
                 .prefix_w = prefix_w,
             };
@@ -303,7 +303,7 @@ test "non-TTY: no defaults returns empty" {
 // hang-indent under the option text.
 // ---------------------------------------------------------------------------
 
-fn renderToBuf(buf: []u8, ctx: prompts.theme.ThemeContext, config: MultiSelectConfig, selected: []const bool, cursor: usize, ws: terminal.Winsize) !struct { rows: usize, text: []const u8 } {
+fn renderToBuf(buf: []u8, ctx: Prompts.ThemeContext, config: MultiSelectConfig, selected: []const bool, cursor: usize, ws: terminal.Winsize) !struct { rows: usize, text: []const u8 } {
     var w: std.Io.Writer = .fixed(buf);
     const rows = try renderList(&w, ctx, config, selected, cursor, ws);
     return .{ .rows = rows, .text = w.buffered() };
@@ -311,7 +311,7 @@ fn renderToBuf(buf: []u8, ctx: prompts.theme.ThemeContext, config: MultiSelectCo
 
 test "renderList: short options are one row each" {
     var buf: [1024]u8 = undefined;
-    const r = try renderToBuf(&buf, prompts.default_style, .{ .message = "Pick", .choices = &.{ "a", "b", "c" } }, &.{ false, false, false }, 0, .{ .row = 24, .col = 80 });
+    const r = try renderToBuf(&buf, Prompts.default_style, .{ .message = "Pick", .choices = &.{ "a", "b", "c" } }, &.{ false, false, false }, 0, .{ .row = 24, .col = 80 });
     // 1 header row + 3 option rows.
     try std.testing.expectEqual(@as(usize, 4), r.rows);
 }
@@ -320,7 +320,7 @@ test "renderList: a wrapping option counts as multiple physical rows" {
     var buf: [4096]u8 = undefined;
     const long = "this is a fairly long option label that will certainly wrap";
     // Narrow terminal forces the long option onto several rows.
-    const r = try renderToBuf(&buf, prompts.default_style, .{ .message = "Pick", .choices = &.{ "short", long } }, &.{ false, false }, 0, .{ .row = 24, .col = 24 });
+    const r = try renderToBuf(&buf, Prompts.default_style, .{ .message = "Pick", .choices = &.{ "short", long } }, &.{ false, false }, 0, .{ .row = 24, .col = 24 });
     // header(1) + short(1) + long(>=3 at width 24) — the key point is it is not 3.
     try std.testing.expect(r.rows > 3);
     // Row count must equal the number of CRLF-separated lines actually emitted.
@@ -330,13 +330,13 @@ test "renderList: a wrapping option counts as multiple physical rows" {
 
 test "renderList: cursor row styles through the cursor and marker tokens" {
     var buf: [1024]u8 = undefined;
-    const custom = prompts.theme.Theme{
+    const custom = Prompts.Theme{
         .prompts = .{
             .cursor = .{ .style = .{ .foreground = .{ .rgb = .{ .r = 9, .g = 8, .b = 7 } } } },
             .marker = .{ .style = .{ .foreground = .{ .rgb = .{ .r = 4, .g = 5, .b = 6 } } } },
         },
     };
-    const ctx = prompts.theme.ThemeContext{
+    const ctx = Prompts.ThemeContext{
         .theme = &custom,
         .caps = .{ .capability = .true_color, .is_tty = true, .color_enabled = true },
     };
@@ -347,7 +347,7 @@ test "renderList: cursor row styles through the cursor and marker tokens" {
 
 test "renderList: no_color renders without any escapes" {
     var buf: [1024]u8 = undefined;
-    const ctx = prompts.theme.ThemeContext{
+    const ctx = Prompts.ThemeContext{
         .caps = .{ .capability = .no_color, .is_tty = true, .color_enabled = false },
     };
     const r = try renderToBuf(&buf, ctx, .{ .message = "Pick", .choices = &.{ "a", "b" } }, &.{ true, false }, 0, .{ .row = 24, .col = 80 });
@@ -357,7 +357,7 @@ test "renderList: no_color renders without any escapes" {
 test "renderList: continuation lines hang-indent under the option text" {
     var buf: [4096]u8 = undefined;
     // unicode=false so the prefix is "    [ ] " = 8 columns.
-    const r = try renderToBuf(&buf, prompts.default_style, .{ .message = "Pick", .choices = &.{"alpha bravo charlie delta"}, .unicode = false }, &.{false}, 0, .{ .row = 24, .col = 20 });
+    const r = try renderToBuf(&buf, Prompts.default_style, .{ .message = "Pick", .choices = &.{"alpha bravo charlie delta"}, .unicode = false }, &.{false}, 0, .{ .row = 24, .col = 20 });
     _ = r;
     // The continuation line is preceded by 8 spaces (prefix width), aligning it
     // under the label text rather than under the bullet.

--- a/packages/prompts/src/number.zig
+++ b/packages/prompts/src/number.zig
@@ -2,7 +2,7 @@
 
 const std = @import("std");
 const terminal = @import("terminal");
-const prompts = @import("prompts.zig");
+const Prompts = @import("Prompts.zig");
 
 pub const NumberConfig = struct {
     message: []const u8,
@@ -17,7 +17,7 @@ pub const NumberConfig = struct {
 
 /// Prompt for numeric input. Returns the entered number, or `error.Interrupted`
 /// if the user presses one of `config.interrupt_keys`.
-pub fn number(p: prompts.Prompts, config: NumberConfig) !i64 {
+pub fn number(p: Prompts, config: NumberConfig) !i64 {
     const writer = p.writer;
     const reader = p.reader;
     const is_tty = terminal.isStdinTty();
@@ -64,25 +64,25 @@ fn readNumberNonTty(reader: anytype, config: NumberConfig) !i64 {
 }
 
 fn readNumberTty(writer: anytype, reader: anytype, config: NumberConfig) !i64 {
-    prompts.flushWriter(writer);
+    Prompts.flushWriter(writer);
     const raw = terminal.enableRawMode(std.Io.File.stdin().handle) catch {
         return config.default orelse return error.InvalidNumber;
     };
     defer {
         raw.disable();
-        prompts.flushWriter(writer);
+        Prompts.flushWriter(writer);
     }
 
     var buf: [32]u8 = undefined;
     var len: usize = 0;
 
     while (true) {
-        prompts.flushWriter(writer);
+        Prompts.flushWriter(writer);
         const k = if (config.interrupt_keys.len > 0)
             try terminal.readKeyOpt(reader, std.Io.File.stdin().handle)
         else
             try terminal.readKey(reader);
-        if (prompts.isInterrupt(k, config.interrupt_keys)) {
+        if (Prompts.isInterrupt(k, config.interrupt_keys)) {
             try writer.writeAll("\r\n");
             return error.Interrupted;
         }

--- a/packages/prompts/src/number.zig
+++ b/packages/prompts/src/number.zig
@@ -17,7 +17,9 @@ pub const NumberConfig = struct {
 
 /// Prompt for numeric input. Returns the entered number, or `error.Interrupted`
 /// if the user presses one of `config.interrupt_keys`.
-pub fn number(writer: anytype, reader: anytype, config: NumberConfig) !i64 {
+pub fn number(p: prompts.Prompts, config: NumberConfig) !i64 {
+    const writer = p.writer;
+    const reader = p.reader;
     const is_tty = terminal.isStdinTty();
 
     while (true) {
@@ -160,7 +162,7 @@ test "non-TTY: parses a typed number" {
     var output: [256]u8 = undefined;
     var writer_stream: std.Io.Writer = .fixed(&output);
 
-    const result = try number(&writer_stream, &reader_stream, .{
+    const result = try number(.{ .writer = &writer_stream, .reader = &reader_stream, .allocator = std.testing.allocator }, .{
         .message = "Count:",
     });
     try std.testing.expectEqual(@as(i64, 42), result);
@@ -175,7 +177,7 @@ test "non-TTY: multi-digit value survives the readLine buffer boundary" {
     var output: [256]u8 = undefined;
     var writer_stream: std.Io.Writer = .fixed(&output);
 
-    const result = try number(&writer_stream, &reader_stream, .{
+    const result = try number(.{ .writer = &writer_stream, .reader = &reader_stream, .allocator = std.testing.allocator }, .{
         .message = "Value:",
     });
     try std.testing.expectEqual(@as(i64, 1234567), result);
@@ -187,7 +189,7 @@ test "non-TTY: empty input falls back to the default" {
     var output: [256]u8 = undefined;
     var writer_stream: std.Io.Writer = .fixed(&output);
 
-    const result = try number(&writer_stream, &reader_stream, .{
+    const result = try number(.{ .writer = &writer_stream, .reader = &reader_stream, .allocator = std.testing.allocator }, .{
         .message = "Port:",
         .default = 3000,
     });
@@ -200,7 +202,7 @@ test "non-TTY: empty input with no default errors" {
     var output: [256]u8 = undefined;
     var writer_stream: std.Io.Writer = .fixed(&output);
 
-    try std.testing.expectError(error.InvalidNumber, number(&writer_stream, &reader_stream, .{
+    try std.testing.expectError(error.InvalidNumber, number(.{ .writer = &writer_stream, .reader = &reader_stream, .allocator = std.testing.allocator }, .{
         .message = "Port:",
     }));
 }
@@ -211,7 +213,7 @@ test "non-TTY: non-numeric input errors" {
     var output: [256]u8 = undefined;
     var writer_stream: std.Io.Writer = .fixed(&output);
 
-    try std.testing.expectError(error.InvalidNumber, number(&writer_stream, &reader_stream, .{
+    try std.testing.expectError(error.InvalidNumber, number(.{ .writer = &writer_stream, .reader = &reader_stream, .allocator = std.testing.allocator }, .{
         .message = "Count:",
     }));
 }

--- a/packages/prompts/src/password.zig
+++ b/packages/prompts/src/password.zig
@@ -2,7 +2,7 @@
 
 const std = @import("std");
 const terminal = @import("terminal");
-const prompts = @import("prompts.zig");
+const Prompts = @import("Prompts.zig");
 
 pub const PasswordConfig = struct {
     message: []const u8,
@@ -11,7 +11,7 @@ pub const PasswordConfig = struct {
 };
 
 /// Prompt for password input with masking. Returns owned string.
-pub fn password(p: prompts.Prompts, config: PasswordConfig) ![]u8 {
+pub fn password(p: Prompts, config: PasswordConfig) ![]u8 {
     const writer = p.writer;
     const reader = p.reader;
     const allocator = p.allocator;
@@ -27,21 +27,21 @@ pub fn password(p: prompts.Prompts, config: PasswordConfig) ![]u8 {
     }
 
     // TTY: raw mode with mask character
-    prompts.flushWriter(writer);
+    Prompts.flushWriter(writer);
     const raw = terminal.enableRawMode(std.Io.File.stdin().handle) catch {
         try writer.writeAll("\n");
         return try allocator.dupe(u8, "");
     };
     defer {
         raw.disable();
-        prompts.flushWriter(writer);
+        Prompts.flushWriter(writer);
     }
 
     var buf = std.ArrayList(u8).empty;
     defer buf.deinit(allocator);
 
     while (true) {
-        prompts.flushWriter(writer);
+        Prompts.flushWriter(writer);
         const k = try terminal.readKey(reader);
         switch (k) {
             .enter => {
@@ -50,7 +50,7 @@ pub fn password(p: prompts.Prompts, config: PasswordConfig) ![]u8 {
             },
             .backspace => {
                 if (buf.items.len > 0) {
-                    prompts.popTrailingGrapheme(&buf);
+                    Prompts.popTrailingGrapheme(&buf);
                     try renderMask(writer, config, terminal.graphemeCount(buf.items));
                 }
             },
@@ -62,7 +62,7 @@ pub fn password(p: prompts.Prompts, config: PasswordConfig) ![]u8 {
             },
             .char => |c| {
                 // One mask glyph per typed character, not per UTF-8 byte.
-                _ = try prompts.appendCodepoint(allocator, &buf, c);
+                _ = try Prompts.appendCodepoint(allocator, &buf, c);
                 try renderMask(writer, config, terminal.graphemeCount(buf.items));
             },
             else => {},
@@ -77,7 +77,7 @@ fn renderMask(writer: anytype, config: PasswordConfig, len: usize) !void {
     for (0..len) |_| {
         try writer.print("{c}", .{config.mask});
     }
-    prompts.flushWriter(writer);
+    Prompts.flushWriter(writer);
 }
 
 fn readLine(reader: anytype, allocator: std.mem.Allocator) ![]u8 {

--- a/packages/prompts/src/password.zig
+++ b/packages/prompts/src/password.zig
@@ -11,7 +11,10 @@ pub const PasswordConfig = struct {
 };
 
 /// Prompt for password input with masking. Returns owned string.
-pub fn password(writer: anytype, reader: anytype, allocator: std.mem.Allocator, config: PasswordConfig) ![]u8 {
+pub fn password(p: prompts.Prompts, config: PasswordConfig) ![]u8 {
+    const writer = p.writer;
+    const reader = p.reader;
+    const allocator = p.allocator;
     const is_tty = terminal.isStdinTty();
 
     try writer.print("{s}{s} ", .{ config.prefix, config.message });
@@ -100,7 +103,7 @@ test "non-TTY: reads password line" {
     var output: [256]u8 = undefined;
     var output_writer: std.Io.Writer = .fixed(&output);
 
-    const result = try password(&output_writer, &input_reader, allocator, .{
+    const result = try password(.{ .writer = &output_writer, .reader = &input_reader, .allocator = allocator }, .{
         .message = "Password:",
     });
     defer allocator.free(result);
@@ -115,7 +118,7 @@ test "non-TTY: EOF returns empty" {
     var output: [256]u8 = undefined;
     var output_writer: std.Io.Writer = .fixed(&output);
 
-    const result = try password(&output_writer, &input_reader, allocator, .{
+    const result = try password(.{ .writer = &output_writer, .reader = &input_reader, .allocator = allocator }, .{
         .message = "Password:",
     });
     defer allocator.free(result);
@@ -130,7 +133,7 @@ test "prompt shows message" {
     var output: [256]u8 = undefined;
     var output_writer: std.Io.Writer = .fixed(&output);
 
-    const result = try password(&output_writer, &input_reader, allocator, .{
+    const result = try password(.{ .writer = &output_writer, .reader = &input_reader, .allocator = allocator }, .{
         .message = "Enter secret:",
     });
     defer allocator.free(result);

--- a/packages/prompts/src/prompts.zig
+++ b/packages/prompts/src/prompts.zig
@@ -6,19 +6,23 @@
 //! ```zig
 //! const prompts = @import("prompts");
 //!
-//! const name = try prompts.text(writer, reader, allocator, .{ .message = "Name:" });
-//! const ok = try prompts.confirm(writer, reader, .{ .message = "Continue?" });
-//! const idx = try prompts.select(writer, reader, .{ .message = "Pick:", .choices = &.{"a", "b"} });
+//! const p: prompts.Prompts = .{ .writer = writer, .reader = reader, .allocator = allocator };
+//!
+//! const name = try p.text(.{ .message = "Name:" });
+//! const ok = try p.confirm(.{ .message = "Continue?" });
+//! const idx = try p.select(.{ .message = "Pick:", .choices = &.{"a", "b"} });
 //! ```
 
 const std = @import("std");
 pub const terminal = @import("terminal");
 pub const theme = @import("theme");
 
-/// Style context used when the caller doesn't pass one: the default theme at
-/// ANSI-16, matching the package's historical fixed colors. zcli applications
-/// pass `context.theme` instead, which carries the app's theme and the
-/// detected terminal capabilities (including NO_COLOR).
+const ThemeContext = theme.ThemeContext;
+
+/// Style context used when a `Prompts` instance doesn't set one: the default
+/// theme at ANSI-16, matching the package's historical fixed colors. zcli
+/// applications set `.theme = context.theme` instead, which carries the app's
+/// theme and the detected terminal capabilities (including NO_COLOR).
 pub const default_style: theme.ThemeContext = .fallback;
 
 /// Render `ref`'s opening escape sequence into `buf`, returning the (possibly
@@ -48,6 +52,38 @@ pub const search_prompt = @import("search.zig");
 pub const number_prompt = @import("number.zig");
 pub const editor_prompt = @import("editor.zig");
 
+/// The prompts API. An instance bundles the environment every prompt needs —
+/// writer, reader, allocator, and theme — so call sites only say what's
+/// specific to the question being asked:
+///
+/// ```zig
+/// const p: prompts.Prompts = .{
+///     .writer = context.stdout(),
+///     .reader = context.stdin(),
+///     .allocator = context.allocator,
+///     .theme = context.theme,
+/// };
+/// const points = try p.number(.{ .message = "Story points:", .min = 0, .max = 100 });
+/// ```
+pub const Prompts = struct {
+    writer: *std.Io.Writer,
+    reader: *std.Io.Reader,
+    /// Owns every string a prompt returns (`text`, `password`, `editor`) and
+    /// the index slice from `multiSelect`.
+    allocator: std.mem.Allocator,
+    /// Theme + terminal capabilities for styling; zcli commands pass `context.theme`.
+    theme: ThemeContext = default_style,
+
+    pub const text = text_prompt.text;
+    pub const confirm = confirm_prompt.confirm;
+    pub const select = select_prompt.select;
+    pub const multiSelect = multi_select_prompt.multiSelect;
+    pub const password = password_prompt.password;
+    pub const search = search_prompt.search;
+    pub const number = number_prompt.number;
+    pub const editor = editor_prompt.editor;
+};
+
 /// Returned by a prompt when the user presses one of the caller's
 /// `interrupt_keys`. The prompt stays domain-agnostic — the caller decides what
 /// the interruption means (go back, cancel, open help, …).
@@ -60,16 +96,6 @@ pub fn isInterrupt(key: terminal.Key, keys: []const terminal.Key) bool {
     }
     return false;
 }
-
-// Re-export main functions
-pub const text = text_prompt.text;
-pub const confirm = confirm_prompt.confirm;
-pub const select = select_prompt.select;
-pub const multiSelect = multi_select_prompt.multiSelect;
-pub const password = password_prompt.password;
-pub const search = search_prompt.search;
-pub const number = number_prompt.number;
-pub const editor = editor_prompt.editor;
 
 /// Append a typed codepoint to `buf` as UTF-8, returning the appended bytes
 /// (a slice into `buf.items`) so the caller can echo them.

--- a/packages/prompts/src/search.zig
+++ b/packages/prompts/src/search.zig
@@ -2,7 +2,7 @@
 
 const std = @import("std");
 const terminal = @import("terminal");
-const prompts = @import("prompts.zig");
+const Prompts = @import("Prompts.zig");
 const lr = @import("list_render.zig");
 
 pub const SearchConfig = struct {
@@ -13,7 +13,7 @@ pub const SearchConfig = struct {
 };
 
 /// Prompt with search filtering. Returns the index of the selected item in the original choices array.
-pub fn search(p: prompts.Prompts, config: SearchConfig) !usize {
+pub fn search(p: Prompts, config: SearchConfig) !usize {
     const writer = p.writer;
     const reader = p.reader;
     const allocator = p.allocator;
@@ -35,7 +35,7 @@ pub fn search(p: prompts.Prompts, config: SearchConfig) !usize {
     }
 
     // TTY: interactive search
-    prompts.flushWriter(writer);
+    Prompts.flushWriter(writer);
     const raw = terminal.enableRawMode(std.Io.File.stdin().handle) catch return 0;
     try writer.writeAll(terminal.ansi.hide_cursor);
     var watcher = terminal.ResizeWatcher.init();
@@ -43,7 +43,7 @@ pub fn search(p: prompts.Prompts, config: SearchConfig) !usize {
         writer.writeAll(terminal.ansi.show_cursor) catch {};
         watcher.deinit();
         raw.disable();
-        prompts.flushWriter(writer);
+        Prompts.flushWriter(writer);
     }
 
     var query = std.ArrayList(u8).empty;
@@ -56,7 +56,7 @@ pub fn search(p: prompts.Prompts, config: SearchConfig) !usize {
     var rows = try renderSearch(writer, p.theme, config, query.items, filtered, cursor, lr.windowSize());
 
     while (true) {
-        prompts.flushWriter(writer);
+        Prompts.flushWriter(writer);
         switch (try terminal.readEvent(reader, stdin, &watcher)) {
             .resize => {
                 try lr.eraseRegion(writer, rows);
@@ -78,14 +78,14 @@ pub fn search(p: prompts.Prompts, config: SearchConfig) !usize {
                         const selected_idx = filtered[cursor];
                         try lr.eraseRegion(writer, rows);
                         var obuf: [64]u8 = undefined;
-                        const open = prompts.openSeq(&obuf, p.theme, p.theme.promptTokens().selected);
-                        try writer.print("  {s}{s}{s}\r\n", .{ open, config.choices[selected_idx], prompts.closeSeq(open) });
+                        const open = Prompts.openSeq(&obuf, p.theme, p.theme.promptTokens().selected);
+                        try writer.print("  {s}{s}{s}\r\n", .{ open, config.choices[selected_idx], Prompts.closeSeq(open) });
                         return selected_idx;
                     }
                 },
                 .backspace => {
                     if (query.items.len > 0) {
-                        prompts.popTrailingGrapheme(&query);
+                        Prompts.popTrailingGrapheme(&query);
                         allocator.free(filtered);
                         filtered = try buildFiltered(allocator, config.choices, query.items);
                         cursor = 0;
@@ -100,7 +100,7 @@ pub fn search(p: prompts.Prompts, config: SearchConfig) !usize {
                     }
                 },
                 .char => |c| {
-                    _ = try prompts.appendCodepoint(allocator, &query, c);
+                    _ = try Prompts.appendCodepoint(allocator, &query, c);
                     allocator.free(filtered);
                     filtered = try buildFiltered(allocator, config.choices, query.items);
                     cursor = 0;
@@ -147,7 +147,7 @@ fn containsIgnoreCase(haystack: []const u8, needle: []const u8) bool {
 /// is deterministic/testable (used by the cross-platform emulator render tests).
 pub fn renderSearch(
     writer: anytype,
-    ctx: prompts.theme.ThemeContext,
+    ctx: Prompts.ThemeContext,
     config: SearchConfig,
     query: []const u8,
     filtered: []const usize,
@@ -178,7 +178,7 @@ pub fn renderSearch(
     const search_prefix_w = terminal.displayWidth(search_prefix);
     var hint_open_buf: [64]u8 = undefined;
     var hint_prefix_buf: [96]u8 = undefined;
-    const hint_open = prompts.openSeq(&hint_open_buf, ctx, tokens.hint);
+    const hint_open = Prompts.openSeq(&hint_open_buf, ctx, tokens.hint);
     if (query.len > 0) {
         rows += try lr.renderItem(writer, &first_line, .{ .first_prefix = search_prefix, .prefix_w = search_prefix_w }, query, @max(usable -| search_prefix_w, 1));
     } else {
@@ -186,7 +186,7 @@ pub fn renderSearch(
         rows += try lr.renderItem(writer, &first_line, .{
             .first_prefix = styled_prefix,
             .prefix_w = search_prefix_w,
-            .line_close = prompts.closeSeq(hint_open),
+            .line_close = Prompts.closeSeq(hint_open),
         }, "type to filter", @max(usable -| search_prefix_w, 1));
     }
 
@@ -195,7 +195,7 @@ pub fn renderSearch(
         rows += try lr.renderItem(writer, &first_line, .{
             .first_prefix = nm_prefix,
             .prefix_w = 2,
-            .line_close = prompts.closeSeq(hint_open),
+            .line_close = Prompts.closeSeq(hint_open),
         }, "no matches", avail);
         return rows;
     }
@@ -218,12 +218,12 @@ pub fn renderSearch(
         var pbuf: [32]u8 = undefined;
         var obuf: [64]u8 = undefined;
         const style: lr.ItemStyle = if (i == cursor) blk: {
-            const open = prompts.openSeq(&obuf, ctx, tokens.selected);
+            const open = Prompts.openSeq(&obuf, ctx, tokens.selected);
             break :blk .{
                 .line_open = open,
                 .first_prefix = std.fmt.bufPrint(&pbuf, "  {s} ", .{cursor_sym}) catch "  ",
                 .prefix_w = prefix_w,
-                .line_close = prompts.closeSeq(open),
+                .line_close = Prompts.closeSeq(open),
             };
         } else .{ .first_prefix = "    ", .prefix_w = prefix_w };
         rows += try lr.renderItem(writer, &first_line, style, choice, avail);
@@ -273,7 +273,7 @@ test "SearchConfig defaults" {
     try std.testing.expectEqualStrings("? ", cfg.prefix);
 }
 
-fn renderToBuf(buf: []u8, ctx: prompts.theme.ThemeContext, config: SearchConfig, query: []const u8, filtered: []const usize, cursor: usize, ws: terminal.Winsize) !struct { rows: usize, text: []const u8 } {
+fn renderToBuf(buf: []u8, ctx: Prompts.ThemeContext, config: SearchConfig, query: []const u8, filtered: []const usize, cursor: usize, ws: terminal.Winsize) !struct { rows: usize, text: []const u8 } {
     var w: std.Io.Writer = .fixed(buf);
     const rows = try renderSearch(&w, ctx, config, query, filtered, cursor, ws);
     return .{ .rows = rows, .text = w.buffered() };
@@ -282,7 +282,7 @@ fn renderToBuf(buf: []u8, ctx: prompts.theme.ThemeContext, config: SearchConfig,
 test "renderSearch: header + search line + results, row count matches lines" {
     var buf: [4096]u8 = undefined;
     const filtered = [_]usize{ 0, 1, 2 };
-    const r = try renderToBuf(&buf, prompts.default_style, .{ .message = "Pick", .choices = &.{ "alpha", "beta", "gamma" } }, "a", &filtered, 0, .{ .row = 24, .col = 80 });
+    const r = try renderToBuf(&buf, Prompts.default_style, .{ .message = "Pick", .choices = &.{ "alpha", "beta", "gamma" } }, "a", &filtered, 0, .{ .row = 24, .col = 80 });
     // header(1) + search(1) + 3 results = 5
     try std.testing.expectEqual(@as(usize, 5), r.rows);
     const lines = std.mem.count(u8, r.text, "\r\n") + 1;
@@ -294,10 +294,10 @@ test "renderSearch: placeholder styles through the hint token; no_color is escap
     const filtered = [_]usize{ 0, 1 };
 
     // Custom hint color flows into the placeholder
-    const custom = prompts.theme.Theme{
+    const custom = Prompts.Theme{
         .prompts = .{ .hint = .{ .style = .{ .foreground = .{ .rgb = .{ .r = 7, .g = 7, .b = 7 } } } } },
     };
-    const color_ctx = prompts.theme.ThemeContext{
+    const color_ctx = Prompts.ThemeContext{
         .theme = &custom,
         .caps = .{ .capability = .true_color, .is_tty = true, .color_enabled = true },
     };
@@ -305,7 +305,7 @@ test "renderSearch: placeholder styles through the hint token; no_color is escap
     try std.testing.expect(std.mem.indexOf(u8, r.text, "38;2;7;7;7") != null);
 
     // no_color renders the placeholder and cursor row without escapes
-    const plain_ctx = prompts.theme.ThemeContext{
+    const plain_ctx = Prompts.ThemeContext{
         .caps = .{ .capability = .no_color, .is_tty = true, .color_enabled = false },
     };
     const p = try renderToBuf(&buf, plain_ctx, .{ .message = "Pick", .choices = &.{ "a", "b" } }, "", &filtered, 0, .{ .row = 24, .col = 80 });
@@ -316,7 +316,7 @@ test "renderSearch: placeholder styles through the hint token; no_color is escap
 test "renderSearch: no matches renders a message row" {
     var buf: [1024]u8 = undefined;
     const empty = [_]usize{};
-    const r = try renderToBuf(&buf, prompts.default_style, .{ .message = "Pick", .choices = &.{ "a", "b" } }, "zzz", &empty, 0, .{ .row = 24, .col = 80 });
+    const r = try renderToBuf(&buf, Prompts.default_style, .{ .message = "Pick", .choices = &.{ "a", "b" } }, "zzz", &empty, 0, .{ .row = 24, .col = 80 });
     try std.testing.expectEqual(@as(usize, 3), r.rows); // header + search + "no matches"
     try std.testing.expect(std.mem.indexOf(u8, r.text, "no matches") != null);
 }

--- a/packages/prompts/src/search.zig
+++ b/packages/prompts/src/search.zig
@@ -10,12 +10,13 @@ pub const SearchConfig = struct {
     choices: []const []const u8,
     prefix: []const u8 = "? ",
     unicode: bool = true,
-    /// Theme + terminal capabilities for styling; zcli commands pass `context.theme`.
-    theme: prompts.theme.ThemeContext = prompts.default_style,
 };
 
 /// Prompt with search filtering. Returns the index of the selected item in the original choices array.
-pub fn search(writer: anytype, reader: anytype, allocator: std.mem.Allocator, config: SearchConfig) !usize {
+pub fn search(p: prompts.Prompts, config: SearchConfig) !usize {
+    const writer = p.writer;
+    const reader = p.reader;
+    const allocator = p.allocator;
     if (config.choices.len == 0) return error.NoChoices;
     const is_tty = terminal.isStdinTty();
 
@@ -52,32 +53,32 @@ pub fn search(writer: anytype, reader: anytype, allocator: std.mem.Allocator, co
     defer allocator.free(filtered);
     const stdin = std.Io.File.stdin().handle;
     var cursor: usize = 0;
-    var rows = try renderSearch(writer, config, query.items, filtered, cursor, lr.windowSize());
+    var rows = try renderSearch(writer, p.theme, config, query.items, filtered, cursor, lr.windowSize());
 
     while (true) {
         prompts.flushWriter(writer);
         switch (try terminal.readEvent(reader, stdin, &watcher)) {
             .resize => {
                 try lr.eraseRegion(writer, rows);
-                rows = try renderSearch(writer, config, query.items, filtered, cursor, lr.windowSize());
+                rows = try renderSearch(writer, p.theme, config, query.items, filtered, cursor, lr.windowSize());
             },
             .key => |k| switch (k) {
                 .up => {
                     if (cursor > 0) cursor -= 1;
                     try lr.eraseRegion(writer, rows);
-                    rows = try renderSearch(writer, config, query.items, filtered, cursor, lr.windowSize());
+                    rows = try renderSearch(writer, p.theme, config, query.items, filtered, cursor, lr.windowSize());
                 },
                 .down => {
                     if (cursor < filtered.len -| 1) cursor += 1;
                     try lr.eraseRegion(writer, rows);
-                    rows = try renderSearch(writer, config, query.items, filtered, cursor, lr.windowSize());
+                    rows = try renderSearch(writer, p.theme, config, query.items, filtered, cursor, lr.windowSize());
                 },
                 .enter => {
                     if (filtered.len > 0) {
                         const selected_idx = filtered[cursor];
                         try lr.eraseRegion(writer, rows);
                         var obuf: [64]u8 = undefined;
-                        const open = prompts.openSeq(&obuf, config.theme, config.theme.promptTokens().selected);
+                        const open = prompts.openSeq(&obuf, p.theme, p.theme.promptTokens().selected);
                         try writer.print("  {s}{s}{s}\r\n", .{ open, config.choices[selected_idx], prompts.closeSeq(open) });
                         return selected_idx;
                     }
@@ -89,7 +90,7 @@ pub fn search(writer: anytype, reader: anytype, allocator: std.mem.Allocator, co
                         filtered = try buildFiltered(allocator, config.choices, query.items);
                         cursor = 0;
                         try lr.eraseRegion(writer, rows);
-                        rows = try renderSearch(writer, config, query.items, filtered, cursor, lr.windowSize());
+                        rows = try renderSearch(writer, p.theme, config, query.items, filtered, cursor, lr.windowSize());
                     }
                 },
                 .ctrl => |c| {
@@ -104,7 +105,7 @@ pub fn search(writer: anytype, reader: anytype, allocator: std.mem.Allocator, co
                     filtered = try buildFiltered(allocator, config.choices, query.items);
                     cursor = 0;
                     try lr.eraseRegion(writer, rows);
-                    rows = try renderSearch(writer, config, query.items, filtered, cursor, lr.windowSize());
+                    rows = try renderSearch(writer, p.theme, config, query.items, filtered, cursor, lr.windowSize());
                 },
                 else => {},
             },
@@ -146,6 +147,7 @@ fn containsIgnoreCase(haystack: []const u8, needle: []const u8) bool {
 /// is deterministic/testable (used by the cross-platform emulator render tests).
 pub fn renderSearch(
     writer: anytype,
+    ctx: prompts.theme.ThemeContext,
     config: SearchConfig,
     query: []const u8,
     filtered: []const usize,
@@ -162,7 +164,7 @@ pub fn renderSearch(
 
     var rows: usize = 0;
     var first_line = true;
-    const tokens = config.theme.promptTokens();
+    const tokens = ctx.promptTokens();
 
     // Header line.
     const hprefix_w = terminal.displayWidth(config.prefix);
@@ -176,7 +178,7 @@ pub fn renderSearch(
     const search_prefix_w = terminal.displayWidth(search_prefix);
     var hint_open_buf: [64]u8 = undefined;
     var hint_prefix_buf: [96]u8 = undefined;
-    const hint_open = prompts.openSeq(&hint_open_buf, config.theme, tokens.hint);
+    const hint_open = prompts.openSeq(&hint_open_buf, ctx, tokens.hint);
     if (query.len > 0) {
         rows += try lr.renderItem(writer, &first_line, .{ .first_prefix = search_prefix, .prefix_w = search_prefix_w }, query, @max(usable -| search_prefix_w, 1));
     } else {
@@ -216,7 +218,7 @@ pub fn renderSearch(
         var pbuf: [32]u8 = undefined;
         var obuf: [64]u8 = undefined;
         const style: lr.ItemStyle = if (i == cursor) blk: {
-            const open = prompts.openSeq(&obuf, config.theme, tokens.selected);
+            const open = prompts.openSeq(&obuf, ctx, tokens.selected);
             break :blk .{
                 .line_open = open,
                 .first_prefix = std.fmt.bufPrint(&pbuf, "  {s} ", .{cursor_sym}) catch "  ",
@@ -271,16 +273,16 @@ test "SearchConfig defaults" {
     try std.testing.expectEqualStrings("? ", cfg.prefix);
 }
 
-fn renderToBuf(buf: []u8, config: SearchConfig, query: []const u8, filtered: []const usize, cursor: usize, ws: terminal.Winsize) !struct { rows: usize, text: []const u8 } {
+fn renderToBuf(buf: []u8, ctx: prompts.theme.ThemeContext, config: SearchConfig, query: []const u8, filtered: []const usize, cursor: usize, ws: terminal.Winsize) !struct { rows: usize, text: []const u8 } {
     var w: std.Io.Writer = .fixed(buf);
-    const rows = try renderSearch(&w, config, query, filtered, cursor, ws);
+    const rows = try renderSearch(&w, ctx, config, query, filtered, cursor, ws);
     return .{ .rows = rows, .text = w.buffered() };
 }
 
 test "renderSearch: header + search line + results, row count matches lines" {
     var buf: [4096]u8 = undefined;
     const filtered = [_]usize{ 0, 1, 2 };
-    const r = try renderToBuf(&buf, .{ .message = "Pick", .choices = &.{ "alpha", "beta", "gamma" } }, "a", &filtered, 0, .{ .row = 24, .col = 80 });
+    const r = try renderToBuf(&buf, prompts.default_style, .{ .message = "Pick", .choices = &.{ "alpha", "beta", "gamma" } }, "a", &filtered, 0, .{ .row = 24, .col = 80 });
     // header(1) + search(1) + 3 results = 5
     try std.testing.expectEqual(@as(usize, 5), r.rows);
     const lines = std.mem.count(u8, r.text, "\r\n") + 1;
@@ -299,14 +301,14 @@ test "renderSearch: placeholder styles through the hint token; no_color is escap
         .theme = &custom,
         .caps = .{ .capability = .true_color, .is_tty = true, .color_enabled = true },
     };
-    const r = try renderToBuf(&buf, .{ .message = "Pick", .choices = &.{ "a", "b" }, .theme = color_ctx }, "", &filtered, 0, .{ .row = 24, .col = 80 });
+    const r = try renderToBuf(&buf, color_ctx, .{ .message = "Pick", .choices = &.{ "a", "b" } }, "", &filtered, 0, .{ .row = 24, .col = 80 });
     try std.testing.expect(std.mem.indexOf(u8, r.text, "38;2;7;7;7") != null);
 
     // no_color renders the placeholder and cursor row without escapes
     const plain_ctx = prompts.theme.ThemeContext{
         .caps = .{ .capability = .no_color, .is_tty = true, .color_enabled = false },
     };
-    const p = try renderToBuf(&buf, .{ .message = "Pick", .choices = &.{ "a", "b" }, .theme = plain_ctx }, "", &filtered, 0, .{ .row = 24, .col = 80 });
+    const p = try renderToBuf(&buf, plain_ctx, .{ .message = "Pick", .choices = &.{ "a", "b" } }, "", &filtered, 0, .{ .row = 24, .col = 80 });
     try std.testing.expect(std.mem.indexOf(u8, p.text, "type to filter") != null);
     try std.testing.expect(std.mem.indexOf(u8, p.text, "\x1b[") == null);
 }
@@ -314,7 +316,7 @@ test "renderSearch: placeholder styles through the hint token; no_color is escap
 test "renderSearch: no matches renders a message row" {
     var buf: [1024]u8 = undefined;
     const empty = [_]usize{};
-    const r = try renderToBuf(&buf, .{ .message = "Pick", .choices = &.{ "a", "b" } }, "zzz", &empty, 0, .{ .row = 24, .col = 80 });
+    const r = try renderToBuf(&buf, prompts.default_style, .{ .message = "Pick", .choices = &.{ "a", "b" } }, "zzz", &empty, 0, .{ .row = 24, .col = 80 });
     try std.testing.expectEqual(@as(usize, 3), r.rows); // header + search + "no matches"
     try std.testing.expect(std.mem.indexOf(u8, r.text, "no matches") != null);
 }

--- a/packages/prompts/src/select.zig
+++ b/packages/prompts/src/select.zig
@@ -2,7 +2,7 @@
 
 const std = @import("std");
 const terminal = @import("terminal");
-const prompts = @import("prompts.zig");
+const Prompts = @import("Prompts.zig");
 const lr = @import("list_render.zig");
 
 pub const SelectConfig = struct {
@@ -17,7 +17,7 @@ pub const SelectConfig = struct {
 
 /// Prompt to select one item from a list. Returns the chosen index, or
 /// `error.Interrupted` if the user presses one of `config.interrupt_keys`.
-pub fn select(p: prompts.Prompts, config: SelectConfig) !usize {
+pub fn select(p: Prompts, config: SelectConfig) !usize {
     const writer = p.writer;
     const reader = p.reader;
     if (config.choices.len == 0) return error.NoChoices;
@@ -38,7 +38,7 @@ pub fn select(p: prompts.Prompts, config: SelectConfig) !usize {
     }
 
     // TTY: interactive selection
-    prompts.flushWriter(writer);
+    Prompts.flushWriter(writer);
     const raw = terminal.enableRawMode(std.Io.File.stdin().handle) catch return 0;
     try writer.writeAll(terminal.ansi.hide_cursor);
     var watcher = terminal.ResizeWatcher.init();
@@ -46,7 +46,7 @@ pub fn select(p: prompts.Prompts, config: SelectConfig) !usize {
         writer.writeAll(terminal.ansi.show_cursor) catch {};
         watcher.deinit();
         raw.disable();
-        prompts.flushWriter(writer);
+        Prompts.flushWriter(writer);
     }
 
     const stdin = std.Io.File.stdin().handle;
@@ -54,14 +54,14 @@ pub fn select(p: prompts.Prompts, config: SelectConfig) !usize {
     var rows = try renderList(writer, p.theme, config, cursor, lr.windowSize());
 
     while (true) {
-        prompts.flushWriter(writer);
+        Prompts.flushWriter(writer);
         switch (try terminal.readEvent(reader, stdin, &watcher)) {
             .resize => {
                 try lr.eraseRegion(writer, rows);
                 rows = try renderList(writer, p.theme, config, cursor, lr.windowSize());
             },
             .key => |k| {
-                if (prompts.isInterrupt(k, config.interrupt_keys)) {
+                if (Prompts.isInterrupt(k, config.interrupt_keys)) {
                     try lr.eraseRegion(writer, rows);
                     return error.Interrupted;
                 }
@@ -79,8 +79,8 @@ pub fn select(p: prompts.Prompts, config: SelectConfig) !usize {
                     .enter => {
                         try lr.eraseRegion(writer, rows);
                         var obuf: [64]u8 = undefined;
-                        const open = prompts.openSeq(&obuf, p.theme, p.theme.promptTokens().selected);
-                        try writer.print("  {s}{s}{s}\r\n", .{ open, config.choices[cursor], prompts.closeSeq(open) });
+                        const open = Prompts.openSeq(&obuf, p.theme, p.theme.promptTokens().selected);
+                        try writer.print("  {s}{s}{s}\r\n", .{ open, config.choices[cursor], Prompts.closeSeq(open) });
                         return cursor;
                     },
                     .ctrl => |c| {
@@ -99,7 +99,7 @@ pub fn select(p: prompts.Prompts, config: SelectConfig) !usize {
 /// Render the header + viewport-limited choice list, returning physical rows
 /// emitted. Width is an explicit parameter so this is deterministic/testable
 /// (used by the cross-platform emulator render tests).
-pub fn renderList(writer: anytype, ctx: prompts.theme.ThemeContext, config: SelectConfig, cursor: usize, ws: terminal.Winsize) !usize {
+pub fn renderList(writer: anytype, ctx: Prompts.ThemeContext, config: SelectConfig, cursor: usize, ws: terminal.Winsize) !usize {
     const width = @max(@as(usize, ws.col), 1);
     const usable = @max(width -| 1, 1);
     const height = @max(@as(usize, ws.row), 2);
@@ -131,12 +131,12 @@ pub fn renderList(writer: anytype, ctx: prompts.theme.ThemeContext, config: Sele
         var pbuf: [32]u8 = undefined;
         var obuf: [64]u8 = undefined;
         const style: lr.ItemStyle = if (i == cursor) blk: {
-            const open = prompts.openSeq(&obuf, ctx, tokens.selected);
+            const open = Prompts.openSeq(&obuf, ctx, tokens.selected);
             break :blk .{
                 .line_open = open,
                 .first_prefix = std.fmt.bufPrint(&pbuf, "  {s} ", .{cursor_sym}) catch "  ",
                 .prefix_w = prefix_w,
-                .line_close = prompts.closeSeq(open),
+                .line_close = Prompts.closeSeq(open),
             };
         } else .{ .first_prefix = "    ", .prefix_w = prefix_w };
         rows += try lr.renderItem(writer, &first_line, style, config.choices[i], avail);
@@ -210,7 +210,7 @@ test "non-TTY: shows numbered choices" {
     try std.testing.expect(std.mem.indexOf(u8, written, "second") != null);
 }
 
-fn renderToBuf(buf: []u8, ctx: prompts.theme.ThemeContext, config: SelectConfig, cursor: usize, ws: terminal.Winsize) !struct { rows: usize, text: []const u8 } {
+fn renderToBuf(buf: []u8, ctx: Prompts.ThemeContext, config: SelectConfig, cursor: usize, ws: terminal.Winsize) !struct { rows: usize, text: []const u8 } {
     var w: std.Io.Writer = .fixed(buf);
     const rows = try renderList(&w, ctx, config, cursor, ws);
     return .{ .rows = rows, .text = w.buffered() };
@@ -218,16 +218,16 @@ fn renderToBuf(buf: []u8, ctx: prompts.theme.ThemeContext, config: SelectConfig,
 
 test "renderList: short options are one row each" {
     var buf: [1024]u8 = undefined;
-    const r = try renderToBuf(&buf, prompts.default_style, .{ .message = "Pick", .choices = &.{ "a", "b", "c" } }, 0, .{ .row = 24, .col = 80 });
+    const r = try renderToBuf(&buf, Prompts.default_style, .{ .message = "Pick", .choices = &.{ "a", "b", "c" } }, 0, .{ .row = 24, .col = 80 });
     try std.testing.expectEqual(@as(usize, 4), r.rows); // header + 3
 }
 
 test "renderList: selected row styles through the theme's selected token" {
     var buf: [1024]u8 = undefined;
-    const custom = prompts.theme.Theme{
+    const custom = Prompts.Theme{
         .palette = .{ .accent = .{ .foreground = .{ .rgb = .{ .r = 1, .g = 2, .b = 3 } } } },
     };
-    const ctx = prompts.theme.ThemeContext{
+    const ctx = Prompts.ThemeContext{
         .theme = &custom,
         .caps = .{ .capability = .true_color, .is_tty = true, .color_enabled = true },
     };
@@ -237,7 +237,7 @@ test "renderList: selected row styles through the theme's selected token" {
 
 test "renderList: no_color renders without any escapes" {
     var buf: [1024]u8 = undefined;
-    const ctx = prompts.theme.ThemeContext{
+    const ctx = Prompts.ThemeContext{
         .caps = .{ .capability = .no_color, .is_tty = true, .color_enabled = false },
     };
     const r = try renderToBuf(&buf, ctx, .{ .message = "Pick", .choices = &.{ "a", "b" } }, 0, .{ .row = 24, .col = 80 });
@@ -247,7 +247,7 @@ test "renderList: no_color renders without any escapes" {
 test "renderList: wrapped option reports true physical row count" {
     var buf: [4096]u8 = undefined;
     const long = "this is a long option label that will certainly wrap at a narrow width";
-    const r = try renderToBuf(&buf, prompts.default_style, .{ .message = "Pick", .choices = &.{ "short", long } }, 0, .{ .row = 24, .col = 24 });
+    const r = try renderToBuf(&buf, Prompts.default_style, .{ .message = "Pick", .choices = &.{ "short", long } }, 0, .{ .row = 24, .col = 24 });
     try std.testing.expect(r.rows > 3);
     const lines = std.mem.count(u8, r.text, "\r\n") + 1;
     try std.testing.expectEqual(lines, r.rows);

--- a/packages/prompts/src/select.zig
+++ b/packages/prompts/src/select.zig
@@ -13,13 +13,13 @@ pub const SelectConfig = struct {
     /// Keys the prompt should not handle itself: pressing one aborts the prompt
     /// with `error.Interrupted`. Empty = handle/ignore all keys.
     interrupt_keys: []const terminal.Key = &.{},
-    /// Theme + terminal capabilities for styling; zcli commands pass `context.theme`.
-    theme: prompts.theme.ThemeContext = prompts.default_style,
 };
 
 /// Prompt to select one item from a list. Returns the chosen index, or
 /// `error.Interrupted` if the user presses one of `config.interrupt_keys`.
-pub fn select(writer: anytype, reader: anytype, config: SelectConfig) !usize {
+pub fn select(p: prompts.Prompts, config: SelectConfig) !usize {
+    const writer = p.writer;
+    const reader = p.reader;
     if (config.choices.len == 0) return error.NoChoices;
     const is_tty = terminal.isStdinTty();
 
@@ -30,8 +30,8 @@ pub fn select(writer: anytype, reader: anytype, config: SelectConfig) !usize {
             try writer.print("  {d}) {s}\n", .{ i, choice });
         }
         try writer.writeAll("> ");
-        const line = readLine(reader, std.heap.page_allocator) catch return 0;
-        defer std.heap.page_allocator.free(line);
+        const line = readLine(reader, p.allocator) catch return 0;
+        defer p.allocator.free(line);
         const num = std.fmt.parseInt(usize, line, 10) catch return 0;
         if (num >= 1 and num <= config.choices.len) return num - 1;
         return 0;
@@ -51,14 +51,14 @@ pub fn select(writer: anytype, reader: anytype, config: SelectConfig) !usize {
 
     const stdin = std.Io.File.stdin().handle;
     var cursor: usize = 0;
-    var rows = try renderList(writer, config, cursor, lr.windowSize());
+    var rows = try renderList(writer, p.theme, config, cursor, lr.windowSize());
 
     while (true) {
         prompts.flushWriter(writer);
         switch (try terminal.readEvent(reader, stdin, &watcher)) {
             .resize => {
                 try lr.eraseRegion(writer, rows);
-                rows = try renderList(writer, config, cursor, lr.windowSize());
+                rows = try renderList(writer, p.theme, config, cursor, lr.windowSize());
             },
             .key => |k| {
                 if (prompts.isInterrupt(k, config.interrupt_keys)) {
@@ -69,17 +69,17 @@ pub fn select(writer: anytype, reader: anytype, config: SelectConfig) !usize {
                     .up => {
                         if (cursor > 0) cursor -= 1;
                         try lr.eraseRegion(writer, rows);
-                        rows = try renderList(writer, config, cursor, lr.windowSize());
+                        rows = try renderList(writer, p.theme, config, cursor, lr.windowSize());
                     },
                     .down => {
                         if (cursor < config.choices.len - 1) cursor += 1;
                         try lr.eraseRegion(writer, rows);
-                        rows = try renderList(writer, config, cursor, lr.windowSize());
+                        rows = try renderList(writer, p.theme, config, cursor, lr.windowSize());
                     },
                     .enter => {
                         try lr.eraseRegion(writer, rows);
                         var obuf: [64]u8 = undefined;
-                        const open = prompts.openSeq(&obuf, config.theme, config.theme.promptTokens().selected);
+                        const open = prompts.openSeq(&obuf, p.theme, p.theme.promptTokens().selected);
                         try writer.print("  {s}{s}{s}\r\n", .{ open, config.choices[cursor], prompts.closeSeq(open) });
                         return cursor;
                     },
@@ -99,7 +99,7 @@ pub fn select(writer: anytype, reader: anytype, config: SelectConfig) !usize {
 /// Render the header + viewport-limited choice list, returning physical rows
 /// emitted. Width is an explicit parameter so this is deterministic/testable
 /// (used by the cross-platform emulator render tests).
-pub fn renderList(writer: anytype, config: SelectConfig, cursor: usize, ws: terminal.Winsize) !usize {
+pub fn renderList(writer: anytype, ctx: prompts.theme.ThemeContext, config: SelectConfig, cursor: usize, ws: terminal.Winsize) !usize {
     const width = @max(@as(usize, ws.col), 1);
     const usable = @max(width -| 1, 1);
     const height = @max(@as(usize, ws.row), 2);
@@ -126,12 +126,12 @@ pub fn renderList(writer: anytype, config: SelectConfig, cursor: usize, ws: term
     const list_budget = @max((height -| 1) -| rows, 1);
     const win = lr.viewport(config.choices.len, cursor, list_budget, &counter, Counter.at);
 
-    const tokens = config.theme.promptTokens();
+    const tokens = ctx.promptTokens();
     for (win.start..win.end) |i| {
         var pbuf: [32]u8 = undefined;
         var obuf: [64]u8 = undefined;
         const style: lr.ItemStyle = if (i == cursor) blk: {
-            const open = prompts.openSeq(&obuf, config.theme, tokens.selected);
+            const open = prompts.openSeq(&obuf, ctx, tokens.selected);
             break :blk .{
                 .line_open = open,
                 .first_prefix = std.fmt.bufPrint(&pbuf, "  {s} ", .{cursor_sym}) catch "  ",
@@ -170,7 +170,7 @@ test "non-TTY: selects by number" {
     var output: [1024]u8 = undefined;
     var output_writer: std.Io.Writer = .fixed(&output);
 
-    const result = try select(&output_writer, &input_reader, .{
+    const result = try select(.{ .writer = &output_writer, .reader = &input_reader, .allocator = std.testing.allocator }, .{
         .message = "Pick:",
         .choices = &.{ "alpha", "beta", "gamma" },
     });
@@ -184,7 +184,7 @@ test "non-TTY: invalid number returns 0" {
     var output: [1024]u8 = undefined;
     var output_writer: std.Io.Writer = .fixed(&output);
 
-    const result = try select(&output_writer, &input_reader, .{
+    const result = try select(.{ .writer = &output_writer, .reader = &input_reader, .allocator = std.testing.allocator }, .{
         .message = "Pick:",
         .choices = &.{ "a", "b" },
     });
@@ -198,7 +198,7 @@ test "non-TTY: shows numbered choices" {
     var output: [1024]u8 = undefined;
     var output_writer: std.Io.Writer = .fixed(&output);
 
-    _ = try select(&output_writer, &input_reader, .{
+    _ = try select(.{ .writer = &output_writer, .reader = &input_reader, .allocator = std.testing.allocator }, .{
         .message = "Pick:",
         .choices = &.{ "first", "second" },
     });
@@ -210,15 +210,15 @@ test "non-TTY: shows numbered choices" {
     try std.testing.expect(std.mem.indexOf(u8, written, "second") != null);
 }
 
-fn renderToBuf(buf: []u8, config: SelectConfig, cursor: usize, ws: terminal.Winsize) !struct { rows: usize, text: []const u8 } {
+fn renderToBuf(buf: []u8, ctx: prompts.theme.ThemeContext, config: SelectConfig, cursor: usize, ws: terminal.Winsize) !struct { rows: usize, text: []const u8 } {
     var w: std.Io.Writer = .fixed(buf);
-    const rows = try renderList(&w, config, cursor, ws);
+    const rows = try renderList(&w, ctx, config, cursor, ws);
     return .{ .rows = rows, .text = w.buffered() };
 }
 
 test "renderList: short options are one row each" {
     var buf: [1024]u8 = undefined;
-    const r = try renderToBuf(&buf, .{ .message = "Pick", .choices = &.{ "a", "b", "c" } }, 0, .{ .row = 24, .col = 80 });
+    const r = try renderToBuf(&buf, prompts.default_style, .{ .message = "Pick", .choices = &.{ "a", "b", "c" } }, 0, .{ .row = 24, .col = 80 });
     try std.testing.expectEqual(@as(usize, 4), r.rows); // header + 3
 }
 
@@ -231,7 +231,7 @@ test "renderList: selected row styles through the theme's selected token" {
         .theme = &custom,
         .caps = .{ .capability = .true_color, .is_tty = true, .color_enabled = true },
     };
-    const r = try renderToBuf(&buf, .{ .message = "Pick", .choices = &.{ "a", "b" }, .theme = ctx }, 0, .{ .row = 24, .col = 80 });
+    const r = try renderToBuf(&buf, ctx, .{ .message = "Pick", .choices = &.{ "a", "b" } }, 0, .{ .row = 24, .col = 80 });
     try std.testing.expect(std.mem.indexOf(u8, r.text, "38;2;1;2;3") != null);
 }
 
@@ -240,14 +240,14 @@ test "renderList: no_color renders without any escapes" {
     const ctx = prompts.theme.ThemeContext{
         .caps = .{ .capability = .no_color, .is_tty = true, .color_enabled = false },
     };
-    const r = try renderToBuf(&buf, .{ .message = "Pick", .choices = &.{ "a", "b" }, .theme = ctx }, 0, .{ .row = 24, .col = 80 });
+    const r = try renderToBuf(&buf, ctx, .{ .message = "Pick", .choices = &.{ "a", "b" } }, 0, .{ .row = 24, .col = 80 });
     try std.testing.expect(std.mem.indexOf(u8, r.text, "\x1b[") == null);
 }
 
 test "renderList: wrapped option reports true physical row count" {
     var buf: [4096]u8 = undefined;
     const long = "this is a long option label that will certainly wrap at a narrow width";
-    const r = try renderToBuf(&buf, .{ .message = "Pick", .choices = &.{ "short", long } }, 0, .{ .row = 24, .col = 24 });
+    const r = try renderToBuf(&buf, prompts.default_style, .{ .message = "Pick", .choices = &.{ "short", long } }, 0, .{ .row = 24, .col = 24 });
     try std.testing.expect(r.rows > 3);
     const lines = std.mem.count(u8, r.text, "\r\n") + 1;
     try std.testing.expectEqual(lines, r.rows);

--- a/packages/prompts/src/text.zig
+++ b/packages/prompts/src/text.zig
@@ -24,7 +24,10 @@ pub const TextConfig = struct {
 
 /// Prompt for text input. Returns an owned string (caller frees), or
 /// `error.Interrupted` if the user presses one of `config.interrupt_keys`.
-pub fn text(writer: anytype, reader: anytype, allocator: std.mem.Allocator, config: TextConfig) ![]u8 {
+pub fn text(p: prompts.Prompts, config: TextConfig) ![]u8 {
+    const writer = p.writer;
+    const reader = p.reader;
+    const allocator = p.allocator;
     const is_tty = terminal.isStdinTty();
     const use_preview = is_tty and config.preview != null;
 
@@ -148,7 +151,7 @@ test "text: non-TTY reads user input" {
     var output: [256]u8 = undefined;
     var output_writer: std.Io.Writer = .fixed(&output);
 
-    const result = try text(&output_writer, &input_reader, allocator, .{
+    const result = try text(.{ .writer = &output_writer, .reader = &input_reader, .allocator = allocator }, .{
         .message = "Name:",
     });
     defer allocator.free(result);
@@ -163,7 +166,7 @@ test "text: non-TTY uses default on empty input" {
     var output: [256]u8 = undefined;
     var output_writer: std.Io.Writer = .fixed(&output);
 
-    const result = try text(&output_writer, &input_reader, allocator, .{
+    const result = try text(.{ .writer = &output_writer, .reader = &input_reader, .allocator = allocator }, .{
         .message = "Name:",
         .default = "world",
     });
@@ -179,7 +182,7 @@ test "text: non-TTY uses default on EOF" {
     var output: [256]u8 = undefined;
     var output_writer: std.Io.Writer = .fixed(&output);
 
-    const result = try text(&output_writer, &input_reader, allocator, .{
+    const result = try text(.{ .writer = &output_writer, .reader = &input_reader, .allocator = allocator }, .{
         .message = "Name:",
         .default = "fallback",
     });
@@ -195,7 +198,7 @@ test "text: prompt message appears in output" {
     var output: [256]u8 = undefined;
     var output_writer: std.Io.Writer = .fixed(&output);
 
-    const result = try text(&output_writer, &input_reader, allocator, .{
+    const result = try text(.{ .writer = &output_writer, .reader = &input_reader, .allocator = allocator }, .{
         .message = "Enter name:",
         .default = "foo",
     });

--- a/packages/prompts/src/text.zig
+++ b/packages/prompts/src/text.zig
@@ -2,7 +2,7 @@
 
 const std = @import("std");
 const terminal = @import("terminal");
-const prompts = @import("prompts.zig");
+const Prompts = @import("Prompts.zig");
 
 /// Optional live preview rendered on the line *above* the prompt, repainted on
 /// every keystroke. `render` receives the current input and writes one line of
@@ -24,7 +24,7 @@ pub const TextConfig = struct {
 
 /// Prompt for text input. Returns an owned string (caller frees), or
 /// `error.Interrupted` if the user presses one of `config.interrupt_keys`.
-pub fn text(p: prompts.Prompts, config: TextConfig) ![]u8 {
+pub fn text(p: Prompts, config: TextConfig) ![]u8 {
     const writer = p.writer;
     const reader = p.reader;
     const allocator = p.allocator;
@@ -58,7 +58,7 @@ pub fn text(p: prompts.Prompts, config: TextConfig) ![]u8 {
     }
 
     // TTY: raw mode character-by-character input
-    prompts.flushWriter(writer);
+    Prompts.flushWriter(writer);
     const raw = terminal.enableRawMode(std.Io.File.stdin().handle) catch {
         // Fallback if raw mode fails
         try writer.writeAll("\n");
@@ -66,19 +66,19 @@ pub fn text(p: prompts.Prompts, config: TextConfig) ![]u8 {
     };
     defer {
         raw.disable();
-        prompts.flushWriter(writer);
+        Prompts.flushWriter(writer);
     }
 
     var buf = std.ArrayList(u8).empty;
     defer buf.deinit(allocator);
 
     while (true) {
-        prompts.flushWriter(writer);
+        Prompts.flushWriter(writer);
         const k = if (config.interrupt_keys.len > 0)
             try terminal.readKeyOpt(reader, std.Io.File.stdin().handle)
         else
             try terminal.readKey(reader);
-        if (prompts.isInterrupt(k, config.interrupt_keys)) {
+        if (Prompts.isInterrupt(k, config.interrupt_keys)) {
             try writer.writeAll("\r\n");
             return error.Interrupted;
         }
@@ -92,7 +92,7 @@ pub fn text(p: prompts.Prompts, config: TextConfig) ![]u8 {
             },
             .backspace => {
                 if (buf.items.len > 0) {
-                    try prompts.eraseTrailingGrapheme(writer, &buf);
+                    try Prompts.eraseTrailingGrapheme(writer, &buf);
                     if (use_preview) try repaintPreview(writer, config.preview.?, buf.items);
                 }
             },
@@ -103,7 +103,7 @@ pub fn text(p: prompts.Prompts, config: TextConfig) ![]u8 {
                 }
             },
             .char => |c| {
-                try writer.writeAll(try prompts.appendCodepoint(allocator, &buf, c));
+                try writer.writeAll(try Prompts.appendCodepoint(allocator, &buf, c));
                 if (use_preview) try repaintPreview(writer, config.preview.?, buf.items);
             },
             else => {},

--- a/packages/prompts/test/render_e2e.zig
+++ b/packages/prompts/test/render_e2e.zig
@@ -1,4 +1,4 @@
-//! Cross-platform rendering end-to-end tests for the list prompts.
+//! Cross-platform rendering end-to-end tests for the list Prompts.
 //!
 //! These drive the real render + erase code paths and replay their byte output
 //! through the in-repo `vterm` terminal emulator, then assert on the resulting
@@ -13,10 +13,10 @@
 //! leftover character from the wider/taller previous frame makes them differ.
 
 const std = @import("std");
-const prompts = @import("prompts");
+const Prompts = @import("prompts");
 const vterm = @import("vterm");
 
-const Winsize = prompts.terminal.Winsize;
+const Winsize = Prompts.terminal.Winsize;
 const testing = std.testing;
 
 /// Replay `bytes` through a fresh `cols`x`rows` emulator and return the visible
@@ -32,25 +32,25 @@ fn screenOf(alloc: std.mem.Allocator, cols: u16, rows: u16, bytes: []const u8) !
 // multi_select
 // ---------------------------------------------------------------------------
 
-fn multiFrame(buf: []u8, config: prompts.MultiSelectConfig, selected: []const bool, cursor: usize, ws: Winsize) ![]const u8 {
+fn multiFrame(buf: []u8, config: Prompts.MultiSelectConfig, selected: []const bool, cursor: usize, ws: Winsize) ![]const u8 {
     var w: std.Io.Writer = .fixed(buf);
-    _ = try prompts.multi_select_prompt.renderList(&w, prompts.default_style, config, selected, cursor, ws);
+    _ = try Prompts.multi_select_prompt.renderList(&w, Prompts.default_style, config, selected, cursor, ws);
     return w.buffered();
 }
 
-fn multiNavScreen(alloc: std.mem.Allocator, config: prompts.MultiSelectConfig, selected: []const bool, from: usize, to: usize, ws: Winsize) ![]u8 {
+fn multiNavScreen(alloc: std.mem.Allocator, config: Prompts.MultiSelectConfig, selected: []const bool, from: usize, to: usize, ws: Winsize) ![]u8 {
     var buf: [16384]u8 = undefined;
     var w: std.Io.Writer = .fixed(&buf);
-    const r0 = try prompts.multi_select_prompt.renderList(&w, prompts.default_style, config, selected, from, ws);
-    try prompts.list_render.eraseRegion(&w, r0);
-    _ = try prompts.multi_select_prompt.renderList(&w, prompts.default_style, config, selected, to, ws);
+    const r0 = try Prompts.multi_select_prompt.renderList(&w, Prompts.default_style, config, selected, from, ws);
+    try Prompts.list_render.eraseRegion(&w, r0);
+    _ = try Prompts.multi_select_prompt.renderList(&w, Prompts.default_style, config, selected, to, ws);
     return screenOf(alloc, ws.col, ws.row, w.buffered());
 }
 
 test "emulator: multi_select navigation leaves no debris when options wrap" {
     const alloc = testing.allocator;
     const ws = Winsize{ .row = 24, .col = 30 };
-    const config = prompts.MultiSelectConfig{ .message = "Pick", .choices = &.{
+    const config = Prompts.MultiSelectConfig{ .message = "Pick", .choices = &.{
         "short",
         "a genuinely long option label that certainly wraps across several rows",
         "third choice here",
@@ -72,7 +72,7 @@ test "emulator: multi_select navigation leaves no debris when options wrap" {
 test "emulator: multi_select wraps wide CJK options without debris" {
     const alloc = testing.allocator;
     const ws = Winsize{ .row = 24, .col = 22 };
-    const config = prompts.MultiSelectConfig{ .message = "Pick", .choices = &.{
+    const config = Prompts.MultiSelectConfig{ .message = "Pick", .choices = &.{
         "ascii option",
         "你好世界这是一个需要换行显示的很长选项",
         "另一个选项",
@@ -96,7 +96,7 @@ test "emulator: multi_select wraps wide CJK options without debris" {
 test "emulator: select navigation leaves no debris when options wrap" {
     const alloc = testing.allocator;
     const ws = Winsize{ .row = 24, .col = 24 };
-    const config = prompts.SelectConfig{ .message = "Choose", .choices = &.{
+    const config = Prompts.SelectConfig{ .message = "Choose", .choices = &.{
         "one",
         "a long choice that will wrap onto multiple lines at this width",
         "two",
@@ -104,15 +104,15 @@ test "emulator: select navigation leaves no debris when options wrap" {
 
     var cbuf: [16384]u8 = undefined;
     var cw: std.Io.Writer = .fixed(&cbuf);
-    _ = try prompts.select_prompt.renderList(&cw, prompts.default_style, config, 1, ws);
+    _ = try Prompts.select_prompt.renderList(&cw, Prompts.default_style, config, 1, ws);
     const clean = try screenOf(alloc, ws.col, ws.row, cw.buffered());
     defer alloc.free(clean);
 
     var nbuf: [16384]u8 = undefined;
     var nw: std.Io.Writer = .fixed(&nbuf);
-    const r0 = try prompts.select_prompt.renderList(&nw, prompts.default_style, config, 0, ws);
-    try prompts.list_render.eraseRegion(&nw, r0);
-    _ = try prompts.select_prompt.renderList(&nw, prompts.default_style, config, 1, ws);
+    const r0 = try Prompts.select_prompt.renderList(&nw, Prompts.default_style, config, 0, ws);
+    try Prompts.list_render.eraseRegion(&nw, r0);
+    _ = try Prompts.select_prompt.renderList(&nw, Prompts.default_style, config, 1, ws);
     const nav = try screenOf(alloc, ws.col, ws.row, nw.buffered());
     defer alloc.free(nav);
 
@@ -123,7 +123,7 @@ test "emulator: select hang-indents wrapped continuation lines on screen" {
     const alloc = testing.allocator;
     // Short message keeps the header on one row so option rows are predictable.
     const ws = Winsize{ .row = 24, .col = 20 };
-    const config = prompts.SelectConfig{ .message = "Pick", .choices = &.{
+    const config = Prompts.SelectConfig{ .message = "Pick", .choices = &.{
         "alpha bravo charlie delta echo",
     } };
 
@@ -131,7 +131,7 @@ test "emulator: select hang-indents wrapped continuation lines on screen" {
     defer term.deinit();
     var buf: [16384]u8 = undefined;
     var w: std.Io.Writer = .fixed(&buf);
-    _ = try prompts.select_prompt.renderList(&w, prompts.default_style, config, 0, ws);
+    _ = try Prompts.select_prompt.renderList(&w, Prompts.default_style, config, 0, ws);
     term.write(w.buffered());
 
     // Row 0: "? Pick" header. Row 1: first option line (prefix "  > "/"  ❯ ").
@@ -161,11 +161,11 @@ test "emulator: backspace-erase clears a wide char's both cells" {
     // Type "ab" then 你 (2 cells), then backspace 你 away and type "c" — the
     // screen must read exactly "abc" with no half-glyph debris in the cells the
     // wide char occupied. A byte- or single-column erase fails this.
-    try w.writeAll(try prompts.appendCodepoint(alloc, &buf, 'a'));
-    try w.writeAll(try prompts.appendCodepoint(alloc, &buf, 'b'));
-    try w.writeAll(try prompts.appendCodepoint(alloc, &buf, '你'));
-    try prompts.eraseTrailingGrapheme(&w, &buf);
-    try w.writeAll(try prompts.appendCodepoint(alloc, &buf, 'c'));
+    try w.writeAll(try Prompts.appendCodepoint(alloc, &buf, 'a'));
+    try w.writeAll(try Prompts.appendCodepoint(alloc, &buf, 'b'));
+    try w.writeAll(try Prompts.appendCodepoint(alloc, &buf, '你'));
+    try Prompts.eraseTrailingGrapheme(&w, &buf);
+    try w.writeAll(try Prompts.appendCodepoint(alloc, &buf, 'c'));
 
     try testing.expectEqualStrings("abc", buf.items);
 
@@ -187,7 +187,7 @@ test "emulator: backspace-erase clears a wide char's both cells" {
 test "emulator: search navigation leaves no debris when results wrap" {
     const alloc = testing.allocator;
     const ws = Winsize{ .row = 24, .col = 28 };
-    const config = prompts.SearchConfig{ .message = "Find", .choices = &.{
+    const config = Prompts.SearchConfig{ .message = "Find", .choices = &.{
         "apple",
         "a very long result entry that will wrap across more than one row",
         "cherry",
@@ -197,15 +197,15 @@ test "emulator: search navigation leaves no debris when results wrap" {
 
     var cbuf: [16384]u8 = undefined;
     var cw: std.Io.Writer = .fixed(&cbuf);
-    _ = try prompts.search_prompt.renderSearch(&cw, prompts.default_style, config, query, &filtered, 1, ws);
+    _ = try Prompts.search_prompt.renderSearch(&cw, Prompts.default_style, config, query, &filtered, 1, ws);
     const clean = try screenOf(alloc, ws.col, ws.row, cw.buffered());
     defer alloc.free(clean);
 
     var nbuf: [16384]u8 = undefined;
     var nw: std.Io.Writer = .fixed(&nbuf);
-    const r0 = try prompts.search_prompt.renderSearch(&nw, prompts.default_style, config, query, &filtered, 0, ws);
-    try prompts.list_render.eraseRegion(&nw, r0);
-    _ = try prompts.search_prompt.renderSearch(&nw, prompts.default_style, config, query, &filtered, 1, ws);
+    const r0 = try Prompts.search_prompt.renderSearch(&nw, Prompts.default_style, config, query, &filtered, 0, ws);
+    try Prompts.list_render.eraseRegion(&nw, r0);
+    _ = try Prompts.search_prompt.renderSearch(&nw, Prompts.default_style, config, query, &filtered, 1, ws);
     const nav = try screenOf(alloc, ws.col, ws.row, nw.buffered());
     defer alloc.free(nav);
 

--- a/packages/prompts/test/render_e2e.zig
+++ b/packages/prompts/test/render_e2e.zig
@@ -34,16 +34,16 @@ fn screenOf(alloc: std.mem.Allocator, cols: u16, rows: u16, bytes: []const u8) !
 
 fn multiFrame(buf: []u8, config: prompts.MultiSelectConfig, selected: []const bool, cursor: usize, ws: Winsize) ![]const u8 {
     var w: std.Io.Writer = .fixed(buf);
-    _ = try prompts.multi_select_prompt.renderList(&w, config, selected, cursor, ws);
+    _ = try prompts.multi_select_prompt.renderList(&w, prompts.default_style, config, selected, cursor, ws);
     return w.buffered();
 }
 
 fn multiNavScreen(alloc: std.mem.Allocator, config: prompts.MultiSelectConfig, selected: []const bool, from: usize, to: usize, ws: Winsize) ![]u8 {
     var buf: [16384]u8 = undefined;
     var w: std.Io.Writer = .fixed(&buf);
-    const r0 = try prompts.multi_select_prompt.renderList(&w, config, selected, from, ws);
+    const r0 = try prompts.multi_select_prompt.renderList(&w, prompts.default_style, config, selected, from, ws);
     try prompts.list_render.eraseRegion(&w, r0);
-    _ = try prompts.multi_select_prompt.renderList(&w, config, selected, to, ws);
+    _ = try prompts.multi_select_prompt.renderList(&w, prompts.default_style, config, selected, to, ws);
     return screenOf(alloc, ws.col, ws.row, w.buffered());
 }
 
@@ -104,15 +104,15 @@ test "emulator: select navigation leaves no debris when options wrap" {
 
     var cbuf: [16384]u8 = undefined;
     var cw: std.Io.Writer = .fixed(&cbuf);
-    _ = try prompts.select_prompt.renderList(&cw, config, 1, ws);
+    _ = try prompts.select_prompt.renderList(&cw, prompts.default_style, config, 1, ws);
     const clean = try screenOf(alloc, ws.col, ws.row, cw.buffered());
     defer alloc.free(clean);
 
     var nbuf: [16384]u8 = undefined;
     var nw: std.Io.Writer = .fixed(&nbuf);
-    const r0 = try prompts.select_prompt.renderList(&nw, config, 0, ws);
+    const r0 = try prompts.select_prompt.renderList(&nw, prompts.default_style, config, 0, ws);
     try prompts.list_render.eraseRegion(&nw, r0);
-    _ = try prompts.select_prompt.renderList(&nw, config, 1, ws);
+    _ = try prompts.select_prompt.renderList(&nw, prompts.default_style, config, 1, ws);
     const nav = try screenOf(alloc, ws.col, ws.row, nw.buffered());
     defer alloc.free(nav);
 
@@ -131,7 +131,7 @@ test "emulator: select hang-indents wrapped continuation lines on screen" {
     defer term.deinit();
     var buf: [16384]u8 = undefined;
     var w: std.Io.Writer = .fixed(&buf);
-    _ = try prompts.select_prompt.renderList(&w, config, 0, ws);
+    _ = try prompts.select_prompt.renderList(&w, prompts.default_style, config, 0, ws);
     term.write(w.buffered());
 
     // Row 0: "? Pick" header. Row 1: first option line (prefix "  > "/"  ❯ ").
@@ -197,15 +197,15 @@ test "emulator: search navigation leaves no debris when results wrap" {
 
     var cbuf: [16384]u8 = undefined;
     var cw: std.Io.Writer = .fixed(&cbuf);
-    _ = try prompts.search_prompt.renderSearch(&cw, config, query, &filtered, 1, ws);
+    _ = try prompts.search_prompt.renderSearch(&cw, prompts.default_style, config, query, &filtered, 1, ws);
     const clean = try screenOf(alloc, ws.col, ws.row, cw.buffered());
     defer alloc.free(clean);
 
     var nbuf: [16384]u8 = undefined;
     var nw: std.Io.Writer = .fixed(&nbuf);
-    const r0 = try prompts.search_prompt.renderSearch(&nw, config, query, &filtered, 0, ws);
+    const r0 = try prompts.search_prompt.renderSearch(&nw, prompts.default_style, config, query, &filtered, 0, ws);
     try prompts.list_render.eraseRegion(&nw, r0);
-    _ = try prompts.search_prompt.renderSearch(&nw, config, query, &filtered, 1, ws);
+    _ = try prompts.search_prompt.renderSearch(&nw, prompts.default_style, config, query, &filtered, 1, ws);
     const nav = try screenOf(alloc, ws.col, ws.row, nw.buffered());
     defer alloc.free(nav);
 

--- a/projects/zcli/src/commands/add/_wizard.zig
+++ b/projects/zcli/src/commands/add/_wizard.zig
@@ -63,15 +63,20 @@ fn runWizardOnce(
     seed_description: ?[]const u8,
 ) !WizardResult {
     const w = context.stdout();
-    const r = context.stdin();
     const io = context.io;
+    const p: prompts.Prompts = .{
+        .writer = w,
+        .reader = context.stdin(),
+        .allocator = arena,
+        .theme = theme.*,
+    };
 
     try heading(w, theme, "Add a command");
     try hint(w, theme, "src/commands/ \u{00b7} Ctrl+C to cancel any time");
     try w.writeAll("\r\n");
 
     // Step 1 — command path (live preview shows the file it will create).
-    const path = try resolveCommandPath(arena, w, r, theme, io, seed_path);
+    const path = try resolveCommandPath(arena, p, io, seed_path);
     const file_path = try buildFilePath(arena, path.parts);
     if (!path.prompted) {
         const line = try std.fmt.allocPrint(arena, "  \u{2192} creates {s}", .{file_path});
@@ -82,21 +87,21 @@ fn runWizardOnce(
     // Step 2 — description.
     const description = blk: {
         if (seed_description) |d| break :blk d;
-        const d = std.mem.trim(u8, try prompts.text(w, r, arena, .{ .message = "Description:" }), " \t\r\n");
+        const d = std.mem.trim(u8, try p.text(.{ .message = "Description:" }), " \t\r\n");
         break :blk if (d.len == 0) "TODO: Add description" else d;
     };
 
     // Steps 3 & 4 — positional arguments and options.
     var args_list = std.ArrayList(ArgSpec).empty;
-    try gatherArgs(arena, w, r, theme, &args_list);
+    try gatherArgs(arena, p, &args_list);
 
     var opts_list = std.ArrayList(OptSpec).empty;
-    try gatherOptions(arena, w, r, theme, &opts_list);
+    try gatherOptions(arena, p, &opts_list);
 
     // Step 5 — review, then choose what to do.
     while (true) {
         try review(arena, w, theme, path.parts, file_path, description, args_list.items, opts_list.items);
-        const action = try prompts.select(w, r, .{ .message = "What next?", .theme = theme.*, .choices = &.{
+        const action = try p.select(.{ .message = "What next?", .choices = &.{
             "Create it",
             "Add another argument",
             "Add another option",
@@ -110,8 +115,8 @@ fn runWizardOnce(
                 try finish(w, theme, path.parts, file_path, new_groups);
                 return .created;
             },
-            1 => try gatherArgs(arena, w, r, theme, &args_list),
-            2 => try gatherOptions(arena, w, r, theme, &opts_list),
+            1 => try gatherArgs(arena, p, &args_list),
+            2 => try gatherOptions(arena, p, &opts_list),
             3 => return .restart,
             else => {
                 try w.writeAll("\r\n");
@@ -144,19 +149,19 @@ const PathPreview = struct {
 
 fn resolveCommandPath(
     arena: std.mem.Allocator,
-    w: *std.Io.Writer,
-    r: *std.Io.Reader,
-    theme: *const ThemeContext,
+    p: prompts.Prompts,
     io: std.Io,
     seed: ?[]const u8,
 ) !PathResult {
+    const w = p.writer;
+    const theme = &p.theme;
     var pp = PathPreview{ .theme = theme };
     var seed_opt = seed;
     var prompted = false;
     while (true) {
         const raw = if (seed_opt) |s| s else blk: {
             prompted = true;
-            break :blk try prompts.text(w, r, arena, .{
+            break :blk try p.text(.{
                 .message = "Command path:",
                 .preview = .{ .context = &pp, .render = PathPreview.render },
             });
@@ -193,11 +198,11 @@ const ArgKind = enum { text, integer, decimal, custom };
 
 fn gatherArgs(
     arena: std.mem.Allocator,
-    w: *std.Io.Writer,
-    r: *std.Io.Reader,
-    theme: *const ThemeContext,
+    p: prompts.Prompts,
     list: *std.ArrayList(ArgSpec),
 ) !void {
+    const w = p.writer;
+    const theme = &p.theme;
     var seen_optional = false;
     for (list.items) |a| {
         if (a.multiple) {
@@ -213,9 +218,9 @@ fn gatherArgs(
 
     while (true) {
         const prompt = if (list.items.len == 0) "Add a positional argument?" else "Add another positional argument?";
-        if (!try prompts.confirm(w, r, .{ .message = prompt, .default = list.items.len == 0 })) break;
+        if (!try p.confirm(.{ .message = prompt, .default = list.items.len == 0 })) break;
 
-        const spec = (try gatherOneArg(arena, w, r, theme, try argNames(arena, list.items), seen_optional)) orelse continue;
+        const spec = (try gatherOneArg(arena, p, try argNames(arena, list.items), seen_optional)) orelse continue;
         try list.append(arena, spec);
         try okArg(arena, w, theme, spec);
         if (spec.multiple) {
@@ -232,12 +237,12 @@ const ArgStep = enum { name, description, type, multiple, required };
 /// user backed out of the item (Escape at the name prompt).
 fn gatherOneArg(
     arena: std.mem.Allocator,
-    w: *std.Io.Writer,
-    r: *std.Io.Reader,
-    theme: *const ThemeContext,
+    p: prompts.Prompts,
     existing_names: []const []const u8,
     seen_optional: bool,
 ) !?ArgSpec {
+    const w = p.writer;
+    const theme = &p.theme;
     var name: []const u8 = "";
     var description: []const u8 = "";
     var kind: ArgKind = .text;
@@ -248,14 +253,14 @@ fn gatherOneArg(
     var step: ArgStep = .name;
     while (true) switch (step) {
         .name => {
-            name = readFieldName(arena, w, r, theme, "  Name:", false, existing_names) catch |e| {
+            name = readFieldName(arena, p, "  Name:", false, existing_names) catch |e| {
                 if (e == error.Interrupted) return null;
                 return e;
             };
             step = .description;
         },
         .description => {
-            const d = prompts.text(w, r, arena, .{ .message = "  Description:", .interrupt_keys = back_keys }) catch |e| {
+            const d = p.text(.{ .message = "  Description:", .interrupt_keys = back_keys }) catch |e| {
                 if (e == error.Interrupted) {
                     step = .name;
                     continue;
@@ -266,7 +271,7 @@ fn gatherOneArg(
             step = .type;
         },
         .type => {
-            kind = selectArgKind(w, r, theme) catch |e| {
+            kind = selectArgKind(p) catch |e| {
                 if (e == error.Interrupted) {
                     step = .description;
                     continue;
@@ -277,7 +282,7 @@ fn gatherOneArg(
                 .text => elem_type = "[]const u8",
                 .integer => elem_type = "i64",
                 .decimal => elem_type = "f64",
-                .custom => elem_type = readZigType(arena, w, r, theme) catch |e| {
+                .custom => elem_type = readZigType(p) catch |e| {
                     if (e == error.Interrupted) continue; // re-select the type
                     return e;
                 },
@@ -287,7 +292,7 @@ fn gatherOneArg(
         .multiple => {
             // A positional can only repeat as []const u8 varargs.
             if (kind == .text) {
-                multiple = prompts.confirm(w, r, .{ .message = "  Multiple? (captures all remaining positionals)", .default = false, .interrupt_keys = back_keys }) catch |e| {
+                multiple = p.confirm(.{ .message = "  Multiple? (captures all remaining positionals)", .default = false, .interrupt_keys = back_keys }) catch |e| {
                     if (e == error.Interrupted) {
                         step = .type;
                         continue;
@@ -306,7 +311,7 @@ fn gatherOneArg(
                 nullable = true;
                 try hint(w, theme, "  (optional \u{2014} follows an earlier optional argument)");
             } else {
-                const req = prompts.confirm(w, r, .{ .message = "  Required?", .default = true, .interrupt_keys = back_keys }) catch |e| {
+                const req = p.confirm(.{ .message = "  Required?", .default = true, .interrupt_keys = back_keys }) catch |e| {
                     if (e == error.Interrupted) {
                         step = if (kind == .text) .multiple else .type;
                         continue;
@@ -320,11 +325,10 @@ fn gatherOneArg(
     };
 }
 
-fn selectArgKind(w: *std.Io.Writer, r: *std.Io.Reader, theme: *const ThemeContext) !ArgKind {
-    const idx = try prompts.select(w, r, .{
+fn selectArgKind(p: prompts.Prompts) !ArgKind {
+    const idx = try p.select(.{
         .message = "  Type:",
         .interrupt_keys = back_keys,
-        .theme = theme.*,
         .choices = &.{
             "Text          ([]const u8)",
             "Integer       (i64)",
@@ -348,19 +352,19 @@ const OptKind = enum { flag, text, integer, decimal, choice, custom };
 
 fn gatherOptions(
     arena: std.mem.Allocator,
-    w: *std.Io.Writer,
-    r: *std.Io.Reader,
-    theme: *const ThemeContext,
+    p: prompts.Prompts,
     list: *std.ArrayList(OptSpec),
 ) !void {
+    const w = p.writer;
+    const theme = &p.theme;
     try heading(w, theme, "Options (flags)");
     try hint(w, theme, "Esc to go back");
 
     while (true) {
         const prompt = if (list.items.len == 0) "Add an option?" else "Add another option?";
-        if (!try prompts.confirm(w, r, .{ .message = prompt, .default = list.items.len == 0 })) break;
+        if (!try p.confirm(.{ .message = prompt, .default = list.items.len == 0 })) break;
 
-        const spec = (try gatherOneOption(arena, w, r, theme, try optNames(arena, list.items), try optShorts(arena, list.items))) orelse continue;
+        const spec = (try gatherOneOption(arena, p, try optNames(arena, list.items), try optShorts(arena, list.items))) orelse continue;
         try list.append(arena, spec);
         try okOpt(arena, w, theme, spec);
     }
@@ -372,9 +376,7 @@ const OptStep = enum { name, description, type, multiple, nullable, default, sho
 /// of the item (Escape at the name prompt).
 fn gatherOneOption(
     arena: std.mem.Allocator,
-    w: *std.Io.Writer,
-    r: *std.Io.Reader,
-    theme: *const ThemeContext,
+    p: prompts.Prompts,
     existing_names: []const []const u8,
     existing_shorts: []const u8,
 ) !?OptSpec {
@@ -397,14 +399,14 @@ fn gatherOneOption(
     var step: OptStep = .name;
     while (true) switch (step) {
         .name => {
-            name = readFieldName(arena, w, r, theme, "  Name:", true, existing_names) catch |e| {
+            name = readFieldName(arena, p, "  Name:", true, existing_names) catch |e| {
                 if (e == error.Interrupted) return null;
                 return e;
             };
             step = .description;
         },
         .description => {
-            const d = prompts.text(w, r, arena, .{ .message = "  Description:", .interrupt_keys = back_keys }) catch |e| {
+            const d = p.text(.{ .message = "  Description:", .interrupt_keys = back_keys }) catch |e| {
                 if (e == error.Interrupted) {
                     step = .name;
                     continue;
@@ -415,7 +417,7 @@ fn gatherOneOption(
             step = .type;
         },
         .type => {
-            kind = selectOptKind(w, r) catch |e| {
+            kind = selectOptKind(p) catch |e| {
                 if (e == error.Interrupted) {
                     step = .description;
                     continue;
@@ -428,13 +430,13 @@ fn gatherOneOption(
                 .integer => elem_type = "i64",
                 .decimal => elem_type = "f64",
                 .choice => {
-                    choices = readChoices(arena, w, r, theme) catch |e| {
+                    choices = readChoices(arena, p) catch |e| {
                         if (e == error.Interrupted) continue; // re-select the type
                         return e;
                     };
                     elem_type = try buildEnumType(arena, choices);
                 },
-                .custom => elem_type = readZigType(arena, w, r, theme) catch |e| {
+                .custom => elem_type = readZigType(p) catch |e| {
                     if (e == error.Interrupted) continue;
                     return e;
                 },
@@ -443,7 +445,7 @@ fn gatherOneOption(
         },
         .multiple => {
             if (multiple_capable(kind)) {
-                multiple = prompts.confirm(w, r, .{ .message = "  Multiple? (repeatable)", .default = false, .interrupt_keys = back_keys }) catch |e| {
+                multiple = p.confirm(.{ .message = "  Multiple? (repeatable)", .default = false, .interrupt_keys = back_keys }) catch |e| {
                     if (e == error.Interrupted) {
                         step = .type;
                         continue;
@@ -456,7 +458,7 @@ fn gatherOneOption(
             step = .nullable;
         },
         .nullable => {
-            nullable = prompts.confirm(w, r, .{ .message = if (multiple) "  Nullable? (omit \u{2192} empty list)" else "  Nullable? (omit \u{2192} null)", .default = false, .interrupt_keys = back_keys }) catch |e| {
+            nullable = p.confirm(.{ .message = if (multiple) "  Nullable? (omit \u{2192} empty list)" else "  Nullable? (omit \u{2192} null)", .default = false, .interrupt_keys = back_keys }) catch |e| {
                 if (e == error.Interrupted) {
                     step = if (multiple_capable(kind)) .multiple else .type;
                     continue;
@@ -471,7 +473,7 @@ fn gatherOneOption(
             } else if (multiple) {
                 default_expr = "&.{}";
             } else {
-                default_expr = promptOptionDefault(arena, w, r, theme, kind, choices) catch |e| {
+                default_expr = promptOptionDefault(arena, p, kind, choices) catch |e| {
                     if (e == error.Interrupted) {
                         step = .nullable;
                         continue;
@@ -482,7 +484,7 @@ fn gatherOneOption(
             step = .short;
         },
         .short => {
-            const want = prompts.confirm(w, r, .{ .message = "  Short flag?", .default = false, .interrupt_keys = back_keys }) catch |e| {
+            const want = p.confirm(.{ .message = "  Short flag?", .default = false, .interrupt_keys = back_keys }) catch |e| {
                 if (e == error.Interrupted) {
                     // Skip back over the non-prompting default step when needed.
                     step = if (!nullable and !multiple) .default else .nullable;
@@ -491,7 +493,7 @@ fn gatherOneOption(
                 return e;
             };
             if (want) {
-                short = readShort(arena, w, r, theme, existing_shorts) catch |e| {
+                short = readShort(p, existing_shorts) catch |e| {
                     if (e == error.Interrupted) continue; // re-ask the short-flag yes/no
                     return e;
                 };
@@ -515,24 +517,22 @@ fn gatherOneOption(
 /// surfaces as `error.Interrupted` for the caller to handle.
 fn promptOptionDefault(
     arena: std.mem.Allocator,
-    w: *std.Io.Writer,
-    r: *std.Io.Reader,
-    theme: *const ThemeContext,
+    p: prompts.Prompts,
     kind: OptKind,
     choices: []const []const u8,
 ) ![]const u8 {
     return switch (kind) {
-        .flag => if (try prompts.confirm(w, r, .{ .message = "  Default on?", .default = false, .interrupt_keys = back_keys })) "true" else "false",
-        .text => try quoteString(arena, std.mem.trim(u8, try prompts.text(w, r, arena, .{ .message = "  Default value:", .interrupt_keys = back_keys }), " \t\r\n")),
-        .integer => try std.fmt.allocPrint(arena, "{d}", .{try prompts.number(w, r, .{ .message = "  Default value:", .default = 0, .interrupt_keys = back_keys })}),
-        .decimal => try std.fmt.allocPrint(arena, "{d}", .{try readFloat(arena, w, r, theme, "  Default value:", 0)}),
-        .choice => try std.fmt.allocPrint(arena, ".{s}", .{choices[try prompts.select(w, r, .{ .message = "  Default:", .choices = choices, .interrupt_keys = back_keys })]}),
-        .custom => try arena.dupe(u8, std.mem.trim(u8, try prompts.text(w, r, arena, .{ .message = "  Default (Zig expression):", .interrupt_keys = back_keys }), " \t\r\n")),
+        .flag => if (try p.confirm(.{ .message = "  Default on?", .default = false, .interrupt_keys = back_keys })) "true" else "false",
+        .text => try quoteString(arena, std.mem.trim(u8, try p.text(.{ .message = "  Default value:", .interrupt_keys = back_keys }), " \t\r\n")),
+        .integer => try std.fmt.allocPrint(arena, "{d}", .{try p.number(.{ .message = "  Default value:", .default = 0, .interrupt_keys = back_keys })}),
+        .decimal => try std.fmt.allocPrint(arena, "{d}", .{try readFloat(p, "  Default value:", 0)}),
+        .choice => try std.fmt.allocPrint(arena, ".{s}", .{choices[try p.select(.{ .message = "  Default:", .choices = choices, .interrupt_keys = back_keys })]}),
+        .custom => try arena.dupe(u8, std.mem.trim(u8, try p.text(.{ .message = "  Default (Zig expression):", .interrupt_keys = back_keys }), " \t\r\n")),
     };
 }
 
-fn selectOptKind(w: *std.Io.Writer, r: *std.Io.Reader) !OptKind {
-    const idx = try prompts.select(w, r, .{
+fn selectOptKind(p: prompts.Prompts) !OptKind {
+    const idx = try p.select(.{
         .message = "  Type:",
         .interrupt_keys = back_keys,
         .choices = &.{
@@ -641,15 +641,15 @@ pub fn finish(
 
 fn readFieldName(
     arena: std.mem.Allocator,
-    w: *std.Io.Writer,
-    r: *std.Io.Reader,
-    theme: *const ThemeContext,
+    p: prompts.Prompts,
     message: []const u8,
     allow_dash: bool,
     existing: []const []const u8,
 ) ![]const u8 {
+    const w = p.writer;
+    const theme = &p.theme;
     while (true) {
-        const raw = std.mem.trim(u8, try prompts.text(w, r, arena, .{ .message = message, .interrupt_keys = back_keys }), " \t\r\n");
+        const raw = std.mem.trim(u8, try p.text(.{ .message = message, .interrupt_keys = back_keys }), " \t\r\n");
         if (raw.len == 0) {
             try warn(w, theme, "  Name cannot be empty.");
             continue;
@@ -682,9 +682,11 @@ fn readFieldName(
     }
 }
 
-fn readZigType(arena: std.mem.Allocator, w: *std.Io.Writer, r: *std.Io.Reader, theme: *const ThemeContext) ![]const u8 {
+fn readZigType(p: prompts.Prompts) ![]const u8 {
+    const w = p.writer;
+    const theme = &p.theme;
     while (true) {
-        const t = std.mem.trim(u8, try prompts.text(w, r, arena, .{ .message = "  Zig type:", .interrupt_keys = back_keys }), " \t\r\n");
+        const t = std.mem.trim(u8, try p.text(.{ .message = "  Zig type:", .interrupt_keys = back_keys }), " \t\r\n");
         if (t.len == 0) {
             try warn(w, theme, "  Type cannot be empty (e.g. u8, []const u8, enum { a, b }).");
             continue;
@@ -693,15 +695,11 @@ fn readZigType(arena: std.mem.Allocator, w: *std.Io.Writer, r: *std.Io.Reader, t
     }
 }
 
-fn readShort(
-    arena: std.mem.Allocator,
-    w: *std.Io.Writer,
-    r: *std.Io.Reader,
-    theme: *const ThemeContext,
-    used: []const u8,
-) !u8 {
+fn readShort(p: prompts.Prompts, used: []const u8) !u8 {
+    const w = p.writer;
+    const theme = &p.theme;
     while (true) {
-        const raw = std.mem.trim(u8, try prompts.text(w, r, arena, .{ .message = "  Short character:", .interrupt_keys = back_keys }), " \t\r\n");
+        const raw = std.mem.trim(u8, try p.text(.{ .message = "  Short character:", .interrupt_keys = back_keys }), " \t\r\n");
         if (raw.len != 1 or !std.ascii.isAlphabetic(raw[0])) {
             try warn(w, theme, "  Enter a single letter (a-z).");
             continue;
@@ -722,16 +720,11 @@ fn readShort(
     }
 }
 
-fn readFloat(
-    arena: std.mem.Allocator,
-    w: *std.Io.Writer,
-    r: *std.Io.Reader,
-    theme: *const ThemeContext,
-    message: []const u8,
-    default: f64,
-) !f64 {
+fn readFloat(p: prompts.Prompts, message: []const u8, default: f64) !f64 {
+    const w = p.writer;
+    const theme = &p.theme;
     while (true) {
-        const raw = std.mem.trim(u8, try prompts.text(w, r, arena, .{ .message = message, .interrupt_keys = back_keys }), " \t\r\n");
+        const raw = std.mem.trim(u8, try p.text(.{ .message = message, .interrupt_keys = back_keys }), " \t\r\n");
         if (raw.len == 0) return default;
         return std.fmt.parseFloat(f64, raw) catch {
             try warn(w, theme, "  Enter a number (e.g. 1.5).");
@@ -740,9 +733,11 @@ fn readFloat(
     }
 }
 
-fn readChoices(arena: std.mem.Allocator, w: *std.Io.Writer, r: *std.Io.Reader, theme: *const ThemeContext) ![]const []const u8 {
+fn readChoices(arena: std.mem.Allocator, p: prompts.Prompts) ![]const []const u8 {
+    const w = p.writer;
+    const theme = &p.theme;
     while (true) {
-        const raw = try prompts.text(w, r, arena, .{ .message = "  Choices (comma-separated):", .interrupt_keys = back_keys });
+        const raw = try p.text(.{ .message = "  Choices (comma-separated):", .interrupt_keys = back_keys });
         var list = std.ArrayList([]const u8).empty;
         var ok = true;
         var it = std.mem.splitScalar(u8, raw, ',');

--- a/projects/zcli/src/commands/add/_wizard.zig
+++ b/projects/zcli/src/commands/add/_wizard.zig
@@ -6,7 +6,7 @@
 const std = @import("std");
 const zcli = @import("zcli");
 const Context = @import("command_registry").Context;
-const prompts = zcli.prompts;
+const Prompts = zcli.Prompts;
 const themed = zcli.theme.styled;
 const ThemeContext = zcli.theme.ThemeContext;
 
@@ -27,7 +27,7 @@ const normalizeName = scaffold.spec.normalizeName;
 // Wizard prompts pass `.interrupt_keys = back_keys` so Escape aborts with
 // `error.Interrupted`; the gather state machines catch that to rewind a step.
 // "Go back" is the wizard's interpretation — prompts just reports the key.
-const back_keys = &[_]prompts.terminal.Key{.escape};
+const back_keys = &[_]Prompts.terminal.Key{.escape};
 
 // ---------------------------------------------------------------------------
 // Interactive wizard
@@ -64,12 +64,8 @@ fn runWizardOnce(
 ) !WizardResult {
     const w = context.stdout();
     const io = context.io;
-    const p: prompts.Prompts = .{
-        .writer = w,
-        .reader = context.stdin(),
-        .allocator = arena,
-        .theme = theme.*,
-    };
+    var p = context.prompts();
+    p.allocator = arena; // wizard state lives in its own arena
 
     try heading(w, theme, "Add a command");
     try hint(w, theme, "src/commands/ \u{00b7} Ctrl+C to cancel any time");
@@ -149,7 +145,7 @@ const PathPreview = struct {
 
 fn resolveCommandPath(
     arena: std.mem.Allocator,
-    p: prompts.Prompts,
+    p: Prompts,
     io: std.Io,
     seed: ?[]const u8,
 ) !PathResult {
@@ -198,7 +194,7 @@ const ArgKind = enum { text, integer, decimal, custom };
 
 fn gatherArgs(
     arena: std.mem.Allocator,
-    p: prompts.Prompts,
+    p: Prompts,
     list: *std.ArrayList(ArgSpec),
 ) !void {
     const w = p.writer;
@@ -237,7 +233,7 @@ const ArgStep = enum { name, description, type, multiple, required };
 /// user backed out of the item (Escape at the name prompt).
 fn gatherOneArg(
     arena: std.mem.Allocator,
-    p: prompts.Prompts,
+    p: Prompts,
     existing_names: []const []const u8,
     seen_optional: bool,
 ) !?ArgSpec {
@@ -325,7 +321,7 @@ fn gatherOneArg(
     };
 }
 
-fn selectArgKind(p: prompts.Prompts) !ArgKind {
+fn selectArgKind(p: Prompts) !ArgKind {
     const idx = try p.select(.{
         .message = "  Type:",
         .interrupt_keys = back_keys,
@@ -352,7 +348,7 @@ const OptKind = enum { flag, text, integer, decimal, choice, custom };
 
 fn gatherOptions(
     arena: std.mem.Allocator,
-    p: prompts.Prompts,
+    p: Prompts,
     list: *std.ArrayList(OptSpec),
 ) !void {
     const w = p.writer;
@@ -376,7 +372,7 @@ const OptStep = enum { name, description, type, multiple, nullable, default, sho
 /// of the item (Escape at the name prompt).
 fn gatherOneOption(
     arena: std.mem.Allocator,
-    p: prompts.Prompts,
+    p: Prompts,
     existing_names: []const []const u8,
     existing_shorts: []const u8,
 ) !?OptSpec {
@@ -517,7 +513,7 @@ fn gatherOneOption(
 /// surfaces as `error.Interrupted` for the caller to handle.
 fn promptOptionDefault(
     arena: std.mem.Allocator,
-    p: prompts.Prompts,
+    p: Prompts,
     kind: OptKind,
     choices: []const []const u8,
 ) ![]const u8 {
@@ -531,7 +527,7 @@ fn promptOptionDefault(
     };
 }
 
-fn selectOptKind(p: prompts.Prompts) !OptKind {
+fn selectOptKind(p: Prompts) !OptKind {
     const idx = try p.select(.{
         .message = "  Type:",
         .interrupt_keys = back_keys,
@@ -641,7 +637,7 @@ pub fn finish(
 
 fn readFieldName(
     arena: std.mem.Allocator,
-    p: prompts.Prompts,
+    p: Prompts,
     message: []const u8,
     allow_dash: bool,
     existing: []const []const u8,
@@ -682,7 +678,7 @@ fn readFieldName(
     }
 }
 
-fn readZigType(p: prompts.Prompts) ![]const u8 {
+fn readZigType(p: Prompts) ![]const u8 {
     const w = p.writer;
     const theme = &p.theme;
     while (true) {
@@ -695,7 +691,7 @@ fn readZigType(p: prompts.Prompts) ![]const u8 {
     }
 }
 
-fn readShort(p: prompts.Prompts, used: []const u8) !u8 {
+fn readShort(p: Prompts, used: []const u8) !u8 {
     const w = p.writer;
     const theme = &p.theme;
     while (true) {
@@ -720,7 +716,7 @@ fn readShort(p: prompts.Prompts, used: []const u8) !u8 {
     }
 }
 
-fn readFloat(p: prompts.Prompts, message: []const u8, default: f64) !f64 {
+fn readFloat(p: Prompts, message: []const u8, default: f64) !f64 {
     const w = p.writer;
     const theme = &p.theme;
     while (true) {
@@ -733,7 +729,7 @@ fn readFloat(p: prompts.Prompts, message: []const u8, default: f64) !f64 {
     }
 }
 
-fn readChoices(arena: std.mem.Allocator, p: prompts.Prompts) ![]const []const u8 {
+fn readChoices(arena: std.mem.Allocator, p: Prompts) ![]const []const u8 {
     const w = p.writer;
     const theme = &p.theme;
     while (true) {

--- a/projects/zcli/src/commands/add/command.zig
+++ b/projects/zcli/src/commands/add/command.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const zcli = @import("zcli");
 const Context = @import("command_registry").Context;
-const prompts = zcli.prompts;
+const Prompts = zcli.Prompts;
 
 const wizard = @import("_wizard.zig");
 const generate = @import("_generate.zig");
@@ -51,7 +51,7 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
     // Interactive on a TTY, classic skeleton when piped. Args and options are
     // added afterward with `add arg`/`add option` (ADR-0005) or, interactively,
     // through the wizard's own prompts.
-    if (!prompts.terminal.isStdinTty()) {
+    if (!Prompts.terminal.isStdinTty()) {
         return skeleton(arena, context, args, options);
     }
 

--- a/projects/zcli/src/commands/guide.zig
+++ b/projects/zcli/src/commands/guide.zig
@@ -229,16 +229,12 @@ const topics = [_]Topic{
         .body =
         \\prompts — interactive input with prompts (bundled)
         \\
-        \\Build a `Prompts` instance once from the context; every prompt is a method
-        \\on it. On non-interactive stdin, handle the piped case yourself (e.g.
-        \\fall back to a flag) rather than blocking.
+        \\`context.prompts()` returns a `zcli.Prompts` instance pre-wired to the
+        \\command's streams, allocator, and theme; every prompt is a method on it.
+        \\On non-interactive stdin, handle the piped case yourself (e.g. fall back
+        \\to a flag) rather than blocking.
         \\
-        \\  const p: zcli.prompts.Prompts = .{
-        \\      .writer = context.stdout(),
-        \\      .reader = context.stdin(),
-        \\      .allocator = context.allocator,
-        \\      .theme = context.theme,
-        \\  };
+        \\  const p = context.prompts();
         \\
         \\  const name = try p.text(.{ .message = "Name:" });
         \\  const ok   = try p.confirm(.{ .message = "Proceed?", .default = true });

--- a/projects/zcli/src/commands/guide.zig
+++ b/projects/zcli/src/commands/guide.zig
@@ -229,18 +229,21 @@ const topics = [_]Topic{
         .body =
         \\prompts — interactive input with prompts (bundled)
         \\
-        \\Each prompt takes the stdout writer and stdin reader; `text` also takes an
-        \\allocator. On non-interactive stdin, handle the piped case yourself (e.g.
+        \\Build a `Prompts` instance once from the context; every prompt is a method
+        \\on it. On non-interactive stdin, handle the piped case yourself (e.g.
         \\fall back to a flag) rather than blocking.
         \\
-        \\  const prompts = zcli.prompts;
-        \\  const w = context.stdout();
-        \\  const r = context.stdin();
+        \\  const p: zcli.prompts.Prompts = .{
+        \\      .writer = context.stdout(),
+        \\      .reader = context.stdin(),
+        \\      .allocator = context.allocator,
+        \\      .theme = context.theme,
+        \\  };
         \\
-        \\  const name = try prompts.text(w, r, context.allocator, .{ .message = "Name:" });
-        \\  const ok   = try prompts.confirm(w, r, .{ .message = "Proceed?", .default = true });
-        \\  const idx  = try prompts.select(w, r, .{ .message = "Pick:", .choices = &.{ "a", "b" } });
-        \\  const pw   = try prompts.password(w, r, context.allocator, .{ .message = "Token:" }); // hidden
+        \\  const name = try p.text(.{ .message = "Name:" });
+        \\  const ok   = try p.confirm(.{ .message = "Proceed?", .default = true });
+        \\  const idx  = try p.select(.{ .message = "Pick:", .choices = &.{ "a", "b" } });
+        \\  const pw   = try p.password(.{ .message = "Token:" }); // hidden
         \\
         \\Progress bars/spinners: `zcli.progress`.
         \\

--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const zcli = @import("zcli");
 const Context = @import("command_registry").Context;
-const prompts = zcli.prompts;
 
 /// A built-in plugin the user can opt into during `init`. `tag` is the enum
 /// tag passed to `zcli.builtin(.<tag>, .{})` in the generated build.zig.
@@ -150,12 +149,7 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         choices[i] = choice.label;
         defaults[i] = choice.default;
     }
-    const p: prompts.Prompts = .{
-        .writer = stdout,
-        .reader = context.stdin(),
-        .allocator = allocator,
-        .theme = context.theme,
-    };
+    const p = context.prompts();
     const selected = try p.multiSelect(.{
         .message = "Select built-in plugins to include:",
         .choices = &choices,

--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -150,11 +150,16 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         choices[i] = choice.label;
         defaults[i] = choice.default;
     }
-    const selected = try prompts.multiSelect(stdout, context.stdin(), allocator, .{
+    const p: prompts.Prompts = .{
+        .writer = stdout,
+        .reader = context.stdin(),
+        .allocator = allocator,
+        .theme = context.theme,
+    };
+    const selected = try p.multiSelect(.{
         .message = "Select built-in plugins to include:",
         .choices = &choices,
         .defaults = &defaults,
-        .theme = context.theme,
     });
     defer allocator.free(selected);
 

--- a/website/layouts/docs.shtml
+++ b/website/layouts/docs.shtml
@@ -247,15 +247,22 @@ exe.root_module.<span class="fn">addImport</span>(<span class="str">"command_reg
           </div>
           <div class="code">
             <div class="code-head"><span class="fname">prompts</span><span class="lang">zig</span></div>
-<pre><span class="kw">const</span> name = <span class="kw">try</span> prompts.<span class="fn">text</span>(writer, reader, allocator, .{
+<pre><span class="kw">const</span> p: prompts.Prompts = .{
+    .writer = context.<span class="fn">stdout</span>(),
+    .reader = context.<span class="fn">stdin</span>(),
+    .allocator = context.allocator,
+    .theme = context.theme,
+};
+
+<span class="kw">const</span> name = <span class="kw">try</span> p.<span class="fn">text</span>(.{
     .message = <span class="str">"Project name:"</span>, .default = <span class="str">"my-project"</span>,
 });
-<span class="kw">const</span> features = <span class="kw">try</span> prompts.<span class="fn">multiSelect</span>(writer, reader, allocator, .{
+<span class="kw">const</span> features = <span class="kw">try</span> p.<span class="fn">multiSelect</span>(.{
     .message = <span class="str">"Features:"</span>,
     .choices = &.{ <span class="str">"typescript"</span>, <span class="str">"eslint"</span>, <span class="str">"prettier"</span> },
     .defaults = &.{ <span class="num">true</span>, <span class="num">true</span>, <span class="num">false</span> },
 });
-<span class="kw">const</span> pw = <span class="kw">try</span> prompts.<span class="fn">password</span>(writer, reader, allocator, .{
+<span class="kw">const</span> pw = <span class="kw">try</span> p.<span class="fn">password</span>(.{
     .message = <span class="str">"Token:"</span>,
 });</pre>
           </div>

--- a/website/layouts/docs.shtml
+++ b/website/layouts/docs.shtml
@@ -247,12 +247,8 @@ exe.root_module.<span class="fn">addImport</span>(<span class="str">"command_reg
           </div>
           <div class="code">
             <div class="code-head"><span class="fname">prompts</span><span class="lang">zig</span></div>
-<pre><span class="kw">const</span> p: prompts.Prompts = .{
-    .writer = context.<span class="fn">stdout</span>(),
-    .reader = context.<span class="fn">stdin</span>(),
-    .allocator = context.allocator,
-    .theme = context.theme,
-};
+<pre><span class="cm">// Pre-wired to the command's streams, allocator, and theme.</span>
+<span class="kw">const</span> p = context.<span class="fn">prompts</span>();
 
 <span class="kw">const</span> name = <span class="kw">try</span> p.<span class="fn">text</span>(.{
     .message = <span class="str">"Project name:"</span>, .default = <span class="str">"my-project"</span>,

--- a/website/layouts/theming.shtml
+++ b/website/layouts/theming.shtml
@@ -159,15 +159,10 @@
 
         <section id="prompts">
           <h2>Prompts</h2>
-          <p>Interactive prompts style their cursor, selected row, multi-select marker, and hint text through <code>theme.prompts</code> tokens. Set <code>context.theme</code> on the <code>Prompts</code> instance and every prompt made through it inherits your theme <em>and</em> the detected capabilities — including <code>NO_COLOR</code>:</p>
+          <p>Interactive prompts style their cursor, selected row, multi-select marker, and hint text through <code>theme.prompts</code> tokens. <code>context.prompts()</code> returns an instance already carrying your theme <em>and</em> the detected capabilities — including <code>NO_COLOR</code> — so every prompt made through it is themed:</p>
           <div class="code">
             <div class="code-head"><span class="fname">prompts</span><span class="lang">zig</span></div>
-<pre><span class="kw">const</span> p: zcli.prompts.Prompts = .{
-    .writer = context.<span class="fn">stdout</span>(),
-    .reader = context.<span class="fn">stdin</span>(),
-    .allocator = context.allocator,
-    .theme = context.theme,
-};
+<pre><span class="kw">const</span> p = context.<span class="fn">prompts</span>();
 <span class="kw">const</span> idx = <span class="kw">try</span> p.<span class="fn">select</span>(.{
     .message = <span class="str">"Pick a region:"</span>,
     .choices = &.{ <span class="str">"us-east"</span>, <span class="str">"eu-west"</span>, <span class="str">"ap-south"</span> },

--- a/website/layouts/theming.shtml
+++ b/website/layouts/theming.shtml
@@ -159,13 +159,18 @@
 
         <section id="prompts">
           <h2>Prompts</h2>
-          <p>Interactive prompts style their cursor, selected row, multi-select marker, and hint text through <code>theme.prompts</code> tokens. Pass <code>context.theme</code> and they inherit your theme <em>and</em> the detected capabilities — including <code>NO_COLOR</code>:</p>
+          <p>Interactive prompts style their cursor, selected row, multi-select marker, and hint text through <code>theme.prompts</code> tokens. Set <code>context.theme</code> on the <code>Prompts</code> instance and every prompt made through it inherits your theme <em>and</em> the detected capabilities — including <code>NO_COLOR</code>:</p>
           <div class="code">
             <div class="code-head"><span class="fname">prompts</span><span class="lang">zig</span></div>
-<pre><span class="kw">const</span> idx = <span class="kw">try</span> zcli.prompts.<span class="fn">select</span>(writer, reader, .{
+<pre><span class="kw">const</span> p: zcli.prompts.Prompts = .{
+    .writer = context.<span class="fn">stdout</span>(),
+    .reader = context.<span class="fn">stdin</span>(),
+    .allocator = context.allocator,
+    .theme = context.theme,
+};
+<span class="kw">const</span> idx = <span class="kw">try</span> p.<span class="fn">select</span>(.{
     .message = <span class="str">"Pick a region:"</span>,
     .choices = &.{ <span class="str">"us-east"</span>, <span class="str">"eu-west"</span>, <span class="str">"ap-south"</span> },
-    .theme = context.theme,
 });</pre>
           </div>
         </section>


### PR DESCRIPTION
## Summary

Reworks the `prompts` package around an instance API, and makes the import itself the type — no `prompts.Prompts` stutter anywhere.

**In a zcli command** (the common case), the context builds the instance, pre-wired to the command's streams, arena allocator, and theme:

```zig
const p = context.prompts();

const points = try p.number(.{ .message = "Story points:", .default = 1, .min = 0, .max = 100 });
const name = try p.text(.{ .message = "Name:" });
```

**Standalone**, the root file is a struct (file-as-struct, like `std.Build` / `std.Io.Writer` / zg's `Graphemes`), so `@import("prompts")` returns the type:

```zig
const Prompts = @import("prompts");
const p: Prompts = .{ .writer = w, .reader = r, .allocator = gpa };
```

## Breaking changes

- The free functions (`prompts.text(writer, reader, alloc, cfg)`, …) are **removed** — all eight prompts are methods on the instance.
- `zcli.prompts` (module re-export) is replaced by **`zcli.Prompts`** — the type, and also the namespace for configs, helpers, and `Prompts.terminal`.
- The `theme` field is **removed** from `SelectConfig`/`MultiSelectConfig`/`SearchConfig`/`EditorConfig`; the instance's `theme` (default `Prompts.default_style`) styles every prompt made through it.
- The package's `theme` module re-export is gone (the `theme` *field* owns that name now); standalone theming goes through direct re-exports: `Prompts.Theme` / `ThemeContext` / `Capabilities` / `StyleRef`.
- The pub render helpers `renderList`/`renderSearch` (used by the vterm render tests) take an explicit `ThemeContext` parameter after `writer`.

## Design notes

- **`context.prompts()`** is the headline ergonomic: command authors never write the type name or wire the four fields. Override a field when needed — the wizard keeps its own arena via `var p = context.prompts(); p.allocator = arena;`.
- **`allocator` lives in the struct** — five of the eight prompts return owned memory, so bundling it keeps the API uniform. Side benefit: `select`'s non-TTY path now allocates from the instance allocator instead of `std.heap.page_allocator`.
- **`EditorConfig` keeps `io`** — only the editor spawns a process; it stays per-config rather than widening the struct for one prompt.
- Method syntax comes from decl aliases at the root of `Prompts.zig` pointing at module functions whose first parameter is `Prompts`.

## Ripple effects

- The `add command` wizard collapses its `(arena, w, r, theme, …)` threading to `(arena, p, …)` across every helper; three helpers dropped now-dead `arena` params.
- The tasks example is now fully themed — most of its prompt calls previously fell back to the unthemed default because passing `.theme` per call was noise.
- Synced: both READMEs, the `zcli guide` prompts topic, the 8 standalone package examples, and the website docs + theming pages.

## Testing

- `zig build test-prompts` — 61/61 unit tests (all module tests migrated to the new signatures)
- Root `zig build` + `zig build test` — clean
- `projects/zcli` unit tests + full `zig build e2e` suite — clean
- Website builds under Zine v0.11.3 with the edited layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)