### PR TITLE
Terminal-native layout engine: ADR-0013 + ui package (steps 1-2)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -19,6 +19,9 @@ pub fn build(b: *std.Build) void {
     const prompts_dep = b.dependency("prompts", .{ .target = target, .optimize = optimize });
     const progress_dep = b.dependency("progress", .{ .target = target, .optimize = optimize });
     const theme_dep = b.dependency("theme", .{ .target = target, .optimize = optimize });
+    // Not exposed on the public umbrella yet: the layout engine (ADR-0013) is
+    // pre-stabilization; it joins the surface once the node/App API lands.
+    const ui_dep = b.dependency("ui", .{ .target = target, .optimize = optimize });
 
     // The public module surface of the zcli package — what consumers (external
     // projects, the examples, projects/zcli) get from `zcli_dep.module("...")`.
@@ -60,6 +63,7 @@ pub fn build(b: *std.Build) void {
         .{ .name = "terminal", .dep = terminal_dep },
         .{ .name = "prompts", .dep = prompts_dep },
         .{ .name = "theme", .dep = theme_dep },
+        .{ .name = "ui", .dep = ui_dep },
         .{ .name = "vterm_example", .dep = vterm_example_dep },
     };
     for (test_packages) |pkg| {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -18,6 +18,7 @@
         .prompts = .{ .path = "packages/prompts" },
         .progress = .{ .path = "packages/progress" },
         .theme = .{ .path = "packages/theme" },
+        .ui = .{ .path = "packages/ui" },
     },
     .paths = .{
         "build.zig",

--- a/docs/adr/0013-terminal-native-layout-engine.md
+++ b/docs/adr/0013-terminal-native-layout-engine.md
@@ -1,0 +1,247 @@
+# Terminal-native layout engine: an immediate-mode UI core for the CLI/TUI hybrid
+
+Status: proposed
+
+The line between CLI and TUI has blurred. The tools defining the category (Claude Code
+and the agent CLIs, most built on ink.js) feel like CLIs — output flows into scrollback
+over time — but carry a live, animated frame at the bottom edge. zcli's interactive
+packages already live in that space, but each widget owns its own ad-hoc repaint loop:
+`progress` and `prompts` both hand-roll `\r\x1b[K` line rewrites, cursor hide/show, and
+flush discipline. That means N independent paint paths, a recurring class of
+coordination bugs (the flush-before-read family), and no way to *compose* — a spinner,
+a multi-bar, and a status line cannot share one frame without manual cursor math.
+
+Ink is the proof of the target authoring model: its user-facing vocabulary is
+essentially two primitives (`Box`, `Text`) plus sugar (`Spacer`, `Static`), and all
+perceived power is composition. But neither of Ink's engine choices transfers:
+
+1. **Yoga is a general flexbox engine** (C++/WASM) solving problems a terminal doesn't
+   have — fractional pixel rounding, baseline alignment across font metrics, aspect
+   ratios, incremental relayout with dirty tracking. A terminal is an integer cell
+   grid, one "font", and tiny: a 250×70 window is ~17k cells, so re-running layout
+   from scratch every frame costs microseconds. The weight buys generality we can't
+   use.
+2. **React exists because JavaScript can't cheaply rebuild a tree every frame**, so Ink
+   needs a reconciler and retained component state. Zig has arenas. Rebuilding the
+   whole node tree per frame into a frame arena is cheaper than reconciling it.
+
+libvaxis, the mature Zig TUI library, was evaluated seriously (and its cell-buffer +
+internal-diff architecture is the right reference for our render layer). Its power is
+retained-widget shaped and priced accordingly: building something simple takes a lot of
+code, and its center of gravity is the full-screen app. zcli's center of gravity is
+CLI-first with TUI moments, and the authoring bar is "a progress frame in ten lines."
+
+The historically hard part of any layout engine — measuring wrapped text — already
+exists in `packages/terminal/src/wrap.zig` (grapheme- and ANSI-aware via zg:
+`displayWidth`, `wrapToWidth`, `wrapCount`), and `vterm` provides a cell model and a
+headless terminal for golden-frame testing. The remaining work is genuinely small.
+
+## Decision
+
+**Build a terminal-native UI core — a new package layered on `terminal` and the
+`vterm` cell model — defined by five interlocking choices.**
+
+### 1. The frame model: static/live split
+
+This, not the layout algorithm, is what produces the CLI/TUI hybrid feel. Output is
+split into a **static** stream — emitted once, flows into scrollback — and a **live
+region** at the bottom edge, erased and redrawn on every frame:
+
+```zig
+try app.emit("✓ built {s}\n", .{name});   // static → flows into scrollback
+try app.frame(try statusFrame(a, t, s));  // live → measured, diffed, repainted
+```
+
+`emit` erases the live region, prints above it, repaints it (Ink's `<Static>`
+mechanics). The live region is clamped to the viewport height and **clips rather than
+scrolls** — scrollback can never be reflowed, so content taller than the terminal is a
+design error we make impossible, not a pathology we corrupt scrollback with (Ink's
+most notorious failure). Default clip is from the bottom. A full-screen TUI is not a
+separate mode: it is a root box with `height = fill` (plus alt-screen), and the static
+stream simply goes unused.
+
+**Resize is a three-tier model**, tiered by write authority, not by cost. Reflowing a
+screenful of this layout is microseconds; the binding constraint everywhere below is
+what the terminal lets an application write, never compute — which is also why no
+background/off-thread reflow exists in this design (see Considered Options):
+
+1. **Live region** — full re-layout at the new size. Unconditional.
+2. **Visible static tail** — repainted, reflowed at the new width. `emit` retains
+   recently emitted blocks in **source form** (node tree, not rendered cells) and
+   tracks the rows each occupies; a block leaves retention once it has fully scrolled
+   above the viewport, so retention stays bounded at about one screenful regardless of
+   session length. On resize, one synchronized write clears the viewport (`CSI 2 J` —
+   viewport only, never scrollback), re-emits the retained tail reflowed at the new
+   width, and repaints the live region below it. Synchronous and single-threaded: the
+   user immediately sees a fully consistent screen at the new width.
+3. **Scrollback** — immutable, by terminal authority rather than by our choice. No
+   escape sequence exists to rewrite a line that has scrolled off; content there keeps
+   the wrap width it was emitted at. The old-wrap seam sits exactly at the top of the
+   viewport, invisible until the user scrolls up.
+
+Because a resize invalidates every saved cursor position (terminals disagree about how
+existing rows move), the tail and live region are addressed **relative to the bottom
+edge** — the one anchor whose semantics survive resize across terminals.
+
+### 2. Immediate mode: a component is a function
+
+The tree is rebuilt every frame into a per-frame arena, laid out, painted, and
+discarded. There are no retained widgets, no reconciler, no framework-held state — a
+component is any function returning a `Node`, and all state (including animation, e.g.
+a spinner's tick) lives in the caller's own structs:
+
+```zig
+fn statusFrame(a: Allocator, t: *const Theme, s: *const State) !Node {
+    return ui.column(a, .{ .border = .rounded, .padding = 1 }, &.{
+        try taskList(a, t, s),
+        ui.row(a, .{ .gap = 1 }, &.{
+            ui.text(t.accent, spinnerGlyph(s.tick)),
+            ui.text(t.body, s.status_line),
+            ui.spacer(),
+            ui.text(t.dim, s.elapsed),
+        }),
+    });
+}
+```
+
+Builders take the arena and **copy child slices into it**. This is the API keystone,
+not a convenience: a `&.{...}` child literal is a stack temporary, so a component
+function returning a `Node` whose children point into its own frame would dangle. The
+arena copy makes component functions safely composable, and it resets every frame.
+
+### 3. The layout protocol: constraints down, sizes up, clipping enforced
+
+The entire contract is two functions per node:
+
+```zig
+pub const Size   = struct { w: u16, h: u16 };
+pub const Limits = struct { max_w: u16, max_h: u16 }; // min implicit 0
+
+measure(node, limits) Size    // returned size NEVER exceeds limits
+render(node, surface) void    // surface is exactly the granted rect
+```
+
+Parents constrain children; children answer "what size do I want, given at most this
+much" (a text's minimum width is 1 — it wraps or clips; fixed-size leaves refuse to
+shrink internally but still clamp the returned value); parents position. "Children
+stick to constraints" is enforced structurally, not by convention: `render` receives a
+clipped sub-surface of the cell buffer, so a misbehaving node physically cannot paint
+outside its rect. Overflow policy is one global rule — clamp and clip.
+
+### 4. The node vocabulary: four variants
+
+```zig
+pub const Node = union(enum) {
+    box:    Box,     // the only container: dir (.row/.column), gap, padding, border
+    text:   Text,    // styled spans; wrap mode .wrap / .truncate / .clip
+    spacer: void,    // sugar for an empty fill(1)
+    custom: Custom,  // escape hatch: context ptr + measure/render fn ptrs
+};
+```
+
+`row()`/`column()` are sugar over `box`. Everything else — spinner, progress bar,
+prompt line, table, markdown block — is a component function composing these, or a
+`custom` leaf when it truly needs cell-level drawing. `custom` receives a `*RenderCtx`
+(theme, io, unicode capability) and is the pressure valve that keeps the core small:
+libvaxis-grade widgets can exist as leaves without the core learning about them.
+
+### 5. The sizing vocabulary: three words, one pass, no solver
+
+```zig
+pub const Dim = union(enum) { fit, len: u16, fill: u16 };
+// plus optional .min / .max clamps for the rare cases that need them
+```
+
+Sizing lives on the node (children self-describe, Ink-style) rather than in parent
+constraint lists (ratatui-style). Distribution inside a box is a single deterministic
+pass: subtract border/padding/gaps; grant `len` children their cells; measure `fit`
+children **in declaration order** against the remaining budget (order-dependent by
+design, documented); split the remainder among `fill` children by weight with
+largest-remainder rounding so rows always sum exactly. Cross axis stretches by
+default, with `align: .start/.center/.end` otherwise.
+
+This vocabulary deliberately deletes flexbox surface: the `justify-content`/
+`align-items` matrix collapses into `spacer`, and `percent` is subsumed by fill
+weights. Defaults make the common case zero-config: column children default to
+`width = fill, height = fit`; row children default to `fit`; text defaults to wrap.
+
+### Rendering
+
+The live region renders into a cell buffer (the `vterm` cell model), is diffed against
+the previous frame, and emits minimal updates wrapped in synchronized output
+(DECSET 2026) to eliminate flicker. `vterm` doubles as the golden-frame test harness;
+measure/layout are pure functions over `Limits`, unit-testable with no terminal.
+
+## Considered Options
+
+- **Bind or port Yoga** — rejected: WASM/C++ dependency against a libc-free static
+  identity, and the engine's weight (fractional units, baselines, incremental
+  relayout) solves non-problems on an integer cell grid.
+- **Adopt libvaxis, or build a retained widget system in its image** — rejected for
+  the core: excellent for full-screen apps, but the retained-widget model carries
+  authoring weight that fights the "progress frame in ten lines" bar, and its event
+  plumbing presumes the TUI is the app. Its cell/diff render layer remains the design
+  reference.
+- **A constraint solver (cassowary, as in ratatui)** — rejected: a general solver for
+  a vocabulary (`fit`/`len`/`fill`) a few hundred lines of direct distribution can
+  satisfy deterministically. Solvers also make layout results harder to predict.
+- **Full flexbox vocabulary (justify/align matrix, percent, wrap)** — rejected:
+  `spacer` and fill weights express the same layouts with less API; every word added
+  to the sizing vocabulary is paid for in every component that must consider it.
+- **Status quo: per-widget repaint loops** — rejected: this is the bug factory the
+  engine exists to close (flush-before-read coordination, no composition into a
+  shared frame, N paint paths to make Windows-safe separately).
+- **Background (off-thread) reflow of non-visible static content on resize** —
+  rejected as impossible, not as too slow: content above the viewport lives in the
+  terminal's scrollback, which no escape sequence can rewrite. A recalculated result
+  would have nowhere to be written. The salvageable insight — "repaint what's visible
+  immediately" — is adopted as tier 2 of the resize model, and it needs no thread:
+  the visible tail is a screenful, and reflowing it is microseconds.
+- **Own the scrollback entirely (alt-screen + app-managed scrolling)** — rejected:
+  the only path to full-history reflow, but it forfeits native selection/copy,
+  mouse-wheel scrolling, terminal search, tmux copy-mode, and output persisting after
+  exit — the CLI half of the hybrid. A full-screen app that wants this can still
+  build its own scrolling viewport as a `custom` leaf.
+
+## Consequences
+
+- **One paint path.** `progress` and `prompts` migrate from hand-rolled line rewrites
+  to component functions over the core; the flush-before-read bug class and cursor
+  hide/show bookkeeping dissolve into `frame()`. Migration is incremental — the old
+  rendering keeps working until each package is ported.
+- **`emit` retains until scroll-off.** The visible-tail repaint means static blocks
+  are kept in source form until they leave the viewport — an internal contract change
+  to `App` (blocks must be arena-copied at emit, not just written), but no API change.
+  When live content is promoted to static remains API-visible (`emit`), and the
+  resize watching in `prompts` moves into the app loop.
+- **The resize seam is accepted and terminal-dependent.** Deep scrollback keeps its
+  old wrap width (invisible until the user scrolls up). Worse, terminals that reflow
+  on their own (Kitty, iTerm2, Windows Terminal) rewrap the viewport *before* we
+  repaint — a width shrink can push rewrapped rows into scrollback, stranding a
+  duplicate of content we then re-emit. Every hybrid pays this tax (Ink apps and
+  Claude Code show the same artifact); source-form retention means our repainted tail
+  is at least *correctly* rewrapped rather than terminal-guessed.
+- **State stays with the user.** No framework-held component state means no state
+  lifecycle to learn or leak; the cost is that callers own their tick counters and
+  selection indices, which is idiomatic Zig anyway.
+- **The arena is load-bearing.** Frame builds allocate freely and reset wholesale;
+  component signatures thread `Allocator` first, per the ADR-0001 arena convention.
+- **Order-dependence is documented, not solved.** `fit` measured in declaration order
+  means sibling order can change distribution. Accepted for predictability and
+  single-pass simplicity.
+- **Windows must degrade gracefully.** Synchronized output support differs between
+  Windows Terminal and the legacy console; the diff renderer treats DECSET 2026 as an
+  optimization, never a correctness dependency. The existing ConPTY e2e harness
+  covers the interactive path.
+- **Explicit non-goals with clean later homes:** overlays/z-layers (a fifth node
+  variant if ever needed), focus management and event routing (a layer above the
+  tree), scrollable viewports (a `custom` leaf first), incremental relayout (unneeded
+  at terminal sizes). None forces a core redesign; none blocks v1 of the engine.
+- **Estimated size:** the surface/diff layer plus measure/layout for the four-node
+  vocabulary is on the order of 1.5–2k lines including tests — the historically hard
+  part (text measurement) already ships in `terminal.wrap`.
+- **Build order:** (1) cell surface + diff renderer, golden-frame tested via `vterm`;
+  (2) `measure`/`render` for box/text/spacer as pure functions; (3) app loop with
+  static/live, arena, resize, sync output; (4) port two real consumers — multi-bar
+  `progress` and a Claude-Code-shaped demo (streaming text above, animated bordered
+  frame below) — to validate the vocabulary before `prompts` migrates.

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,53 @@
+# ui
+
+The terminal-native layout engine behind zcli's CLI/TUI hybrid ([ADR-0013](../../docs/adr/0013-terminal-native-layout-engine.md)).
+
+> **Status: pre-stabilization.** Built through step 2 of the ADR's build order
+> (cell surface + diff renderer, node tree + layout). The `App` loop
+> (static/live frame model, resize) is next; until it lands this package is
+> not exported on the zcli umbrella and its API may change freely.
+
+## The model
+
+Output splits into a **static** stream that flows into scrollback and a
+**live region** at the bottom edge that repaints in place. The live region is
+immediate-mode: a component is any function returning a `Node`; the tree is
+rebuilt into a frame arena every frame, measured (constraints down, sizes
+up), painted onto a cell `Surface`, and diffed — only changed cells reach the
+terminal.
+
+Four nodes: `box` (the only container), `text`, `spacer`, and `custom` (the
+escape hatch for cell-level drawing). Three sizing words: `fit`, `len(n)`,
+`fill(weight)`. Right-alignment is a spacer; percentages are fill weights.
+
+```zig
+fn statusLine(a: std.mem.Allocator, s: *const State) !ui.Node {
+    return ui.row(a, .{ .gap = 1 }, &.{
+        ui.text(.{ .bold = true }, spinnerGlyph(s.tick)), // animation = your state
+        ui.text(.{}, s.message),
+        ui.spacer(),
+        ui.text(.{ .dim = true }, s.elapsed),
+    });
+}
+```
+
+Builders copy child slices into the arena, so component functions compose
+without dangling-temporary hazards. Styles are `theme.Style` values on the
+nodes; the diff renderer emits them capability-aware (`no_color` through
+true color). Text measurement is `terminal.wrap` — the same grapheme-aware
+wrapper paints and measures, so layout and rendering always agree.
+
+Note: the default `.wrap` mode word-wraps and drops break spaces. Labels with
+significant whitespace (padded numbers, aligned columns) want `.clip` or
+`.truncate` via `ui.textOpts`.
+
+## Try it
+
+```sh
+zig build run-demo   # animated frame; needs a real terminal
+zig build test       # pure layout tests + vterm golden-frame tests
+```
+
+The demo (`examples/demo.zig`) also documents what the coming `App` loop will
+own: reserving the live region's rows, cursor parking/restore, and surface
+double-buffering.

--- a/packages/ui/build.zig
+++ b/packages/ui/build.zig
@@ -1,0 +1,60 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const zg = b.dependency("zg", .{ .target = target, .optimize = optimize });
+    const theme_dep = b.dependency("theme", .{ .target = target, .optimize = optimize });
+    const terminal_dep = b.dependency("terminal", .{ .target = target, .optimize = optimize });
+
+    // Main ui module
+    const mod = b.addModule("ui", .{
+        .root_source_file = b.path("src/ui.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    mod.addImport("Graphemes", zg.module("Graphemes"));
+    mod.addImport("theme", theme_dep.module("theme"));
+    mod.addImport("terminal", terminal_dep.module("terminal"));
+
+    // Tests are rooted at src/test.zig so the vterm golden-frame harness is a
+    // test-only import, never a dependency of the shipped module.
+    const vterm_dep = b.dependency("vterm", .{ .target = target, .optimize = optimize });
+
+    const test_mod = b.addModule("test-ui", .{
+        .root_source_file = b.path("src/test.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    test_mod.addImport("Graphemes", zg.module("Graphemes"));
+    test_mod.addImport("theme", theme_dep.module("theme"));
+    test_mod.addImport("terminal", terminal_dep.module("terminal"));
+    test_mod.addImport("vterm", vterm_dep.module("vterm"));
+
+    const tests = b.addTest(.{
+        .root_module = test_mod,
+    });
+
+    const run_tests = b.addRunArtifact(tests);
+    const test_step = b.step("test", "Run ui tests");
+    test_step.dependOn(&run_tests.step);
+
+    // Runnable demo — `zig build run-demo` (it animates, so it needs a real
+    // terminal). Compiled by `test` so it can't bitrot.
+    const demo = b.addExecutable(.{
+        .name = "ui-demo",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("examples/demo.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    demo.root_module.addImport("ui", mod);
+    demo.root_module.addImport("terminal", terminal_dep.module("terminal"));
+    test_step.dependOn(&demo.step);
+
+    const run_demo = b.addRunArtifact(demo);
+    const demo_step = b.step("run-demo", "Run the animated ui demo (needs a TTY)");
+    demo_step.dependOn(&run_demo.step);
+}

--- a/packages/ui/build.zig.zon
+++ b/packages/ui/build.zig.zon
@@ -1,0 +1,21 @@
+.{
+    .name = .ui,
+    .version = "0.1.0",
+    .fingerprint = 0x27ff46b080c69f87, // Changing this has security and trust implications.
+    .minimum_zig_version = "0.16.0",
+    .dependencies = .{
+        .theme = .{ .path = "../theme" },
+        .terminal = .{ .path = "../terminal" },
+        .vterm = .{ .path = "../vterm" },
+        .zg = .{
+            .url = "https://codeberg.org/atman/zg/archive/v0.16.2.tar.gz",
+            .hash = "zg-0.16.2-oGqU3HqftgI6rwFS90ypwfjgToH8Pz829OKuFURlm773",
+        },
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src/",
+        "examples/",
+    },
+}

--- a/packages/ui/examples/demo.zig
+++ b/packages/ui/examples/demo.zig
@@ -1,0 +1,202 @@
+//! Runnable showcase for the ui package (ADR-0013 steps 1–2): an animated
+//! "deploy" frame — spinner, task list, live progress gauges, right-aligned
+//! elapsed time — repainted in place through the frame-diff renderer.
+//!
+//! Everything on screen is the four-node vocabulary: the frame is a bordered
+//! column of rows; right-alignment is a spacer; the gauges are one `custom`
+//! leaf stretched with `fill`. The whole tree is rebuilt into an arena every
+//! frame (a component is just a function), and the diff renderer emits only
+//! the cells that changed.
+//!
+//! This example hand-rolls what the App loop (build-order step 3) will own:
+//! reserving the live region's rows, parking the cursor at the top-left,
+//! double-buffering surfaces, and restoring the cursor on exit.
+//!
+//! Run with: zig build run-demo   (from packages/ui, needs a real terminal)
+
+const std = @import("std");
+const ui = @import("ui");
+const terminal = @import("terminal");
+
+const frame_ms: u64 = 80;
+const total_frames: u32 = 72;
+
+const spinner = [_][]const u8{ "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏" };
+
+const heading: ui.Style = .{ .bold = true, .foreground = .cyan };
+const faint: ui.Style = .{ .dim = true };
+const good: ui.Style = .{ .foreground = .green };
+const busy: ui.Style = .{ .foreground = .yellow };
+
+const Task = struct {
+    name: []const u8,
+    start: u32,
+    duration: u32,
+
+    fn fraction(self: Task, frame: u32) f32 {
+        if (frame <= self.start) return 0;
+        const elapsed = frame - self.start;
+        if (elapsed >= self.duration) return 1;
+        return @as(f32, @floatFromInt(elapsed)) / @as(f32, @floatFromInt(self.duration));
+    }
+};
+
+const tasks = [_]Task{
+    .{ .name = "compile zcli", .start = 0, .duration = 28 },
+    .{ .name = "run tests", .start = 10, .duration = 34 },
+    .{ .name = "bundle examples", .start = 22, .duration = 26 },
+    .{ .name = "publish release", .start = 36, .duration = 24 },
+};
+
+/// A progress gauge as a `custom` leaf: it reports a small natural size and
+/// paints whatever width the layout grants it — combined with `.fill` sizing
+/// it stretches to absorb the row's leftover space.
+const Gauge = struct {
+    frac: f32,
+
+    fn measureFn(_: *anyopaque, _: *const ui.RenderCtx, limits: ui.Limits) ui.Size {
+        return .{ .w = @min(limits.max_w, 10), .h = @min(limits.max_h, 1) };
+    }
+
+    fn renderFn(context: *anyopaque, _: *const ui.RenderCtx, region: ui.Region) anyerror!void {
+        const self: *const Gauge = @ptrCast(@alignCast(context));
+        const w = region.width();
+        const filled: u16 = @intFromFloat(self.frac * @as(f32, @floatFromInt(w)));
+        var x: u16 = 0;
+        while (x < w) : (x += 1) {
+            const on = x < filled;
+            _ = try region.writeText(x, 0, if (on) "█" else "░", if (on) good else faint);
+        }
+    }
+
+    fn node(a: std.mem.Allocator, frac: f32) !ui.Node {
+        const self = try a.create(Gauge);
+        self.* = .{ .frac = frac };
+        return .{
+            .width = .{ .fill = 1 },
+            .kind = .{ .custom = .{
+                .context = self,
+                .measureFn = measureFn,
+                .renderFn = renderFn,
+            } },
+        };
+    }
+};
+
+fn taskRow(a: std.mem.Allocator, task: Task, frame: u32) !ui.Node {
+    const frac = task.fraction(frame);
+    const running = frame > task.start and frac < 1;
+    const glyph = if (frac >= 1)
+        ui.text(good, "✓")
+    else if (running)
+        ui.text(busy, spinner[frame % spinner.len])
+    else
+        ui.text(faint, "◦");
+    const name_style: ui.Style = if (running) .{ .bold = true } else if (frac >= 1) .{} else faint;
+    const pct = try std.fmt.allocPrint(a, "{d:>3}%", .{@as(u8, @intFromFloat(frac * 100))});
+
+    return ui.row(a, .{ .gap = 1 }, &.{
+        glyph,
+        ui.textOpts(.{ .style = name_style, .wrap = .truncate, .width = .{ .len = 16 } }, task.name),
+        try Gauge.node(a, frac),
+        // .clip, not the .wrap default: the word-wrapper treats the pad
+        // spaces in "  0%" as a break gap and would drop them.
+        ui.textOpts(.{ .style = faint, .wrap = .clip }, pct),
+    });
+}
+
+fn buildFrame(a: std.mem.Allocator, frame: u32, width: u16) !ui.Node {
+    var sum: f32 = 0;
+    var all_done = true;
+    for (tasks) |t| {
+        const f = t.fraction(frame);
+        sum += f;
+        if (f < 1) all_done = false;
+    }
+
+    const elapsed = try std.fmt.allocPrint(a, "{d:.1}s", .{
+        @as(f32, @floatFromInt(frame)) * @as(f32, @floatFromInt(frame_ms)) / 1000.0,
+    });
+
+    var rows = std.ArrayList(ui.Node).empty;
+    try rows.append(a, try ui.row(a, .{ .gap = 1 }, &.{
+        if (all_done) ui.text(good, "✓") else ui.text(heading, spinner[frame % spinner.len]),
+        ui.text(heading, "Deploying zcli demo"),
+        ui.spacer(),
+        ui.text(faint, elapsed),
+    }));
+    for (tasks) |t| try rows.append(a, try taskRow(a, t, frame));
+    try rows.append(a, try ui.row(a, .{ .gap = 1 }, &.{
+        ui.text(if (all_done) good else ui.Style{}, "overall"),
+        try Gauge.node(a, sum / tasks.len),
+    }));
+
+    return ui.column(a, .{
+        .border = .rounded,
+        .border_style = faint,
+        .padding = .symmetric(1, 0),
+        .width = .{ .len = width },
+    }, rows.items);
+}
+
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+    const gpa = init.gpa;
+
+    var out_buf: [16384]u8 = undefined;
+    var stdout = std.Io.File.stdout().writer(io, &out_buf);
+    const w = &stdout.interface;
+
+    const ws = terminal.getWindowSize(std.Io.File.stdout().handle) catch terminal.Winsize{ .row = 24, .col = 80 };
+    const width: u16 = @min(64, ws.col);
+
+    var arena = std.heap.ArenaAllocator.init(gpa);
+    defer arena.deinit();
+
+    // The frame's height is constant in this demo, so measure once upfront to
+    // size the region and the surfaces.
+    const rctx0 = ui.RenderCtx{ .allocator = arena.allocator() };
+    const probe = try buildFrame(arena.allocator(), 0, width);
+    const size = ui.measure(&rctx0, &probe, .{ .max_w = width, .max_h = ws.row -| 2 });
+
+    var prev = try ui.Surface.init(gpa, size.w, size.h);
+    defer prev.deinit();
+    var next = try ui.Surface.init(gpa, size.w, size.h);
+    defer next.deinit();
+
+    try w.writeAll("ui demo — the frame below repaints in place through the diff renderer\n\n");
+
+    // Reserve the live region's rows, then park the cursor at its top-left
+    // (the diff renderer's addressing contract).
+    try w.writeAll("\x1b[?25l");
+    var i: u16 = 0;
+    while (i < size.h) : (i += 1) try w.writeAll("\n");
+    try w.print("\x1b[{d}A", .{size.h});
+    try w.flush();
+
+    const renderer = ui.Renderer{ .capability = .ansi_16 };
+
+    var painted: ?*ui.Surface = null;
+    var frame: u32 = 0;
+    while (frame <= total_frames) : (frame += 1) {
+        _ = arena.reset(.retain_capacity);
+        const rctx = ui.RenderCtx{ .allocator = arena.allocator() };
+
+        next.clear();
+        const tree = try buildFrame(arena.allocator(), frame, width);
+        try ui.render(&rctx, &tree, next.root());
+
+        try renderer.paint(w, painted, &next);
+        try w.flush();
+
+        std.mem.swap(ui.Surface, &prev, &next);
+        painted = &prev;
+
+        io.sleep(.{ .nanoseconds = frame_ms * std.time.ns_per_ms }, .awake) catch break;
+    }
+
+    // Leave the finished frame in scrollback: cursor below the region, shown.
+    try w.print("\x1b[{d}B", .{size.h -| 1});
+    try w.writeAll("\n\x1b[?25h");
+    try w.flush();
+}

--- a/packages/ui/src/diff.zig
+++ b/packages/ui/src/diff.zig
@@ -1,0 +1,277 @@
+//! Frame-diff renderer: turns a (previous, next) surface pair into a minimal
+//! byte stream of relative cursor moves and SGR runs (ADR-0013).
+//!
+//! Addressing contract: the cursor is at column 0 of the region's TOP row on
+//! entry and is returned there on exit. All vertical movement is relative
+//! (CUD/CUU) and columns are addressed with CR + CUF, never absolute CUP —
+//! the live region floats in normal-screen scrollback, where absolute rows
+//! are meaningless. The caller (the App loop) owns creating the region's
+//! rows and parking the cursor; this renderer never scrolls.
+
+const std = @import("std");
+const theme = @import("theme");
+const surface_mod = @import("surface.zig");
+
+const Surface = surface_mod.Surface;
+const Cell = surface_mod.Cell;
+const Style = surface_mod.Style;
+const styleEql = surface_mod.styleEql;
+
+pub const Renderer = struct {
+    capability: theme.TerminalCapability,
+    /// Wrap paints in synchronized output (DECSET 2026) so the terminal
+    /// presents the frame atomically. An anti-flicker optimization, never a
+    /// correctness dependency — terminals that don't know the mode ignore it.
+    sync: bool = true,
+
+    /// Paint `next` given that the terminal currently shows `prev`. Passing
+    /// `prev = null` (or surfaces of different sizes) forces a full repaint
+    /// that assumes nothing about what's on screen. Emits nothing at all for
+    /// an unchanged frame.
+    pub fn paint(
+        self: Renderer,
+        writer: *std.Io.Writer,
+        prev: ?*const Surface,
+        next: *const Surface,
+    ) !void {
+        const full = prev == null or
+            prev.?.width != next.width or prev.?.height != next.height;
+
+        var st = EmitState{
+            .writer = writer,
+            .capability = self.capability,
+            .sync = self.sync,
+        };
+
+        var row: u16 = 0;
+        while (row < next.height) : (row += 1) {
+            if (full) {
+                try self.paintRowFull(&st, next, row);
+            } else {
+                try self.paintRowDiff(&st, prev.?, next, row);
+            }
+        }
+        try st.finish();
+    }
+
+    /// Full repaint of one row: emit from column 0 through the last cell that
+    /// is visibly non-empty, then erase the unknown remainder with EL.
+    fn paintRowFull(self: Renderer, st: *EmitState, next: *const Surface, row: u16) !void {
+        _ = self;
+        var last: u16 = 0;
+        var has_content = false;
+        var x: u16 = 0;
+        while (x < next.width) : (x += 1) {
+            const c = next.cell(x, row);
+            if (!(c.isBlank() and styleEql(c.style, .{}))) {
+                last = x;
+                has_content = true;
+            }
+        }
+        try st.moveTo(row, 0);
+        if (has_content) try st.emitCells(next, row, 0, last);
+        // Erase the unknown remainder — unless the row ran through the last
+        // column, where there is nothing right of the cursor to erase (and
+        // with autowrap disabled the cursor is clamped ON the last cell, so
+        // EL would eat it). Normalize style first: EL fills with the SGR
+        // background.
+        if (!has_content or last + 1 < next.width) {
+            try st.setStyle(.{});
+            try st.writer.writeAll("\x1b[K");
+        }
+    }
+
+    /// Diff one row: emit the single span from the first to the last changed
+    /// cell (unchanged cells inside the span repaint — cheaper than extra
+    /// cursor moves). A span never starts on a wide continuation: either half
+    /// changing repaints from the head, so a wide grapheme is always whole.
+    fn paintRowDiff(
+        self: Renderer,
+        st: *EmitState,
+        prev: *const Surface,
+        next: *const Surface,
+        row: u16,
+    ) !void {
+        _ = self;
+        var first: u16 = 0;
+        var last: u16 = 0;
+        var dirty = false;
+        var x: u16 = 0;
+        while (x < next.width) : (x += 1) {
+            if (cellEql(prev, prev.cell(x, row), next, next.cell(x, row))) continue;
+            if (!dirty) first = x;
+            last = x;
+            dirty = true;
+        }
+        if (!dirty) return;
+
+        while (first > 0 and next.cell(first, row).isContinuation()) first -= 1;
+        if (next.cell(last, row).width == 2) last += 1;
+
+        try st.moveTo(row, first);
+        try st.emitCells(next, row, first, last);
+    }
+};
+
+fn cellEql(ps: *const Surface, a: Cell, ns: *const Surface, b: Cell) bool {
+    return a.width == b.width and
+        styleEql(a.style, b.style) and
+        std.mem.eql(u8, ps.cellText(a), ns.cellText(b));
+}
+
+const EmitState = struct {
+    writer: *std.Io.Writer,
+    capability: theme.TerminalCapability,
+    sync: bool,
+    started: bool = false,
+    cur_row: u16 = 0,
+    cur_col: u16 = 0,
+    cur_style: Style = .{},
+
+    /// Lazily open the paint: the sync guard, autowrap OFF, and an SGR reset
+    /// (the terminal's current attributes are unknown). Only runs if
+    /// something gets painted, so an unchanged frame emits zero bytes.
+    ///
+    /// Autowrap (DECAWM) is disabled for the paint's duration because this
+    /// renderer legitimately writes the last column (borders, full-width
+    /// rows), and a wrap there desynchronizes relative row addressing —
+    /// worse, terminals disagree on WHEN it happens (deferred on the xterm
+    /// family, immediate on the legacy Windows console). With wrap off the
+    /// cursor deterministically clamps and CR/CUU stay exact.
+    fn start(self: *EmitState) !void {
+        if (self.started) return;
+        self.started = true;
+        if (self.sync) try self.writer.writeAll("\x1b[?2026h");
+        try self.writer.writeAll("\x1b[?7l");
+        if (self.capability != .no_color) try self.writer.writeAll("\x1b[0m");
+    }
+
+    /// Return the cursor to the region's top-left, restore default SGR and
+    /// autowrap, and close the sync guard.
+    fn finish(self: *EmitState) !void {
+        if (!self.started) return;
+        try self.setStyle(.{});
+        try self.writer.writeByte('\r');
+        if (self.cur_row > 0) try self.writer.print("\x1b[{d}A", .{self.cur_row});
+        try self.writer.writeAll("\x1b[?7h");
+        if (self.sync) try self.writer.writeAll("\x1b[?2026l");
+    }
+
+    /// Move to (row, col) in region coordinates. Rows are visited in order,
+    /// so vertical movement is always downward.
+    fn moveTo(self: *EmitState, row: u16, col: u16) !void {
+        try self.start();
+        std.debug.assert(row >= self.cur_row);
+        if (row > self.cur_row) {
+            try self.writer.print("\x1b[{d}B", .{row - self.cur_row});
+            self.cur_row = row;
+        }
+        try self.writer.writeByte('\r');
+        if (col > 0) try self.writer.print("\x1b[{d}C", .{col});
+        self.cur_col = col;
+    }
+
+    fn setStyle(self: *EmitState, style: Style) !void {
+        if (self.capability == .no_color) return;
+        if (styleEql(style, self.cur_style)) return;
+        try self.writer.writeAll("\x1b[0m");
+        _ = try style.writeSequence(self.writer, self.capability);
+        self.cur_style = style;
+    }
+
+    /// Emit the cells first..=last of `row`, skipping continuations (their
+    /// head's grapheme paints both columns).
+    fn emitCells(self: *EmitState, s: *const Surface, row: u16, first: u16, last: u16) !void {
+        var x = first;
+        while (x <= last) {
+            const c = s.cell(x, row);
+            if (c.isContinuation()) {
+                // Only reachable when a span begins mid-character during a
+                // full repaint of a blank-headed row; paint it as a space.
+                x += 1;
+                continue;
+            }
+            try self.setStyle(c.style);
+            if (c.text_len == 0) {
+                try self.writer.writeByte(' ');
+            } else {
+                try self.writer.writeAll(s.cellText(c));
+            }
+            self.cur_col += @max(c.width, 1);
+            x += @max(c.width, 1);
+        }
+    }
+};
+
+// ============================================================================
+// Tests (byte-level; behavior-level golden tests live in golden_test.zig)
+// ============================================================================
+
+const testing = std.testing;
+
+fn paintToString(
+    allocator: std.mem.Allocator,
+    r: Renderer,
+    prev: ?*const Surface,
+    next: *const Surface,
+) ![]u8 {
+    var aw = std.Io.Writer.Allocating.init(allocator);
+    defer aw.deinit();
+    try r.paint(&aw.writer, prev, next);
+    return allocator.dupe(u8, aw.written());
+}
+
+test "unchanged frame emits zero bytes" {
+    var a = try Surface.init(testing.allocator, 8, 2);
+    defer a.deinit();
+    var b = try Surface.init(testing.allocator, 8, 2);
+    defer b.deinit();
+    _ = try a.root().writeText(0, 0, "same", .{});
+    _ = try b.root().writeText(0, 0, "same", .{});
+
+    const out = try paintToString(testing.allocator, .{ .capability = .ansi_16 }, &a, &b);
+    defer testing.allocator.free(out);
+    try testing.expectEqual(@as(usize, 0), out.len);
+}
+
+test "diff paints only the changed span" {
+    var a = try Surface.init(testing.allocator, 20, 2);
+    defer a.deinit();
+    var b = try Surface.init(testing.allocator, 20, 2);
+    defer b.deinit();
+    _ = try a.root().writeText(0, 0, "stable line", .{});
+    _ = try a.root().writeText(0, 1, "count 1", .{});
+    _ = try b.root().writeText(0, 0, "stable line", .{});
+    _ = try b.root().writeText(0, 1, "count 2", .{});
+
+    const out = try paintToString(testing.allocator, .{ .capability = .ansi_16, .sync = false }, &a, &b);
+    defer testing.allocator.free(out);
+    // Only the one changed cell on row 1: move down, column 6, paint "2",
+    // return. No trace of the unchanged text.
+    try testing.expect(std.mem.indexOf(u8, out, "stable") == null);
+    try testing.expect(std.mem.indexOf(u8, out, "2") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "count") == null);
+    try testing.expect(out.len < 32);
+}
+
+test "sync guard wraps the paint when enabled" {
+    var next = try Surface.init(testing.allocator, 4, 1);
+    defer next.deinit();
+    _ = try next.root().writeText(0, 0, "x", .{});
+
+    const out = try paintToString(testing.allocator, .{ .capability = .ansi_16 }, null, &next);
+    defer testing.allocator.free(out);
+    try testing.expect(std.mem.startsWith(u8, out, "\x1b[?2026h"));
+    try testing.expect(std.mem.endsWith(u8, out, "\x1b[?2026l"));
+}
+
+test "no_color paints text but never SGR" {
+    var next = try Surface.init(testing.allocator, 6, 1);
+    defer next.deinit();
+    _ = try next.root().writeText(0, 0, "hi", .{ .bold = true, .foreground = .red });
+
+    const out = try paintToString(testing.allocator, .{ .capability = .no_color, .sync = false }, null, &next);
+    defer testing.allocator.free(out);
+    try testing.expect(std.mem.indexOf(u8, out, "hi") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "m") == null); // no SGR final byte
+}

--- a/packages/ui/src/golden_test.zig
+++ b/packages/ui/src/golden_test.zig
@@ -1,0 +1,195 @@
+//! Golden-frame tests: paint through the diff renderer into a real (virtual)
+//! terminal and assert on what a user would see. This is the behavior-level
+//! complement to the byte-level tests in diff.zig — vterm parses the actual
+//! escape stream, so these tests catch addressing and SGR mistakes that
+//! byte-golden strings would bake in.
+//!
+//! vterm's parser speaks 16-color SGR (bold/italic/underline), so everything
+//! here renders at `.ansi_16`.
+
+const std = @import("std");
+const vterm = @import("vterm");
+const ui = @import("ui.zig");
+const diff = @import("diff.zig");
+const surface_mod = @import("surface.zig");
+
+const Surface = surface_mod.Surface;
+const Renderer = diff.Renderer;
+const VTerm = vterm.VTerm;
+
+const testing = std.testing;
+
+fn paintInto(vt: *VTerm, r: Renderer, prev: ?*const Surface, next: *const Surface) !void {
+    var aw = std.Io.Writer.Allocating.init(testing.allocator);
+    defer aw.deinit();
+    try r.paint(&aw.writer, prev, next);
+    vt.write(aw.written());
+}
+
+test "full paint: text, attributes, colors land where the surface says" {
+    var vt = try VTerm.init(testing.allocator, 12, 4);
+    defer vt.deinit();
+    var s = try Surface.init(testing.allocator, 12, 3);
+    defer s.deinit();
+
+    _ = try s.root().writeText(0, 0, "hello", .{ .bold = true });
+    _ = try s.root().writeText(0, 1, "你好", .{});
+    _ = try s.root().writeText(2, 2, "end", .{ .foreground = .red });
+
+    try paintInto(&vt, .{ .capability = .ansi_16 }, null, &s);
+
+    try testing.expect(vt.containsText("hello"));
+    try testing.expect(vt.hasAttribute(0, 0, .bold));
+    try testing.expectEqual(@as(u21, '你'), vt.getCell(0, 1).char);
+    try testing.expectEqual(@as(u21, '好'), vt.getCell(2, 1).char);
+    try testing.expect(vt.containsText("end"));
+    try testing.expectEqual(vterm.Color.red, vt.getTextColor(2, 2));
+    // Styles must not bleed between runs: row 1 is unstyled.
+    try testing.expect(!vt.hasAttribute(0, 1, .bold));
+    // The renderer parks the cursor back at the region's top-left.
+    try testing.expect(vt.cursorAt(0, 0));
+}
+
+test "full paint erases stale content on painted rows only" {
+    var vt = try VTerm.init(testing.allocator, 8, 3);
+    defer vt.deinit();
+    // Fill the terminal with junk (7 X's per 8-wide row — a full row would
+    // autowrap and scroll), then park the cursor at the region origin.
+    vt.write("XXXXXXX\r\nXXXXXXX\r\nXXXXXXX\x1b[H");
+
+    var s = try Surface.init(testing.allocator, 8, 2);
+    defer s.deinit();
+    _ = try s.root().writeText(0, 0, "ok", .{});
+
+    try paintInto(&vt, .{ .capability = .ansi_16 }, null, &s);
+
+    try testing.expect(vt.containsText("ok"));
+    // EL cleared the rest of both painted rows...
+    try testing.expectEqual(@as(u21, 0), vt.getCell(5, 0).char);
+    try testing.expectEqual(@as(u21, 0), vt.getCell(0, 1).char);
+    // ...but the row below the region was never touched.
+    try testing.expectEqual(@as(u21, 'X'), vt.getCell(0, 2).char);
+}
+
+test "diff paint updates the changed cells and leaves the rest intact" {
+    var vt = try VTerm.init(testing.allocator, 20, 3);
+    defer vt.deinit();
+
+    var frame1 = try Surface.init(testing.allocator, 20, 2);
+    defer frame1.deinit();
+    _ = try frame1.root().writeText(0, 0, "building...", .{});
+    _ = try frame1.root().writeText(0, 1, "elapsed 1s", .{});
+
+    var frame2 = try Surface.init(testing.allocator, 20, 2);
+    defer frame2.deinit();
+    _ = try frame2.root().writeText(0, 0, "building...", .{});
+    _ = try frame2.root().writeText(0, 1, "elapsed 2s", .{});
+
+    const r = Renderer{ .capability = .ansi_16 };
+    try paintInto(&vt, r, null, &frame1);
+    try testing.expect(vt.containsText("elapsed 1s"));
+
+    try paintInto(&vt, r, &frame1, &frame2);
+    try testing.expect(vt.containsText("building..."));
+    try testing.expect(vt.containsText("elapsed 2s"));
+    try testing.expect(!vt.containsText("elapsed 1s"));
+    try testing.expect(vt.cursorAt(0, 0));
+}
+
+test "diff paint dissolves a wide grapheme cleanly on screen" {
+    var vt = try VTerm.init(testing.allocator, 10, 2);
+    defer vt.deinit();
+
+    var frame1 = try Surface.init(testing.allocator, 10, 1);
+    defer frame1.deinit();
+    _ = try frame1.root().writeText(0, 0, "你", .{});
+
+    var frame2 = try Surface.init(testing.allocator, 10, 1);
+    defer frame2.deinit();
+    _ = try frame2.root().writeText(1, 0, "x", .{});
+
+    const r = Renderer{ .capability = .ansi_16 };
+    try paintInto(&vt, r, null, &frame1);
+    try testing.expectEqual(@as(u21, '你'), vt.getCell(0, 0).char);
+
+    try paintInto(&vt, r, &frame1, &frame2);
+    // The head column was repainted as a blank, not left as half a glyph.
+    try testing.expectEqual(@as(u21, ' '), vt.getCell(0, 0).char);
+    try testing.expectEqual(@as(u21, 'x'), vt.getCell(1, 0).char);
+}
+
+/// A frame the way a consumer will build one: a component function returning
+/// a node tree from the frame arena, sized by measure, painted, then diffed.
+fn statusFrame(a: std.mem.Allocator, glyph: []const u8, elapsed: []const u8) !ui.Node {
+    return ui.column(a, .{
+        .border = .rounded,
+        .padding = .symmetric(1, 0),
+        .width = .{ .len = 24 },
+    }, &.{
+        try ui.row(a, .{ .gap = 1 }, &.{
+            ui.text(.{ .bold = true }, glyph),
+            ui.text(.{}, "building..."),
+            ui.spacer(),
+            ui.text(.{}, elapsed),
+        }),
+    });
+}
+
+test "end to end: a bordered status frame builds, paints, and diffs" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const rctx = ui.RenderCtx{ .allocator = arena.allocator() };
+
+    var vt = try VTerm.init(testing.allocator, 24, 4);
+    defer vt.deinit();
+
+    const frame1 = try statusFrame(arena.allocator(), "*", "12s");
+    const size = ui.measure(&rctx, &frame1, .{ .max_w = 24, .max_h = 4 });
+    try testing.expectEqual(ui.Size{ .w = 24, .h = 3 }, size);
+
+    var prev = try Surface.init(testing.allocator, size.w, size.h);
+    defer prev.deinit();
+    var next = try Surface.init(testing.allocator, size.w, size.h);
+    defer next.deinit();
+
+    const r = Renderer{ .capability = .ansi_16 };
+    try ui.render(&rctx, &frame1, prev.root());
+    try paintInto(&vt, r, null, &prev);
+
+    try testing.expectEqual(@as(u21, '╭'), vt.getCell(0, 0).char);
+    try testing.expectEqual(@as(u21, '╯'), vt.getCell(23, 2).char);
+    try testing.expect(vt.containsText("building..."));
+    try testing.expect(vt.containsText("12s"));
+    try testing.expect(vt.hasAttribute(2, 1, .bold)); // the glyph, inside border+pad
+
+    const frame2 = try statusFrame(arena.allocator(), "*", "13s");
+    try ui.render(&rctx, &frame2, next.root());
+    try paintInto(&vt, r, &prev, &next);
+
+    try testing.expect(vt.containsText("building..."));
+    try testing.expect(vt.containsText("13s"));
+    try testing.expect(!vt.containsText("12s"));
+    try testing.expect(vt.cursorAt(0, 0));
+}
+
+test "style-only change repaints in place" {
+    var vt = try VTerm.init(testing.allocator, 10, 1);
+    defer vt.deinit();
+
+    var frame1 = try Surface.init(testing.allocator, 10, 1);
+    defer frame1.deinit();
+    _ = try frame1.root().writeText(0, 0, "warn", .{});
+
+    var frame2 = try Surface.init(testing.allocator, 10, 1);
+    defer frame2.deinit();
+    _ = try frame2.root().writeText(0, 0, "warn", .{ .foreground = .yellow, .bold = true });
+
+    const r = Renderer{ .capability = .ansi_16 };
+    try paintInto(&vt, r, null, &frame1);
+    try testing.expectEqual(vterm.Color.default, vt.getTextColor(0, 0));
+
+    try paintInto(&vt, r, &frame1, &frame2);
+    try testing.expect(vt.containsText("warn"));
+    try testing.expectEqual(vterm.Color.yellow, vt.getTextColor(0, 0));
+    try testing.expect(vt.hasAttribute(0, 0, .bold));
+}

--- a/packages/ui/src/layout_test.zig
+++ b/packages/ui/src/layout_test.zig
@@ -1,0 +1,311 @@
+//! Layout tests: measure and render as pure functions over Limits, painted
+//! onto a Surface directly (no terminal, no escape parsing — those live in
+//! golden_test.zig).
+
+const std = @import("std");
+const ui = @import("ui.zig");
+const node_mod = @import("node.zig");
+
+const testing = std.testing;
+
+const Harness = struct {
+    arena: std.heap.ArenaAllocator,
+
+    fn init() Harness {
+        return .{ .arena = std.heap.ArenaAllocator.init(testing.allocator) };
+    }
+
+    fn deinit(self: *Harness) void {
+        self.arena.deinit();
+    }
+
+    fn ctx(self: *Harness) ui.RenderCtx {
+        return .{ .allocator = self.arena.allocator() };
+    }
+
+    fn a(self: *Harness) std.mem.Allocator {
+        return self.arena.allocator();
+    }
+};
+
+/// Render `node` into a fresh surface of the given size and return the given
+/// row as a plain string (blanks as spaces) for easy assertions.
+fn rowString(h: *Harness, s: *ui.Surface, y: u16) ![]u8 {
+    var list = std.ArrayList(u8).empty;
+    var x: u16 = 0;
+    while (x < s.width) : (x += 1) {
+        const c = s.cell(x, y);
+        if (c.isContinuation()) continue;
+        if (c.text_len == 0) {
+            try list.append(h.a(), ' ');
+        } else {
+            try list.appendSlice(h.a(), s.cellText(c));
+        }
+    }
+    return list.items;
+}
+
+fn renderInto(h: *Harness, node: ui.Node, s: *ui.Surface) !void {
+    const rctx = h.ctx();
+    try ui.render(&rctx, &node, s.root());
+}
+
+// ============================================================================
+// Measure
+// ============================================================================
+
+test "text measures wrapped: constrained width produces lines" {
+    var h = Harness.init();
+    defer h.deinit();
+    const rctx = h.ctx();
+
+    const n = ui.text(.{}, "hello world");
+    try testing.expectEqual(ui.Size{ .w = 11, .h = 1 }, ui.measure(&rctx, &n, .{ .max_w = 20, .max_h = 10 }));
+    try testing.expectEqual(ui.Size{ .w = 5, .h = 2 }, ui.measure(&rctx, &n, .{ .max_w = 7, .max_h = 10 }));
+    // Height offer caps the reported lines.
+    try testing.expectEqual(ui.Size{ .w = 5, .h = 1 }, ui.measure(&rctx, &n, .{ .max_w = 5, .max_h = 1 }));
+}
+
+test "truncating text is always one line" {
+    var h = Harness.init();
+    defer h.deinit();
+    const rctx = h.ctx();
+
+    const n = ui.textOpts(.{ .wrap = .truncate }, "hello world");
+    try testing.expectEqual(ui.Size{ .w = 7, .h = 1 }, ui.measure(&rctx, &n, .{ .max_w = 7, .max_h = 10 }));
+}
+
+test "column stacks fit children; gap counts" {
+    var h = Harness.init();
+    defer h.deinit();
+    const rctx = h.ctx();
+
+    const plain = try ui.column(h.a(), .{}, &.{
+        ui.text(.{}, "aa"),
+        ui.text(.{}, "bbb"),
+    });
+    try testing.expectEqual(ui.Size{ .w = 3, .h = 2 }, ui.measure(&rctx, &plain, .{ .max_w = 20, .max_h = 20 }));
+
+    const gapped = try ui.column(h.a(), .{ .gap = 1 }, &.{
+        ui.text(.{}, "aa"),
+        ui.text(.{}, "bbb"),
+    });
+    try testing.expectEqual(ui.Size{ .w = 3, .h = 3 }, ui.measure(&rctx, &gapped, .{ .max_w = 20, .max_h = 20 }));
+}
+
+test "border and padding are chrome on both axes" {
+    var h = Harness.init();
+    defer h.deinit();
+    const rctx = h.ctx();
+
+    const n = try ui.column(h.a(), .{ .border = .single, .padding = .all(1) }, &.{
+        ui.text(.{}, "hi"),
+    });
+    try testing.expectEqual(ui.Size{ .w = 6, .h = 5 }, ui.measure(&rctx, &n, .{ .max_w = 20, .max_h = 20 }));
+}
+
+test "a .len dim measures as exactly n, not content size" {
+    var h = Harness.init();
+    defer h.deinit();
+    const rctx = h.ctx();
+
+    const n = ui.textOpts(.{ .width = .{ .len = 10 } }, "ab");
+    try testing.expectEqual(ui.Size{ .w = 10, .h = 1 }, ui.measure(&rctx, &n, .{ .max_w = 20, .max_h = 20 }));
+    // ...but never more than the offer.
+    try testing.expectEqual(ui.Size{ .w = 6, .h = 1 }, ui.measure(&rctx, &n, .{ .max_w = 6, .max_h = 20 }));
+}
+
+test "min_width raises a measured size within the offer" {
+    var h = Harness.init();
+    defer h.deinit();
+    const rctx = h.ctx();
+
+    var n = ui.text(.{}, "ab");
+    n.min_width = 8;
+    try testing.expectEqual(ui.Size{ .w = 8, .h = 1 }, ui.measure(&rctx, &n, .{ .max_w = 20, .max_h = 20 }));
+    try testing.expectEqual(ui.Size{ .w = 5, .h = 1 }, ui.measure(&rctx, &n, .{ .max_w = 5, .max_h = 20 }));
+}
+
+test "fill children contribute nothing at measure time" {
+    var h = Harness.init();
+    defer h.deinit();
+    const rctx = h.ctx();
+
+    const n = try ui.row(h.a(), .{}, &.{
+        ui.text(.{}, "ab"),
+        ui.spacer(),
+        ui.text(.{}, "cd"),
+    });
+    try testing.expectEqual(ui.Size{ .w = 4, .h = 1 }, ui.measure(&rctx, &n, .{ .max_w = 40, .max_h = 5 }));
+}
+
+// ============================================================================
+// Render
+// ============================================================================
+
+test "spacer pushes trailing content to the right edge" {
+    var h = Harness.init();
+    defer h.deinit();
+    var s = try ui.Surface.init(testing.allocator, 10, 1);
+    defer s.deinit();
+
+    const n = try ui.row(h.a(), .{}, &.{
+        ui.text(.{}, "ab"),
+        ui.spacer(),
+        ui.text(.{}, "cd"),
+    });
+    try renderInto(&h, n, &s);
+    try testing.expectEqualStrings("ab      cd", try rowString(&h, &s, 0));
+}
+
+test "fill weights split leftover space with exact sum" {
+    var h = Harness.init();
+    defer h.deinit();
+    var s = try ui.Surface.init(testing.allocator, 10, 1);
+    defer s.deinit();
+
+    // budget 10, weights 1:3 → floor 2/7, remainders tie, first child wins → 3/7.
+    const n = try ui.row(h.a(), .{}, &.{
+        ui.textOpts(.{ .width = .{ .fill = 1 }, .wrap = .clip }, "aaaaaaaaaa"),
+        ui.textOpts(.{ .width = .{ .fill = 3 }, .wrap = .clip }, "bbbbbbbbbb"),
+    });
+    try renderInto(&h, n, &s);
+    try testing.expectEqualStrings("aaabbbbbbb", try rowString(&h, &s, 0));
+}
+
+test "equal weights: largest-remainder gives earlier children the extras" {
+    var h = Harness.init();
+    defer h.deinit();
+    var s = try ui.Surface.init(testing.allocator, 10, 1);
+    defer s.deinit();
+
+    const n = try ui.row(h.a(), .{}, &.{
+        ui.textOpts(.{ .width = .{ .fill = 1 }, .wrap = .clip }, "aaaaaaaaaa"),
+        ui.textOpts(.{ .width = .{ .fill = 1 }, .wrap = .clip }, "bbbbbbbbbb"),
+        ui.textOpts(.{ .width = .{ .fill = 1 }, .wrap = .clip }, "cccccccccc"),
+    });
+    try renderInto(&h, n, &s);
+    try testing.expectEqualStrings("aaaabbbccc", try rowString(&h, &s, 0));
+}
+
+test "fit is measured in declaration order against what remains" {
+    var h = Harness.init();
+    defer h.deinit();
+    var s = try ui.Surface.init(testing.allocator, 8, 1);
+    defer s.deinit();
+
+    // First fit child takes its natural 6; the second gets the leftover 2.
+    const n = try ui.row(h.a(), .{}, &.{
+        ui.textOpts(.{ .wrap = .clip }, "aaaaaa"),
+        ui.textOpts(.{ .wrap = .clip }, "bbbbbb"),
+    });
+    try renderInto(&h, n, &s);
+    try testing.expectEqualStrings("aaaaaabb", try rowString(&h, &s, 0));
+}
+
+test "column wraps text at the box width" {
+    var h = Harness.init();
+    defer h.deinit();
+    var s = try ui.Surface.init(testing.allocator, 7, 2);
+    defer s.deinit();
+
+    const n = try ui.column(h.a(), .{}, &.{
+        ui.text(.{}, "hello world"),
+    });
+    try renderInto(&h, n, &s);
+    try testing.expectEqualStrings("hello  ", try rowString(&h, &s, 0));
+    try testing.expectEqualStrings("world  ", try rowString(&h, &s, 1));
+}
+
+test "border draws around padded content" {
+    var h = Harness.init();
+    defer h.deinit();
+    var s = try ui.Surface.init(testing.allocator, 6, 3);
+    defer s.deinit();
+
+    const n = try ui.column(h.a(), .{ .border = .rounded, .width = .{ .fill = 1 }, .height = .{ .fill = 1 } }, &.{
+        ui.text(.{}, "hi"),
+    });
+    try renderInto(&h, n, &s);
+    try testing.expectEqualStrings("╭────╮", try rowString(&h, &s, 0));
+    try testing.expectEqualStrings("│hi  │", try rowString(&h, &s, 1));
+    try testing.expectEqualStrings("╰────╯", try rowString(&h, &s, 2));
+}
+
+test "align_self centers and ends on the cross axis" {
+    var h = Harness.init();
+    defer h.deinit();
+    var s = try ui.Surface.init(testing.allocator, 10, 2);
+    defer s.deinit();
+
+    const n = try ui.column(h.a(), .{}, &.{
+        ui.textOpts(.{ .width = .fit, .align_self = .center }, "ab"),
+        ui.textOpts(.{ .width = .fit, .align_self = .end }, "cd"),
+    });
+    try renderInto(&h, n, &s);
+    try testing.expectEqualStrings("    ab    ", try rowString(&h, &s, 0));
+    try testing.expectEqualStrings("        cd", try rowString(&h, &s, 1));
+}
+
+test "truncate renders an ellipsis at the clip point" {
+    var h = Harness.init();
+    defer h.deinit();
+    var s = try ui.Surface.init(testing.allocator, 5, 1);
+    defer s.deinit();
+
+    const n = ui.textOpts(.{ .wrap = .truncate }, "abcdefgh");
+    try renderInto(&h, n, &s);
+    try testing.expectEqualStrings("abcd…", try rowString(&h, &s, 0));
+}
+
+test "custom leaf measures and renders through its vtable" {
+    var h = Harness.init();
+    defer h.deinit();
+    var s = try ui.Surface.init(testing.allocator, 8, 1);
+    defer s.deinit();
+
+    const Gauge = struct {
+        fn measureFn(_: *anyopaque, _: *const ui.RenderCtx, limits: ui.Limits) ui.Size {
+            return .{ .w = @min(3, limits.max_w), .h = @min(1, limits.max_h) };
+        }
+        fn renderFn(_: *anyopaque, _: *const ui.RenderCtx, region: ui.Region) anyerror!void {
+            _ = try region.writeText(0, 0, "xyz", .{});
+        }
+    };
+    var payload: u8 = 0;
+    const n = ui.Node{ .kind = .{ .custom = .{
+        .context = @ptrCast(&payload),
+        .measureFn = Gauge.measureFn,
+        .renderFn = Gauge.renderFn,
+    } } };
+
+    const rctx = h.ctx();
+    try testing.expectEqual(ui.Size{ .w = 3, .h = 1 }, ui.measure(&rctx, &n, .{ .max_w = 8, .max_h = 4 }));
+    try renderInto(&h, n, &s);
+    try testing.expectEqualStrings("xyz     ", try rowString(&h, &s, 0));
+}
+
+test "component functions compose: children are arena-copied, not borrowed" {
+    var h = Harness.init();
+    defer h.deinit();
+    var s = try ui.Surface.init(testing.allocator, 12, 1);
+    defer s.deinit();
+
+    const Component = struct {
+        // The child slice literal here is a stack temporary of THIS call —
+        // the builder must copy it for the returned node to stay valid.
+        fn statusLine(a: std.mem.Allocator) !ui.Node {
+            return ui.row(a, .{}, &.{
+                ui.text(.{}, "ok"),
+                ui.spacer(),
+                ui.text(.{}, "3s"),
+            });
+        }
+    };
+
+    const n = try ui.column(h.a(), .{}, &.{
+        try Component.statusLine(h.a()),
+    });
+    try renderInto(&h, n, &s);
+    try testing.expectEqualStrings("ok        3s", try rowString(&h, &s, 0));
+}

--- a/packages/ui/src/node.zig
+++ b/packages/ui/src/node.zig
@@ -1,0 +1,509 @@
+//! The node tree and layout: measure (constraints down, sizes up) and render
+//! (paint into a clipped region) for the four-node vocabulary of ADR-0013.
+//!
+//! Both passes are pure functions over `Limits` — no terminal I/O, no
+//! retained state — which is what makes layout unit-testable without a TTY
+//! and cheap enough to re-run from scratch every frame. Text measurement is
+//! `terminal.wrap`: the same greedy wrapper paints and measures, so layout
+//! and rendering can never disagree about where a line breaks.
+//!
+//! Axis mapping: a box distributes its MAIN axis (width for `.row`, height
+//! for `.column`) among children by their `Dim`; the CROSS axis stretches by
+//! default, with `align_self` placing children that resolve smaller. A `Dim`
+//! of `.auto` resolves per context: fit on the main axis, stretch on the
+//! cross axis — and `fill(1)` for a spacer's main axis. That one rule is
+//! what makes the ADR's zero-config defaults fall out.
+
+const std = @import("std");
+const Graphemes = @import("Graphemes");
+const terminal = @import("terminal");
+const surface_mod = @import("surface.zig");
+
+pub const Style = surface_mod.Style;
+pub const Region = surface_mod.Region;
+
+pub const Size = struct { w: u16, h: u16 };
+
+/// What a parent offers a child: at most this much. Minimums are implicit
+/// zero; a leaf with an intrinsic minimum clamps itself and clips at render.
+pub const Limits = struct {
+    max_w: u16,
+    max_h: u16,
+
+    pub fn shrink(self: Limits, dw: u32, dh: u32) Limits {
+        return .{
+            .max_w = @intCast(self.max_w -| @min(dw, self.max_w)),
+            .max_h = @intCast(self.max_h -| @min(dh, self.max_h)),
+        };
+    }
+};
+
+/// The sizing vocabulary. `.auto` is the context-dependent default (see the
+/// module docs); the other three are the ADR's three words.
+pub const Dim = union(enum) {
+    auto,
+    fit,
+    len: u16,
+    fill: u16,
+};
+
+pub const Align = enum { start, center, end };
+pub const Direction = enum { row, column };
+pub const WrapMode = enum { wrap, truncate, clip };
+
+pub const BorderStyle = enum { none, single, rounded, double, ascii };
+
+pub const Padding = struct {
+    top: u16 = 0,
+    right: u16 = 0,
+    bottom: u16 = 0,
+    left: u16 = 0,
+
+    pub fn all(n: u16) Padding {
+        return .{ .top = n, .right = n, .bottom = n, .left = n };
+    }
+
+    pub fn symmetric(x: u16, y: u16) Padding {
+        return .{ .top = y, .right = x, .bottom = y, .left = x };
+    }
+};
+
+/// Context threaded through measure/render. Deliberately small: styles are
+/// structured data on the nodes themselves, so the core needs no theme — a
+/// `custom` leaf that wants one carries it in its own context pointer.
+pub const RenderCtx = struct {
+    /// The frame arena. Layout scratch and builder child-copies live here and
+    /// are freed wholesale when the frame ends.
+    allocator: std.mem.Allocator,
+    /// Chooses border/ellipsis glyphs (`terminal.unicodeSupported` upstream).
+    unicode: bool = true,
+};
+
+pub const Node = struct {
+    width: Dim = .auto,
+    height: Dim = .auto,
+    /// Cross-axis placement when this node resolves smaller than the space
+    /// its parent offers. (`align` is a Zig keyword.)
+    align_self: Align = .start,
+    min_width: ?u16 = null,
+    max_width: ?u16 = null,
+    min_height: ?u16 = null,
+    max_height: ?u16 = null,
+    kind: Kind,
+};
+
+pub const Kind = union(enum) {
+    box: Box,
+    text: Text,
+    spacer,
+    custom: Custom,
+};
+
+pub const Box = struct {
+    dir: Direction = .column,
+    children: []const Node = &.{},
+    gap: u16 = 0,
+    padding: Padding = .{},
+    border: BorderStyle = .none,
+    border_style: Style = .{},
+    /// Background: every cell of the box's region is blanked in this style
+    /// before children paint.
+    style: Style = .{},
+};
+
+pub const Text = struct {
+    content: []const u8,
+    style: Style = .{},
+    wrap: WrapMode = .wrap,
+};
+
+pub const Custom = struct {
+    context: *anyopaque,
+    measureFn: *const fn (context: *anyopaque, ctx: *const RenderCtx, limits: Limits) Size,
+    renderFn: *const fn (context: *anyopaque, ctx: *const RenderCtx, region: Region) anyerror!void,
+};
+
+// ============================================================================
+// Measure
+// ============================================================================
+
+/// What size does `node` want, given at most `limits`? Never exceeds them.
+pub fn measure(ctx: *const RenderCtx, node: *const Node, limits: Limits) Size {
+    const clamped = clampLimits(node, limits);
+    var size: Size = switch (node.kind) {
+        .box => |*b| measureBox(ctx, b, clamped),
+        .text => |*t| measureText(t, clamped),
+        .spacer => .{ .w = 0, .h = 0 },
+        .custom => |c| c.measureFn(c.context, ctx, clamped),
+    };
+    size.w = @min(size.w, clamped.max_w);
+    size.h = @min(size.h, clamped.max_h);
+    // `.len` means exactly n cells (clamped to the offer), not content size —
+    // the render pass grants exactly n, so measure must report the same.
+    switch (node.width) {
+        .len => |n| size.w = @min(n, clamped.max_w),
+        else => {},
+    }
+    switch (node.height) {
+        .len => |n| size.h = @min(n, clamped.max_h),
+        else => {},
+    }
+    if (node.min_width) |m| size.w = @max(size.w, @min(m, clamped.max_w));
+    if (node.min_height) |m| size.h = @max(size.h, @min(m, clamped.max_h));
+    return size;
+}
+
+/// Apply the node's own caps to what the parent offered: explicit `max_*`
+/// clamps, and a `.len` dim IS the size on that axis — measuring inside it
+/// (e.g. wrapping text at a fixed width) must see the fixed extent.
+fn clampLimits(node: *const Node, limits: Limits) Limits {
+    var l = limits;
+    if (node.max_width) |m| l.max_w = @min(l.max_w, m);
+    if (node.max_height) |m| l.max_h = @min(l.max_h, m);
+    switch (node.width) {
+        .len => |n| l.max_w = @min(l.max_w, n),
+        else => {},
+    }
+    switch (node.height) {
+        .len => |n| l.max_h = @min(l.max_h, n),
+        else => {},
+    }
+    return l;
+}
+
+fn measureText(t: *const Text, limits: Limits) Size {
+    if (limits.max_w == 0 or limits.max_h == 0) return .{ .w = 0, .h = 0 };
+    switch (t.wrap) {
+        .truncate, .clip => {
+            const w = terminal.displayWidth(t.content);
+            return .{ .w = @intCast(@min(w, limits.max_w)), .h = 1 };
+        },
+        .wrap => {
+            var m = WrapMeasure{};
+            terminal.wrapForEach(t.content, limits.max_w, &m, WrapMeasure.add) catch unreachable;
+            return .{
+                .w = @intCast(@min(m.widest, limits.max_w)),
+                .h = @intCast(@min(m.lines, limits.max_h)),
+            };
+        },
+    }
+}
+
+const WrapMeasure = struct {
+    lines: usize = 0,
+    widest: usize = 0,
+
+    fn add(self: *WrapMeasure, line: []const u8) anyerror!void {
+        self.lines += 1;
+        self.widest = @max(self.widest, terminal.displayWidth(line));
+    }
+};
+
+/// A box wants its chrome plus its content: fixed and fit children summed on
+/// the main axis (fill children contribute nothing at measure time — they
+/// only absorb surplus at render), the largest child on the cross axis.
+fn measureBox(ctx: *const RenderCtx, b: *const Box, limits: Limits) Size {
+    const chrome_w: u32 = @as(u32, b.padding.left) + b.padding.right + borderCols(b) * 2;
+    const chrome_h: u32 = @as(u32, b.padding.top) + b.padding.bottom + borderCols(b) * 2;
+    const inner = limits.shrink(chrome_w, chrome_h);
+
+    var main_used: u32 = 0;
+    var cross_max: u32 = 0;
+    var first = true;
+    for (b.children) |*child| {
+        const gap: u32 = if (first) 0 else b.gap;
+        first = false;
+        const remaining: u16 = @intCast(innerMain(b.dir, inner) -| (main_used + gap));
+        const child_size = switch (mainDim(b.dir, child)) {
+            .fill => Size{ .w = 0, .h = 0 },
+            // .len is folded into the child's limits by clampLimits; .auto on
+            // the main axis is fit (spacers resolved to .fill by mainDim).
+            .len, .auto, .fit => measure(ctx, child, limitsFor(b.dir, remaining, innerCross(b.dir, inner))),
+        };
+        main_used += gap + mainOf(b.dir, child_size);
+        cross_max = @max(cross_max, crossOf(b.dir, child_size));
+    }
+
+    const w: u32 = chrome_w + (if (b.dir == .row) main_used else cross_max);
+    const h: u32 = chrome_h + (if (b.dir == .row) cross_max else main_used);
+    return .{
+        .w = @intCast(@min(w, limits.max_w)),
+        .h = @intCast(@min(h, limits.max_h)),
+    };
+}
+
+// ============================================================================
+// Render
+// ============================================================================
+
+/// Paint `node` into `region` — exactly the rect the parent granted; the
+/// region's clipping is what enforces "children stick to constraints".
+pub fn render(ctx: *const RenderCtx, node: *const Node, region: Region) anyerror!void {
+    if (region.width() == 0 or region.height() == 0) return;
+    switch (node.kind) {
+        .box => |*b| try renderBox(ctx, b, region),
+        .text => |*t| try renderText(ctx, t, region),
+        .spacer => {},
+        .custom => |c| try c.renderFn(c.context, ctx, region),
+    }
+}
+
+fn renderText(ctx: *const RenderCtx, t: *const Text, region: Region) !void {
+    switch (t.wrap) {
+        .clip => _ = try region.writeText(0, 0, t.content, t.style),
+        .truncate => try writeTruncated(ctx, region, t.content, t.style),
+        .wrap => {
+            var w = WrapWriter{ .region = region, .style = t.style };
+            try terminal.wrapForEach(t.content, region.width(), &w, WrapWriter.add);
+        },
+    }
+}
+
+const WrapWriter = struct {
+    region: Region,
+    style: Style,
+    line: u16 = 0,
+
+    fn add(self: *WrapWriter, line_text: []const u8) anyerror!void {
+        if (self.line >= self.region.height()) return;
+        _ = try self.region.writeText(0, self.line, line_text, self.style);
+        self.line += 1;
+    }
+};
+
+fn writeTruncated(ctx: *const RenderCtx, region: Region, content: []const u8, style: Style) !void {
+    const w = region.width();
+    if (terminal.displayWidth(content) <= w) {
+        _ = try region.writeText(0, 0, content, style);
+        return;
+    }
+    const ellipsis: []const u8 = if (ctx.unicode) "…" else "...";
+    const ellipsis_w: u16 = if (ctx.unicode) 1 else 3;
+    if (w <= ellipsis_w) {
+        // No room for content at all; the (possibly clipped) ellipsis is the message.
+        _ = try region.writeText(0, 0, ellipsis, style);
+        return;
+    }
+    const keep = prefixForWidth(content, w - ellipsis_w);
+    const cols = try region.writeText(0, 0, content[0..keep], style);
+    _ = try region.writeText(cols, 0, ellipsis, style);
+}
+
+/// Byte length of the longest prefix of `text` that fits `width` columns.
+fn prefixForWidth(text: []const u8, width: u16) usize {
+    var cols: usize = 0;
+    var end: usize = 0;
+    var it = Graphemes.iterator(text);
+    while (it.next()) |g| {
+        const gw = g.displayWidth(text);
+        const w: usize = if (gw > 0) @intCast(gw) else 0;
+        if (cols + w > width) break;
+        cols += w;
+        end = g.offset + g.len;
+    }
+    return end;
+}
+
+fn renderBox(ctx: *const RenderCtx, b: *const Box, region: Region) !void {
+    region.fill(b.style);
+    try drawBorder(ctx, b, region);
+
+    const bc = borderCols(b);
+    const inner = region.sub(.{
+        .x = @intCast(@min(@as(u32, b.padding.left) + bc, region.width())),
+        .y = @intCast(@min(@as(u32, b.padding.top) + bc, region.height())),
+        .w = @intCast(region.width() -| (@as(u32, b.padding.left) + b.padding.right + bc * 2)),
+        .h = @intCast(region.height() -| (@as(u32, b.padding.top) + b.padding.bottom + bc * 2)),
+    });
+    if (b.children.len == 0 or inner.width() == 0 or inner.height() == 0) return;
+
+    // --- Distribute the main axis: len, then fit in declaration order, then
+    // fill by weight with largest-remainder rounding (ADR-0013 §5).
+    const main_total: u32 = if (b.dir == .row) inner.width() else inner.height();
+    const gaps: u32 = @as(u32, b.gap) * @as(u32, @intCast(b.children.len - 1));
+    var budget: u32 = main_total -| gaps;
+
+    const assigned = try ctx.allocator.alloc(u16, b.children.len);
+    var fill_total: u32 = 0;
+    for (b.children, assigned) |*child, *slot| {
+        switch (mainDim(b.dir, child)) {
+            .len => |n| {
+                slot.* = @intCast(@min(n, budget));
+                budget -= slot.*;
+            },
+            .fill => |weight| {
+                slot.* = 0; // resolved below
+                fill_total += weight;
+            },
+            .auto, .fit => {
+                const s = measure(ctx, child, limitsFor(b.dir, @intCast(budget), innerCross(b.dir, .{ .max_w = inner.width(), .max_h = inner.height() })));
+                slot.* = mainOf(b.dir, s);
+                budget -= slot.*;
+            },
+        }
+    }
+    if (fill_total > 0) try distributeFill(ctx, b, assigned, budget, fill_total);
+
+    // --- Position and recurse.
+    const cross_total: u16 = if (b.dir == .row) inner.height() else inner.width();
+    var offset: u32 = 0;
+    for (b.children, assigned) |*child, main_size| {
+        defer offset += main_size + b.gap;
+        if (main_size == 0) continue;
+
+        var cross_size: u16 = cross_total;
+        switch (crossDim(b.dir, child)) {
+            .auto, .fill => {}, // stretch
+            .len => |n| cross_size = @min(n, cross_total),
+            .fit => {
+                const s = measure(ctx, child, limitsFor(b.dir, main_size, cross_total));
+                cross_size = @min(crossOf(b.dir, s), cross_total);
+            },
+        }
+        const cross_offset: u16 = switch (child.align_self) {
+            .start => 0,
+            .center => (cross_total - cross_size) / 2,
+            .end => cross_total - cross_size,
+        };
+
+        const child_region = inner.sub(if (b.dir == .row) .{
+            .x = @intCast(@min(offset, inner.width())),
+            .y = cross_offset,
+            .w = main_size,
+            .h = cross_size,
+        } else .{
+            .x = cross_offset,
+            .y = @intCast(@min(offset, inner.height())),
+            .w = cross_size,
+            .h = main_size,
+        });
+        try render(ctx, child, child_region);
+    }
+}
+
+/// Split `budget` among fill children proportionally to weight, exact-sum:
+/// each gets floor(budget·weight/total), and leftover cells go to the largest
+/// fractional remainders (declaration order breaks ties).
+fn distributeFill(ctx: *const RenderCtx, b: *const Box, assigned: []u16, budget: u32, fill_total: u32) !void {
+    const fracs = try ctx.allocator.alloc(u32, assigned.len);
+    var leftover = budget;
+    for (b.children, assigned, fracs) |*child, *slot, *frac| {
+        frac.* = 0;
+        switch (mainDim(b.dir, child)) {
+            .fill => |weight| {
+                const exact: u64 = @as(u64, budget) * weight;
+                slot.* = @intCast(exact / fill_total);
+                frac.* = @intCast(exact % fill_total);
+                leftover -= slot.*;
+            },
+            else => {},
+        }
+    }
+    while (leftover > 0) : (leftover -= 1) {
+        var best: usize = 0;
+        var best_frac: u32 = 0;
+        for (fracs, 0..) |f, i| {
+            if (f > best_frac) {
+                best_frac = f;
+                best = i;
+            }
+        }
+        if (best_frac == 0) break; // exact division everywhere; nothing to round up
+        fracs[best] = 0;
+        assigned[best] += 1;
+    }
+}
+
+// ============================================================================
+// Axis helpers
+// ============================================================================
+
+/// The child's dim on the box's main axis. A spacer's `.auto` means
+/// `fill(1)` — that one special case is what makes `ui.spacer()` sugar.
+fn mainDim(dir: Direction, node: *const Node) Dim {
+    const dim = if (dir == .row) node.width else node.height;
+    if (dim == .auto and node.kind == .spacer) return .{ .fill = 1 };
+    return dim;
+}
+
+fn crossDim(dir: Direction, node: *const Node) Dim {
+    return if (dir == .row) node.height else node.width;
+}
+
+fn mainOf(dir: Direction, s: Size) u16 {
+    return if (dir == .row) s.w else s.h;
+}
+
+fn crossOf(dir: Direction, s: Size) u16 {
+    return if (dir == .row) s.h else s.w;
+}
+
+fn innerMain(dir: Direction, l: Limits) u32 {
+    return if (dir == .row) l.max_w else l.max_h;
+}
+
+fn innerCross(dir: Direction, l: Limits) u16 {
+    return if (dir == .row) l.max_h else l.max_w;
+}
+
+fn limitsFor(dir: Direction, main: u16, cross: u16) Limits {
+    return if (dir == .row)
+        .{ .max_w = main, .max_h = cross }
+    else
+        .{ .max_w = cross, .max_h = main };
+}
+
+// ============================================================================
+// Borders
+// ============================================================================
+
+fn borderCols(b: *const Box) u32 {
+    return if (b.border == .none) 0 else 1;
+}
+
+const BorderChars = struct {
+    tl: []const u8,
+    tr: []const u8,
+    bl: []const u8,
+    br: []const u8,
+    h: []const u8,
+    v: []const u8,
+};
+
+const ascii_border = BorderChars{ .tl = "+", .tr = "+", .bl = "+", .br = "+", .h = "-", .v = "|" };
+
+fn borderChars(style: BorderStyle, unicode: bool) BorderChars {
+    if (!unicode) return ascii_border;
+    return switch (style) {
+        .none => unreachable,
+        .ascii => ascii_border,
+        .single => .{ .tl = "┌", .tr = "┐", .bl = "└", .br = "┘", .h = "─", .v = "│" },
+        .rounded => .{ .tl = "╭", .tr = "╮", .bl = "╰", .br = "╯", .h = "─", .v = "│" },
+        .double => .{ .tl = "╔", .tr = "╗", .bl = "╚", .br = "╝", .h = "═", .v = "║" },
+    };
+}
+
+fn drawBorder(ctx: *const RenderCtx, b: *const Box, region: Region) !void {
+    if (b.border == .none) return;
+    const w = region.width();
+    const h = region.height();
+    if (w < 2 or h < 2) return; // no room for chrome; content wins
+
+    const c = borderChars(b.border, ctx.unicode);
+    const s = b.border_style;
+
+    _ = try region.writeText(0, 0, c.tl, s);
+    _ = try region.writeText(w - 1, 0, c.tr, s);
+    _ = try region.writeText(0, h - 1, c.bl, s);
+    _ = try region.writeText(w - 1, h - 1, c.br, s);
+    var x: u16 = 1;
+    while (x < w - 1) : (x += 1) {
+        _ = try region.writeText(x, 0, c.h, s);
+        _ = try region.writeText(x, h - 1, c.h, s);
+    }
+    var y: u16 = 1;
+    while (y < h - 1) : (y += 1) {
+        _ = try region.writeText(0, y, c.v, s);
+        _ = try region.writeText(w - 1, y, c.v, s);
+    }
+}

--- a/packages/ui/src/surface.zig
+++ b/packages/ui/src/surface.zig
@@ -1,0 +1,423 @@
+//! Cell surface: the paint target for one live-region frame (ADR-0013).
+//!
+//! A `Surface` is a grid of styled grapheme cells plus an append-only byte
+//! buffer that owns the grapheme text. Cells reference their grapheme by
+//! offset into that buffer, so writes never allocate per-cell and the whole
+//! surface resets between frames in O(1) (`clear`).
+//!
+//! All writing goes through a `Region` — a clipped rectangular view. Layout
+//! hands each node a region of exactly the rect it was granted, which is what
+//! makes "children stick to constraints" structural: writes outside the
+//! region are dropped, not clamped into a sibling's cells.
+
+const std = @import("std");
+const Graphemes = @import("Graphemes");
+const theme = @import("theme");
+
+pub const Style = theme.Style;
+
+pub const Cell = struct {
+    text_off: u32 = 0,
+    text_len: u8 = 0, // 0 = blank (renders as a styled space)
+    width: u8 = 1, // display columns; 0 = continuation of the wide cell to the left
+    style: Style = .{},
+
+    pub const blank: Cell = .{};
+
+    pub fn isBlank(self: Cell) bool {
+        return self.text_len == 0 and self.width != 0;
+    }
+
+    pub fn isContinuation(self: Cell) bool {
+        return self.width == 0;
+    }
+};
+
+/// Style equality by value. `std.meta.eql` is wrong for `Style`: the `.hex`
+/// color variant is a slice, which it compares by pointer — two equal hex
+/// strings from different buffers would spuriously differ and force the diff
+/// renderer to repaint. Colors here compare by content.
+pub fn styleEql(a: Style, b: Style) bool {
+    return colorEql(a.foreground, b.foreground) and
+        colorEql(a.background, b.background) and
+        a.bold == b.bold and
+        a.dim == b.dim and
+        a.italic == b.italic and
+        a.underline == b.underline and
+        a.strikethrough == b.strikethrough and
+        a.reverse == b.reverse;
+}
+
+fn colorEql(a: ?theme.Color, b: ?theme.Color) bool {
+    if (a == null and b == null) return true;
+    if (a == null or b == null) return false;
+    const ca = a.?;
+    const cb = b.?;
+    if (std.meta.activeTag(ca) != std.meta.activeTag(cb)) return false;
+    return switch (ca) {
+        .indexed => |v| v == cb.indexed,
+        .rgb => |v| v.r == cb.rgb.r and v.g == cb.rgb.g and v.b == cb.rgb.b,
+        .hex => |v| std.mem.eql(u8, v, cb.hex),
+        else => true,
+    };
+}
+
+pub const Rect = struct { x: u16, y: u16, w: u16, h: u16 };
+
+pub const Surface = struct {
+    allocator: std.mem.Allocator,
+    width: u16,
+    height: u16,
+    cells: []Cell,
+    bytes: std.ArrayList(u8),
+
+    pub fn init(allocator: std.mem.Allocator, width: u16, height: u16) !Surface {
+        const cells = try allocator.alloc(Cell, @as(usize, width) * height);
+        @memset(cells, Cell.blank);
+        return .{
+            .allocator = allocator,
+            .width = width,
+            .height = height,
+            .cells = cells,
+            .bytes = .empty,
+        };
+    }
+
+    pub fn deinit(self: *Surface) void {
+        self.allocator.free(self.cells);
+        self.bytes.deinit(self.allocator);
+    }
+
+    /// Reset every cell to blank and drop all grapheme bytes (capacity kept).
+    pub fn clear(self: *Surface) void {
+        @memset(self.cells, Cell.blank);
+        self.bytes.clearRetainingCapacity();
+    }
+
+    pub fn resize(self: *Surface, width: u16, height: u16) !void {
+        const new_cells = try self.allocator.alloc(Cell, @as(usize, width) * height);
+        self.allocator.free(self.cells);
+        self.cells = new_cells;
+        self.width = width;
+        self.height = height;
+        self.clear();
+    }
+
+    pub fn cell(self: *const Surface, x: u16, y: u16) Cell {
+        std.debug.assert(x < self.width and y < self.height);
+        return self.cells[self.idx(x, y)];
+    }
+
+    /// The grapheme bytes of `c` (empty slice for a blank cell).
+    pub fn cellText(self: *const Surface, c: Cell) []const u8 {
+        return self.bytes.items[c.text_off..][0..c.text_len];
+    }
+
+    /// The whole surface as a writable region.
+    pub fn root(self: *Surface) Region {
+        return .{
+            .surface = self,
+            .rect = .{ .x = 0, .y = 0, .w = self.width, .h = self.height },
+        };
+    }
+
+    fn idx(self: *const Surface, x: u16, y: u16) usize {
+        return @as(usize, y) * self.width + x;
+    }
+
+    /// Blank the cell at (x, y) with `style`, dissolving any wide grapheme it
+    /// overlaps: overwriting either half destroys the other half too (kept
+    /// blank in its own style), so a continuation cell can never be orphaned.
+    fn blankAt(self: *Surface, x: u16, y: u16, style: Style) void {
+        const i = self.idx(x, y);
+        const old = self.cells[i];
+        if (old.width == 0) {
+            // Continuation: a head always sits immediately to its left.
+            self.cells[i - 1] = .{ .style = self.cells[i - 1].style };
+        } else if (old.width == 2) {
+            self.cells[i + 1] = .{ .style = self.cells[i + 1].style };
+        }
+        self.cells[i] = .{ .style = style };
+    }
+
+    /// Place one grapheme at (x, y). Caller has already clipped: the grapheme
+    /// fits entirely within the surface.
+    fn put(self: *Surface, x: u16, y: u16, text: []const u8, w: u8, style: Style) !void {
+        std.debug.assert(w == 1 or w == 2);
+        std.debug.assert(x + w <= self.width and y < self.height);
+        self.blankAt(x, y, style);
+        if (w == 2) self.blankAt(x + 1, y, style);
+        // A plain space IS a blank cell (blankAt above already styled it), and
+        // a grapheme too long for text_len degrades to blank rather than tearing.
+        if (text.len == 1 and text[0] == ' ') return;
+        if (text.len > std.math.maxInt(u8)) return;
+        const off: u32 = @intCast(self.bytes.items.len);
+        try self.bytes.appendSlice(self.allocator, text);
+        const i = self.idx(x, y);
+        self.cells[i] = .{
+            .text_off = off,
+            .text_len = @intCast(text.len),
+            .width = w,
+            .style = style,
+        };
+        if (w == 2) self.cells[i + 1] = .{ .width = 0, .style = style };
+    }
+};
+
+/// A clipped rectangular view of a surface. All coordinates on the API are
+/// region-relative; the rect is absolute and pre-clipped to the surface.
+pub const Region = struct {
+    surface: *Surface,
+    rect: Rect,
+
+    pub fn width(self: Region) u16 {
+        return self.rect.w;
+    }
+
+    pub fn height(self: Region) u16 {
+        return self.rect.h;
+    }
+
+    /// A sub-view of this region; `rect` is relative to this region and is
+    /// clipped against it, so the result can never write outside its parent.
+    pub fn sub(self: Region, rect: Rect) Region {
+        const base_x: u32 = self.rect.x;
+        const base_y: u32 = self.rect.y;
+        const x = @min(base_x + rect.x, base_x + self.rect.w);
+        const y = @min(base_y + rect.y, base_y + self.rect.h);
+        const end_x = @min(x + rect.w, base_x + self.rect.w);
+        const end_y = @min(y + rect.h, base_y + self.rect.h);
+        return .{
+            .surface = self.surface,
+            .rect = .{
+                .x = @intCast(x),
+                .y = @intCast(y),
+                .w = @intCast(end_x - x),
+                .h = @intCast(end_y - y),
+            },
+        };
+    }
+
+    /// Blank every cell in the region with `style` (a box painting its
+    /// background). A wide grapheme straddling the region edge is dissolved.
+    pub fn fill(self: Region, style: Style) void {
+        var y: u16 = 0;
+        while (y < self.rect.h) : (y += 1) {
+            var x: u16 = 0;
+            while (x < self.rect.w) : (x += 1) {
+                self.surface.blankAt(self.rect.x + x, self.rect.y + y, style);
+            }
+        }
+    }
+
+    /// Write a single-line run of styled text starting at (x, y), returning
+    /// the number of columns advanced. Clips at the region's right edge; a
+    /// wide grapheme that would straddle the edge is dropped. Control bytes
+    /// and ANSI escapes are zero width and skipped — styling is structured
+    /// (`style`), never embedded escapes — matching how `terminal.wrap`
+    /// measures, so layout and paint always agree on width.
+    pub fn writeText(self: Region, x: u16, y: u16, text: []const u8, style: Style) !u16 {
+        if (y >= self.rect.h or x >= self.rect.w) return 0;
+        const abs_y = self.rect.y + y;
+        const start: u32 = @as(u32, self.rect.x) + x;
+        const right: u32 = @as(u32, self.rect.x) + self.rect.w;
+        var col: u32 = start;
+
+        var skip_until: usize = 0;
+        var it = Graphemes.iterator(text);
+        while (it.next()) |g| {
+            if (col >= right) break;
+            if (g.offset < skip_until) continue;
+            if (text[g.offset] == 0x1b) {
+                skip_until = escapeSeqEnd(text, g.offset);
+                continue;
+            }
+            if (text[g.offset] < 0x20 or text[g.offset] == 0x7f) continue;
+            const gw = g.displayWidth(text);
+            if (gw <= 0) continue;
+            const w: u8 = @intCast(@min(gw, 2));
+            if (col + w > right) break;
+            try self.surface.put(@intCast(col), abs_y, text[g.offset..][0..g.len], w, style);
+            col += w;
+        }
+        return @intCast(col - start);
+    }
+};
+
+/// Index just past the ANSI escape sequence starting at `text[i]` (an ESC the
+/// caller already saw). Same recognizer as `terminal.wrap`: CSI, OSC (BEL/ST
+/// terminated), and two-byte `ESC x` forms; a truncated sequence consumes to
+/// end of string.
+fn escapeSeqEnd(text: []const u8, i: usize) usize {
+    if (i + 1 >= text.len) return i + 1;
+    switch (text[i + 1]) {
+        '[' => {
+            var j = i + 2;
+            while (j < text.len) : (j += 1) {
+                if (text[j] >= 0x40 and text[j] <= 0x7e) return j + 1;
+            }
+            return text.len;
+        },
+        ']' => {
+            var j = i + 2;
+            while (j < text.len) : (j += 1) {
+                if (text[j] == 0x07) return j + 1;
+                if (text[j] == 0x1b and j + 1 < text.len and text[j + 1] == '\\') return j + 2;
+            }
+            return text.len;
+        },
+        else => return i + 2,
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+const testing = std.testing;
+
+test "writeText places cells and reports columns" {
+    var s = try Surface.init(testing.allocator, 10, 2);
+    defer s.deinit();
+
+    const cols = try s.root().writeText(1, 0, "hi", .{ .bold = true });
+    try testing.expectEqual(@as(u16, 2), cols);
+    try testing.expect(s.cell(0, 0).isBlank());
+    try testing.expectEqualStrings("h", s.cellText(s.cell(1, 0)));
+    try testing.expectEqualStrings("i", s.cellText(s.cell(2, 0)));
+    try testing.expect(s.cell(1, 0).style.bold);
+}
+
+test "writeText normalizes a space to a styled blank cell" {
+    var s = try Surface.init(testing.allocator, 10, 1);
+    defer s.deinit();
+
+    _ = try s.root().writeText(0, 0, "a b", .{ .underline = true });
+    const gap = s.cell(1, 0);
+    try testing.expect(gap.isBlank());
+    try testing.expect(gap.style.underline);
+}
+
+test "writeText clips at the region right edge" {
+    var s = try Surface.init(testing.allocator, 10, 1);
+    defer s.deinit();
+
+    const region = s.root().sub(.{ .x = 0, .y = 0, .w = 4, .h = 1 });
+    const cols = try region.writeText(0, 0, "abcdef", .{});
+    try testing.expectEqual(@as(u16, 4), cols);
+    try testing.expectEqualStrings("d", s.cellText(s.cell(3, 0)));
+    try testing.expect(s.cell(4, 0).isBlank());
+}
+
+test "wide grapheme occupies head plus continuation" {
+    var s = try Surface.init(testing.allocator, 10, 1);
+    defer s.deinit();
+
+    const cols = try s.root().writeText(0, 0, "你a", .{});
+    try testing.expectEqual(@as(u16, 3), cols);
+    try testing.expectEqual(@as(u8, 2), s.cell(0, 0).width);
+    try testing.expect(s.cell(1, 0).isContinuation());
+    try testing.expectEqualStrings("a", s.cellText(s.cell(2, 0)));
+}
+
+test "wide grapheme that would straddle the edge is dropped" {
+    var s = try Surface.init(testing.allocator, 3, 1);
+    defer s.deinit();
+
+    // "你" fits (cols 0-1); "好" would straddle the edge at col 2 → dropped.
+    const cols = try s.root().writeText(0, 0, "你好", .{});
+    try testing.expectEqual(@as(u16, 2), cols);
+    try testing.expect(s.cell(2, 0).isBlank());
+}
+
+test "overwriting either half of a wide grapheme dissolves it" {
+    var s = try Surface.init(testing.allocator, 10, 1);
+    defer s.deinit();
+
+    _ = try s.root().writeText(0, 0, "你", .{});
+    _ = try s.root().writeText(1, 0, "x", .{});
+    try testing.expect(s.cell(0, 0).isBlank());
+    try testing.expectEqualStrings("x", s.cellText(s.cell(1, 0)));
+
+    _ = try s.root().writeText(2, 0, "好", .{});
+    _ = try s.root().writeText(2, 0, "y", .{});
+    try testing.expectEqualStrings("y", s.cellText(s.cell(2, 0)));
+    try testing.expect(s.cell(3, 0).isBlank());
+}
+
+test "writeText skips ANSI escapes and control bytes" {
+    var s = try Surface.init(testing.allocator, 10, 1);
+    defer s.deinit();
+
+    const cols = try s.root().writeText(0, 0, "\x1b[31ma\tb\x1b]0;t\x07c", .{});
+    try testing.expectEqual(@as(u16, 3), cols);
+    try testing.expectEqualStrings("a", s.cellText(s.cell(0, 0)));
+    try testing.expectEqualStrings("b", s.cellText(s.cell(1, 0)));
+    try testing.expectEqualStrings("c", s.cellText(s.cell(2, 0)));
+}
+
+test "sub regions clip against their parent" {
+    var s = try Surface.init(testing.allocator, 10, 4);
+    defer s.deinit();
+
+    const outer = s.root().sub(.{ .x = 2, .y = 1, .w = 5, .h = 2 });
+    try testing.expectEqual(@as(u16, 5), outer.width());
+
+    // Inner rect extends past the parent on both axes → clipped.
+    const inner = outer.sub(.{ .x = 3, .y = 1, .w = 10, .h = 10 });
+    try testing.expectEqual(@as(u16, 2), inner.width());
+    try testing.expectEqual(@as(u16, 1), inner.height());
+
+    _ = try inner.writeText(0, 0, "abcdef", .{});
+    // Inner origin is absolute (5, 2); only 2 columns fit.
+    try testing.expectEqualStrings("a", s.cellText(s.cell(5, 2)));
+    try testing.expectEqualStrings("b", s.cellText(s.cell(6, 2)));
+    try testing.expect(s.cell(7, 2).isBlank());
+}
+
+test "writes outside the region are dropped entirely" {
+    var s = try Surface.init(testing.allocator, 10, 2);
+    defer s.deinit();
+
+    const region = s.root().sub(.{ .x = 0, .y = 0, .w = 4, .h = 1 });
+    try testing.expectEqual(@as(u16, 0), try region.writeText(4, 0, "x", .{}));
+    try testing.expectEqual(@as(u16, 0), try region.writeText(0, 1, "x", .{}));
+    for (s.cells) |c| try testing.expect(c.isBlank());
+}
+
+test "fill styles every cell in the region" {
+    var s = try Surface.init(testing.allocator, 4, 2);
+    defer s.deinit();
+
+    _ = try s.root().writeText(0, 0, "abcd", .{});
+    const region = s.root().sub(.{ .x = 1, .y = 0, .w = 2, .h = 2 });
+    region.fill(.{ .reverse = true });
+
+    try testing.expectEqualStrings("a", s.cellText(s.cell(0, 0)));
+    try testing.expect(s.cell(1, 0).isBlank());
+    try testing.expect(s.cell(1, 0).style.reverse);
+    try testing.expect(s.cell(2, 1).style.reverse);
+    try testing.expect(!s.cell(3, 0).style.reverse);
+    try testing.expectEqualStrings("d", s.cellText(s.cell(3, 0)));
+}
+
+test "clear resets cells and byte storage" {
+    var s = try Surface.init(testing.allocator, 4, 1);
+    defer s.deinit();
+
+    _ = try s.root().writeText(0, 0, "abcd", .{});
+    try testing.expect(s.bytes.items.len > 0);
+    s.clear();
+    try testing.expectEqual(@as(usize, 0), s.bytes.items.len);
+    for (s.cells) |c| try testing.expect(c.isBlank());
+}
+
+test "styleEql compares hex colors by content" {
+    var buf_a = "#FF8040".*;
+    var buf_b = "#FF8040".*;
+    const a = Style{ .foreground = .{ .hex = &buf_a } };
+    const b = Style{ .foreground = .{ .hex = &buf_b } };
+    try testing.expect(styleEql(a, b));
+    try testing.expect(!styleEql(a, .{}));
+    try testing.expect(styleEql(.{}, .{}));
+}

--- a/packages/ui/src/test.zig
+++ b/packages/ui/src/test.zig
@@ -1,0 +1,9 @@
+//! Test root for the ui package. Rooted here (not at ui.zig) so the golden
+//! tests can import vterm, which is a test-only dependency of this package.
+
+test {
+    _ = @import("surface.zig");
+    _ = @import("diff.zig");
+    _ = @import("layout_test.zig");
+    _ = @import("golden_test.zig");
+}

--- a/packages/ui/src/ui.zig
+++ b/packages/ui/src/ui.zig
@@ -1,0 +1,122 @@
+//! ui — the terminal-native layout engine (ADR-0013).
+//!
+//! An immediate-mode UI core for the CLI/TUI hybrid: output splits into a
+//! static stream (flows into scrollback) and a live region at the bottom
+//! edge, rebuilt as a node tree every frame into an arena, laid out
+//! constraints-down/sizes-up, painted onto a cell surface, and diffed.
+//!
+//! A component is any function returning a `Node`. The builders below take
+//! the frame arena and COPY child slices into it — the API keystone that
+//! makes component functions composable: a `&.{...}` child literal is a
+//! stack temporary, and without the copy a helper returning a `Node` would
+//! hand its parent dangling children.
+
+const std = @import("std");
+
+const surface = @import("surface.zig");
+pub const Surface = surface.Surface;
+pub const Region = surface.Region;
+pub const Rect = surface.Rect;
+pub const Cell = surface.Cell;
+pub const Style = surface.Style;
+pub const styleEql = surface.styleEql;
+
+pub const Renderer = @import("diff.zig").Renderer;
+
+const node_mod = @import("node.zig");
+pub const Node = node_mod.Node;
+pub const Kind = node_mod.Kind;
+pub const Box = node_mod.Box;
+pub const TextNode = node_mod.Text;
+pub const Custom = node_mod.Custom;
+pub const Size = node_mod.Size;
+pub const Limits = node_mod.Limits;
+pub const Dim = node_mod.Dim;
+pub const Align = node_mod.Align;
+pub const Direction = node_mod.Direction;
+pub const WrapMode = node_mod.WrapMode;
+pub const BorderStyle = node_mod.BorderStyle;
+pub const Padding = node_mod.Padding;
+pub const RenderCtx = node_mod.RenderCtx;
+pub const measure = node_mod.measure;
+pub const render = node_mod.render;
+
+/// Box options shared by `row` and `column` (direction is the builder).
+pub const BoxOpts = struct {
+    gap: u16 = 0,
+    padding: Padding = .{},
+    border: BorderStyle = .none,
+    border_style: Style = .{},
+    style: Style = .{},
+    width: Dim = .auto,
+    height: Dim = .auto,
+    align_self: Align = .start,
+    min_width: ?u16 = null,
+    max_width: ?u16 = null,
+    min_height: ?u16 = null,
+    max_height: ?u16 = null,
+};
+
+pub fn row(a: std.mem.Allocator, opts: BoxOpts, children: []const Node) !Node {
+    return box(a, .row, opts, children);
+}
+
+pub fn column(a: std.mem.Allocator, opts: BoxOpts, children: []const Node) !Node {
+    return box(a, .column, opts, children);
+}
+
+pub fn box(a: std.mem.Allocator, dir: Direction, opts: BoxOpts, children: []const Node) !Node {
+    return .{
+        .width = opts.width,
+        .height = opts.height,
+        .align_self = opts.align_self,
+        .min_width = opts.min_width,
+        .max_width = opts.max_width,
+        .min_height = opts.min_height,
+        .max_height = opts.max_height,
+        .kind = .{ .box = .{
+            .dir = dir,
+            .children = try a.dupe(Node, children),
+            .gap = opts.gap,
+            .padding = opts.padding,
+            .border = opts.border,
+            .border_style = opts.border_style,
+            .style = opts.style,
+        } },
+    };
+}
+
+/// A wrapping styled text node. `content` is borrowed, not copied — it must
+/// outlive the frame (string literals and user state always do; a string
+/// formatted for this frame belongs in the frame arena).
+pub fn text(style: Style, content: []const u8) Node {
+    return .{ .kind = .{ .text = .{ .content = content, .style = style } } };
+}
+
+/// `text` with explicit text options (wrap mode, sizing).
+pub const TextOpts = struct {
+    style: Style = .{},
+    wrap: WrapMode = .wrap,
+    width: Dim = .auto,
+    height: Dim = .auto,
+    align_self: Align = .start,
+};
+
+pub fn textOpts(opts: TextOpts, content: []const u8) Node {
+    return .{
+        .width = opts.width,
+        .height = opts.height,
+        .align_self = opts.align_self,
+        .kind = .{ .text = .{ .content = content, .style = opts.style, .wrap = opts.wrap } },
+    };
+}
+
+/// Empty space that absorbs leftover main-axis room (`fill(1)`). Right-align
+/// by preceding with a spacer; center by surrounding with two.
+pub fn spacer() Node {
+    return .{ .kind = .spacer };
+}
+
+test {
+    _ = @import("node.zig");
+}

--- a/packages/vterm/src/tests/parser_test.zig
+++ b/packages/vterm/src/tests/parser_test.zig
@@ -290,3 +290,23 @@ test "large parameter values" {
     term.write("\x1b[999C"); // Move right by 999
     try testing.expectEqual(@as(u16, 9), term.cursor.x); // Clamped to width-1
 }
+
+test "DECAWM off clamps at the last column instead of wrapping" {
+    var term = try VTerm.init(testing.allocator, 4, 2);
+    defer term.deinit();
+
+    // Autowrap on (default): the 5th char wraps to row 1.
+    term.write("abcde");
+    try testing.expectEqual(@as(u21, 'e'), term.getCell(0, 1).char);
+
+    // Autowrap off: overflow overwrites the last column, cursor stays put.
+    term.write("\x1b[H\x1b[2J\x1b[?7l");
+    term.write("abcde");
+    try testing.expectEqual(@as(u21, 'e'), term.getCell(3, 0).char);
+    try testing.expectEqual(@as(u21, 0), term.getCell(0, 1).char);
+    try testing.expect(term.cursorAt(3, 0));
+
+    // Restore: wraps again.
+    term.write("\x1b[?7h\x1b[H\x1b[2Jabcde");
+    try testing.expectEqual(@as(u21, 'e'), term.getCell(0, 1).char);
+}

--- a/packages/vterm/src/vterm.zig
+++ b/packages/vterm/src/vterm.zig
@@ -116,6 +116,7 @@ pub const VTerm = struct {
     // Terminal modes
     alt_screen: bool,
     cursor_visible: bool,
+    autowrap: bool, // DECAWM (CSI ?7 h/l); off = clamp at the last column
 
     // Circular buffer coordinate translation
     pub fn bufferLineIndex(self: *VTerm, logical_line: u32) u16 {
@@ -211,6 +212,7 @@ pub const VTerm = struct {
             // Terminal modes
             .alt_screen = false,
             .cursor_visible = true,
+            .autowrap = true,
         };
     }
 
@@ -282,18 +284,27 @@ pub const VTerm = struct {
         const width = charWidth(char);
 
         // Handle delayed wrapping: if cursor is at width, wrap before writing
+        // (with DECAWM off, clamp to the last column and overwrite instead)
         if (self.cursor.x >= self.width) {
-            self.cursor.x = 0;
-            self.virtual_cursor_y += 1;
-            self.cursor.y = @min(self.virtual_cursor_y, self.height - 1);
+            if (self.autowrap) {
+                self.cursor.x = 0;
+                self.virtual_cursor_y += 1;
+                self.cursor.y = @min(self.virtual_cursor_y, self.height - 1);
+            } else {
+                self.cursor.x = self.width - 1;
+            }
         }
 
         // For wide characters, check if there's room for both cells
         if (width == 2 and self.cursor.x >= self.width - 1) {
-            // Not enough room, wrap to next line
-            self.cursor.x = 0;
-            self.virtual_cursor_y += 1;
-            self.cursor.y = @min(self.virtual_cursor_y, self.height - 1);
+            if (self.autowrap) {
+                // Not enough room, wrap to next line
+                self.cursor.x = 0;
+                self.virtual_cursor_y += 1;
+                self.cursor.y = @min(self.virtual_cursor_y, self.height - 1);
+            } else {
+                self.cursor.x = self.width - 2;
+            }
         }
 
         // Track that we've written to at least one line
@@ -327,6 +338,11 @@ pub const VTerm = struct {
         // Wrap when cursor reaches width (immediate wrapping for putChar)
         // This allows cursor to be positioned at width for delayed wrapping in write()
         if (self.cursor.x >= self.width) {
+            if (!self.autowrap) {
+                // DECAWM off: stay on this line, clamped to the last column
+                self.cursor.x = self.width - 1;
+                return;
+            }
             // Check if we're already at the last line - if so, clamp cursor instead of wrapping
             if (self.cursor.y >= self.height - 1 and self.virtual_cursor_y >= self.height - 1) {
                 // At bottom of terminal - clamp cursor to last position instead of wrapping
@@ -709,6 +725,7 @@ pub const VTerm = struct {
     fn handlePrivateMode(self: *VTerm, enable: bool) void {
         const mode = self.getParam(0, 0);
         switch (mode) {
+            7 => self.autowrap = enable, // DECAWM auto-wrap
             25 => self.cursor_visible = enable, // Cursor visibility
             1049 => self.alt_screen = enable, // Alternate screen buffer
             else => {}, // Ignore other modes


### PR DESCRIPTION
## What

The foundation for zcli v2's CLI/TUI hybrid — an Ink-inspired, immediate-mode layout engine without the weight of Yoga or the authoring cost of retained-widget TUI libraries.

- **ADR-0013** (proposed): the full design — static/live frame model with a three-tier resize story, constraints-down/sizes-up protocol, four-node vocabulary (`box`/`text`/`spacer`/`custom`), `fit`/`len`/`fill` sizing with a single-pass distributor (no solver), and why the rejected alternatives (Yoga bind, libvaxis-style retained widgets, cassowary, owning scrollback) lost.
- **`packages/ui`** — build-order steps 1–2:
  - `surface.zig`: styled grapheme cells; clipped `Region` views are the only write path, so a child physically cannot paint outside its granted rect.
  - `diff.zig`: frame diff → minimal escape stream. Relative addressing only (the live region floats in scrollback), capability-aware SGR via `theme.Style`, DECSET 2026 sync guard, zero bytes for an unchanged frame.
  - `node.zig`: measure/render as pure functions; `Dim.auto` = fit on main axis / stretch on cross / `fill(1)` for spacers — one rule, all the zero-config defaults. Text measurement reuses `terminal.wrap`, so layout and paint can never disagree on a line break.
  - `ui.zig`: arena-copying builders — a component is a plain function returning a `Node`.
- **`feat(vterm)`: DECAWM (mode ?7)** — the renderer disables autowrap per paint (writing the last column otherwise desyncs relative addressing, differently per terminal family); vterm learned the mode so golden tests exercise the honest byte stream.

## Try it

```sh
cd packages/ui && zig build run-demo
```

Animated bordered deploy frame — spinner, task list, `custom`-leaf gauges stretched with `fill`. First paint draws the frame; after that a typical 80ms frame is ~55 bytes.

## Testing

- Pure layout unit tests (no TTY) + vterm golden-frame tests: the escape stream is parsed by a real terminal emulator and asserted on screen content, SGR, and cursor parking.
- `packages/ui` wired into root test aggregation (`zig build test-ui`); full repo suite green.
- Deliberately **not** exported on the public umbrella yet — the App loop (step 3: `emit`/`frame`, resize tail-repaint) stabilizes the API first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)