### PR TITLE
ui: App — the static/live frame loop (ADR-0013 step 3)

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -2,10 +2,12 @@
 
 The terminal-native layout engine behind zcli's CLI/TUI hybrid ([ADR-0013](../../docs/adr/0013-terminal-native-layout-engine.md)).
 
-> **Status: pre-stabilization.** Built through step 2 of the ADR's build order
-> (cell surface + diff renderer, node tree + layout). The `App` loop
-> (static/live frame model, resize) is next; until it lands this package is
-> not exported on the zcli umbrella and its API may change freely.
+> **Status: pre-stabilization.** Built through step 3 of the ADR's build
+> order (cell surface + diff renderer, node tree + layout, `App` static/live
+> loop with live-region resize). Still to come: the visible static-tail
+> repaint on resize (ADR tier 2) and porting `progress`/`prompts` onto the
+> engine. Until then this package is not exported on the zcli umbrella and
+> its API may change freely.
 
 ## The model
 
@@ -29,7 +31,20 @@ fn statusLine(a: std.mem.Allocator, s: *const State) !ui.Node {
         ui.text(.{ .dim = true }, s.elapsed),
     });
 }
+
+var app = try ui.App.init(gpa, writer, .{});
+defer app.deinit(); // cursor restored, final frame left in scrollback
+
+try app.emit("✓ built {s}", .{name});               // static → scrollback
+try app.frame(try statusLine(app.arena(), &state)); // live → diffed repaint
 ```
+
+`App` owns the frame arena (`app.arena()`, reset when `frame()` returns),
+the live region's rows, the cursor (hidden while a region is up, parked at
+the region's top-left between calls), and the double-buffered surfaces.
+`emit` is line-oriented and the only way to write while a region is up. The
+live region re-measures against the terminal on every frame, so it re-lays
+out on resize; its height clamps to the viewport and clips from the bottom.
 
 Builders copy child slices into the arena, so component functions compose
 without dangling-temporary hazards. Styles are `theme.Style` values on the

--- a/packages/ui/examples/demo.zig
+++ b/packages/ui/examples/demo.zig
@@ -1,16 +1,14 @@
-//! Runnable showcase for the ui package (ADR-0013 steps 1–2): an animated
-//! "deploy" frame — spinner, task list, live progress gauges, right-aligned
-//! elapsed time — repainted in place through the frame-diff renderer.
+//! Runnable showcase for the ui package (ADR-0013): the CLI/TUI hybrid in
+//! one screen. An animated "deploy" frame — spinner, task list, live
+//! progress gauges — repaints in place at the bottom edge, while completed
+//! tasks are `emit`ted as static lines that flow into scrollback above it.
 //!
 //! Everything on screen is the four-node vocabulary: the frame is a bordered
 //! column of rows; right-alignment is a spacer; the gauges are one `custom`
-//! leaf stretched with `fill`. The whole tree is rebuilt into an arena every
-//! frame (a component is just a function), and the diff renderer emits only
-//! the cells that changed.
-//!
-//! This example hand-rolls what the App loop (build-order step 3) will own:
-//! reserving the live region's rows, parking the cursor at the top-left,
-//! double-buffering surfaces, and restoring the cursor on exit.
+//! leaf stretched with `fill`. The tree is rebuilt from the App's frame
+//! arena every frame (a component is just a function), and the diff renderer
+//! emits only the cells that changed. The `App` owns the live region's rows,
+//! the cursor, and the surfaces — the loop below is just build + emit.
 //!
 //! Run with: zig build run-demo   (from packages/ui, needs a real terminal)
 
@@ -145,58 +143,33 @@ pub fn main(init: std.process.Init) !void {
 
     var out_buf: [16384]u8 = undefined;
     var stdout = std.Io.File.stdout().writer(io, &out_buf);
-    const w = &stdout.interface;
 
     const ws = terminal.getWindowSize(std.Io.File.stdout().handle) catch terminal.Winsize{ .row = 24, .col = 80 };
     const width: u16 = @min(64, ws.col);
 
-    var arena = std.heap.ArenaAllocator.init(gpa);
-    defer arena.deinit();
+    var app = try ui.App.init(gpa, &stdout.interface, .{ .capability = .ansi_16 });
+    defer app.deinit();
 
-    // The frame's height is constant in this demo, so measure once upfront to
-    // size the region and the surfaces.
-    const rctx0 = ui.RenderCtx{ .allocator = arena.allocator() };
-    const probe = try buildFrame(arena.allocator(), 0, width);
-    const size = ui.measure(&rctx0, &probe, .{ .max_w = width, .max_h = ws.row -| 2 });
+    try app.emit("ui demo — finished tasks scroll up as static lines; the frame repaints in place", .{});
 
-    var prev = try ui.Surface.init(gpa, size.w, size.h);
-    defer prev.deinit();
-    var next = try ui.Surface.init(gpa, size.w, size.h);
-    defer next.deinit();
-
-    try w.writeAll("ui demo — the frame below repaints in place through the diff renderer\n\n");
-
-    // Reserve the live region's rows, then park the cursor at its top-left
-    // (the diff renderer's addressing contract).
-    try w.writeAll("\x1b[?25l");
-    var i: u16 = 0;
-    while (i < size.h) : (i += 1) try w.writeAll("\n");
-    try w.print("\x1b[{d}A", .{size.h});
-    try w.flush();
-
-    const renderer = ui.Renderer{ .capability = .ansi_16 };
-
-    var painted: ?*ui.Surface = null;
+    var announced = [_]bool{false} ** tasks.len;
     var frame: u32 = 0;
     while (frame <= total_frames) : (frame += 1) {
-        _ = arena.reset(.retain_capacity);
-        const rctx = ui.RenderCtx{ .allocator = arena.allocator() };
+        for (tasks, &announced) |task, *done| {
+            if (!done.* and task.fraction(frame) >= 1) {
+                done.* = true;
+                try app.emit("✓ {s} ({d:.1}s)", .{
+                    task.name,
+                    @as(f32, @floatFromInt((task.start + task.duration) * frame_ms)) / 1000.0,
+                });
+            }
+        }
 
-        next.clear();
-        const tree = try buildFrame(arena.allocator(), frame, width);
-        try ui.render(&rctx, &tree, next.root());
-
-        try renderer.paint(w, painted, &next);
-        try w.flush();
-
-        std.mem.swap(ui.Surface, &prev, &next);
-        painted = &prev;
-
+        try app.frame(try buildFrame(app.arena(), frame, width));
         io.sleep(.{ .nanoseconds = frame_ms * std.time.ns_per_ms }, .awake) catch break;
     }
 
-    // Leave the finished frame in scrollback: cursor below the region, shown.
-    try w.print("\x1b[{d}B", .{size.h -| 1});
-    try w.writeAll("\n\x1b[?25h");
-    try w.flush();
+    try app.emit("deploy finished in {d:.1}s", .{
+        @as(f32, @floatFromInt(total_frames * frame_ms)) / 1000.0,
+    });
 }

--- a/packages/ui/src/app.zig
+++ b/packages/ui/src/app.zig
@@ -1,0 +1,220 @@
+//! App: the static/live frame loop (ADR-0013 step 3).
+//!
+//! Owns everything the demo used to hand-roll: the frame arena, the
+//! double-buffered surfaces, reserving the live region's rows, parking the
+//! cursor at the region's top-left (the diff renderer's addressing
+//! contract), and cursor hide/restore.
+//!
+//! The two verbs:
+//!
+//! - `emit` — static output. Erases the live region, prints above it (into
+//!   what becomes scrollback), and repaints the region below. Line-oriented:
+//!   a trailing newline is added if the format string lacks one. Streaming
+//!   partial lines into the static stream is future work (it needs cursor
+//!   column tracking across emits).
+//! - `frame` — live output. Measures the node against the terminal (height
+//!   clamped to the viewport, ADR-0013's clip rule), lays it out, paints the
+//!   diff against the previous frame, and resets the frame arena.
+//!
+//! Build each frame's tree from `app.arena()`: allocations live until the
+//! next `frame()` call consumes them, then the arena resets wholesale —
+//! that's the immediate-mode contract.
+//!
+//! Cursor bookkeeping invariant: between calls, the cursor sits at column 0
+//! of the live region's top row (or at the start of an empty line when no
+//! region is painted). Callers must hand over the terminal at the start of a
+//! line, and must not write to the App's writer directly while a live region
+//! is up — that's what `emit` is for.
+
+const std = @import("std");
+const theme = @import("theme");
+const terminal = @import("terminal");
+const surface_mod = @import("surface.zig");
+const node_mod = @import("node.zig");
+const diff_mod = @import("diff.zig");
+
+const Surface = surface_mod.Surface;
+const Node = node_mod.Node;
+const Size = node_mod.Size;
+const Limits = node_mod.Limits;
+const RenderCtx = node_mod.RenderCtx;
+
+pub const App = struct {
+    pub const Options = struct {
+        capability: theme.TerminalCapability = .ansi_16,
+        /// Chooses border/ellipsis glyphs (`terminal.unicodeSupported`).
+        unicode: bool = true,
+        /// Wrap paints in synchronized output (DECSET 2026).
+        sync: bool = true,
+        /// Fixed terminal size (tests, non-TTY output). `null` polls the
+        /// real terminal on every frame, which is what makes the live
+        /// region re-layout on resize.
+        term_size: ?Size = null,
+    };
+
+    writer: *std.Io.Writer,
+    options: Options,
+
+    frame_arena: std.heap.ArenaAllocator,
+    /// What the terminal currently shows (diff source) / the paint target.
+    front: Surface,
+    back: Surface,
+    /// Rows currently reserved on screen for the live region.
+    live_rows: u16 = 0,
+    /// Whether `front` matches what's on screen (false forces a full paint).
+    front_valid: bool = false,
+    /// Whether we've taken over the terminal (cursor hidden) yet.
+    started: bool = false,
+
+    pub fn init(gpa: std.mem.Allocator, writer: *std.Io.Writer, options: Options) !App {
+        return .{
+            .writer = writer,
+            .options = options,
+            .frame_arena = std.heap.ArenaAllocator.init(gpa),
+            .front = try Surface.init(gpa, 0, 0),
+            .back = try Surface.init(gpa, 0, 0),
+        };
+    }
+
+    /// Restores the terminal (cursor shown, parked on a fresh line below the
+    /// live region — the final frame stays visible, flowing into scrollback)
+    /// and frees everything.
+    pub fn deinit(self: *App) void {
+        if (self.started) {
+            if (self.live_rows > 1) {
+                self.writer.print("\x1b[{d}B", .{self.live_rows - 1}) catch {};
+            }
+            if (self.live_rows > 0) self.writer.writeAll("\r\n") catch {};
+            self.writer.writeAll("\x1b[?25h") catch {};
+        }
+        self.writer.flush() catch {};
+        self.front.deinit();
+        self.back.deinit();
+        self.frame_arena.deinit();
+    }
+
+    /// The frame arena: build each frame's node tree from this. Valid until
+    /// the `frame()` call that consumes the tree returns.
+    pub fn arena(self: *App) std.mem.Allocator {
+        return self.frame_arena.allocator();
+    }
+
+    /// Static output: printed above the live region, flows into scrollback,
+    /// never repainted. Line-oriented (see module docs).
+    pub fn emit(self: *App, comptime fmt: []const u8, args: anytype) !void {
+        const had_live = self.live_rows > 0;
+        try self.clearLive();
+        try self.writer.print(fmt, args);
+        if (comptime !std.mem.endsWith(u8, fmt, "\n")) try self.writer.writeByte('\n');
+        if (had_live) try self.repaintLive();
+        try self.writer.flush();
+    }
+
+    /// Live output: measure, lay out, paint the diff. The tree (built from
+    /// `self.arena()`) is consumed — the arena resets when this returns.
+    pub fn frame(self: *App, node: Node) !void {
+        defer _ = self.frame_arena.reset(.retain_capacity);
+
+        const ts = self.termSize();
+        // The viewport clamp: a live region taller than the terminal cannot
+        // exist (ADR-0013 — scrollback corruption made impossible, not
+        // handled). One row is held back so the region plus the static
+        // line above it fit without forcing a scroll on every repaint.
+        const limits = Limits{ .max_w = ts.w, .max_h = ts.h -| 1 };
+        const rctx = RenderCtx{
+            .allocator = self.frame_arena.allocator(),
+            .unicode = self.options.unicode,
+        };
+
+        var size = node_mod.measure(&rctx, &node, limits);
+        // A root with `.fill` stretches to the terminal edge (a full-screen
+        // app is just a root with `height = fill`, not a separate mode).
+        if (node.width == .fill) size.w = limits.max_w;
+        if (node.height == .fill) size.h = limits.max_h;
+
+        if (size.w == 0 or size.h == 0) {
+            try self.clearLive();
+            try self.writer.flush();
+            return;
+        }
+
+        try self.start();
+
+        if (size.w != self.back.width or size.h != self.back.height) {
+            try self.back.resize(size.w, size.h);
+            try self.front.resize(size.w, size.h);
+            self.front_valid = false;
+        }
+        if (size.h != self.live_rows) {
+            // Region height changed (or first frame): re-reserve from
+            // scratch. Erasing rather than incrementally growing keeps the
+            // bookkeeping trivial; the sync guard makes it flicker-free.
+            try self.clearLive();
+            try self.reserve(size.h);
+        }
+
+        self.back.clear();
+        try node_mod.render(&rctx, &node, self.back.root());
+
+        const prev: ?*const Surface = if (self.front_valid) &self.front else null;
+        const renderer = diff_mod.Renderer{
+            .capability = self.options.capability,
+            .sync = self.options.sync,
+        };
+        try renderer.paint(self.writer, prev, &self.back);
+        std.mem.swap(Surface, &self.front, &self.back);
+        self.front_valid = true;
+        try self.writer.flush();
+    }
+
+    // ------------------------------------------------------------------
+    // Region bookkeeping. Invariant: cursor at column 0 of the region's
+    // top row (or of an empty line when live_rows == 0).
+    // ------------------------------------------------------------------
+
+    /// Erase the live region (cursor-to-end-of-screen — the region is the
+    /// bottom edge; everything below it is ours).
+    fn clearLive(self: *App) !void {
+        if (self.live_rows == 0) return;
+        try self.writer.writeAll("\r\x1b[0J");
+        self.live_rows = 0;
+        self.front_valid = false;
+    }
+
+    /// Create `rows` rows starting at the cursor's line (scrolling as
+    /// needed) and park at the region's top-left.
+    fn reserve(self: *App, rows: u16) !void {
+        std.debug.assert(self.live_rows == 0);
+        try self.writer.writeByte('\r');
+        var i: u16 = 1;
+        while (i < rows) : (i += 1) try self.writer.writeAll("\n");
+        if (rows > 1) try self.writer.print("\x1b[{d}A", .{rows - 1});
+        self.live_rows = rows;
+    }
+
+    /// Re-reserve and fully repaint the last frame (after `emit` erased it).
+    fn repaintLive(self: *App) !void {
+        if (self.front.width == 0 or self.front.height == 0) return;
+        try self.start();
+        try self.reserve(self.front.height);
+        const renderer = diff_mod.Renderer{
+            .capability = self.options.capability,
+            .sync = self.options.sync,
+        };
+        try renderer.paint(self.writer, null, &self.front);
+        self.front_valid = true;
+    }
+
+    fn start(self: *App) !void {
+        if (self.started) return;
+        self.started = true;
+        try self.writer.writeAll("\x1b[?25l");
+    }
+
+    fn termSize(self: *App) Size {
+        if (self.options.term_size) |s| return s;
+        const ws = terminal.getWindowSize(std.Io.File.stdout().handle) catch
+            return .{ .w = 80, .h = 24 };
+        return .{ .w = ws.col, .h = ws.row };
+    }
+};

--- a/packages/ui/src/app_test.zig
+++ b/packages/ui/src/app_test.zig
@@ -1,0 +1,207 @@
+//! App loop tests: drive emit/frame against a vterm and assert on what a
+//! user would see — the static stream flowing above, the live region
+//! repainting in place below, and terminal state restored on deinit.
+
+const std = @import("std");
+const vterm = @import("vterm");
+const ui = @import("ui.zig");
+
+const testing = std.testing;
+const VTerm = vterm.VTerm;
+
+/// An App writing into a capture buffer, replayed into a vterm on demand.
+const Harness = struct {
+    aw: std.Io.Writer.Allocating,
+    vt: VTerm,
+    app: ui.App,
+    fed: usize = 0,
+
+    fn init(w: u16, h: u16) !*Harness {
+        const self = try testing.allocator.create(Harness);
+        errdefer testing.allocator.destroy(self);
+        self.* = .{
+            .aw = std.Io.Writer.Allocating.init(testing.allocator),
+            .vt = try VTerm.init(testing.allocator, w, h),
+            .app = undefined,
+        };
+        self.app = try ui.App.init(testing.allocator, &self.aw.writer, .{
+            .term_size = .{ .w = w, .h = h },
+        });
+        return self;
+    }
+
+    fn deinit(self: *Harness) void {
+        self.app.deinit();
+        self.vt.deinit();
+        self.aw.deinit();
+        testing.allocator.destroy(self);
+    }
+
+    /// Feed everything newly written into the terminal.
+    fn replay(self: *Harness) void {
+        self.vt.write(self.aw.written()[self.fed..]);
+        self.fed = self.aw.written().len;
+    }
+
+    fn statusFrame(self: *Harness, msg: []const u8) !ui.Node {
+        const a = self.app.arena();
+        return ui.column(a, .{ .border = .single, .width = .{ .len = 20 } }, &.{
+            ui.text(.{}, msg),
+        });
+    }
+};
+
+test "frame paints the live region at the cursor" {
+    var h = try Harness.init(30, 8);
+    defer h.deinit();
+
+    try h.app.frame(try h.statusFrame("working"));
+    h.replay();
+
+    try testing.expect(h.vt.containsText("working"));
+    try testing.expectEqual(@as(u21, '┌'), h.vt.getCell(0, 0).char);
+    try testing.expectEqual(@as(u21, '┘'), h.vt.getCell(19, 2).char);
+    // Parked at the region's top-left, hidden.
+    try testing.expect(h.vt.cursorAt(0, 0));
+    try testing.expect(!h.vt.cursor_visible);
+}
+
+test "second frame diffs in place" {
+    var h = try Harness.init(30, 8);
+    defer h.deinit();
+
+    try h.app.frame(try h.statusFrame("step 1"));
+    h.replay();
+    const before = h.fed;
+
+    try h.app.frame(try h.statusFrame("step 2"));
+    h.replay();
+
+    try testing.expect(h.vt.containsText("step 2"));
+    try testing.expect(!h.vt.containsText("step 1"));
+    // A one-cell change costs a fraction of the first full paint.
+    try testing.expect(h.fed - before < before / 2);
+}
+
+test "emit prints static above and repaints the live region below" {
+    var h = try Harness.init(30, 8);
+    defer h.deinit();
+
+    try h.app.frame(try h.statusFrame("running"));
+    try h.app.emit("compiled {s}", .{"zcli"}); // no trailing \n: App adds it
+    h.replay();
+
+    // Static line sits above the live frame.
+    const line0 = try h.vt.getLine(testing.allocator, 0);
+    defer testing.allocator.free(line0);
+    try testing.expect(std.mem.startsWith(u8, line0, "compiled zcli"));
+    // Live region repainted intact below it.
+    try testing.expectEqual(@as(u21, '┌'), h.vt.getCell(0, 1).char);
+    try testing.expect(h.vt.containsText("running"));
+    try testing.expect(h.vt.cursorAt(0, 1));
+
+    // And the next frame still diffs against the repainted region.
+    try h.app.frame(try h.statusFrame("almost!"));
+    h.replay();
+    try testing.expect(h.vt.containsText("compiled zcli"));
+    try testing.expect(h.vt.containsText("almost!"));
+    try testing.expect(!h.vt.containsText("running"));
+}
+
+test "emit works before any frame exists" {
+    var h = try Harness.init(30, 8);
+    defer h.deinit();
+
+    try h.app.emit("hello\n", .{});
+    h.replay();
+    try testing.expect(h.vt.containsText("hello"));
+    // No live region: nothing reserved, cursor not hidden.
+    try testing.expect(h.vt.cursor_visible);
+}
+
+test "live region grows and shrinks between frames" {
+    var h = try Harness.init(30, 10);
+    defer h.deinit();
+
+    const a1 = h.app.arena();
+    try h.app.frame(try ui.column(a1, .{}, &.{ui.text(.{}, "one")}));
+    h.replay();
+    try testing.expect(h.vt.containsText("one"));
+
+    const a2 = h.app.arena();
+    try h.app.frame(try ui.column(a2, .{}, &.{
+        ui.text(.{}, "alpha"),
+        ui.text(.{}, "beta"),
+        ui.text(.{}, "gamma"),
+    }));
+    h.replay();
+    try testing.expect(h.vt.containsText("alpha"));
+    try testing.expect(h.vt.containsText("gamma"));
+    try testing.expect(!h.vt.containsText("one"));
+
+    const a3 = h.app.arena();
+    try h.app.frame(try ui.column(a3, .{}, &.{ui.text(.{}, "small")}));
+    h.replay();
+    try testing.expect(h.vt.containsText("small"));
+    try testing.expect(!h.vt.containsText("alpha"));
+    try testing.expect(!h.vt.containsText("gamma"));
+}
+
+test "width resize re-lays-out the live region" {
+    var h = try Harness.init(30, 8);
+    defer h.deinit();
+
+    const a1 = h.app.arena();
+    try h.app.frame(try ui.column(a1, .{ .width = .{ .fill = 1 } }, &.{
+        ui.text(.{}, "hello world resize"),
+    }));
+    h.replay();
+    try testing.expect(h.vt.containsText("hello world resize"));
+
+    // Terminal narrows: the same content must rewrap onto two rows.
+    h.app.options.term_size = .{ .w = 12, .h = 8 };
+    const a2 = h.app.arena();
+    try h.app.frame(try ui.column(a2, .{ .width = .{ .fill = 1 } }, &.{
+        ui.text(.{}, "hello world resize"),
+    }));
+    h.replay();
+    try testing.expect(h.vt.containsText("hello world"));
+    try testing.expect(h.vt.containsText("resize"));
+    try testing.expect(!h.vt.containsText("hello world resize"));
+}
+
+test "live region height clamps to the viewport" {
+    var h = try Harness.init(30, 4);
+    defer h.deinit();
+
+    const a = h.app.arena();
+    var lines: [8]ui.Node = undefined;
+    for (&lines, 0..) |*n, i| {
+        n.* = ui.text(.{}, if (i == 0) "first" else "later");
+    }
+    try h.app.frame(try ui.column(a, .{}, &lines));
+    h.replay();
+
+    // 8 content rows offered a 4-row terminal: clamped to 3 (viewport - 1),
+    // clipped from the bottom — the top rows win.
+    try testing.expect(h.vt.containsText("first"));
+    try testing.expectEqual(@as(u16, 3), h.app.live_rows);
+}
+
+test "deinit shows the cursor and parks below the live region" {
+    var h = try Harness.init(30, 8);
+    defer h.deinit();
+
+    try h.app.frame(try h.statusFrame("bye"));
+    h.app.deinit();
+    // Re-init so Harness.deinit's second app.deinit is harmless.
+    h.app = try ui.App.init(testing.allocator, &h.aw.writer, .{
+        .term_size = .{ .w = 30, .h = 8 },
+    });
+    h.replay();
+
+    try testing.expect(h.vt.cursor_visible);
+    // Below the 3-row frame (rows 0-2), on a fresh line.
+    try testing.expect(h.vt.cursorAt(0, 3));
+    try testing.expect(h.vt.containsText("bye"));
+}

--- a/packages/ui/src/test.zig
+++ b/packages/ui/src/test.zig
@@ -6,4 +6,5 @@ test {
     _ = @import("diff.zig");
     _ = @import("layout_test.zig");
     _ = @import("golden_test.zig");
+    _ = @import("app_test.zig");
 }

--- a/packages/ui/src/ui.zig
+++ b/packages/ui/src/ui.zig
@@ -22,6 +22,7 @@ pub const Style = surface.Style;
 pub const styleEql = surface.styleEql;
 
 pub const Renderer = @import("diff.zig").Renderer;
+pub const App = @import("app.zig").App;
 
 const node_mod = @import("node.zig");
 pub const Node = node_mod.Node;


### PR DESCRIPTION
## What

Step 3 of ADR-0013's build order: the `App` type that turns the surface/diff/layout core (#166) into the actual CLI/TUI hybrid.

```zig
var app = try ui.App.init(gpa, writer, .{});
defer app.deinit(); // cursor restored, final frame left in scrollback

try app.emit("✓ built {s}", .{name});               // static → scrollback
try app.frame(try statusLine(app.arena(), &state)); // live → diffed repaint
```

- **`emit`** — erase live region, print above (flows into scrollback), repaint region below. Line-oriented.
- **`frame`** — measure against the terminal (height clamps to viewport, clips from the bottom), lay out, diff-paint, reset the frame arena.
- App owns the frame arena, double-buffered surfaces, live-region row reservation, cursor parking (region top-left between calls) and hide/restore. Terminal size re-polls each frame → the live region re-lays-out on resize (tier 1). A `.fill` root stretches to the terminal edge, so full-screen is a sizing choice, not a mode.

The demo now dogfoods `App`: completed tasks stream up as static `emit` lines while the bordered frame animates below — `zig build run-demo` in `packages/ui`.

## Not in this slice

The visible static-tail repaint on width resize (ADR tier 2 — retained source blocks, bottom-anchored viewport repaint) is the next PR; it needs scrollback-aware golden tests. Consumer ports (`progress` multi-bar) follow it.

## Testing

New `app_test.zig` drives the App against vterm end-to-end: static-above/live-below interleaving, diff-in-place after emit, region grow/shrink, width-resize rewrap, viewport clamping, cursor restore on deinit. Full repo suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)