### PR TITLE
ui: progress widgets + Claude-Code-shaped hybrid example (ADR-0013 step 4)

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -2,12 +2,12 @@
 
 The terminal-native layout engine behind zcli's CLI/TUI hybrid ([ADR-0013](../../docs/adr/0013-terminal-native-layout-engine.md)).
 
-> **Status: pre-stabilization.** Built through step 3 of the ADR's build
-> order plus the full three-tier resize model (live region re-layout, and
-> the visible static tail retained in source form and reflowed on width
-> change). Still to come: porting `progress`/`prompts` onto the engine.
-> Until then this package is not exported on the zcli umbrella and its API
-> may change freely.
+> **Status: pre-stabilization.** The ADR's build order is complete: surface +
+> diff renderer, node tree + layout, `App` static/live loop, the three-tier
+> resize model, and the progress widget vocabulary (`ui.widgets`). Migrating
+> the shipped `progress`/`prompts` packages onto the engine is a separate,
+> breaking decision. Until it's made, this package is not exported on the
+> zcli umbrella and its API may change freely.
 
 ## The model
 
@@ -56,13 +56,32 @@ Note: the default `.wrap` mode word-wraps and drops break spaces. Labels with
 significant whitespace (padded numbers, aligned columns) want `.clip` or
 `.truncate` via `ui.textOpts`.
 
+## Widgets
+
+`ui.widgets` is the progress vocabulary as component functions — a spinner
+is a `text` node, a bar is one `custom` leaf, a multi-bar is a column of
+rows. No widget owns a repaint loop or state: animation is your tick,
+progress is your fraction, the frame diff does the rest. Styling flows
+through the theme's `ProgressTheme` tokens (the same ones the progress
+package consumes), so a future migration keeps its look.
+
+```zig
+try ui.row(a, .{ .gap = 1 }, &.{
+    ui.widgets.spinner(.{}, state.tick),
+    try ui.widgets.multiBar(a, .{}, &.{
+        .{ .label = "api", .fraction = 0.6 },
+        .{ .label = "assets", .fraction = 0.9 },
+    }),
+});
+```
+
 ## Try it
 
 ```sh
-zig build run-demo   # animated frame; needs a real terminal
-zig build test       # pure layout tests + vterm golden-frame tests
+zig build run-demo     # deploy-style task frame; needs a real terminal
+zig build run-hybrid   # the Claude-Code shape: streaming prose + live multi-bar
+zig build test         # pure layout tests + vterm golden-frame tests
 ```
 
-The demo (`examples/demo.zig`) also documents what the coming `App` loop will
-own: reserving the live region's rows, cursor parking/restore, and surface
-double-buffering.
+Resize the terminal while either runs: the live frame re-lays-out and the
+visible static tail rewraps with it.

--- a/packages/ui/build.zig
+++ b/packages/ui/build.zig
@@ -40,21 +40,24 @@ pub fn build(b: *std.Build) void {
     const test_step = b.step("test", "Run ui tests");
     test_step.dependOn(&run_tests.step);
 
-    // Runnable demo — `zig build run-demo` (it animates, so it needs a real
-    // terminal). Compiled by `test` so it can't bitrot.
-    const demo = b.addExecutable(.{
-        .name = "ui-demo",
-        .root_module = b.createModule(.{
-            .root_source_file = b.path("examples/demo.zig"),
-            .target = target,
-            .optimize = optimize,
-        }),
-    });
-    demo.root_module.addImport("ui", mod);
-    demo.root_module.addImport("terminal", terminal_dep.module("terminal"));
-    test_step.dependOn(&demo.step);
+    // Runnable examples — `zig build run-<name>` (they animate, so they need
+    // a real terminal). Each is compiled by `test` so it can't bitrot.
+    const example_names = [_][]const u8{ "demo", "hybrid" };
+    for (example_names) |name| {
+        const exe = b.addExecutable(.{
+            .name = b.fmt("ui-{s}", .{name}),
+            .root_module = b.createModule(.{
+                .root_source_file = b.path(b.fmt("examples/{s}.zig", .{name})),
+                .target = target,
+                .optimize = optimize,
+            }),
+        });
+        exe.root_module.addImport("ui", mod);
+        exe.root_module.addImport("terminal", terminal_dep.module("terminal"));
+        test_step.dependOn(&exe.step);
 
-    const run_demo = b.addRunArtifact(demo);
-    const demo_step = b.step("run-demo", "Run the animated ui demo (needs a TTY)");
-    demo_step.dependOn(&run_demo.step);
+        const run = b.addRunArtifact(exe);
+        const run_step = b.step(b.fmt("run-{s}", .{name}), b.fmt("Run the animated {s} example (needs a TTY)", .{name}));
+        run_step.dependOn(&run.step);
+    }
 }

--- a/packages/ui/examples/demo.zig
+++ b/packages/ui/examples/demo.zig
@@ -19,12 +19,9 @@ const terminal = @import("terminal");
 const frame_ms: u64 = 80;
 const total_frames: u32 = 72;
 
-const spinner = [_][]const u8{ "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏" };
-
 const heading: ui.Style = .{ .bold = true, .foreground = .cyan };
 const faint: ui.Style = .{ .dim = true };
 const good: ui.Style = .{ .foreground = .green };
-const busy: ui.Style = .{ .foreground = .yellow };
 
 const Task = struct {
     name: []const u8,
@@ -46,48 +43,13 @@ const tasks = [_]Task{
     .{ .name = "publish release", .start = 36, .duration = 24 },
 };
 
-/// A progress gauge as a `custom` leaf: it reports a small natural size and
-/// paints whatever width the layout grants it — combined with `.fill` sizing
-/// it stretches to absorb the row's leftover space.
-const Gauge = struct {
-    frac: f32,
-
-    fn measureFn(_: *anyopaque, _: *const ui.RenderCtx, limits: ui.Limits) ui.Size {
-        return .{ .w = @min(limits.max_w, 10), .h = @min(limits.max_h, 1) };
-    }
-
-    fn renderFn(context: *anyopaque, _: *const ui.RenderCtx, region: ui.Region) anyerror!void {
-        const self: *const Gauge = @ptrCast(@alignCast(context));
-        const w = region.width();
-        const filled: u16 = @intFromFloat(self.frac * @as(f32, @floatFromInt(w)));
-        var x: u16 = 0;
-        while (x < w) : (x += 1) {
-            const on = x < filled;
-            _ = try region.writeText(x, 0, if (on) "█" else "░", if (on) good else faint);
-        }
-    }
-
-    fn node(a: std.mem.Allocator, frac: f32) !ui.Node {
-        const self = try a.create(Gauge);
-        self.* = .{ .frac = frac };
-        return .{
-            .width = .{ .fill = 1 },
-            .kind = .{ .custom = .{
-                .context = self,
-                .measureFn = measureFn,
-                .renderFn = renderFn,
-            } },
-        };
-    }
-};
-
 fn taskRow(a: std.mem.Allocator, task: Task, frame: u32) !ui.Node {
     const frac = task.fraction(frame);
     const running = frame > task.start and frac < 1;
     const glyph = if (frac >= 1)
         ui.text(good, "✓")
     else if (running)
-        ui.text(busy, spinner[frame % spinner.len])
+        ui.widgets.spinner(.{}, frame)
     else
         ui.text(faint, "◦");
     const name_style: ui.Style = if (running) .{ .bold = true } else if (frac >= 1) .{} else faint;
@@ -96,7 +58,7 @@ fn taskRow(a: std.mem.Allocator, task: Task, frame: u32) !ui.Node {
     return ui.row(a, .{ .gap = 1 }, &.{
         glyph,
         ui.textOpts(.{ .style = name_style, .wrap = .truncate, .width = .{ .len = 16 } }, task.name),
-        try Gauge.node(a, frac),
+        try ui.widgets.bar(a, .{}, frac),
         // .clip, not the .wrap default: the word-wrapper treats the pad
         // spaces in "  0%" as a break gap and would drop them.
         ui.textOpts(.{ .style = faint, .wrap = .clip }, pct),
@@ -118,7 +80,7 @@ fn buildFrame(a: std.mem.Allocator, frame: u32, width: u16) !ui.Node {
 
     var rows = std.ArrayList(ui.Node).empty;
     try rows.append(a, try ui.row(a, .{ .gap = 1 }, &.{
-        if (all_done) ui.text(good, "✓") else ui.text(heading, spinner[frame % spinner.len]),
+        if (all_done) ui.text(good, "✓") else ui.widgets.spinner(.{}, frame),
         ui.text(heading, "Deploying zcli demo"),
         ui.spacer(),
         ui.text(faint, elapsed),
@@ -126,7 +88,7 @@ fn buildFrame(a: std.mem.Allocator, frame: u32, width: u16) !ui.Node {
     for (tasks) |t| try rows.append(a, try taskRow(a, t, frame));
     try rows.append(a, try ui.row(a, .{ .gap = 1 }, &.{
         ui.text(if (all_done) good else ui.Style{}, "overall"),
-        try Gauge.node(a, sum / tasks.len),
+        try ui.widgets.bar(a, .{}, sum / tasks.len),
     }));
 
     return ui.column(a, .{

--- a/packages/ui/examples/hybrid.zig
+++ b/packages/ui/examples/hybrid.zig
@@ -1,0 +1,111 @@
+//! The Claude-Code-shaped hybrid (ADR-0013 step 4): streaming text flowing
+//! into scrollback while an animated, bordered status frame — spinner,
+//! multi-bar of parallel fetches — repaints in place at the bottom edge.
+//!
+//! This is the shape the whole engine exists for: `emit` for every line of
+//! prose (static, line-oriented, retained for resize reflow), `frame` for
+//! the live region, `ui.widgets` for the progress vocabulary. Resize the
+//! terminal mid-run: the prose tail rewraps along with the frame.
+//!
+//! Run with: zig build run-hybrid   (from packages/ui, needs a real terminal)
+
+const std = @import("std");
+const ui = @import("ui");
+const terminal = @import("terminal");
+
+const frame_ms: u64 = 80;
+
+const prose = [_][]const u8{
+    "I'll refactor the parser to use the new streaming API.",
+    "",
+    "Looking at src/parser.zig, the tokenizer currently buffers the",
+    "whole input before emitting anything. The streaming API lets us",
+    "yield tokens as they decode, which drops peak memory on large",
+    "files and lets the formatter start work immediately.",
+    "",
+    "Fetching the three modules that depend on the tokenizer so the",
+    "call sites migrate in the same change...",
+};
+
+const Fetch = struct {
+    name: []const u8,
+    start: u32,
+    duration: u32,
+
+    fn fraction(self: Fetch, frame: u32) f32 {
+        if (frame <= self.start) return 0;
+        const elapsed = frame - self.start;
+        if (elapsed >= self.duration) return 1;
+        return @as(f32, @floatFromInt(elapsed)) / @as(f32, @floatFromInt(self.duration));
+    }
+};
+
+const fetches = [_]Fetch{
+    .{ .name = "src/parser.zig", .start = 4, .duration = 40 },
+    .{ .name = "src/formatter.zig", .start = 12, .duration = 44 },
+    .{ .name = "src/lsp/handlers.zig", .start = 20, .duration = 36 },
+};
+const total_frames: u32 = 72;
+
+fn statusFrame(a: std.mem.Allocator, frame: u32, width: u16) !ui.Node {
+    const elapsed = try std.fmt.allocPrint(a, "{d:.1}s", .{
+        @as(f32, @floatFromInt(frame)) * @as(f32, @floatFromInt(frame_ms)) / 1000.0,
+    });
+
+    var items: [fetches.len]ui.widgets.MultiBarItem = undefined;
+    for (fetches, &items) |f, *item| {
+        item.* = .{ .label = f.name, .fraction = f.fraction(frame) };
+    }
+
+    return ui.column(a, .{
+        .border = .rounded,
+        .border_style = .{ .dim = true },
+        .padding = .symmetric(1, 0),
+        .width = .{ .len = width },
+        .gap = 0,
+    }, &.{
+        try ui.row(a, .{ .gap = 1 }, &.{
+            ui.widgets.spinner(.{}, frame),
+            ui.text(.{ .bold = true }, "Reading dependencies"),
+            ui.spacer(),
+            ui.text(.{ .dim = true }, elapsed),
+        }),
+        try ui.widgets.multiBar(a, .{}, &items),
+    });
+}
+
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+    const gpa = init.gpa;
+
+    var out_buf: [16384]u8 = undefined;
+    var stdout = std.Io.File.stdout().writer(io, &out_buf);
+
+    const ws = terminal.getWindowSize(std.Io.File.stdout().handle) catch terminal.Winsize{ .row = 24, .col = 80 };
+    const width: u16 = @min(64, ws.col);
+
+    var app = try ui.App.init(gpa, &stdout.interface, .{ .capability = .ansi_256 });
+    defer app.deinit();
+
+    var prose_i: usize = 0;
+    var announced = [_]bool{false} ** fetches.len;
+    var frame: u32 = 0;
+    while (frame <= total_frames) : (frame += 1) {
+        // Stream a prose line into the static region every few ticks.
+        if (frame % 4 == 0 and prose_i < prose.len) {
+            try app.emit("{s}", .{prose[prose_i]});
+            prose_i += 1;
+        }
+        for (fetches, &announced) |f, *done| {
+            if (!done.* and f.fraction(frame) >= 1) {
+                done.* = true;
+                try app.emit("✓ read {s}", .{f.name});
+            }
+        }
+
+        try app.frame(try statusFrame(app.arena(), frame, width));
+        io.sleep(.{ .nanoseconds = frame_ms * std.time.ns_per_ms }, .awake) catch break;
+    }
+
+    try app.emit("all dependencies read — starting the refactor", .{});
+}

--- a/packages/ui/src/test.zig
+++ b/packages/ui/src/test.zig
@@ -5,6 +5,7 @@ test {
     _ = @import("surface.zig");
     _ = @import("diff.zig");
     _ = @import("layout_test.zig");
+    _ = @import("widgets_test.zig");
     _ = @import("golden_test.zig");
     _ = @import("app_test.zig");
 }

--- a/packages/ui/src/ui.zig
+++ b/packages/ui/src/ui.zig
@@ -23,6 +23,7 @@ pub const styleEql = surface.styleEql;
 
 pub const Renderer = @import("diff.zig").Renderer;
 pub const App = @import("app.zig").App;
+pub const widgets = @import("widgets.zig");
 
 const node_mod = @import("node.zig");
 pub const Node = node_mod.Node;

--- a/packages/ui/src/widgets.zig
+++ b/packages/ui/src/widgets.zig
@@ -1,0 +1,169 @@
+//! Progress widgets as component functions (ADR-0013 step 4: the consumer
+//! port that validates the vocabulary). Everything here is composition —
+//! spinner and percent are `text` nodes, a bar is one `custom` leaf, a
+//! multi-bar is a column of rows. No widget owns a repaint loop or any
+//! state: animation is the caller's tick, progress is the caller's
+//! fraction, and the App's frame diff does the rest.
+//!
+//! Styling flows through the theme's component tokens (`ProgressTheme`),
+//! the same tokens the progress package consumes today, so a future
+//! migration of that package onto this engine keeps its look unchanged.
+
+const std = @import("std");
+const theme_mod = @import("theme");
+const terminal = @import("terminal");
+const node_mod = @import("node.zig");
+const surface_mod = @import("surface.zig");
+
+const Node = node_mod.Node;
+const Dim = node_mod.Dim;
+const Limits = node_mod.Limits;
+const Size = node_mod.Size;
+const RenderCtx = node_mod.RenderCtx;
+const Style = surface_mod.Style;
+const Region = surface_mod.Region;
+
+pub const Theme = theme_mod.Theme;
+
+/// The default spinner frames (the progress package's `.dots`).
+pub const dots_frames: []const []const u8 =
+    &.{ "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏" };
+
+pub const SpinnerOpts = struct {
+    theme: *const Theme = &theme_mod.default_theme,
+    frames: []const []const u8 = dots_frames,
+};
+
+/// An animated spinner glyph. `tick` is caller state — advance it on your
+/// own cadence and the frame diff repaints exactly one cell.
+pub fn spinner(opts: SpinnerOpts, tick: usize) Node {
+    return .{ .kind = .{ .text = .{
+        .content = opts.frames[tick % opts.frames.len],
+        .style = opts.theme.progress.spinner.resolve(opts.theme.palette),
+        .wrap = .clip,
+    } } };
+}
+
+pub const BarOpts = struct {
+    theme: *const Theme = &theme_mod.default_theme,
+    /// Bars default to absorbing the row's leftover space.
+    width: Dim = .{ .fill = 1 },
+    /// Glyphs when the terminal supports unicode; a non-unicode RenderCtx
+    /// falls back to `#`/`-` regardless.
+    filled_char: []const u8 = "█",
+    empty_char: []const u8 = "░",
+};
+
+/// A progress bar for `fraction` in [0, 1] — a `custom` leaf that paints
+/// whatever width the layout grants it.
+pub fn bar(a: std.mem.Allocator, opts: BarOpts, fraction: f32) !Node {
+    const ctx = try a.create(BarCtx);
+    ctx.* = .{
+        .fraction = std.math.clamp(fraction, 0.0, 1.0),
+        .filled = opts.theme.progress.bar_fill.resolve(opts.theme.palette),
+        .empty = opts.theme.progress.bar_empty.resolve(opts.theme.palette),
+        .filled_char = opts.filled_char,
+        .empty_char = opts.empty_char,
+    };
+    return .{
+        .width = opts.width,
+        .kind = .{ .custom = .{
+            .context = ctx,
+            .measureFn = BarCtx.measureFn,
+            .renderFn = BarCtx.renderFn,
+        } },
+    };
+}
+
+const BarCtx = struct {
+    fraction: f32,
+    filled: Style,
+    empty: Style,
+    filled_char: []const u8,
+    empty_char: []const u8,
+
+    fn measureFn(_: *anyopaque, _: *const RenderCtx, limits: Limits) Size {
+        return .{ .w = @min(limits.max_w, 10), .h = @min(limits.max_h, 1) };
+    }
+
+    fn renderFn(context: *anyopaque, rctx: *const RenderCtx, region: Region) anyerror!void {
+        const self: *const BarCtx = @ptrCast(@alignCast(context));
+        const w = region.width();
+        const filled: u16 = @intFromFloat(self.fraction * @as(f32, @floatFromInt(w)));
+        const on_char = if (rctx.unicode) self.filled_char else "#";
+        const off_char = if (rctx.unicode) self.empty_char else "-";
+        var x: u16 = 0;
+        while (x < w) : (x += 1) {
+            const on = x < filled;
+            _ = try region.writeText(
+                x,
+                0,
+                if (on) on_char else off_char,
+                if (on) self.filled else self.empty,
+            );
+        }
+    }
+};
+
+pub const MultiBarItem = struct {
+    label: []const u8,
+    fraction: f32,
+};
+
+pub const MultiBarOpts = struct {
+    theme: *const Theme = &theme_mod.default_theme,
+    bar: BarOpts = .{},
+    gap: u16 = 1,
+    show_percent: bool = true,
+    /// Column width for labels; `null` sizes to the widest label.
+    label_width: ?u16 = null,
+};
+
+/// A stack of labeled progress bars: label column (truncated to fit), bar
+/// absorbing the leftover width, right-aligned percent.
+pub fn multiBar(a: std.mem.Allocator, opts: MultiBarOpts, items: []const MultiBarItem) !Node {
+    var bar_opts = opts.bar;
+    bar_opts.theme = opts.theme;
+
+    var label_w: u16 = opts.label_width orelse 0;
+    if (opts.label_width == null) {
+        for (items) |item| {
+            label_w = @max(label_w, @as(u16, @intCast(terminal.displayWidth(item.label))));
+        }
+    }
+
+    const rows = try a.alloc(Node, items.len);
+    for (items, rows) |item, *row_node| {
+        const fraction = std.math.clamp(item.fraction, 0.0, 1.0);
+        var cells: [3]Node = undefined;
+        var n: usize = 0;
+        cells[n] = .{
+            .width = .{ .len = label_w },
+            .kind = .{ .text = .{ .content = item.label, .wrap = .truncate } },
+        };
+        n += 1;
+        cells[n] = try bar(a, bar_opts, fraction);
+        n += 1;
+        if (opts.show_percent) {
+            const pct = try std.fmt.allocPrint(a, "{d:>3}%", .{
+                @as(u8, @intFromFloat(fraction * 100)),
+            });
+            cells[n] = .{
+                .width = .{ .len = 4 },
+                .kind = .{ .text = .{
+                    .content = pct,
+                    .style = opts.theme.palette.get(.muted),
+                    .wrap = .clip,
+                } },
+            };
+            n += 1;
+        }
+        row_node.* = .{ .kind = .{ .box = .{
+            .dir = .row,
+            .children = try a.dupe(Node, cells[0..n]),
+            .gap = opts.gap,
+        } } };
+    }
+
+    return .{ .kind = .{ .box = .{ .dir = .column, .children = rows } } };
+}

--- a/packages/ui/src/widgets_test.zig
+++ b/packages/ui/src/widgets_test.zig
@@ -1,0 +1,117 @@
+//! Widget tests: pure component functions rendered onto a Surface.
+
+const std = @import("std");
+const theme_mod = @import("theme");
+const ui = @import("ui.zig");
+const widgets = @import("widgets.zig");
+
+const testing = std.testing;
+
+const Harness = struct {
+    arena: std.heap.ArenaAllocator,
+
+    fn init() Harness {
+        return .{ .arena = std.heap.ArenaAllocator.init(testing.allocator) };
+    }
+
+    fn deinit(self: *Harness) void {
+        self.arena.deinit();
+    }
+
+    fn a(self: *Harness) std.mem.Allocator {
+        return self.arena.allocator();
+    }
+
+    fn render(self: *Harness, node: ui.Node, s: *ui.Surface, unicode: bool) !void {
+        const rctx = ui.RenderCtx{ .allocator = self.a(), .unicode = unicode };
+        try ui.render(&rctx, &node, s.root());
+    }
+};
+
+fn rowString(h: *Harness, s: *ui.Surface, y: u16) ![]u8 {
+    var list = std.ArrayList(u8).empty;
+    var x: u16 = 0;
+    while (x < s.width) : (x += 1) {
+        const c = s.cell(x, y);
+        if (c.isContinuation()) continue;
+        if (c.text_len == 0) {
+            try list.append(h.a(), ' ');
+        } else {
+            try list.appendSlice(h.a(), s.cellText(c));
+        }
+    }
+    return list.items;
+}
+
+test "spinner cycles its frames by tick and wears the theme token" {
+    const t = theme_mod.default_theme;
+    const s0 = widgets.spinner(.{}, 0);
+    const s1 = widgets.spinner(.{}, 1);
+    const wrapped = widgets.spinner(.{}, widgets.dots_frames.len);
+
+    try testing.expectEqualStrings("⠋", s0.kind.text.content);
+    try testing.expectEqualStrings("⠙", s1.kind.text.content);
+    try testing.expectEqualStrings("⠋", wrapped.kind.text.content);
+    const expected = t.progress.spinner.resolve(t.palette);
+    try testing.expect(ui.styleEql(expected, s0.kind.text.style));
+}
+
+test "bar paints floor(fraction*width) filled cells in the token styles" {
+    var h = Harness.init();
+    defer h.deinit();
+    var s = try ui.Surface.init(testing.allocator, 10, 1);
+    defer s.deinit();
+
+    try h.render(try widgets.bar(h.a(), .{}, 0.5), &s, true);
+    try testing.expectEqualStrings("█████░░░░░", try rowString(&h, &s, 0));
+
+    const t = theme_mod.default_theme;
+    const fill_style = t.progress.bar_fill.resolve(t.palette);
+    const empty_style = t.progress.bar_empty.resolve(t.palette);
+    try testing.expect(ui.styleEql(fill_style, s.cell(0, 0).style));
+    try testing.expect(ui.styleEql(empty_style, s.cell(9, 0).style));
+}
+
+test "bar clamps fraction and falls back to ascii without unicode" {
+    var h = Harness.init();
+    defer h.deinit();
+    var s = try ui.Surface.init(testing.allocator, 8, 1);
+    defer s.deinit();
+
+    try h.render(try widgets.bar(h.a(), .{}, 1.7), &s, false);
+    try testing.expectEqualStrings("########", try rowString(&h, &s, 0));
+
+    s.clear();
+    try h.render(try widgets.bar(h.a(), .{}, -3.0), &s, false);
+    try testing.expectEqualStrings("--------", try rowString(&h, &s, 0));
+}
+
+test "multiBar aligns labels, bars, and percents into columns" {
+    var h = Harness.init();
+    defer h.deinit();
+    var s = try ui.Surface.init(testing.allocator, 24, 2);
+    defer s.deinit();
+
+    const node = try widgets.multiBar(h.a(), .{}, &.{
+        .{ .label = "api", .fraction = 0.5 },
+        .{ .label = "assets", .fraction = 1.0 },
+    });
+    try h.render(node, &s, true);
+
+    // label column = widest label (6), gap, bar fills 12, gap, percent 4.
+    try testing.expectEqualStrings("api    ██████░░░░░░  50%", try rowString(&h, &s, 0));
+    try testing.expectEqualStrings("assets ████████████ 100%", try rowString(&h, &s, 1));
+}
+
+test "multiBar truncates labels to a fixed label_width" {
+    var h = Harness.init();
+    defer h.deinit();
+    var s = try ui.Surface.init(testing.allocator, 20, 1);
+    defer s.deinit();
+
+    const node = try widgets.multiBar(h.a(), .{ .label_width = 5, .show_percent = false }, &.{
+        .{ .label = "very-long-name", .fraction = 0.0 },
+    });
+    try h.render(node, &s, true);
+    try testing.expectEqualStrings("very… ░░░░░░░░░░░░░░", try rowString(&h, &s, 0));
+}


### PR DESCRIPTION
## What

The final step of ADR-0013's build order: the consumer port that validates the vocabulary.

**`ui.widgets`** — the progress vocabulary as component functions:
- `spinner(opts, tick)` — a `text` node; tick is caller state, the diff repaints one cell
- `bar(a, opts, fraction)` — one `custom` leaf painting whatever width layout grants (default `.fill`), ascii fallback via `RenderCtx.unicode`
- `multiBar(a, opts, items)` — label column (truncated, sized to widest), bar absorbing leftover width, right-aligned percent

No widget owns a repaint loop or state. Styling resolves through the theme's `ProgressTheme` tokens — the same `StyleRef`s the shipped progress package consumes — so a future migration of that package keeps its look.

**`examples/hybrid.zig`** (`zig build run-hybrid`) — the shape the engine exists for: prose streaming into scrollback via `emit` while a bordered spinner + multi-bar frame repaints below. Resize mid-run and the prose tail rewraps with the frame. The deploy demo now dogfoods the widgets instead of its hand-rolled gauge.

## Deliberately not in this PR

Rewriting `packages/progress` itself onto the engine. It's shipped public API with its own io-driven, self-animating model — that migration is a breaking decision worth its own discussion (as is `prompts`, and whether/when `ui` joins the public umbrella). This PR proves the vocabulary can express what progress does today.

## Testing

Widget tests render onto a `Surface` and assert exact rows: bar fill counts and token styles, multiBar column alignment, label truncation, ascii fallback, fraction clamping. Examples compile under `zig build test`; full repo suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)