### PR TITLE
progress: rewrite on the ui engine + MultiBar (migration plan PR 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,11 +205,11 @@ Also: `confirm`, `multiSelect`, `search` (type-to-filter), `number` (range-valid
 ```zig
 const progress = zcli.progress;  // or standalone: @import("progress")
 
-var spinner = progress.spinner(io, .{ .style = .dots });
+var spinner = try progress.spinner(allocator, io, .{ .style = .dots });
 spinner.start("Connecting to server...");
 spinner.succeed("Synced successfully"); // or .fail() / .warn() / .info()
 
-var bar = progress.progressBar(io, .{ .total = items.len, .show_eta = true });
+var bar = try progress.progressBar(allocator, io, .{ .total = items.len, .show_eta = true });
 for (items, 0..) |item, i| {
     process(item);
     bar.update(i + 1, null);
@@ -217,7 +217,7 @@ for (items, 0..) |item, i| {
 bar.finish();
 ```
 
-Nine spinner styles; animations auto-disable when not a TTY, symbols adapt to unicode support. Details in [packages/progress](packages/progress/).
+Nine spinner styles, plus stacked multi-bars for parallel work; animations auto-disable when not a TTY, symbols adapt to unicode support. Details in [packages/progress](packages/progress/).
 
 ## Theming
 

--- a/examples/tasks/src/commands/import.zig
+++ b/examples/tasks/src/commands/import.zig
@@ -38,7 +38,7 @@ pub fn execute(args: Args, _: Options, context: *Context) !void {
     var data = parsed.value;
 
     // Import with progress bar
-    var bar = progress.progressBar(context.io, .{
+    var bar = try progress.progressBar(context.allocator, context.io, .{
         .total = imported.value.tasks.len,
         .show_eta = true,
         .theme = context.theme,

--- a/examples/tasks/src/commands/sync.zig
+++ b/examples/tasks/src/commands/sync.zig
@@ -13,13 +13,13 @@ pub const Options = struct {};
 
 pub fn execute(_: Args, _: Options, context: *Context) !void {
     const io = context.io;
-    var spinner = progress.spinner(io, .{ .style = .dots, .theme = context.theme });
+    var spinner = try progress.spinner(context.allocator, io, .{ .style = .dots, .theme = context.theme });
     spinner.start("Connecting to server...");
 
     io.sleep(.{ .nanoseconds = 500 * std.time.ns_per_ms }, .awake) catch {};
-    spinner.setText("Uploading changes...");
+    spinner.setMessage("Uploading changes...");
     io.sleep(.{ .nanoseconds = 400 * std.time.ns_per_ms }, .awake) catch {};
-    spinner.setText("Downloading updates...");
+    spinner.setMessage("Downloading updates...");
     io.sleep(.{ .nanoseconds = 600 * std.time.ns_per_ms }, .awake) catch {};
 
     spinner.succeed("Synced successfully");

--- a/packages/progress/README.md
+++ b/packages/progress/README.md
@@ -6,9 +6,10 @@ Progress indicators for Zig CLIs: animated spinners for indeterminate work and p
 
 - **Spinners**: nine styles (`dots`, `dots2`, `dots3`, `line`, `arrow`, `bounce`, `clock`, `moon`, `simple`), each with a tuned frame interval
 - **Progress bars**: percentage, current/total, ETA, elapsed time, and rate — all opt-in via `ProgressBarConfig`
-- **TTY-aware**: non-TTY output (pipes, CI logs) gets static lines instead of control codes
+- **Multi-bars**: stacked labeled bars for parallel work, thread-safe updates
+- **TTY-aware**: piped output (pipes, CI logs) degrades to plain lines — spinners print one line per message, bars a single finish line
 - **Result symbols**: `succeed`/`fail`/`warn`/`info` finish states with themed colors and Unicode→ASCII fallback
-- **Cursor hygiene**: the cursor is hidden while a spinner runs and restored on any finish path (configurable)
+- **Engine-rendered**: frames run on the [`ui`](../ui/) layout engine — diffed repaints, resize re-layout, and cursor hygiene are the engine's job; finish results are emitted as static lines that flow into scrollback
 
 ## Installation
 
@@ -33,13 +34,13 @@ exe.root_module.addImport("progress", progress_dep.module("progress"));
 const progress = @import("progress");
 
 // Spinner — indeterminate work
-var spinner = progress.spinner(io, .{ .style = .dots });
+var spinner = try progress.spinner(allocator, io, .{ .style = .dots });
 spinner.start("Connecting to server...");
-spinner.setText("Uploading changes...");
+spinner.setMessage("Uploading changes...");
 spinner.succeed("Synced successfully"); // or .fail() / .warn() / .info() / .stop()
 
 // Progress bar — known total
-var bar = progress.progressBar(io, .{
+var bar = try progress.progressBar(allocator, io, .{
     .total = items.len,
     .show_eta = true,
 });
@@ -47,7 +48,14 @@ for (items, 0..) |item, i| {
     process(item);
     bar.update(i + 1, null);
 }
-bar.finish();
+bar.finish(); // the final frame persists on screen
+
+// Multi-bar — parallel work (updates may come from worker threads)
+var mb = try progress.multiBar(allocator, io, .{});
+defer mb.deinit();
+const api = try mb.add("api.tar.gz", total_bytes);
+mb.set(api, downloaded);
+mb.finish();
 ```
 
 See [examples/tasks](../../examples/tasks/) (`sync`, `import` commands) for these running in a real CLI.
@@ -62,7 +70,7 @@ the detected capabilities (including `NO_COLOR` and true color):
 
 ```zig
 // In a zcli command — the context already carries the app theme:
-var spinner = progress.spinner(io, .{ .theme = context.theme });
+var spinner = try progress.spinner(context.allocator, io, .{ .theme = context.theme });
 ```
 
 Standalone, the default (`ThemeContext.fallback`) is the default theme at
@@ -70,5 +78,6 @@ ANSI-16. Token defaults are defined in [`theme`](../theme/)'s `ProgressTheme`.
 
 ## Dependencies
 
+- [`ui`](../ui/) — the layout engine that renders every frame
 - [`theme`](../theme/) — colors for the spinner and finish symbols
 - [`terminal`](../terminal/) — TTY detection and Unicode/ASCII symbol fallback

--- a/packages/progress/build.zig
+++ b/packages/progress/build.zig
@@ -4,17 +4,12 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    // Get theme dependency
-    const theme_dep = b.dependency("theme", .{
-        .target = target,
-        .optimize = optimize,
-    });
+    const theme_dep = b.dependency("theme", .{ .target = target, .optimize = optimize });
     const theme_module = theme_dep.module("theme");
-    const terminal_dep = b.dependency("terminal", .{
-        .target = target,
-        .optimize = optimize,
-    });
+    const terminal_dep = b.dependency("terminal", .{ .target = target, .optimize = optimize });
     const terminal_module = terminal_dep.module("terminal");
+    const ui_dep = b.dependency("ui", .{ .target = target, .optimize = optimize });
+    const ui_module = ui_dep.module("ui");
 
     // Main progress module
     const progress_mod = b.addModule("progress", .{
@@ -24,22 +19,27 @@ pub fn build(b: *std.Build) void {
     });
     progress_mod.addImport("theme", theme_module);
     progress_mod.addImport("terminal", terminal_module);
+    progress_mod.addImport("ui", ui_module);
 
-    // Tests
-    const test_step = b.step("test", "Run unit tests");
+    // Tests are rooted at src/test.zig so the vterm golden-frame harness is
+    // a test-only import, never a dependency of the shipped module.
+    const vterm_dep = b.dependency("vterm", .{ .target = target, .optimize = optimize });
 
     const test_mod = b.addModule("test-progress", .{
-        .root_source_file = b.path("src/progress.zig"),
+        .root_source_file = b.path("src/test.zig"),
         .target = target,
         .optimize = optimize,
     });
     test_mod.addImport("theme", theme_module);
     test_mod.addImport("terminal", terminal_module);
+    test_mod.addImport("ui", ui_module);
+    test_mod.addImport("vterm", vterm_dep.module("vterm"));
 
     const tests = b.addTest(.{
         .root_module = test_mod,
     });
 
     const run_tests = b.addRunArtifact(tests);
+    const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_tests.step);
 }

--- a/packages/progress/build.zig.zon
+++ b/packages/progress/build.zig.zon
@@ -6,6 +6,8 @@
     .dependencies = .{
         .theme = .{ .path = "../theme" },
         .terminal = .{ .path = "../terminal" },
+        .ui = .{ .path = "../ui" },
+        .vterm = .{ .path = "../vterm" },
     },
     .paths = .{
         "build.zig",

--- a/packages/progress/src/progress.zig
+++ b/packages/progress/src/progress.zig
@@ -1,29 +1,46 @@
 //! progress - Progress indicators for CLI applications
 //!
-//! Provides spinners for indeterminate progress and progress bars for
-//! known totals. Auto-disables animations when output is not a TTY.
+//! Spinners for indeterminate progress, bars for known totals, and stacked
+//! multi-bars for parallel work. Rendering runs on the ui engine (ADR-0013):
+//! each indicator owns a small `ui.App` live region, so diffing, resize
+//! re-layout, cursor bookkeeping, and flush discipline are the engine's
+//! problem — this package only describes what a frame looks like. Finishing
+//! an indicator emits its result as a static line that flows into scrollback
+//! (or, for bars, persists the final frame).
+//!
+//! When output is not a TTY, indicators degrade to plain lines: spinners
+//! print one status line per message, bars are silent until a single finish
+//! line, and animations never spawn.
 //!
 //! Basic usage:
 //! ```zig
 //! const progress = @import("progress");
 //!
 //! // Spinner for indeterminate progress — animates itself until finished
-//! var spinner = progress.spinner(io, .{});
+//! var spinner = try progress.spinner(allocator, io, .{});
 //! spinner.start("Loading...");
 //! // ... do work ...
 //! spinner.succeed("Done!");
 //!
 //! // Progress bar for known totals
-//! var bar = progress.progressBar(io, .{ .total = 100 });
+//! var bar = try progress.progressBar(allocator, io, .{ .total = 100 });
 //! for (0..100) |i| {
 //!     bar.update(i + 1, null);
 //! }
 //! bar.finish();
+//!
+//! // Stacked bars for parallel work
+//! var mb = try progress.multiBar(allocator, io, .{});
+//! defer mb.deinit();
+//! const dl = try mb.add("api.tar.gz", 1024);
+//! mb.set(dl, 512);
+//! mb.finish();
 //! ```
 
 const std = @import("std");
 const theme = @import("theme");
 const terminal = @import("terminal");
+const ui = @import("ui");
 
 /// Spinner animation styles
 pub const SpinnerStyle = enum {
@@ -81,8 +98,6 @@ pub const ResultSymbol = struct {
 /// Spinner configuration
 pub const SpinnerConfig = struct {
     style: SpinnerStyle = .dots,
-    /// Whether to hide cursor during animation
-    hide_cursor: bool = true,
     /// Prefix before spinner
     prefix: []const u8 = "",
     /// Suffix after message
@@ -95,234 +110,176 @@ pub const SpinnerConfig = struct {
     theme: theme.ThemeContext = .fallback,
 };
 
-/// Spinner for indeterminate progress
-pub fn Spinner(comptime WriterType: type) type {
-    return struct {
-        const Self = @This();
+/// Spinner for indeterminate progress.
+pub const Spinner = struct {
+    io: std.Io,
+    config: SpinnerConfig,
+    app: ui.App,
+    message: []const u8 = "",
+    tick: usize = 0,
+    active: bool = false,
+    closed: bool = false,
+    /// Guards message/tick/active and the App while animating.
+    mutex: std.Io.Mutex = .init,
+    animation: ?std.Io.Future(void) = null,
 
-        writer: WriterType,
-        io: std.Io,
-        config: SpinnerConfig,
-        message: []const u8,
-        frame_index: usize,
-        is_tty: bool,
-        active: bool,
-        /// Guards message/frame_index/active and all writes while animating.
-        mutex: std.Io.Mutex,
-        animation: ?std.Io.Future(void),
+    /// Initialize a new spinner writing to `writer`.
+    pub fn init(allocator: std.mem.Allocator, writer: *std.Io.Writer, io: std.Io, config: SpinnerConfig) !Spinner {
+        return .{
+            .io = io,
+            .config = config,
+            .app = try ui.App.init(allocator, writer, .{
+                .capability = config.theme.capability(),
+                .unicode = config.unicode,
+                .interactive = terminal.isStdoutTty(),
+            }),
+        };
+    }
 
-        /// Initialize a new spinner
-        pub fn init(writer: WriterType, io: std.Io, config: SpinnerConfig) Self {
-            return .{
-                .writer = writer,
-                .io = io,
-                .config = config,
-                .message = "",
-                .frame_index = 0,
-                .is_tty = detectTTY(),
-                .active = false,
-                .mutex = .init,
-                .animation = null,
-            };
+    /// Release the spinner without a result (safe after any finish method).
+    pub fn deinit(self: *Spinner) void {
+        self.close();
+    }
+
+    /// Start the spinner with a message. On a TTY this spawns a background
+    /// task that animates the spinner until a finish method is called, so
+    /// the spinner must not be moved or copied after `start`. If the `Io`
+    /// implementation cannot run the animation concurrently, the spinner
+    /// degrades to a static frame.
+    pub fn start(self: *Spinner, message: []const u8) void {
+        self.message = message;
+        self.active = true;
+        self.tick = 0;
+        self.render();
+        if (self.app.options.interactive) {
+            self.animation = self.io.concurrent(animate, .{self}) catch null;
         }
+    }
 
-        /// Start the spinner with a message. On a TTY this spawns a background
-        /// task that animates the spinner until a finish method is called, so
-        /// the spinner must not be moved or copied after `start`. If the `Io`
-        /// implementation cannot run the animation concurrently, the spinner
-        /// degrades to a static frame.
-        pub fn start(self: *Self, message: []const u8) void {
-            self.message = message;
-            self.active = true;
-            self.frame_index = 0;
+    /// Update the spinner message
+    pub fn setMessage(self: *Spinner, message: []const u8) void {
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
+        self.message = message;
+        if (self.active) self.render();
+    }
 
-            if (self.is_tty and self.config.hide_cursor) {
-                self.writeAll("\x1b[?25l"); // Hide cursor
-            }
+    /// Stop the spinner with a success message
+    pub fn succeed(self: *Spinner, message: []const u8) void {
+        self.finishRole(.success, ResultSymbol.success(self.config.unicode), message);
+    }
 
-            self.render();
+    /// Stop the spinner with a failure message
+    pub fn fail(self: *Spinner, message: []const u8) void {
+        self.finishRole(.err, ResultSymbol.failure(self.config.unicode), message);
+    }
 
-            if (self.is_tty) {
-                self.animation = self.io.concurrent(animate, .{self}) catch null;
-            }
-        }
+    /// Stop the spinner with a warning message
+    pub fn warn(self: *Spinner, message: []const u8) void {
+        self.finishRole(.warning, ResultSymbol.warning(self.config.unicode), message);
+    }
 
-        /// Update the spinner message
-        pub fn setText(self: *Self, message: []const u8) void {
+    /// Stop the spinner with an info message
+    pub fn info(self: *Spinner, message: []const u8) void {
+        self.finishRole(.info, ResultSymbol.info(self.config.unicode), message);
+    }
+
+    /// Stop and persist `symbol` + the message as a plain static line.
+    pub fn persist(self: *Spinner, symbol: []const u8, message: []const u8) void {
+        self.stopAnimation();
+        self.app.clear() catch {};
+        self.app.emit("{s} {s}", .{ symbol, message }) catch {};
+        self.close();
+    }
+
+    /// Stop the spinner leaving no output behind.
+    pub fn stop(self: *Spinner) void {
+        self.stopAnimation();
+        self.app.clear() catch {};
+        self.close();
+    }
+
+    /// Background task: advance and redraw the spinner every frame
+    /// interval until a finish method cancels it.
+    fn animate(self: *Spinner) void {
+        const interval_ns = self.config.style.interval() * std.time.ns_per_ms;
+        while (true) {
+            self.io.sleep(.{ .nanoseconds = interval_ns }, .awake) catch return;
             self.mutex.lockUncancelable(self.io);
             defer self.mutex.unlock(self.io);
-            self.message = message;
-            if (self.active) self.render();
+            if (!self.active) return;
+            self.tick +%= 1;
+            self.render();
         }
+    }
 
-        /// Background task: advance and redraw the spinner every frame
-        /// interval until a finish method cancels it.
-        fn animate(self: *Self) void {
-            const interval_ns = self.config.style.interval() * std.time.ns_per_ms;
-            while (true) {
-                self.io.sleep(.{ .nanoseconds = interval_ns }, .awake) catch return;
-                self.mutex.lockUncancelable(self.io);
-                defer self.mutex.unlock(self.io);
-                if (!self.active) return;
-                self.frame_index = (self.frame_index + 1) % self.config.style.frames().len;
-                self.render();
-            }
+    /// Deactivate and reap the animation task. After this returns the
+    /// caller has exclusive use of the App.
+    fn stopAnimation(self: *Spinner) void {
+        self.mutex.lockUncancelable(self.io);
+        self.active = false;
+        self.mutex.unlock(self.io);
+        if (self.animation) |*future| {
+            future.cancel(self.io);
+            self.animation = null;
         }
+    }
 
-        /// Deactivate and reap the animation task. After this returns the
-        /// caller has exclusive use of the writer.
-        fn stopAnimation(self: *Self) void {
-            self.mutex.lockUncancelable(self.io);
-            self.active = false;
-            self.mutex.unlock(self.io);
-            if (self.animation) |*future| {
-                future.cancel(self.io);
-                self.animation = null;
-            }
+    fn finishRole(self: *Spinner, role: theme.SemanticRole, symbol: []const u8, message: []const u8) void {
+        self.stopAnimation();
+        self.app.clear() catch {};
+        if (self.app.options.interactive) {
+            // The result line is static output; the role style is baked into
+            // the emitted text (retained escapes are zero-width for reflow).
+            var buf: [64]u8 = undefined;
+            var w: std.Io.Writer = .fixed(&buf);
+            const wrote = self.config.theme.resolve(role).writeSequence(&w, self.config.theme.capability()) catch false;
+            self.app.emit("{s}{s}{s} {s}", .{
+                w.buffered(),
+                symbol,
+                if (wrote) "\x1b[0m" else "",
+                message,
+            }) catch {};
+        } else {
+            self.app.emit("{s} {s}", .{ symbol, message }) catch {};
         }
+        self.close();
+    }
 
-        /// Stop the spinner with a success message
-        pub fn succeed(self: *Self, message: []const u8) void {
-            self.finishWithRole(ResultSymbol.success(self.config.unicode), .success, message);
+    fn render(self: *Spinner) void {
+        if (!self.app.options.interactive) {
+            // Piped: one plain status line per message.
+            self.app.emit("{s}- {s}{s}", .{ self.config.prefix, self.message, self.config.suffix }) catch {};
+            return;
         }
+        self.renderFrame() catch {};
+    }
 
-        /// Stop the spinner with a failure message
-        pub fn fail(self: *Self, message: []const u8) void {
-            self.finishWithRole(ResultSymbol.failure(self.config.unicode), .err, message);
-        }
+    fn renderFrame(self: *Spinner) !void {
+        const a = self.app.arena();
+        const tail = try std.fmt.allocPrint(a, " {s}{s}", .{ self.message, self.config.suffix });
+        try self.app.frame(try ui.row(a, .{}, &.{
+            ui.textOpts(.{ .wrap = .clip }, self.config.prefix),
+            ui.widgets.spinner(.{
+                .theme = self.config.theme.theme,
+                .frames = self.config.style.frames(),
+            }, self.tick),
+            ui.textOpts(.{ .wrap = .clip }, tail),
+        }));
+    }
 
-        /// Stop the spinner with a warning message
-        pub fn warn(self: *Self, message: []const u8) void {
-            self.finishWithRole(ResultSymbol.warning(self.config.unicode), .warning, message);
-        }
-
-        /// Stop the spinner with an info message
-        pub fn info(self: *Self, message: []const u8) void {
-            self.finishWithRole(ResultSymbol.info(self.config.unicode), .info, message);
-        }
-
-        /// Stop the spinner without a result symbol
-        pub fn stop(self: *Self) void {
-            self.stopAndClear();
-        }
-
-        /// Stop and persist the current message
-        pub fn stopAndPersist(self: *Self, symbol: []const u8, message: []const u8) void {
-            self.finishPlain(symbol, message);
-        }
-
-        fn writeAll(self: *Self, data: []const u8) void {
-            self.writer.writeAll(data) catch {};
-        }
-
-        /// Write the style's escape sequence; returns true if one was written
-        fn writeStyle(self: *Self, style: theme.Style) bool {
-            return style.writeSequence(self.writer, self.config.theme.capability()) catch false;
-        }
-
-        fn finishWithRole(self: *Self, symbol: []const u8, role: theme.SemanticRole, message: []const u8) void {
-            self.stopAnimation();
-
-            if (self.is_tty) {
-                self.writeAll("\r\x1b[K"); // Clear line
-                const wrote_color = self.writeStyle(self.config.theme.resolve(role));
-                self.writeAll(symbol);
-                if (wrote_color) {
-                    self.writeAll("\x1b[0m");
-                }
-                self.writeAll(" ");
-                self.writeAll(message);
-                self.writeAll("\n");
-
-                if (self.config.hide_cursor) {
-                    self.writeAll("\x1b[?25h"); // Show cursor
-                }
-            } else {
-                self.writeAll(symbol);
-                self.writeAll(" ");
-                self.writeAll(message);
-                self.writeAll("\n");
-            }
-            flushWriter(self.writer);
-        }
-
-        fn finishPlain(self: *Self, symbol: []const u8, message: []const u8) void {
-            self.stopAnimation();
-
-            if (self.is_tty) {
-                self.writeAll("\r\x1b[K");
-                self.writeAll(symbol);
-                self.writeAll(" ");
-                self.writeAll(message);
-                self.writeAll("\n");
-
-                if (self.config.hide_cursor) {
-                    self.writeAll("\x1b[?25h");
-                }
-            } else {
-                self.writeAll(symbol);
-                self.writeAll(" ");
-                self.writeAll(message);
-                self.writeAll("\n");
-            }
-            flushWriter(self.writer);
-        }
-
-        fn stopAndClear(self: *Self) void {
-            self.stopAnimation();
-
-            if (self.is_tty) {
-                self.writeAll("\r\x1b[K"); // Clear line
-                if (self.config.hide_cursor) {
-                    self.writeAll("\x1b[?25h"); // Show cursor
-                }
-                flushWriter(self.writer);
-            }
-        }
-
-        fn render(self: *Self) void {
-            if (!self.is_tty) {
-                // Non-TTY: no animation; print a plain status line per message
-                self.writeAll(self.config.prefix);
-                self.writeAll("- ");
-                self.writeAll(self.message);
-                self.writeAll(self.config.suffix);
-                self.writeAll("\n");
-                flushWriter(self.writer);
-                return;
-            }
-
-            const style_frames = self.config.style.frames();
-            const frame = style_frames[self.frame_index];
-
-            // Move to beginning of line and clear
-            self.writeAll("\r\x1b[K");
-
-            // Write prefix
-            self.writeAll(self.config.prefix);
-
-            // Write themed spinner frame
-            const spinner_style = self.config.theme.resolveRef(self.config.theme.progressTokens().spinner);
-            const wrote_color = self.writeStyle(spinner_style);
-            self.writeAll(frame);
-            if (wrote_color) {
-                self.writeAll("\x1b[0m");
-            }
-
-            // Write message
-            self.writeAll(" ");
-            self.writeAll(self.message);
-            self.writeAll(self.config.suffix);
-            flushWriter(self.writer);
-        }
-    };
-}
+    fn close(self: *Spinner) void {
+        if (self.closed) return;
+        self.closed = true;
+        self.app.deinit();
+    }
+};
 
 /// Progress bar configuration
 pub const ProgressBarConfig = struct {
     /// Total value for 100% completion
     total: usize = 100,
-    /// Width of the progress bar in characters
+    /// Width of the bar itself in characters (excluding brackets and stats)
     width: usize = 40,
     /// Character for completed portion
     complete_char: []const u8 = "█",
@@ -336,204 +293,290 @@ pub const ProgressBarConfig = struct {
     show_elapsed: bool = false,
     /// Whether to show rate (items/sec)
     show_rate: bool = false,
-    /// Whether to clear the bar on finish
+    /// Whether to clear the bar on finish (otherwise the final frame persists)
     clear_on_finish: bool = false,
-    /// Format string for the bar: {bar} {percent} {current}/{total} {eta}
     prefix: []const u8 = "",
     suffix: []const u8 = "",
+    /// Whether terminal supports unicode
+    unicode: bool = true,
     /// Theme + terminal capabilities for styling (fill/empty via the theme's
     /// `progress.bar_fill`/`bar_empty` tokens); zcli commands pass `context.theme`.
     theme: theme.ThemeContext = .fallback,
 };
 
-/// Progress bar for determinate progress
-pub fn ProgressBar(comptime WriterType: type) type {
-    return struct {
-        const Self = @This();
+/// Progress bar for determinate progress. Caller-driven: each `update`
+/// paints one frame. Piped output stays silent until one finish line.
+pub const ProgressBar = struct {
+    io: std.Io,
+    config: ProgressBarConfig,
+    app: ui.App,
+    current: usize = 0,
+    start_time: i64,
+    message: []const u8 = "",
+    closed: bool = false,
 
-        writer: WriterType,
-        io: std.Io,
-        config: ProgressBarConfig,
-        current: usize,
-        start_time: i64,
-        is_tty: bool,
-        message: []const u8,
+    /// Initialize a new progress bar writing to `writer`.
+    pub fn init(allocator: std.mem.Allocator, writer: *std.Io.Writer, io: std.Io, config: ProgressBarConfig) !ProgressBar {
+        return .{
+            .io = io,
+            .config = config,
+            .app = try ui.App.init(allocator, writer, .{
+                .capability = config.theme.capability(),
+                .unicode = config.unicode,
+                .interactive = terminal.isStdoutTty(),
+            }),
+            .start_time = nowMsIo(io),
+        };
+    }
 
-        fn nowMs(self: *Self) i64 {
-            return @intCast(@divTrunc(std.Io.Clock.Timestamp.now(self.io, .awake).raw.nanoseconds, std.time.ns_per_ms));
+    /// Release the bar without finishing (safe after `finish`).
+    pub fn deinit(self: *ProgressBar) void {
+        self.close();
+    }
+
+    /// Update progress with optional message
+    pub fn update(self: *ProgressBar, current: usize, message: ?[]const u8) void {
+        self.current = @min(current, self.config.total);
+        if (message) |m| {
+            self.message = m;
         }
+        self.render();
+    }
 
-        /// Initialize a new progress bar
-        pub fn init(writer: WriterType, io: std.Io, config: ProgressBarConfig) Self {
-            return .{
-                .writer = writer,
-                .io = io,
-                .config = config,
-                .current = 0,
-                .start_time = @intCast(@divTrunc(std.Io.Clock.Timestamp.now(io, .awake).raw.nanoseconds, std.time.ns_per_ms)),
-                .is_tty = detectTTY(),
-                .message = "",
+    /// Increment progress by amount
+    pub fn increment(self: *ProgressBar, amount: usize) void {
+        self.update(self.current + amount, null);
+    }
+
+    /// Set the message without updating progress
+    pub fn setMessage(self: *ProgressBar, message: []const u8) void {
+        self.message = message;
+        self.render();
+    }
+
+    /// Mark progress as complete. The final frame persists on screen
+    /// (unless `clear_on_finish`); piped output gets one summary line.
+    pub fn finish(self: *ProgressBar) void {
+        self.current = self.config.total;
+        if (!self.app.options.interactive) {
+            self.app.emit("{s}{s}{s}{d}/{d} (100%){s}", .{
+                self.config.prefix,
+                self.message,
+                if (self.message.len > 0) " " else "",
+                self.config.total,
+                self.config.total,
+                self.config.suffix,
+            }) catch {};
+        } else if (self.config.clear_on_finish) {
+            self.app.clear() catch {};
+        } else {
+            self.render();
+        }
+        self.close();
+    }
+
+    /// Finish with a custom message
+    pub fn finishWithMessage(self: *ProgressBar, message: []const u8) void {
+        self.message = message;
+        self.finish();
+    }
+
+    fn nowMs(self: *ProgressBar) i64 {
+        return nowMsIo(self.io);
+    }
+
+    fn render(self: *ProgressBar) void {
+        if (!self.app.options.interactive) return;
+        self.renderFrame() catch {};
+    }
+
+    fn renderFrame(self: *ProgressBar) !void {
+        const a = self.app.arena();
+        const fraction: f32 = if (self.config.total > 0)
+            @as(f32, @floatFromInt(self.current)) / @as(f32, @floatFromInt(self.config.total))
+        else
+            0;
+
+        const left = try std.fmt.allocPrint(a, "{s}{s}{s}", .{
+            self.config.prefix,
+            self.message,
+            if (self.message.len > 0) " " else "",
+        });
+
+        // Stats after the bar: " 50% 5/10 ETA: 3s [1m2s] 1.5/s"
+        var stats_buf: [160]u8 = undefined;
+        var sw: std.Io.Writer = .fixed(&stats_buf);
+        if (self.config.show_percentage) {
+            const percent = if (self.config.total > 0) (self.current * 100) / self.config.total else 0;
+            sw.print(" {d:>3}%", .{percent}) catch {};
+        }
+        sw.print(" {d}/{d}", .{ self.current, self.config.total }) catch {};
+        if (self.config.show_eta and self.current > 0 and self.current < self.config.total) {
+            const elapsed = self.nowMs() - self.start_time;
+            if (elapsed > 0) {
+                const remaining = self.config.total - self.current;
+                const ms_per_item: i64 = @divTrunc(elapsed, @as(i64, @intCast(self.current)));
+                const eta_secs: u64 = @intCast(@divTrunc(ms_per_item * @as(i64, @intCast(remaining)), 1000));
+                var eta_buf: [16]u8 = undefined;
+                sw.print(" ETA: {s}", .{formatDuration(eta_secs, &eta_buf)}) catch {};
+            }
+        }
+        if (self.config.show_elapsed) {
+            const elapsed_secs: u64 = @intCast(@divTrunc(self.nowMs() - self.start_time, 1000));
+            var elapsed_buf: [16]u8 = undefined;
+            sw.print(" [{s}]", .{formatDuration(elapsed_secs, &elapsed_buf)}) catch {};
+        }
+        if (self.config.show_rate and self.current > 0) {
+            const elapsed_ms = self.nowMs() - self.start_time;
+            if (elapsed_ms > 0) {
+                const rate: f64 = @as(f64, @floatFromInt(self.current)) /
+                    (@as(f64, @floatFromInt(elapsed_ms)) / 1000.0);
+                sw.print(" {d:.1}/s", .{rate}) catch {};
+            }
+        }
+        const stats = try a.dupe(u8, sw.buffered());
+
+        try self.app.frame(try ui.row(a, .{}, &.{
+            ui.textOpts(.{ .wrap = .clip }, left),
+            ui.textOpts(.{ .wrap = .clip }, "["),
+            try ui.widgets.bar(a, .{
+                .theme = self.config.theme.theme,
+                .width = .{ .len = @intCast(self.config.width) },
+                .filled_char = self.config.complete_char,
+                .empty_char = self.config.incomplete_char,
+            }, fraction),
+            ui.textOpts(.{ .wrap = .clip }, "]"),
+            ui.textOpts(.{ .wrap = .clip }, stats),
+            ui.textOpts(.{ .wrap = .clip }, self.config.suffix),
+        }));
+    }
+
+    fn close(self: *ProgressBar) void {
+        if (self.closed) return;
+        self.closed = true;
+        self.app.deinit();
+    }
+};
+
+/// Multi-bar configuration
+pub const MultiBarConfig = struct {
+    /// Frame width in columns (label column + bars + percents)
+    width: usize = 60,
+    /// Whether to show per-bar percentages
+    show_percent: bool = true,
+    /// Whether terminal supports unicode
+    unicode: bool = true,
+    /// Theme + terminal capabilities for styling; zcli commands pass `context.theme`.
+    theme: theme.ThemeContext = .fallback,
+};
+
+/// Stacked progress bars for parallel work. Thread-safe: `set`/`increment`
+/// may be called from worker threads. Caller-driven (no animation task).
+/// Piped output is silent — log your own lines when not a TTY.
+pub const MultiBar = struct {
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    config: MultiBarConfig,
+    app: ui.App,
+    items: std.ArrayList(Item) = .empty,
+    closed: bool = false,
+    /// Guards items and the App across worker threads.
+    mutex: std.Io.Mutex = .init,
+
+    const Item = struct {
+        label: []u8,
+        current: usize,
+        total: usize,
+    };
+
+    /// Initialize a multi-bar writing to `writer`.
+    pub fn init(allocator: std.mem.Allocator, writer: *std.Io.Writer, io: std.Io, config: MultiBarConfig) !MultiBar {
+        return .{
+            .allocator = allocator,
+            .io = io,
+            .config = config,
+            .app = try ui.App.init(allocator, writer, .{
+                .capability = config.theme.capability(),
+                .unicode = config.unicode,
+                .interactive = terminal.isStdoutTty(),
+            }),
+        };
+    }
+
+    pub fn deinit(self: *MultiBar) void {
+        self.close();
+        for (self.items.items) |item| self.allocator.free(item.label);
+        self.items.deinit(self.allocator);
+    }
+
+    /// Add a bar; the returned handle indexes `set`/`increment`.
+    pub fn add(self: *MultiBar, label: []const u8, total: usize) !usize {
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
+        const owned = try self.allocator.dupe(u8, label);
+        errdefer self.allocator.free(owned);
+        try self.items.append(self.allocator, .{ .label = owned, .current = 0, .total = total });
+        self.render();
+        return self.items.items.len - 1;
+    }
+
+    /// Set a bar's progress.
+    pub fn set(self: *MultiBar, bar_handle: usize, current: usize) void {
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
+        const item = &self.items.items[bar_handle];
+        item.current = @min(current, item.total);
+        self.render();
+    }
+
+    /// Increment a bar's progress by amount.
+    pub fn increment(self: *MultiBar, bar_handle: usize, amount: usize) void {
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
+        const item = &self.items.items[bar_handle];
+        item.current = @min(item.current + amount, item.total);
+        self.render();
+    }
+
+    /// Finish: the final frame persists on screen, flowing into scrollback.
+    pub fn finish(self: *MultiBar) void {
+        self.close();
+    }
+
+    fn render(self: *MultiBar) void {
+        if (!self.app.options.interactive) return;
+        self.renderFrame() catch {};
+    }
+
+    fn renderFrame(self: *MultiBar) !void {
+        const a = self.app.arena();
+        const bars = try a.alloc(ui.widgets.MultiBarItem, self.items.items.len);
+        for (self.items.items, bars) |item, *b| {
+            b.* = .{
+                .label = item.label,
+                .fraction = if (item.total > 0)
+                    @as(f32, @floatFromInt(item.current)) / @as(f32, @floatFromInt(item.total))
+                else
+                    0,
             };
         }
+        var node = try ui.widgets.multiBar(a, .{
+            .theme = self.config.theme.theme,
+            .show_percent = self.config.show_percent,
+        }, bars);
+        node.width = .{ .len = @intCast(self.config.width) };
+        try self.app.frame(node);
+    }
 
-        /// Update progress with optional message
-        pub fn update(self: *Self, current: usize, message: ?[]const u8) void {
-            self.current = @min(current, self.config.total);
-            if (message) |m| {
-                self.message = m;
-            }
-            self.render();
-        }
+    fn close(self: *MultiBar) void {
+        if (self.closed) return;
+        self.closed = true;
+        self.app.deinit();
+    }
+};
 
-        /// Increment progress by amount
-        pub fn increment(self: *Self, amount: usize) void {
-            self.update(self.current + amount, null);
-        }
-
-        /// Set the message without updating progress
-        pub fn setMessage(self: *Self, message: []const u8) void {
-            self.message = message;
-            self.render();
-        }
-
-        /// Mark progress as complete
-        pub fn finish(self: *Self) void {
-            self.current = self.config.total;
-            self.render();
-
-            if (self.is_tty) {
-                if (self.config.clear_on_finish) {
-                    self.writeAll("\r\x1b[K");
-                } else {
-                    self.writeAll("\n");
-                }
-            } else {
-                self.writeAll("\n");
-            }
-            flushWriter(self.writer);
-        }
-
-        /// Finish with a custom message
-        pub fn finishWithMessage(self: *Self, message: []const u8) void {
-            self.message = message;
-            self.finish();
-        }
-
-        fn writeAll(self: *Self, data: []const u8) void {
-            self.writer.writeAll(data) catch {};
-        }
-
-        fn render(self: *Self) void {
-            const percent = if (self.config.total > 0)
-                (self.current * 100) / self.config.total
-            else
-                0;
-
-            const filled = if (self.config.total > 0)
-                (self.current * self.config.width) / self.config.total
-            else
-                0;
-            const empty = self.config.width - filled;
-
-            if (self.is_tty) {
-                self.writeAll("\r\x1b[K");
-            }
-
-            // Prefix
-            if (self.config.prefix.len > 0) {
-                self.writeAll(self.config.prefix);
-            }
-
-            // Message
-            if (self.message.len > 0) {
-                self.writeAll(self.message);
-                self.writeAll(" ");
-            }
-
-            // Bar (styled only on a TTY, like the spinner — piped output stays plain)
-            const ctx = self.config.theme;
-            const tokens = ctx.progressTokens();
-            self.writeAll("[");
-            if (filled > 0) {
-                const wrote = self.is_tty and (ctx.resolveRef(tokens.bar_fill).writeSequence(self.writer, ctx.capability()) catch false);
-                for (0..filled) |_| {
-                    self.writeAll(self.config.complete_char);
-                }
-                if (wrote) self.writeAll("\x1b[0m");
-            }
-            if (empty > 0) {
-                const wrote = self.is_tty and (ctx.resolveRef(tokens.bar_empty).writeSequence(self.writer, ctx.capability()) catch false);
-                for (0..empty) |_| {
-                    self.writeAll(self.config.incomplete_char);
-                }
-                if (wrote) self.writeAll("\x1b[0m");
-            }
-            self.writeAll("]");
-
-            // Percentage
-            if (self.config.show_percentage) {
-                var buf: [8]u8 = undefined;
-                const percent_str = std.fmt.bufPrint(&buf, " {d:>3}%", .{percent}) catch "???%";
-                self.writeAll(percent_str);
-            }
-
-            // Current/Total
-            var count_buf: [32]u8 = undefined;
-            const count_str = std.fmt.bufPrint(&count_buf, " {d}/{d}", .{ self.current, self.config.total }) catch "";
-            self.writeAll(count_str);
-
-            // ETA
-            if (self.config.show_eta and self.current > 0) {
-                const elapsed = self.nowMs() - self.start_time;
-                if (elapsed > 0 and self.current < self.config.total) {
-                    const remaining = self.config.total - self.current;
-                    const ms_per_item: i64 = @divTrunc(elapsed, @as(i64, @intCast(self.current)));
-                    const eta_ms: i64 = ms_per_item * @as(i64, @intCast(remaining));
-                    const eta_secs: u64 = @intCast(@divTrunc(eta_ms, 1000));
-
-                    var eta_buf: [16]u8 = undefined;
-                    const eta_str = formatDuration(eta_secs, &eta_buf);
-                    self.writeAll(" ETA: ");
-                    self.writeAll(eta_str);
-                }
-            }
-
-            // Elapsed
-            if (self.config.show_elapsed) {
-                const elapsed_ms = self.nowMs() - self.start_time;
-                const elapsed_secs: u64 = @intCast(@divTrunc(elapsed_ms, 1000));
-
-                var elapsed_buf: [16]u8 = undefined;
-                const elapsed_str = formatDuration(elapsed_secs, &elapsed_buf);
-                self.writeAll(" [");
-                self.writeAll(elapsed_str);
-                self.writeAll("]");
-            }
-
-            // Rate
-            if (self.config.show_rate and self.current > 0) {
-                const elapsed_ms = self.nowMs() - self.start_time;
-                if (elapsed_ms > 0) {
-                    const rate: f64 = @as(f64, @floatFromInt(self.current)) / (@as(f64, @floatFromInt(elapsed_ms)) / 1000.0);
-
-                    var rate_buf: [16]u8 = undefined;
-                    const rate_str = std.fmt.bufPrint(&rate_buf, " {d:.1}/s", .{rate}) catch "";
-                    self.writeAll(rate_str);
-                }
-            }
-
-            // Suffix
-            if (self.config.suffix.len > 0) {
-                self.writeAll(self.config.suffix);
-            }
-
-            // For non-TTY, add newline since we can't overwrite
-            if (!self.is_tty) {
-                self.writeAll("\n");
-            }
-            flushWriter(self.writer);
-        }
-    };
+fn nowMsIo(io: std.Io) i64 {
+    return @intCast(@divTrunc(std.Io.Clock.Timestamp.now(io, .awake).raw.nanoseconds, std.time.ns_per_ms));
 }
 
 /// Format duration in seconds to human readable string
@@ -551,21 +594,6 @@ fn formatDuration(secs: u64, buf: []u8) []const u8 {
     }
 }
 
-/// Detect if stdout is a TTY
-fn detectTTY() bool {
-    // Use direct handle check without io
-    return terminal.isStdoutTty();
-}
-
-/// Flush a writer if it supports flushing. Works with both pointer and value writer types.
-fn flushWriter(writer: anytype) void {
-    const W = @TypeOf(writer);
-    const T = if (@typeInfo(W) == .pointer) @typeInfo(W).pointer.child else W;
-    if (@hasDecl(T, "flush")) {
-        writer.flush() catch {};
-    }
-}
-
 // Thread-local buffer for stdout writer
 threadlocal var stdout_buffer: [4096]u8 = undefined;
 threadlocal var stdout_writer_storage: std.Io.File.Writer = undefined;
@@ -580,196 +608,199 @@ fn getStdoutWriter(io: std.Io) *std.Io.Writer {
 }
 
 /// Create a spinner with the default writer (stdout)
-pub fn spinner(io: std.Io, config: SpinnerConfig) Spinner(*std.Io.Writer) {
-    return Spinner(*std.Io.Writer).init(getStdoutWriter(io), io, config);
+pub fn spinner(allocator: std.mem.Allocator, io: std.Io, config: SpinnerConfig) !Spinner {
+    return Spinner.init(allocator, getStdoutWriter(io), io, config);
 }
 
 /// Create a progress bar with the default writer (stdout)
-pub fn progressBar(io: std.Io, config: ProgressBarConfig) ProgressBar(*std.Io.Writer) {
-    return ProgressBar(*std.Io.Writer).init(getStdoutWriter(io), io, config);
+pub fn progressBar(allocator: std.mem.Allocator, io: std.Io, config: ProgressBarConfig) !ProgressBar {
+    return ProgressBar.init(allocator, getStdoutWriter(io), io, config);
+}
+
+/// Create a multi-bar with the default writer (stdout)
+pub fn multiBar(allocator: std.mem.Allocator, io: std.Io, config: MultiBarConfig) !MultiBar {
+    return MultiBar.init(allocator, getStdoutWriter(io), io, config);
 }
 
 // ============================================================================
-// Tests
+// Tests (vterm golden-frame tests live in vterm_test.zig)
 // ============================================================================
+
+const testing = std.testing;
+
+/// Force a test indicator into interactive mode with a fixed terminal —
+/// tests never have a real TTY, and App must not poll for one.
+fn forceInteractive(app: *ui.App) void {
+    app.options.interactive = true;
+    app.options.term_size = .{ .w = 80, .h = 24 };
+}
 
 test "spinner style frames" {
     const dots_frames = SpinnerStyle.dots.frames();
-    try std.testing.expect(dots_frames.len > 0);
-    try std.testing.expectEqualStrings("⠋", dots_frames[0]);
+    try testing.expect(dots_frames.len > 0);
+    try testing.expectEqualStrings("⠋", dots_frames[0]);
 
     const simple_frames = SpinnerStyle.simple.frames();
-    try std.testing.expect(simple_frames.len == 4);
+    try testing.expect(simple_frames.len == 4);
 }
 
 test "spinner style intervals" {
-    try std.testing.expect(SpinnerStyle.dots.interval() > 0);
-    try std.testing.expect(SpinnerStyle.clock.interval() > SpinnerStyle.dots.interval());
+    try testing.expect(SpinnerStyle.dots.interval() > 0);
+    try testing.expect(SpinnerStyle.clock.interval() > SpinnerStyle.dots.interval());
 }
 
 test "format duration" {
     var buf: [16]u8 = undefined;
 
-    try std.testing.expectEqualStrings("5s", formatDuration(5, &buf));
-    try std.testing.expectEqualStrings("1m30s", formatDuration(90, &buf));
-    try std.testing.expectEqualStrings("1h30m", formatDuration(5400, &buf));
+    try testing.expectEqualStrings("5s", formatDuration(5, &buf));
+    try testing.expectEqualStrings("1m30s", formatDuration(90, &buf));
+    try testing.expectEqualStrings("1h30m", formatDuration(5400, &buf));
 }
 
 test "spinner initialization" {
     var output: [1024]u8 = undefined;
     var writer: std.Io.Writer = .fixed(&output);
 
-    const s = Spinner(@TypeOf(&writer)).init(&writer, std.testing.io, .{});
-    try std.testing.expect(!s.active);
-    try std.testing.expectEqual(@as(usize, 0), s.frame_index);
+    var s = try Spinner.init(testing.allocator, &writer, testing.io, .{});
+    defer s.deinit();
+    try testing.expect(!s.active);
+    try testing.expectEqual(@as(usize, 0), s.tick);
 }
 
-test "spinner animates and finishes on a TTY" {
-    var output: [4096]u8 = undefined;
+test "spinner animates and finishes when interactive" {
+    var output: [8192]u8 = undefined;
     var writer: std.Io.Writer = .fixed(&output);
 
-    var s = Spinner(@TypeOf(&writer)).init(&writer, std.testing.io, .{});
-    s.is_tty = true; // force the TTY path; the fixed writer captures ANSI output
+    var s = try Spinner.init(testing.allocator, &writer, testing.io, .{});
+    forceInteractive(&s.app);
 
     s.start("working");
-    s.setText("still working");
+    s.setMessage("still working");
     s.succeed("done");
 
-    try std.testing.expect(!s.active);
-    try std.testing.expect(s.animation == null);
+    try testing.expect(!s.active);
+    try testing.expect(s.animation == null);
     const written = writer.buffered();
-    try std.testing.expect(std.mem.indexOf(u8, written, "working") != null);
-    try std.testing.expect(std.mem.indexOf(u8, written, "done") != null);
-    try std.testing.expect(std.mem.indexOf(u8, written, "\x1b[?25h") != null); // cursor restored
+    try testing.expect(std.mem.indexOf(u8, written, "working") != null);
+    try testing.expect(std.mem.indexOf(u8, written, "done") != null);
+    try testing.expect(std.mem.indexOf(u8, written, "\x1b[?25h") != null); // cursor restored
 }
 
-test "spinner prints status lines when not a TTY" {
-    var output: [4096]u8 = undefined;
+test "spinner prints status lines when not interactive" {
+    var output: [8192]u8 = undefined;
     var writer: std.Io.Writer = .fixed(&output);
 
-    var s = Spinner(@TypeOf(&writer)).init(&writer, std.testing.io, .{});
-    s.is_tty = false;
+    var s = try Spinner.init(testing.allocator, &writer, testing.io, .{});
+    s.app.options.interactive = false;
 
     s.start("connecting");
-    s.setText("uploading");
+    s.setMessage("uploading");
     s.succeed("synced");
 
     const written = writer.buffered();
-    try std.testing.expect(std.mem.indexOf(u8, written, "- connecting\n") != null);
-    try std.testing.expect(std.mem.indexOf(u8, written, "- uploading\n") != null);
-    try std.testing.expect(std.mem.indexOf(u8, written, " synced\n") != null);
+    try testing.expect(std.mem.indexOf(u8, written, "- connecting\n") != null);
+    try testing.expect(std.mem.indexOf(u8, written, "- uploading\n") != null);
+    try testing.expect(std.mem.indexOf(u8, written, " synced\n") != null);
+    // Plain output: no escapes at all.
+    try testing.expect(std.mem.indexOfScalar(u8, written, 0x1b) == null);
 }
 
 test "spinner result symbols style through the palette roles" {
-    var output: [4096]u8 = undefined;
+    var output: [8192]u8 = undefined;
     var writer: std.Io.Writer = .fixed(&output);
 
     const custom = theme.Theme{
         .palette = .{ .success = .{ .foreground = .{ .rgb = .{ .r = 1, .g = 2, .b = 3 } } } },
     };
-    var s = Spinner(@TypeOf(&writer)).init(&writer, std.testing.io, .{
+    var s = try Spinner.init(testing.allocator, &writer, testing.io, .{
         .theme = .{
             .theme = &custom,
             .caps = .{ .capability = .true_color, .is_tty = true, .color_enabled = true },
         },
     });
-    s.is_tty = true;
+    forceInteractive(&s.app);
 
     s.start("working");
     s.succeed("done");
 
-    try std.testing.expect(std.mem.indexOf(u8, writer.buffered(), "38;2;1;2;3") != null);
+    try testing.expect(std.mem.indexOf(u8, writer.buffered(), "38;2;1;2;3") != null);
 }
 
 test "spinner frame styles through the progress.spinner token" {
-    var output: [4096]u8 = undefined;
+    var output: [8192]u8 = undefined;
     var writer: std.Io.Writer = .fixed(&output);
 
     const custom = theme.Theme{
         .progress = .{ .spinner = .{ .style = .{ .foreground = .{ .rgb = .{ .r = 9, .g = 8, .b = 7 } } } } },
     };
-    var s = Spinner(@TypeOf(&writer)).init(&writer, std.testing.io, .{
+    var s = try Spinner.init(testing.allocator, &writer, testing.io, .{
         .theme = .{
             .theme = &custom,
             .caps = .{ .capability = .true_color, .is_tty = true, .color_enabled = true },
         },
     });
-    s.is_tty = true;
+    forceInteractive(&s.app);
 
     s.start("working");
     s.stop();
 
-    try std.testing.expect(std.mem.indexOf(u8, writer.buffered(), "38;2;9;8;7") != null);
+    try testing.expect(std.mem.indexOf(u8, writer.buffered(), "38;2;9;8;7") != null);
 }
 
 test "spinner renders no color sequences under no_color" {
-    var output: [4096]u8 = undefined;
+    var output: [8192]u8 = undefined;
     var writer: std.Io.Writer = .fixed(&output);
 
-    var s = Spinner(@TypeOf(&writer)).init(&writer, std.testing.io, .{
+    var s = try Spinner.init(testing.allocator, &writer, testing.io, .{
         .theme = .{ .caps = .{ .capability = .no_color, .is_tty = true, .color_enabled = false } },
     });
-    s.is_tty = true;
+    forceInteractive(&s.app);
 
     s.start("working");
     s.succeed("done");
 
     const written = writer.buffered();
-    try std.testing.expect(std.mem.indexOf(u8, written, "done") != null);
+    try testing.expect(std.mem.indexOf(u8, written, "done") != null);
     // Cursor-control escapes remain; SGR color/attribute sequences must not
-    try std.testing.expect(std.mem.indexOf(u8, written, "38;2") == null);
-    try std.testing.expect(std.mem.indexOf(u8, written, "\x1b[0m") == null);
+    try testing.expect(std.mem.indexOf(u8, written, "38;2") == null);
+    try testing.expect(std.mem.indexOf(u8, written, "\x1b[0m") == null);
 }
 
 test "progress bar initialization" {
     var output: [1024]u8 = undefined;
     var writer: std.Io.Writer = .fixed(&output);
 
-    const bar = ProgressBar(@TypeOf(&writer)).init(&writer, std.testing.io, .{
+    var bar = try ProgressBar.init(testing.allocator, &writer, testing.io, .{
         .total = 100,
         .width = 20,
     });
-    try std.testing.expectEqual(@as(usize, 0), bar.current);
-    try std.testing.expectEqual(@as(usize, 100), bar.config.total);
+    defer bar.deinit();
+    try testing.expectEqual(@as(usize, 0), bar.current);
+    try testing.expectEqual(@as(usize, 100), bar.config.total);
 }
 
-test "progress bar update" {
-    var output: [4096]u8 = undefined;
+test "progress bar update and increment clamp to total" {
+    var output: [8192]u8 = undefined;
     var writer: std.Io.Writer = .fixed(&output);
 
-    var bar = ProgressBar(@TypeOf(&writer)).init(&writer, std.testing.io, .{
+    var bar = try ProgressBar.init(testing.allocator, &writer, testing.io, .{
         .total = 100,
         .width = 10,
         .show_eta = false,
     });
-
-    // Mock non-TTY behavior for testing
-    bar.is_tty = false;
+    defer bar.deinit();
+    bar.app.options.interactive = false;
 
     bar.update(50, null);
-    try std.testing.expect(bar.current == 50);
-}
-
-test "progress bar increment" {
-    var output: [4096]u8 = undefined;
-    var writer: std.Io.Writer = .fixed(&output);
-
-    var bar = ProgressBar(@TypeOf(&writer)).init(&writer, std.testing.io, .{
-        .total = 100,
-        .width = 10,
-        .show_eta = false,
-    });
-    bar.is_tty = false;
-
+    try testing.expect(bar.current == 50);
     bar.increment(10);
-    try std.testing.expect(bar.current == 10);
-
-    bar.increment(5);
-    try std.testing.expect(bar.current == 15);
+    try testing.expect(bar.current == 60);
+    bar.update(150, null);
+    try testing.expect(bar.current == 100);
 }
 
-test "progress bar styles fill and empty through the theme tokens on a TTY" {
-    var output: [4096]u8 = undefined;
+test "progress bar styles fill and empty through the theme tokens" {
+    var output: [16384]u8 = undefined;
     var writer: std.Io.Writer = .fixed(&output);
 
     const custom = theme.Theme{
@@ -778,7 +809,7 @@ test "progress bar styles fill and empty through the theme tokens on a TTY" {
             .bar_empty = .{ .style = .{ .foreground = .{ .rgb = .{ .r = 4, .g = 5, .b = 6 } } } },
         },
     };
-    var bar = ProgressBar(@TypeOf(&writer)).init(&writer, std.testing.io, .{
+    var bar = try ProgressBar.init(testing.allocator, &writer, testing.io, .{
         .total = 10,
         .width = 10,
         .show_eta = false,
@@ -787,41 +818,71 @@ test "progress bar styles fill and empty through the theme tokens on a TTY" {
             .caps = .{ .capability = .true_color, .is_tty = true, .color_enabled = true },
         },
     });
-    bar.is_tty = true;
+    defer bar.deinit();
+    forceInteractive(&bar.app);
 
     bar.update(5, null);
 
     const written = writer.buffered();
-    try std.testing.expect(std.mem.indexOf(u8, written, "38;2;1;2;3") != null); // fill
-    try std.testing.expect(std.mem.indexOf(u8, written, "38;2;4;5;6") != null); // empty
+    try testing.expect(std.mem.indexOf(u8, written, "38;2;1;2;3") != null); // fill
+    try testing.expect(std.mem.indexOf(u8, written, "38;2;4;5;6") != null); // empty
 }
 
-test "progress bar stays plain when piped (non-TTY)" {
-    var output: [4096]u8 = undefined;
+test "progress bar is silent when piped, except one finish line" {
+    var output: [8192]u8 = undefined;
     var writer: std.Io.Writer = .fixed(&output);
 
-    var bar = ProgressBar(@TypeOf(&writer)).init(&writer, std.testing.io, .{
+    var bar = try ProgressBar.init(testing.allocator, &writer, testing.io, .{
         .total = 10,
-        .width = 10,
         .show_eta = false,
     });
-    bar.is_tty = false;
+    bar.app.options.interactive = false;
 
     bar.update(5, null);
+    try testing.expectEqual(@as(usize, 0), writer.buffered().len);
 
-    try std.testing.expect(std.mem.indexOf(u8, writer.buffered(), "\x1b[") == null);
+    bar.finishWithMessage("imported");
+    const written = writer.buffered();
+    try testing.expectEqualStrings("imported 10/10 (100%)\n", written);
+    try testing.expect(std.mem.indexOfScalar(u8, written, 0x1b) == null);
 }
 
-test "progress bar does not exceed total" {
-    var output: [4096]u8 = undefined;
+test "multi bar tracks items and clamps" {
+    var output: [8192]u8 = undefined;
     var writer: std.Io.Writer = .fixed(&output);
 
-    var bar = ProgressBar(@TypeOf(&writer)).init(&writer, std.testing.io, .{
-        .total = 100,
-        .show_eta = false,
-    });
-    bar.is_tty = false;
+    var mb = try MultiBar.init(testing.allocator, &writer, testing.io, .{});
+    defer mb.deinit();
+    mb.app.options.interactive = false;
 
-    bar.update(150, null);
-    try std.testing.expect(bar.current == 100);
+    const a_bar = try mb.add("api", 100);
+    const b_bar = try mb.add("assets", 50);
+    mb.set(a_bar, 42);
+    mb.increment(b_bar, 60); // clamps at 50
+    try testing.expectEqual(@as(usize, 42), mb.items.items[a_bar].current);
+    try testing.expectEqual(@as(usize, 50), mb.items.items[b_bar].current);
+    // Piped: silent.
+    try testing.expectEqual(@as(usize, 0), writer.buffered().len);
+    mb.finish();
+}
+
+test "multi bar renders labels, bars, and percents when interactive" {
+    var output: [32768]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&output);
+
+    var mb = try MultiBar.init(testing.allocator, &writer, testing.io, .{});
+    defer mb.deinit();
+    forceInteractive(&mb.app);
+
+    const h = try mb.add("api.tar.gz", 100);
+    mb.set(h, 50);
+    mb.finish();
+
+    // Byte-level assertions only see the first full paint — an update diffs
+    // down to the changed cells (vterm_test.zig asserts the updated screen).
+    const written = writer.buffered();
+    try testing.expect(std.mem.indexOf(u8, written, "api.tar.gz") != null);
+    try testing.expect(std.mem.indexOf(u8, written, "  0%") != null);
+    try testing.expect(std.mem.indexOf(u8, written, "░") != null);
+    try testing.expect(std.mem.indexOf(u8, written, "█") != null); // from the 50% diff
 }

--- a/packages/progress/src/test.zig
+++ b/packages/progress/src/test.zig
@@ -1,0 +1,8 @@
+//! Test root for the progress package. Rooted here (not at progress.zig) so
+//! the vterm golden-frame harness is a test-only import, never a dependency
+//! of the shipped module.
+
+test {
+    _ = @import("progress.zig");
+    _ = @import("vterm_test.zig");
+}

--- a/packages/progress/src/vterm_test.zig
+++ b/packages/progress/src/vterm_test.zig
@@ -1,0 +1,119 @@
+//! Golden-frame tests: drive the indicators through a virtual terminal and
+//! assert what a user sees — the finish-line contract (result persists as a
+//! static line, live region gone) is the heart of the ui-engine port.
+
+const std = @import("std");
+const vterm = @import("vterm");
+const progress = @import("progress.zig");
+
+const testing = std.testing;
+const VTerm = vterm.VTerm;
+
+const Capture = struct {
+    aw: std.Io.Writer.Allocating,
+    vt: VTerm,
+    fed: usize = 0,
+
+    fn init(w: u16, h: u16) !Capture {
+        return .{
+            .aw = std.Io.Writer.Allocating.init(testing.allocator),
+            .vt = try VTerm.init(testing.allocator, w, h),
+        };
+    }
+
+    fn deinit(self: *Capture) void {
+        self.vt.deinit();
+        self.aw.deinit();
+    }
+
+    fn replay(self: *Capture) void {
+        self.vt.write(self.aw.written()[self.fed..]);
+        self.fed = self.aw.written().len;
+    }
+};
+
+fn force(app: anytype, w: u16, h: u16) void {
+    app.options.interactive = true;
+    app.options.term_size = .{ .w = w, .h = h };
+}
+
+test "spinner succeed replaces the live line with one static result line" {
+    var c = try Capture.init(40, 6);
+    defer c.deinit();
+
+    var s = try progress.Spinner.init(testing.allocator, &c.aw.writer, testing.io, .{});
+    force(&s.app, 40, 6);
+
+    s.start("working on it");
+    c.replay();
+    try testing.expect(c.vt.containsText("working on it"));
+
+    s.succeed("all done");
+    c.replay();
+    try testing.expect(c.vt.containsText("all done"));
+    try testing.expect(!c.vt.containsText("working on it"));
+    // The result is a static line at the top; the cursor is restored and
+    // parked at the start of the next line, ready for normal output.
+    const line0 = try c.vt.getLine(testing.allocator, 0);
+    defer testing.allocator.free(line0);
+    try testing.expect(std.mem.indexOf(u8, line0, "all done") != null);
+    try testing.expect(c.vt.cursor_visible);
+    try testing.expect(c.vt.cursorAt(0, 1));
+}
+
+test "progress bar final frame persists below earlier output" {
+    var c = try Capture.init(60, 6);
+    defer c.deinit();
+
+    var bar = try progress.ProgressBar.init(testing.allocator, &c.aw.writer, testing.io, .{
+        .total = 10,
+        .width = 10,
+        .show_eta = false,
+    });
+    force(&bar.app, 60, 6);
+
+    bar.update(5, "importing");
+    c.replay();
+    try testing.expect(c.vt.containsText("importing"));
+    try testing.expect(c.vt.containsText("50%"));
+
+    bar.finish();
+    c.replay();
+    try testing.expect(c.vt.containsText("100%"));
+    try testing.expect(c.vt.containsText("10/10"));
+    try testing.expect(c.vt.cursor_visible);
+}
+
+test "multi bar stacks one row per item and updates in place" {
+    var c = try Capture.init(60, 8);
+    defer c.deinit();
+
+    var mb = try progress.MultiBar.init(testing.allocator, &c.aw.writer, testing.io, .{});
+    defer mb.deinit();
+    force(&mb.app, 60, 8);
+
+    const api = try mb.add("api", 100);
+    const assets = try mb.add("assets", 100);
+    c.replay();
+    try testing.expect(c.vt.containsText("api"));
+    try testing.expect(c.vt.containsText("assets"));
+    try testing.expect(c.vt.containsText("  0%"));
+
+    mb.set(api, 50);
+    mb.set(assets, 100);
+    c.replay();
+    try testing.expect(c.vt.containsText(" 50%"));
+    try testing.expect(c.vt.containsText("100%"));
+
+    // Rows are stable: api on row 0, assets on row 1.
+    const line0 = try c.vt.getLine(testing.allocator, 0);
+    defer testing.allocator.free(line0);
+    const line1 = try c.vt.getLine(testing.allocator, 1);
+    defer testing.allocator.free(line1);
+    try testing.expect(std.mem.startsWith(u8, line0, "api"));
+    try testing.expect(std.mem.startsWith(u8, line1, "assets"));
+
+    mb.finish();
+    c.replay();
+    try testing.expect(c.vt.cursor_visible);
+}

--- a/packages/ui/src/app.zig
+++ b/packages/ui/src/app.zig
@@ -50,6 +50,12 @@ pub const App = struct {
         /// real terminal on every frame, which is what makes the live
         /// region re-layout on resize.
         term_size: ?Size = null,
+        /// Whether the output is a live terminal (callers pass
+        /// `terminal.isStdoutTty()`). When false — piped to a file, CI —
+        /// the App degrades to plain line output: `frame` is a no-op,
+        /// `emit` prints without escapes or retention, the cursor is never
+        /// touched.
+        interactive: bool = true,
     };
 
     /// A static block kept for the resize tail repaint (ADR-0013 resize
@@ -125,6 +131,12 @@ pub const App = struct {
     /// resize can reflow the visible tail (ADR-0013 resize tier 2).
     pub fn emit(self: *App, comptime fmt: []const u8, args: anytype) !void {
         const line_fmt = comptime if (std.mem.endsWith(u8, fmt, "\n")) fmt else fmt ++ "\n";
+        if (!self.options.interactive) {
+            // Plain line output: no live region exists, nothing to retain.
+            try self.writer.print(line_fmt, args);
+            try self.writer.flush();
+            return;
+        }
         const ts = self.termSize();
         self.last_width = ts.w;
 
@@ -147,8 +159,10 @@ pub const App = struct {
 
     /// Live output: measure, lay out, paint the diff. The tree (built from
     /// `self.arena()`) is consumed — the arena resets when this returns.
+    /// A no-op when the output is not interactive.
     pub fn frame(self: *App, node: Node) !void {
         defer _ = self.frame_arena.reset(.retain_capacity);
+        if (!self.options.interactive) return;
 
         const ts = self.termSize();
         const width_changed = self.last_width != null and self.last_width.? != ts.w;
@@ -211,6 +225,14 @@ pub const App = struct {
         std.mem.swap(Surface, &self.front, &self.back);
         self.front_valid = true;
         if (tail_repaint and self.options.sync) try self.writer.writeAll("\x1b[?2026l");
+        try self.writer.flush();
+    }
+
+    /// Erase the live region and leave nothing in its place — the ending
+    /// for a widget whose result is an `emit`ted line (or no output at
+    /// all), as opposed to `deinit`'s leave-the-final-frame-visible.
+    pub fn clear(self: *App) !void {
+        try self.clearLive();
         try self.writer.flush();
     }
 

--- a/packages/ui/src/app_test.zig
+++ b/packages/ui/src/app_test.zig
@@ -281,6 +281,47 @@ test "height-only change does not disturb the static tail" {
     try testing.expect(h.vt.containsText("running"));
 }
 
+test "non-interactive App degrades to plain line output" {
+    var aw = std.Io.Writer.Allocating.init(testing.allocator);
+    defer aw.deinit();
+    var app = try ui.App.init(testing.allocator, &aw.writer, .{
+        .term_size = .{ .w = 30, .h = 8 },
+        .interactive = false,
+    });
+    defer app.deinit();
+
+    const a = app.arena();
+    try app.frame(try ui.column(a, .{}, &.{ui.text(.{ .bold = true }, "live")}));
+    try testing.expectEqual(@as(usize, 0), aw.written().len);
+
+    try app.emit("plain {s}", .{"line"});
+    try testing.expectEqualStrings("plain line\n", aw.written());
+
+    app.deinit();
+    app = try ui.App.init(testing.allocator, &aw.writer, .{ .interactive = false });
+    // No escapes anywhere: no cursor hide/show, no clears, no SGR.
+    try testing.expect(std.mem.indexOfScalar(u8, aw.written(), 0x1b) == null);
+}
+
+test "clear erases the live region leaving nothing" {
+    var h = try Harness.init(30, 8);
+    defer h.deinit();
+
+    try h.app.frame(try h.statusFrame("busy"));
+    h.replay();
+    try testing.expect(h.vt.containsText("busy"));
+
+    try h.app.clear();
+    h.replay();
+    try testing.expect(!h.vt.containsText("busy"));
+    try testing.expectEqual(@as(u16, 0), h.app.live_rows);
+    // A following emit must not resurrect the region.
+    try h.app.emit("done", .{});
+    h.replay();
+    try testing.expect(h.vt.containsText("done"));
+    try testing.expect(!h.vt.containsText("busy"));
+}
+
 test "deinit shows the cursor and parks below the live region" {
     var h = try Harness.init(30, 8);
     defer h.deinit();


### PR DESCRIPTION
## What

PR 1 of the approved migration plan (`.context/ui-migration-plan.md`): the progress package keeps its ora-style API but renders through the engine — frames are node trees diffed by a `ui.App`, and every finish path is emit/clear/deinit. The persisted result line (`succeed("Done!")`) is now literally static output flowing into scrollback. All hand-rolled ANSI is deleted; the concurrency shape (io.concurrent + mutex) is unchanged, just guarding the App instead of a raw writer.

**New capability: `MultiBar`** — stacked labeled bars for parallel work, thread-safe `set`/`increment` from workers, final frame persists on finish.

**App groundwork** (separate commit): `Options.interactive` — piped output degrades to plain lines (frame no-ops, emit prints clean text) — and `clear()` for erase-and-emit endings.

## Breaking (all approved)

- `spinner()`/`progressBar()` take an allocator and return errors; types are no longer writer-generic
- Renames: `setText` → `setMessage`, `stopAndPersist` → `persist`
- `SpinnerConfig.hide_cursor` removed — the engine owns the cursor
- Piped bars: silent until one finish summary line (was a full bar line per update — CI log spam)
- `deinit()` added (idempotent); finish paths close the App

## Testing

Behavioral suite adapted (forced-interactive App replaces the old `is_tty` flag), plus vterm golden tests for the finish-line contract: `succeed` replaces the live line with exactly one static result line + restored cursor; bar final frames persist; multi-bar rows update in place. One test found the diff renderer working as intended: a 0%→50% update emits only the changed digit cell. Consumers (tasks example) and READMEs updated; full repo suite green.

Next: PR 2 (prompts), PR 3 (`zcli.ui` + `context.ui()`), PR 4 (sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)