### PR TITLE
prompts: list prompts on the ui engine (migration plan PR 2a)

### DIFF
--- a/packages/prompts/build.zig
+++ b/packages/prompts/build.zig
@@ -6,6 +6,7 @@ pub fn build(b: *std.Build) void {
 
     const terminal_dep = b.dependency("terminal", .{ .target = target, .optimize = optimize });
     const theme_dep = b.dependency("theme", .{ .target = target, .optimize = optimize });
+    const ui_dep = b.dependency("ui", .{ .target = target, .optimize = optimize });
 
     const prompts_mod = b.addModule("prompts", .{
         .root_source_file = b.path("src/Prompts.zig"),
@@ -14,6 +15,7 @@ pub fn build(b: *std.Build) void {
     });
     prompts_mod.addImport("terminal", terminal_dep.module("terminal"));
     prompts_mod.addImport("theme", theme_dep.module("theme"));
+    prompts_mod.addImport("ui", ui_dep.module("ui"));
 
     const test_step = b.step("test", "Run prompts tests");
     const test_mod = b.addModule("test-prompts", .{
@@ -23,6 +25,7 @@ pub fn build(b: *std.Build) void {
     });
     test_mod.addImport("terminal", terminal_dep.module("terminal"));
     test_mod.addImport("theme", theme_dep.module("theme"));
+    test_mod.addImport("ui", ui_dep.module("ui"));
     const tests = b.addTest(.{ .root_module = test_mod });
     test_step.dependOn(&b.addRunArtifact(tests).step);
 
@@ -38,6 +41,7 @@ pub fn build(b: *std.Build) void {
     });
     render_e2e_mod.addImport("prompts", prompts_mod);
     render_e2e_mod.addImport("vterm", vterm_dep.module("vterm"));
+    render_e2e_mod.addImport("ui", ui_dep.module("ui"));
     const render_e2e_tests = b.addTest(.{ .root_module = render_e2e_mod });
     test_step.dependOn(&b.addRunArtifact(render_e2e_tests).step);
 

--- a/packages/prompts/build.zig.zon
+++ b/packages/prompts/build.zig.zon
@@ -5,6 +5,7 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .terminal = .{ .path = "../terminal" },
+        .ui = .{ .path = "../ui" },
         .theme = .{ .path = "../theme" },
         // Test-only: the render_e2e tests replay prompt output through the vterm
         // emulator. Only the test module imports it; the shipped `prompts` module

--- a/packages/prompts/src/list_render.zig
+++ b/packages/prompts/src/list_render.zig
@@ -154,3 +154,39 @@ test "renderItem hang-indents continuation lines under the label" {
     try testing.expect(std.mem.indexOf(u8, w.buffered(), "  > alpha") != null);
     try testing.expect(std.mem.indexOf(u8, w.buffered(), "\r\n    ") != null);
 }
+
+// ---------------------------------------------------------------------------
+// Node builders for the ui-engine render path (ADR-0013 migration). The
+// imperative renderItem/eraseRegion machinery above remains until the line
+// prompts migrate too, then gets swept.
+// ---------------------------------------------------------------------------
+
+pub const ui = @import("ui");
+
+/// One list row for the engine: a fixed-width prefix cell and a wrapped label
+/// of `label_w` columns. The hang indent the imperative path computed by hand
+/// falls out of the layout — the prefix cell is one line tall, so a wrapped
+/// label's continuation lines get blank cells beneath it. The label width is
+/// explicit (not `fill`) so the row's measured height includes the wrap — a
+/// fill child contributes nothing at measure time (ADR-0013 §5) and would
+/// under-reserve the live region.
+pub fn itemRow(
+    a: std.mem.Allocator,
+    prefix: ui.Node,
+    prefix_w: u16,
+    label: []const u8,
+    label_w: u16,
+    label_style: ui.Style,
+) !ui.Node {
+    var p = prefix;
+    p.width = .{ .len = prefix_w };
+    return ui.row(a, .{}, &.{
+        p,
+        ui.textOpts(.{ .style = label_style, .width = .{ .len = label_w } }, label),
+    });
+}
+
+/// A single-style clipped prefix cell (glyphs never word-wrap).
+pub fn prefixCell(style: ui.Style, content: []const u8) ui.Node {
+    return ui.textOpts(.{ .style = style, .wrap = .clip }, content);
+}

--- a/packages/prompts/src/multi_select.zig
+++ b/packages/prompts/src/multi_select.zig
@@ -1,9 +1,14 @@
 //! Multi-selection prompt with toggle via space key.
+//!
+//! Rendering runs on the ui engine (see select.zig); input handling stays
+//! here. Toggling a marker repaints exactly one cell — the frame diff does
+//! the rest.
 
 const std = @import("std");
 const terminal = @import("terminal");
 const Prompts = @import("Prompts.zig");
 const lr = @import("list_render.zig");
+const ui = lr.ui;
 
 pub const MultiSelectConfig = struct {
     message: []const u8,
@@ -53,14 +58,17 @@ pub fn multiSelect(p: Prompts, config: MultiSelectConfig) ![]usize {
     const raw = terminal.enableRawMode(std.Io.File.stdin().handle) catch {
         return collectDefaults(allocator, config);
     };
-    try writer.writeAll(terminal.ansi.hide_cursor);
     var watcher = terminal.ResizeWatcher.init();
     defer {
-        writer.writeAll(terminal.ansi.show_cursor) catch {};
         watcher.deinit();
         raw.disable();
         Prompts.flushWriter(writer);
     }
+    var app = try ui.App.init(p.allocator, writer, .{
+        .capability = p.theme.capability(),
+        .unicode = config.unicode,
+    });
+    defer app.deinit();
 
     var selected = try allocator.alloc(bool, config.choices.len);
     defer allocator.free(selected);
@@ -74,48 +82,40 @@ pub fn multiSelect(p: Prompts, config: MultiSelectConfig) ![]usize {
 
     const stdin = std.Io.File.stdin().handle;
     var cursor: usize = 0;
-    var rows = try renderList(writer, p.theme, config, selected, cursor, lr.windowSize());
+    try renderFrame(&app, p.theme, config, selected, cursor);
 
     while (true) {
-        Prompts.flushWriter(writer);
         switch (try terminal.readEvent(reader, stdin, &watcher)) {
-            .resize => {
-                try lr.eraseRegion(writer, rows);
-                rows = try renderList(writer, p.theme, config, selected, cursor, lr.windowSize());
-            },
+            .resize => try renderFrame(&app, p.theme, config, selected, cursor),
             .key => |k| switch (k) {
                 .up => {
                     if (cursor > 0) cursor -= 1;
-                    try lr.eraseRegion(writer, rows);
-                    rows = try renderList(writer, p.theme, config, selected, cursor, lr.windowSize());
+                    try renderFrame(&app, p.theme, config, selected, cursor);
                 },
                 .down => {
                     if (cursor < config.choices.len - 1) cursor += 1;
-                    try lr.eraseRegion(writer, rows);
-                    rows = try renderList(writer, p.theme, config, selected, cursor, lr.windowSize());
+                    try renderFrame(&app, p.theme, config, selected, cursor);
                 },
                 .char => |c| {
                     if (c == ' ') {
                         selected[cursor] = !selected[cursor];
-                        try lr.eraseRegion(writer, rows);
-                        rows = try renderList(writer, p.theme, config, selected, cursor, lr.windowSize());
+                        try renderFrame(&app, p.theme, config, selected, cursor);
                     }
                 },
                 .enter => {
-                    try lr.eraseRegion(writer, rows);
-                    // Show summary
-                    var first = true;
-                    var obuf: [64]u8 = undefined;
-                    const open = Prompts.openSeq(&obuf, p.theme, p.theme.promptTokens().selected);
-                    try writer.print("  {s}", .{open});
+                    try app.clear();
+                    // Emit the summary of selected choices as a static line.
+                    var summary = std.ArrayList(u8).empty;
+                    defer summary.deinit(allocator);
                     for (config.choices, 0..) |choice, i| {
                         if (selected[i]) {
-                            if (!first) try writer.writeAll(", ");
-                            try writer.writeAll(choice);
-                            first = false;
+                            if (summary.items.len > 0) try summary.appendSlice(allocator, ", ");
+                            try summary.appendSlice(allocator, choice);
                         }
                     }
-                    try writer.print("{s}\r\n", .{Prompts.closeSeq(open)});
+                    var obuf: [64]u8 = undefined;
+                    const open = Prompts.openSeq(&obuf, p.theme, p.theme.promptTokens().selected);
+                    try app.emit("  {s}{s}{s}", .{ open, summary.items, Prompts.closeSeq(open) });
 
                     // Collect selected indices
                     var result = std.ArrayList(usize).empty;
@@ -126,7 +126,7 @@ pub fn multiSelect(p: Prompts, config: MultiSelectConfig) ![]usize {
                 },
                 .ctrl => |c| {
                     if (c == 'c') {
-                        try lr.eraseRegion(writer, rows);
+                        try app.clear();
                         return error.UserAborted;
                     }
                 },
@@ -136,48 +136,42 @@ pub fn multiSelect(p: Prompts, config: MultiSelectConfig) ![]usize {
     }
 }
 
-/// Render the header and (viewport-limited) choice list at the given terminal
-/// size, returning the number of physical rows emitted. Width is taken as an
-/// explicit parameter (not queried) so this is deterministic and unit-testable.
-/// Uses the shared `list_render` machinery; only the marker/cursor styling is
-/// multi-select-specific.
-///
-/// Lines are separated by (not terminated with) CRLF: after rendering, the
-/// cursor sits at the end of the last row, which `lr.eraseRegion` relies on to
-/// avoid scrolling the screen when the region reaches the bottom.
-///
-/// Public for the cross-platform emulator render tests.
-pub fn renderList(
-    writer: anytype,
+fn renderFrame(app: *ui.App, ctx: Prompts.ThemeContext, config: MultiSelectConfig, selected: []const bool, cursor: usize) !void {
+    try app.frame(try frameNode(app.arena(), ctx, config, selected, cursor, lr.windowSize()));
+}
+
+/// Build the header and (viewport-limited) choice list as one frame. Pure
+/// and size-explicit so it is deterministic and unit-testable; only the
+/// marker/cursor styling is multi-select-specific.
+pub fn frameNode(
+    a: std.mem.Allocator,
     ctx: Prompts.ThemeContext,
     config: MultiSelectConfig,
     selected: []const bool,
     cursor: usize,
     ws: terminal.Winsize,
-) !usize {
+) !ui.Node {
     const width = @max(@as(usize, ws.col), 1);
-    // Leave the last column unused so a full-width line can't trigger the
-    // terminal's deferred auto-wrap (DECAWM) and desync our row count.
-    const usable = @max(width -| 1, 1);
+    const usable: u16 = @intCast(@min(@max(width -| 1, 1), std.math.maxInt(u16)));
     const height = @max(@as(usize, ws.row), 2);
 
     const cursor_sym = terminal.symbols.select_cursor(config.unicode);
     const sel_sym = terminal.symbols.selected(config.unicode);
     const unsel_sym = terminal.symbols.unselected(config.unicode);
-    // Cursor row "  <cur> <marker> " and plain row "    <marker> " are both this
-    // wide (assuming a single-column cursor glyph), so wrapped text and the
-    // hang-indent of continuation lines all align.
-    const prefix_w = 5 + terminal.displayWidth(sel_sym);
-    const avail = @max(usable -| prefix_w, 1);
+    // Cursor row "  <cur> <marker> " and plain row "    <marker> " are both
+    // this wide (single-column cursor glyph), so labels and their wrapped
+    // continuation lines all align.
+    const prefix_w: u16 = @intCast(5 + terminal.displayWidth(sel_sym));
+    const avail: u16 = @intCast(@max(@as(usize, usable) -| prefix_w, 1));
 
-    var rows: usize = 0;
-    var first_line = true;
+    var rows = std.ArrayList(ui.Node).empty;
 
     // Header (hang-indents any wrap under the message text).
-    const hprefix_w = terminal.displayWidth(config.prefix);
-    var hbuf: [512]u8 = undefined;
-    const header = std.fmt.bufPrint(&hbuf, "{s} (space to toggle, enter to confirm)", .{config.message}) catch config.message;
-    rows += try lr.renderItem(writer, &first_line, .{ .first_prefix = config.prefix, .prefix_w = hprefix_w }, header, @max(usable -| hprefix_w, 1));
+    const hprefix_w: u16 = @intCast(terminal.displayWidth(config.prefix));
+    const havail: u16 = @intCast(@max(@as(usize, usable) -| hprefix_w, 1));
+    const header = try std.fmt.allocPrint(a, "{s} (space to toggle, enter to confirm)", .{config.message});
+    try rows.append(a, try lr.itemRow(a, lr.prefixCell(.{}, config.prefix), hprefix_w, header, havail, .{}));
+    const header_rows = terminal.wrapCount(header, havail);
 
     // Viewport over choices; row counts are computed on demand (no allocation).
     const Counter = struct {
@@ -189,33 +183,30 @@ pub fn renderList(
     };
     const counter = Counter{ .choices = config.choices, .avail = avail };
     // Reserve one screen row (below the header) so trailing content never scrolls.
-    const list_budget = @max((height -| 1) -| rows, 1);
+    const list_budget = @max((height -| 1) -| header_rows, 1);
     const win = lr.viewport(config.choices.len, cursor, list_budget, &counter, Counter.at);
 
     const tokens = ctx.promptTokens();
+    const cursor_style = ctx.resolveRef(tokens.cursor);
+    const marker_style = ctx.resolveRef(tokens.marker);
     for (win.start..win.end) |i| {
         const marker = if (selected[i]) sel_sym else unsel_sym;
-        var pbuf: [192]u8 = undefined;
-        var cbuf: [64]u8 = undefined;
-        var mbuf: [64]u8 = undefined;
-        const style: lr.ItemStyle = if (i == cursor) blk: {
-            const cur_open = Prompts.openSeq(&cbuf, ctx, tokens.cursor);
-            const mark_open = Prompts.openSeq(&mbuf, ctx, tokens.marker);
-            break :blk .{
-                .first_prefix = std.fmt.bufPrint(&pbuf, "  {s}{s}{s} {s}{s}{s} ", .{
-                    cur_open,  cursor_sym, Prompts.closeSeq(cur_open),
-                    mark_open, marker,     Prompts.closeSeq(mark_open),
-                }) catch "  ",
-                .prefix_w = prefix_w,
-            };
-        } else .{
-            .first_prefix = std.fmt.bufPrint(&pbuf, "    {s} ", .{marker}) catch "    ",
-            .prefix_w = prefix_w,
-        };
-        rows += try lr.renderItem(writer, &first_line, style, config.choices[i], avail);
+        const prefix = if (i == cursor)
+            try ui.row(a, .{}, &.{
+                lr.prefixCell(.{}, "  "),
+                lr.prefixCell(cursor_style, cursor_sym),
+                lr.prefixCell(.{}, " "),
+                lr.prefixCell(marker_style, marker),
+            })
+        else
+            try ui.row(a, .{}, &.{
+                lr.prefixCell(.{}, "    "),
+                lr.prefixCell(.{}, marker),
+            });
+        try rows.append(a, try lr.itemRow(a, prefix, prefix_w, config.choices[i], avail, .{}));
     }
 
-    return rows;
+    return ui.column(a, .{ .width = .{ .len = usable } }, rows.items);
 }
 
 fn readLine(reader: anytype, allocator: std.mem.Allocator) ![]u8 {
@@ -298,38 +289,56 @@ test "non-TTY: no defaults returns empty" {
 }
 
 // ---------------------------------------------------------------------------
-// Render tests — the regression guard for the erase-count bug: a wrapped option
-// must report the true number of physical rows, and continuation lines must
-// hang-indent under the option text.
+// Frame tests — the regression guard for the erase-count bug's modern form: a
+// wrapped option must measure its true physical rows (so the App reserves
+// enough region), and continuation lines must hang-indent under the label.
 // ---------------------------------------------------------------------------
 
-fn renderToBuf(buf: []u8, ctx: Prompts.ThemeContext, config: MultiSelectConfig, selected: []const bool, cursor: usize, ws: terminal.Winsize) !struct { rows: usize, text: []const u8 } {
-    var w: std.Io.Writer = .fixed(buf);
-    const rows = try renderList(&w, ctx, config, selected, cursor, ws);
-    return .{ .rows = rows, .text = w.buffered() };
+const FrameHarness = struct {
+    arena: std.heap.ArenaAllocator,
+
+    fn init() FrameHarness {
+        return .{ .arena = std.heap.ArenaAllocator.init(std.testing.allocator) };
+    }
+    fn deinit(self: *FrameHarness) void {
+        self.arena.deinit();
+    }
+    fn a(self: *FrameHarness) std.mem.Allocator {
+        return self.arena.allocator();
+    }
+    fn rctx(self: *FrameHarness) ui.RenderCtx {
+        return .{ .allocator = self.a() };
+    }
+};
+
+test "frameNode: short options are one row each" {
+    var h = FrameHarness.init();
+    defer h.deinit();
+    const node = try frameNode(h.a(), Prompts.default_style, .{ .message = "Pick", .choices = &.{ "a", "b", "c" } }, &.{ false, false, false }, 0, .{ .row = 24, .col = 80 });
+    const rc = h.rctx();
+    const size = ui.measure(&rc, &node, .{ .max_w = 100, .max_h = 50 });
+    try std.testing.expectEqual(@as(u16, 4), size.h); // header + 3
 }
 
-test "renderList: short options are one row each" {
-    var buf: [1024]u8 = undefined;
-    const r = try renderToBuf(&buf, Prompts.default_style, .{ .message = "Pick", .choices = &.{ "a", "b", "c" } }, &.{ false, false, false }, 0, .{ .row = 24, .col = 80 });
-    // 1 header row + 3 option rows.
-    try std.testing.expectEqual(@as(usize, 4), r.rows);
-}
-
-test "renderList: a wrapping option counts as multiple physical rows" {
-    var buf: [4096]u8 = undefined;
+test "frameNode: a wrapping option measures its true physical rows" {
+    var h = FrameHarness.init();
+    defer h.deinit();
     const long = "this is a fairly long option label that will certainly wrap";
-    // Narrow terminal forces the long option onto several rows.
-    const r = try renderToBuf(&buf, Prompts.default_style, .{ .message = "Pick", .choices = &.{ "short", long } }, &.{ false, false }, 0, .{ .row = 24, .col = 24 });
-    // header(1) + short(1) + long(>=3 at width 24) — the key point is it is not 3.
-    try std.testing.expect(r.rows > 3);
-    // Row count must equal the number of CRLF-separated lines actually emitted.
-    const lines = std.mem.count(u8, r.text, "\r\n") + 1;
-    try std.testing.expectEqual(lines, r.rows);
+    const node = try frameNode(h.a(), Prompts.default_style, .{ .message = "Pick", .choices = &.{ "short", long } }, &.{ false, false }, 0, .{ .row = 24, .col = 24 });
+    const rc = h.rctx();
+    const size = ui.measure(&rc, &node, .{ .max_w = 100, .max_h = 50 });
+    try std.testing.expect(size.h > 3);
+    // header (wraps: it carries the toggle hint) + short(1) + the long
+    // label's wrap count at the item width (usable 23 minus the prefix).
+    const header_rows = terminal.wrapCount("Pick (space to toggle, enter to confirm)", 23 - 2);
+    const prefix_w = 5 + terminal.displayWidth(terminal.symbols.selected(true));
+    const expected = header_rows + 1 + terminal.wrapCount(long, 23 - prefix_w);
+    try std.testing.expectEqual(@as(u16, @intCast(expected)), size.h);
 }
 
-test "renderList: cursor row styles through the cursor and marker tokens" {
-    var buf: [1024]u8 = undefined;
+test "frameNode: cursor row styles through the cursor and marker tokens" {
+    var h = FrameHarness.init();
+    defer h.deinit();
     const custom = Prompts.Theme{
         .prompts = .{
             .cursor = .{ .style = .{ .foreground = .{ .rgb = .{ .r = 9, .g = 8, .b = 7 } } } },
@@ -340,26 +349,38 @@ test "renderList: cursor row styles through the cursor and marker tokens" {
         .theme = &custom,
         .caps = .{ .capability = .true_color, .is_tty = true, .color_enabled = true },
     };
-    const r = try renderToBuf(&buf, ctx, .{ .message = "Pick", .choices = &.{ "a", "b" } }, &.{ true, false }, 0, .{ .row = 24, .col = 80 });
-    try std.testing.expect(std.mem.indexOf(u8, r.text, "38;2;9;8;7") != null); // cursor glyph
-    try std.testing.expect(std.mem.indexOf(u8, r.text, "38;2;4;5;6") != null); // marker
+    const node = try frameNode(h.a(), ctx, .{ .message = "Pick", .choices = &.{ "a", "b" } }, &.{ true, false }, 0, .{ .row = 24, .col = 80 });
+
+    var s = try ui.Surface.init(std.testing.allocator, 79, 3);
+    defer s.deinit();
+    const rc = h.rctx();
+    try ui.render(&rc, &node, s.root());
+
+    // Cursor row (row 1): glyph at col 2 wears the cursor token, the marker
+    // next to it wears the marker token; the plain row's marker is unstyled.
+    try std.testing.expect(ui.styleEql(ctx.resolveRef(ctx.promptTokens().cursor), s.cell(2, 1).style));
+    try std.testing.expect(ui.styleEql(ctx.resolveRef(ctx.promptTokens().marker), s.cell(4, 1).style));
+    try std.testing.expect(ui.styleEql(.{}, s.cell(4, 2).style));
 }
 
-test "renderList: no_color renders without any escapes" {
-    var buf: [1024]u8 = undefined;
-    const ctx = Prompts.ThemeContext{
-        .caps = .{ .capability = .no_color, .is_tty = true, .color_enabled = false },
-    };
-    const r = try renderToBuf(&buf, ctx, .{ .message = "Pick", .choices = &.{ "a", "b" } }, &.{ true, false }, 0, .{ .row = 24, .col = 80 });
-    try std.testing.expect(std.mem.indexOf(u8, r.text, "\x1b[") == null);
-}
-
-test "renderList: continuation lines hang-indent under the option text" {
-    var buf: [4096]u8 = undefined;
+test "frameNode: continuation lines hang-indent under the option text" {
+    var h = FrameHarness.init();
+    defer h.deinit();
     // unicode=false so the prefix is "    [ ] " = 8 columns.
-    const r = try renderToBuf(&buf, Prompts.default_style, .{ .message = "Pick", .choices = &.{"alpha bravo charlie delta"}, .unicode = false }, &.{false}, 0, .{ .row = 24, .col = 20 });
-    _ = r;
-    // The continuation line is preceded by 8 spaces (prefix width), aligning it
-    // under the label text rather than under the bullet.
-    try std.testing.expect(std.mem.indexOf(u8, buf[0..], "\r\n        ") != null);
+    const node = try frameNode(h.a(), Prompts.default_style, .{ .message = "Pick", .choices = &.{"alpha bravo charlie delta"}, .unicode = false }, &.{false}, 0, .{ .row = 24, .col = 20 });
+
+    var s = try ui.Surface.init(std.testing.allocator, 19, 8);
+    defer s.deinit();
+    const rc = h.rctx();
+    try ui.render(&rc, &node, s.root());
+
+    // The header (with its toggle hint) wraps at this width; the option's
+    // first line follows it: marker "[" at col 4, label from col 8.
+    const opt: u16 = @intCast(terminal.wrapCount("Pick (space to toggle, enter to confirm)", 19 - 2));
+    try std.testing.expectEqualStrings("[", s.cellText(s.cell(4, opt)));
+    try std.testing.expectEqualStrings("a", s.cellText(s.cell(8, opt)));
+    // The next row is a continuation: columns 0-7 blank (hang indent).
+    var x: u16 = 0;
+    while (x < 8) : (x += 1) try std.testing.expect(s.cell(x, opt + 1).isBlank());
+    try std.testing.expect(!s.cell(8, opt + 1).isBlank());
 }

--- a/packages/prompts/src/search.zig
+++ b/packages/prompts/src/search.zig
@@ -1,9 +1,13 @@
 //! Search/filter prompt — type to filter a list, arrow keys to navigate, Enter to select.
+//!
+//! Rendering runs on the ui engine (see select.zig); input handling and the
+//! filter state stay here.
 
 const std = @import("std");
 const terminal = @import("terminal");
 const Prompts = @import("Prompts.zig");
 const lr = @import("list_render.zig");
+const ui = lr.ui;
 
 pub const SearchConfig = struct {
     message: []const u8,
@@ -37,14 +41,17 @@ pub fn search(p: Prompts, config: SearchConfig) !usize {
     // TTY: interactive search
     Prompts.flushWriter(writer);
     const raw = terminal.enableRawMode(std.Io.File.stdin().handle) catch return 0;
-    try writer.writeAll(terminal.ansi.hide_cursor);
     var watcher = terminal.ResizeWatcher.init();
     defer {
-        writer.writeAll(terminal.ansi.show_cursor) catch {};
         watcher.deinit();
         raw.disable();
         Prompts.flushWriter(writer);
     }
+    var app = try ui.App.init(p.allocator, writer, .{
+        .capability = p.theme.capability(),
+        .unicode = config.unicode,
+    });
+    defer app.deinit();
 
     var query = std.ArrayList(u8).empty;
     defer query.deinit(allocator);
@@ -53,33 +60,27 @@ pub fn search(p: Prompts, config: SearchConfig) !usize {
     defer allocator.free(filtered);
     const stdin = std.Io.File.stdin().handle;
     var cursor: usize = 0;
-    var rows = try renderSearch(writer, p.theme, config, query.items, filtered, cursor, lr.windowSize());
+    try renderFrame(&app, p.theme, config, query.items, filtered, cursor);
 
     while (true) {
-        Prompts.flushWriter(writer);
         switch (try terminal.readEvent(reader, stdin, &watcher)) {
-            .resize => {
-                try lr.eraseRegion(writer, rows);
-                rows = try renderSearch(writer, p.theme, config, query.items, filtered, cursor, lr.windowSize());
-            },
+            .resize => try renderFrame(&app, p.theme, config, query.items, filtered, cursor),
             .key => |k| switch (k) {
                 .up => {
                     if (cursor > 0) cursor -= 1;
-                    try lr.eraseRegion(writer, rows);
-                    rows = try renderSearch(writer, p.theme, config, query.items, filtered, cursor, lr.windowSize());
+                    try renderFrame(&app, p.theme, config, query.items, filtered, cursor);
                 },
                 .down => {
                     if (cursor < filtered.len -| 1) cursor += 1;
-                    try lr.eraseRegion(writer, rows);
-                    rows = try renderSearch(writer, p.theme, config, query.items, filtered, cursor, lr.windowSize());
+                    try renderFrame(&app, p.theme, config, query.items, filtered, cursor);
                 },
                 .enter => {
                     if (filtered.len > 0) {
                         const selected_idx = filtered[cursor];
-                        try lr.eraseRegion(writer, rows);
+                        try app.clear();
                         var obuf: [64]u8 = undefined;
                         const open = Prompts.openSeq(&obuf, p.theme, p.theme.promptTokens().selected);
-                        try writer.print("  {s}{s}{s}\r\n", .{ open, config.choices[selected_idx], Prompts.closeSeq(open) });
+                        try app.emit("  {s}{s}{s}", .{ open, config.choices[selected_idx], Prompts.closeSeq(open) });
                         return selected_idx;
                     }
                 },
@@ -89,13 +90,12 @@ pub fn search(p: Prompts, config: SearchConfig) !usize {
                         allocator.free(filtered);
                         filtered = try buildFiltered(allocator, config.choices, query.items);
                         cursor = 0;
-                        try lr.eraseRegion(writer, rows);
-                        rows = try renderSearch(writer, p.theme, config, query.items, filtered, cursor, lr.windowSize());
+                        try renderFrame(&app, p.theme, config, query.items, filtered, cursor);
                     }
                 },
                 .ctrl => |c| {
                     if (c == 'c') {
-                        try lr.eraseRegion(writer, rows);
+                        try app.clear();
                         return error.UserAborted;
                     }
                 },
@@ -104,13 +104,16 @@ pub fn search(p: Prompts, config: SearchConfig) !usize {
                     allocator.free(filtered);
                     filtered = try buildFiltered(allocator, config.choices, query.items);
                     cursor = 0;
-                    try lr.eraseRegion(writer, rows);
-                    rows = try renderSearch(writer, p.theme, config, query.items, filtered, cursor, lr.windowSize());
+                    try renderFrame(&app, p.theme, config, query.items, filtered, cursor);
                 },
                 else => {},
             },
         }
     }
+}
+
+fn renderFrame(app: *ui.App, ctx: Prompts.ThemeContext, config: SearchConfig, query: []const u8, filtered: []const usize, cursor: usize) !void {
+    try app.frame(try frameNode(app.arena(), ctx, config, query, filtered, cursor, lr.windowSize()));
 }
 
 /// Build array of indices into choices that match the query (case-insensitive substring).
@@ -142,62 +145,50 @@ fn containsIgnoreCase(haystack: []const u8, needle: []const u8) bool {
     return false;
 }
 
-/// Render the header, search-input line, and viewport-limited results, returning
-/// the number of physical rows emitted. Width is an explicit parameter so this
-/// is deterministic/testable (used by the cross-platform emulator render tests).
-pub fn renderSearch(
-    writer: anytype,
+/// Build the header, search-input line, and viewport-limited results as one
+/// frame. Pure and size-explicit so it is deterministic and unit-testable.
+pub fn frameNode(
+    a: std.mem.Allocator,
     ctx: Prompts.ThemeContext,
     config: SearchConfig,
     query: []const u8,
     filtered: []const usize,
     cursor: usize,
     ws: terminal.Winsize,
-) !usize {
+) !ui.Node {
     const width = @max(@as(usize, ws.col), 1);
-    const usable = @max(width -| 1, 1);
+    const usable: u16 = @intCast(@min(@max(width -| 1, 1), std.math.maxInt(u16)));
     const height = @max(@as(usize, ws.row), 2);
 
     const cursor_sym = terminal.symbols.select_cursor(config.unicode);
-    const prefix_w: usize = 4; // "  <cur> " / "    "
-    const avail = @max(usable -| prefix_w, 1);
+    const prefix_w: u16 = 4; // "  <cur> " / "    "
+    const avail: u16 = @intCast(@max(@as(usize, usable) -| prefix_w, 1));
 
-    var rows: usize = 0;
-    var first_line = true;
+    var rows = std.ArrayList(ui.Node).empty;
     const tokens = ctx.promptTokens();
+    const hint_style = ctx.resolveRef(tokens.hint);
 
     // Header line.
-    const hprefix_w = terminal.displayWidth(config.prefix);
-    rows += try lr.renderItem(writer, &first_line, .{ .first_prefix = config.prefix, .prefix_w = hprefix_w }, config.message, @max(usable -| hprefix_w, 1));
+    const hprefix_w: u16 = @intCast(terminal.displayWidth(config.prefix));
+    const havail: u16 = @intCast(@max(@as(usize, usable) -| hprefix_w, 1));
+    try rows.append(a, try lr.itemRow(a, lr.prefixCell(.{}, config.prefix), hprefix_w, config.message, havail, .{}));
+    var used: usize = terminal.wrapCount(config.message, havail);
 
-    // Search-input line: "  Search: <query>". The hint style rides in the
-    // prefix (emitted verbatim), not the label: the wrapper drops escapes at
-    // the edges of labels (it measures them as zero-width and slices lines
-    // from the first visible grapheme).
+    // Search-input line: "  Search: <query>" (hint-styled placeholder when empty).
     const search_prefix = "  Search: ";
-    const search_prefix_w = terminal.displayWidth(search_prefix);
-    var hint_open_buf: [64]u8 = undefined;
-    var hint_prefix_buf: [96]u8 = undefined;
-    const hint_open = Prompts.openSeq(&hint_open_buf, ctx, tokens.hint);
+    const search_prefix_w: u16 = @intCast(terminal.displayWidth(search_prefix));
+    const savail: u16 = @intCast(@max(@as(usize, usable) -| search_prefix_w, 1));
     if (query.len > 0) {
-        rows += try lr.renderItem(writer, &first_line, .{ .first_prefix = search_prefix, .prefix_w = search_prefix_w }, query, @max(usable -| search_prefix_w, 1));
+        try rows.append(a, try lr.itemRow(a, lr.prefixCell(.{}, search_prefix), search_prefix_w, query, savail, .{}));
+        used += terminal.wrapCount(query, savail);
     } else {
-        const styled_prefix = std.fmt.bufPrint(&hint_prefix_buf, "{s}{s}", .{ search_prefix, hint_open }) catch search_prefix;
-        rows += try lr.renderItem(writer, &first_line, .{
-            .first_prefix = styled_prefix,
-            .prefix_w = search_prefix_w,
-            .line_close = Prompts.closeSeq(hint_open),
-        }, "type to filter", @max(usable -| search_prefix_w, 1));
+        try rows.append(a, try lr.itemRow(a, lr.prefixCell(.{}, search_prefix), search_prefix_w, "type to filter", savail, hint_style));
+        used += 1;
     }
 
     if (filtered.len == 0) {
-        const nm_prefix = std.fmt.bufPrint(&hint_prefix_buf, "  {s}", .{hint_open}) catch "  ";
-        rows += try lr.renderItem(writer, &first_line, .{
-            .first_prefix = nm_prefix,
-            .prefix_w = 2,
-            .line_close = Prompts.closeSeq(hint_open),
-        }, "no matches", avail);
-        return rows;
+        try rows.append(a, try lr.itemRow(a, lr.prefixCell(.{}, "  "), 2, "no matches", avail, hint_style));
+        return ui.column(a, .{ .width = .{ .len = usable } }, rows.items);
     }
 
     // Results viewport (row counts computed on demand).
@@ -210,26 +201,21 @@ pub fn renderSearch(
         }
     };
     const counter = Counter{ .choices = config.choices, .filtered = filtered, .avail = avail };
-    const list_budget = @max((height -| 1) -| rows, 1);
+    const list_budget = @max((height -| 1) -| used, 1);
     const win = lr.viewport(filtered.len, cursor, list_budget, &counter, Counter.at);
 
+    const selected_style = ctx.resolveRef(tokens.selected);
     for (win.start..win.end) |i| {
         const choice = config.choices[filtered[i]];
-        var pbuf: [32]u8 = undefined;
-        var obuf: [64]u8 = undefined;
-        const style: lr.ItemStyle = if (i == cursor) blk: {
-            const open = Prompts.openSeq(&obuf, ctx, tokens.selected);
-            break :blk .{
-                .line_open = open,
-                .first_prefix = std.fmt.bufPrint(&pbuf, "  {s} ", .{cursor_sym}) catch "  ",
-                .prefix_w = prefix_w,
-                .line_close = Prompts.closeSeq(open),
-            };
-        } else .{ .first_prefix = "    ", .prefix_w = prefix_w };
-        rows += try lr.renderItem(writer, &first_line, style, choice, avail);
+        const on = i == cursor;
+        const prefix = if (on)
+            lr.prefixCell(selected_style, try std.fmt.allocPrint(a, "  {s} ", .{cursor_sym}))
+        else
+            lr.prefixCell(.{}, "");
+        try rows.append(a, try lr.itemRow(a, prefix, prefix_w, choice, avail, if (on) selected_style else .{}));
     }
 
-    return rows;
+    return ui.column(a, .{ .width = .{ .len = usable } }, rows.items);
 }
 
 fn readLine(reader: anytype, allocator: std.mem.Allocator) ![]u8 {
@@ -273,50 +259,64 @@ test "SearchConfig defaults" {
     try std.testing.expectEqualStrings("? ", cfg.prefix);
 }
 
-fn renderToBuf(buf: []u8, ctx: Prompts.ThemeContext, config: SearchConfig, query: []const u8, filtered: []const usize, cursor: usize, ws: terminal.Winsize) !struct { rows: usize, text: []const u8 } {
-    var w: std.Io.Writer = .fixed(buf);
-    const rows = try renderSearch(&w, ctx, config, query, filtered, cursor, ws);
-    return .{ .rows = rows, .text = w.buffered() };
-}
+const FrameHarness = struct {
+    arena: std.heap.ArenaAllocator,
 
-test "renderSearch: header + search line + results, row count matches lines" {
-    var buf: [4096]u8 = undefined;
+    fn init() FrameHarness {
+        return .{ .arena = std.heap.ArenaAllocator.init(std.testing.allocator) };
+    }
+    fn deinit(self: *FrameHarness) void {
+        self.arena.deinit();
+    }
+    fn a(self: *FrameHarness) std.mem.Allocator {
+        return self.arena.allocator();
+    }
+    fn rctx(self: *FrameHarness) ui.RenderCtx {
+        return .{ .allocator = self.a() };
+    }
+};
+
+test "frameNode: header + search line + results measure one row each" {
+    var h = FrameHarness.init();
+    defer h.deinit();
     const filtered = [_]usize{ 0, 1, 2 };
-    const r = try renderToBuf(&buf, Prompts.default_style, .{ .message = "Pick", .choices = &.{ "alpha", "beta", "gamma" } }, "a", &filtered, 0, .{ .row = 24, .col = 80 });
+    const node = try frameNode(h.a(), Prompts.default_style, .{ .message = "Pick", .choices = &.{ "alpha", "beta", "gamma" } }, "a", &filtered, 0, .{ .row = 24, .col = 80 });
+    const rc = h.rctx();
+    const size = ui.measure(&rc, &node, .{ .max_w = 100, .max_h = 50 });
     // header(1) + search(1) + 3 results = 5
-    try std.testing.expectEqual(@as(usize, 5), r.rows);
-    const lines = std.mem.count(u8, r.text, "\r\n") + 1;
-    try std.testing.expectEqual(lines, r.rows);
+    try std.testing.expectEqual(@as(u16, 5), size.h);
 }
 
-test "renderSearch: placeholder styles through the hint token; no_color is escape-free" {
-    var buf: [4096]u8 = undefined;
+test "frameNode: empty query shows the hint-styled placeholder" {
+    var h = FrameHarness.init();
+    defer h.deinit();
     const filtered = [_]usize{ 0, 1 };
-
-    // Custom hint color flows into the placeholder
     const custom = Prompts.Theme{
         .prompts = .{ .hint = .{ .style = .{ .foreground = .{ .rgb = .{ .r = 7, .g = 7, .b = 7 } } } } },
     };
-    const color_ctx = Prompts.ThemeContext{
+    const ctx = Prompts.ThemeContext{
         .theme = &custom,
         .caps = .{ .capability = .true_color, .is_tty = true, .color_enabled = true },
     };
-    const r = try renderToBuf(&buf, color_ctx, .{ .message = "Pick", .choices = &.{ "a", "b" } }, "", &filtered, 0, .{ .row = 24, .col = 80 });
-    try std.testing.expect(std.mem.indexOf(u8, r.text, "38;2;7;7;7") != null);
+    const node = try frameNode(h.a(), ctx, .{ .message = "Pick", .choices = &.{ "a", "b" } }, "", &filtered, 0, .{ .row = 24, .col = 80 });
 
-    // no_color renders the placeholder and cursor row without escapes
-    const plain_ctx = Prompts.ThemeContext{
-        .caps = .{ .capability = .no_color, .is_tty = true, .color_enabled = false },
-    };
-    const p = try renderToBuf(&buf, plain_ctx, .{ .message = "Pick", .choices = &.{ "a", "b" } }, "", &filtered, 0, .{ .row = 24, .col = 80 });
-    try std.testing.expect(std.mem.indexOf(u8, p.text, "type to filter") != null);
-    try std.testing.expect(std.mem.indexOf(u8, p.text, "\x1b[") == null);
+    var s = try ui.Surface.init(std.testing.allocator, 79, 4);
+    defer s.deinit();
+    const rc = h.rctx();
+    try ui.render(&rc, &node, s.root());
+
+    // Row 1: "  Search: type to filter" — placeholder wears the hint token.
+    try std.testing.expectEqualStrings("t", s.cellText(s.cell(10, 1)));
+    try std.testing.expect(ui.styleEql(ctx.resolveRef(ctx.promptTokens().hint), s.cell(10, 1).style));
 }
 
-test "renderSearch: no matches renders a message row" {
-    var buf: [1024]u8 = undefined;
-    const empty = [_]usize{};
-    const r = try renderToBuf(&buf, Prompts.default_style, .{ .message = "Pick", .choices = &.{ "a", "b" } }, "zzz", &empty, 0, .{ .row = 24, .col = 80 });
-    try std.testing.expectEqual(@as(usize, 3), r.rows); // header + search + "no matches"
-    try std.testing.expect(std.mem.indexOf(u8, r.text, "no matches") != null);
+test "frameNode: no matches renders the hint row and stops" {
+    var h = FrameHarness.init();
+    defer h.deinit();
+    const filtered = [_]usize{};
+    const node = try frameNode(h.a(), Prompts.default_style, .{ .message = "Pick", .choices = &.{ "a", "b" } }, "zz", &filtered, 0, .{ .row = 24, .col = 80 });
+    const rc = h.rctx();
+    const size = ui.measure(&rc, &node, .{ .max_w = 100, .max_h = 50 });
+    // header + query line + "no matches"
+    try std.testing.expectEqual(@as(u16, 3), size.h);
 }

--- a/packages/prompts/src/select.zig
+++ b/packages/prompts/src/select.zig
@@ -1,9 +1,16 @@
 //! Single selection prompt with arrow key navigation.
+//!
+//! Rendering runs on the ui engine: each interaction paints one frame of a
+//! node tree (diffed in place — navigation repaints only the rows that
+//! changed), and the chosen answer is emitted as a static line that flows
+//! into scrollback. Input stays here: raw mode, key events, and resize
+//! watching are the prompt's job; the App is display-only.
 
 const std = @import("std");
 const terminal = @import("terminal");
 const Prompts = @import("Prompts.zig");
 const lr = @import("list_render.zig");
+const ui = lr.ui;
 
 pub const SelectConfig = struct {
     message: []const u8,
@@ -40,52 +47,53 @@ pub fn select(p: Prompts, config: SelectConfig) !usize {
     // TTY: interactive selection
     Prompts.flushWriter(writer);
     const raw = terminal.enableRawMode(std.Io.File.stdin().handle) catch return 0;
-    try writer.writeAll(terminal.ansi.hide_cursor);
     var watcher = terminal.ResizeWatcher.init();
     defer {
-        writer.writeAll(terminal.ansi.show_cursor) catch {};
         watcher.deinit();
         raw.disable();
         Prompts.flushWriter(writer);
     }
+    // The App owns the cursor (hidden on first frame, restored by deinit)
+    // and the live region. Runs before the raw/watcher cleanup above (LIFO),
+    // so its restore bytes still go out under raw mode — which is why the
+    // App terminates lines with CRLF.
+    var app = try ui.App.init(p.allocator, writer, .{
+        .capability = p.theme.capability(),
+        .unicode = config.unicode,
+    });
+    defer app.deinit();
 
     const stdin = std.Io.File.stdin().handle;
     var cursor: usize = 0;
-    var rows = try renderList(writer, p.theme, config, cursor, lr.windowSize());
+    try renderFrame(&app, p.theme, config, cursor);
 
     while (true) {
-        Prompts.flushWriter(writer);
         switch (try terminal.readEvent(reader, stdin, &watcher)) {
-            .resize => {
-                try lr.eraseRegion(writer, rows);
-                rows = try renderList(writer, p.theme, config, cursor, lr.windowSize());
-            },
+            .resize => try renderFrame(&app, p.theme, config, cursor),
             .key => |k| {
                 if (Prompts.isInterrupt(k, config.interrupt_keys)) {
-                    try lr.eraseRegion(writer, rows);
+                    try app.clear();
                     return error.Interrupted;
                 }
                 switch (k) {
                     .up => {
                         if (cursor > 0) cursor -= 1;
-                        try lr.eraseRegion(writer, rows);
-                        rows = try renderList(writer, p.theme, config, cursor, lr.windowSize());
+                        try renderFrame(&app, p.theme, config, cursor);
                     },
                     .down => {
                         if (cursor < config.choices.len - 1) cursor += 1;
-                        try lr.eraseRegion(writer, rows);
-                        rows = try renderList(writer, p.theme, config, cursor, lr.windowSize());
+                        try renderFrame(&app, p.theme, config, cursor);
                     },
                     .enter => {
-                        try lr.eraseRegion(writer, rows);
+                        try app.clear();
                         var obuf: [64]u8 = undefined;
                         const open = Prompts.openSeq(&obuf, p.theme, p.theme.promptTokens().selected);
-                        try writer.print("  {s}{s}{s}\r\n", .{ open, config.choices[cursor], Prompts.closeSeq(open) });
+                        try app.emit("  {s}{s}{s}", .{ open, config.choices[cursor], Prompts.closeSeq(open) });
                         return cursor;
                     },
                     .ctrl => |c| {
                         if (c == 'c') {
-                            try lr.eraseRegion(writer, rows);
+                            try app.clear();
                             return error.UserAborted;
                         }
                     },
@@ -96,24 +104,38 @@ pub fn select(p: Prompts, config: SelectConfig) !usize {
     }
 }
 
-/// Render the header + viewport-limited choice list, returning physical rows
-/// emitted. Width is an explicit parameter so this is deterministic/testable
-/// (used by the cross-platform emulator render tests).
-pub fn renderList(writer: anytype, ctx: Prompts.ThemeContext, config: SelectConfig, cursor: usize, ws: terminal.Winsize) !usize {
+fn renderFrame(app: *ui.App, ctx: Prompts.ThemeContext, config: SelectConfig, cursor: usize) !void {
+    try app.frame(try frameNode(app.arena(), ctx, config, cursor, lr.windowSize()));
+}
+
+/// Build the header + viewport-limited choice list as one frame. Pure and
+/// size-explicit, so it is deterministic/testable (the emulator render tests
+/// drive it through an App with a fixed terminal size).
+pub fn frameNode(
+    a: std.mem.Allocator,
+    ctx: Prompts.ThemeContext,
+    config: SelectConfig,
+    cursor: usize,
+    ws: terminal.Winsize,
+) !ui.Node {
     const width = @max(@as(usize, ws.col), 1);
-    const usable = @max(width -| 1, 1);
+    // Leave the last column unused, matching the historical look (and the
+    // row estimates below always agree with the painted layout).
+    const usable: u16 = @intCast(@min(@max(width -| 1, 1), std.math.maxInt(u16)));
     const height = @max(@as(usize, ws.row), 2);
 
     const cursor_sym = terminal.symbols.select_cursor(config.unicode);
     // "  <cur> " and "    " are both 4 columns (single-column cursor glyph).
-    const prefix_w: usize = 4;
-    const avail = @max(usable -| prefix_w, 1);
+    const prefix_w: u16 = 4;
+    const avail = @max(@as(usize, usable) -| prefix_w, 1);
 
-    var rows: usize = 0;
-    var first_line = true;
+    var rows = std.ArrayList(ui.Node).empty;
 
-    const hprefix_w = terminal.displayWidth(config.prefix);
-    rows += try lr.renderItem(writer, &first_line, .{ .first_prefix = config.prefix, .prefix_w = hprefix_w }, config.message, @max(usable -| hprefix_w, 1));
+    // Header (any wrap hang-indents under the message text).
+    const hprefix_w: u16 = @intCast(terminal.displayWidth(config.prefix));
+    const havail: u16 = @intCast(@max(@as(usize, usable) -| hprefix_w, 1));
+    try rows.append(a, try lr.itemRow(a, lr.prefixCell(.{}, config.prefix), hprefix_w, config.message, havail, .{}));
+    const header_rows = terminal.wrapCount(config.message, havail);
 
     const Counter = struct {
         choices: []const []const u8,
@@ -123,26 +145,20 @@ pub fn renderList(writer: anytype, ctx: Prompts.ThemeContext, config: SelectConf
         }
     };
     const counter = Counter{ .choices = config.choices, .avail = avail };
-    const list_budget = @max((height -| 1) -| rows, 1);
+    const list_budget = @max((height -| 1) -| header_rows, 1);
     const win = lr.viewport(config.choices.len, cursor, list_budget, &counter, Counter.at);
 
-    const tokens = ctx.promptTokens();
+    const selected_style = ctx.resolveRef(ctx.promptTokens().selected);
     for (win.start..win.end) |i| {
-        var pbuf: [32]u8 = undefined;
-        var obuf: [64]u8 = undefined;
-        const style: lr.ItemStyle = if (i == cursor) blk: {
-            const open = Prompts.openSeq(&obuf, ctx, tokens.selected);
-            break :blk .{
-                .line_open = open,
-                .first_prefix = std.fmt.bufPrint(&pbuf, "  {s} ", .{cursor_sym}) catch "  ",
-                .prefix_w = prefix_w,
-                .line_close = Prompts.closeSeq(open),
-            };
-        } else .{ .first_prefix = "    ", .prefix_w = prefix_w };
-        rows += try lr.renderItem(writer, &first_line, style, config.choices[i], avail);
+        const on = i == cursor;
+        const prefix = if (on)
+            lr.prefixCell(selected_style, try std.fmt.allocPrint(a, "  {s} ", .{cursor_sym}))
+        else
+            lr.prefixCell(.{}, "");
+        try rows.append(a, try lr.itemRow(a, prefix, prefix_w, config.choices[i], @intCast(avail), if (on) selected_style else .{}));
     }
 
-    return rows;
+    return ui.column(a, .{ .width = .{ .len = usable } }, rows.items);
 }
 
 fn readLine(reader: anytype, allocator: std.mem.Allocator) ![]u8 {
@@ -210,20 +226,52 @@ test "non-TTY: shows numbered choices" {
     try std.testing.expect(std.mem.indexOf(u8, written, "second") != null);
 }
 
-fn renderToBuf(buf: []u8, ctx: Prompts.ThemeContext, config: SelectConfig, cursor: usize, ws: terminal.Winsize) !struct { rows: usize, text: []const u8 } {
-    var w: std.Io.Writer = .fixed(buf);
-    const rows = try renderList(&w, ctx, config, cursor, ws);
-    return .{ .rows = rows, .text = w.buffered() };
+// ---------------------------------------------------------------------------
+// Frame tests: measure/render the component as pure functions.
+// ---------------------------------------------------------------------------
+
+const FrameHarness = struct {
+    arena: std.heap.ArenaAllocator,
+
+    fn init() FrameHarness {
+        return .{ .arena = std.heap.ArenaAllocator.init(std.testing.allocator) };
+    }
+    fn deinit(self: *FrameHarness) void {
+        self.arena.deinit();
+    }
+    fn a(self: *FrameHarness) std.mem.Allocator {
+        return self.arena.allocator();
+    }
+    fn rctx(self: *FrameHarness) ui.RenderCtx {
+        return .{ .allocator = self.a() };
+    }
+};
+
+test "frameNode: header plus one row per short option" {
+    var h = FrameHarness.init();
+    defer h.deinit();
+    const node = try frameNode(h.a(), Prompts.default_style, .{ .message = "Pick", .choices = &.{ "a", "b", "c" } }, 0, .{ .row = 24, .col = 80 });
+    const rc = h.rctx();
+    const size = ui.measure(&rc, &node, .{ .max_w = 100, .max_h = 50 });
+    try std.testing.expectEqual(@as(u16, 4), size.h); // header + 3
 }
 
-test "renderList: short options are one row each" {
-    var buf: [1024]u8 = undefined;
-    const r = try renderToBuf(&buf, Prompts.default_style, .{ .message = "Pick", .choices = &.{ "a", "b", "c" } }, 0, .{ .row = 24, .col = 80 });
-    try std.testing.expectEqual(@as(usize, 4), r.rows); // header + 3
+test "frameNode: wrapped option occupies its true physical rows" {
+    var h = FrameHarness.init();
+    defer h.deinit();
+    const long = "this is a long option label that will certainly wrap at a narrow width";
+    const node = try frameNode(h.a(), Prompts.default_style, .{ .message = "Pick", .choices = &.{ "short", long } }, 0, .{ .row = 24, .col = 24 });
+    const rc = h.rctx();
+    const size = ui.measure(&rc, &node, .{ .max_w = 100, .max_h = 50 });
+    try std.testing.expect(size.h > 3);
+    // header(1) + short(1) + the long label's wrap count at the item width.
+    const expected = 2 + terminal.wrapCount(long, 24 - 1 - 4);
+    try std.testing.expectEqual(@as(u16, @intCast(expected)), size.h);
 }
 
-test "renderList: selected row styles through the theme's selected token" {
-    var buf: [1024]u8 = undefined;
+test "frameNode: selected row carries the theme's selected token" {
+    var h = FrameHarness.init();
+    defer h.deinit();
     const custom = Prompts.Theme{
         .palette = .{ .accent = .{ .foreground = .{ .rgb = .{ .r = 1, .g = 2, .b = 3 } } } },
     };
@@ -231,24 +279,17 @@ test "renderList: selected row styles through the theme's selected token" {
         .theme = &custom,
         .caps = .{ .capability = .true_color, .is_tty = true, .color_enabled = true },
     };
-    const r = try renderToBuf(&buf, ctx, .{ .message = "Pick", .choices = &.{ "a", "b" } }, 0, .{ .row = 24, .col = 80 });
-    try std.testing.expect(std.mem.indexOf(u8, r.text, "38;2;1;2;3") != null);
-}
+    const node = try frameNode(h.a(), ctx, .{ .message = "Pick", .choices = &.{ "a", "b" } }, 0, .{ .row = 24, .col = 80 });
 
-test "renderList: no_color renders without any escapes" {
-    var buf: [1024]u8 = undefined;
-    const ctx = Prompts.ThemeContext{
-        .caps = .{ .capability = .no_color, .is_tty = true, .color_enabled = false },
-    };
-    const r = try renderToBuf(&buf, ctx, .{ .message = "Pick", .choices = &.{ "a", "b" } }, 0, .{ .row = 24, .col = 80 });
-    try std.testing.expect(std.mem.indexOf(u8, r.text, "\x1b[") == null);
-}
+    var s = try ui.Surface.init(std.testing.allocator, 79, 3);
+    defer s.deinit();
+    const rc = h.rctx();
+    try ui.render(&rc, &node, s.root());
 
-test "renderList: wrapped option reports true physical row count" {
-    var buf: [4096]u8 = undefined;
-    const long = "this is a long option label that will certainly wrap at a narrow width";
-    const r = try renderToBuf(&buf, Prompts.default_style, .{ .message = "Pick", .choices = &.{ "short", long } }, 0, .{ .row = 24, .col = 24 });
-    try std.testing.expect(r.rows > 3);
-    const lines = std.mem.count(u8, r.text, "\r\n") + 1;
-    try std.testing.expectEqual(lines, r.rows);
+    const selected_style = ctx.resolveRef(ctx.promptTokens().selected);
+    // Row 1 is the cursor row: glyph cell and label cell styled; row 2 plain.
+    try std.testing.expectEqualStrings("a", s.cellText(s.cell(4, 1)));
+    try std.testing.expect(ui.styleEql(selected_style, s.cell(4, 1).style));
+    try std.testing.expectEqualStrings("b", s.cellText(s.cell(4, 2)));
+    try std.testing.expect(ui.styleEql(.{}, s.cell(4, 2).style));
 }

--- a/packages/prompts/test/render_e2e.zig
+++ b/packages/prompts/test/render_e2e.zig
@@ -1,50 +1,78 @@
-//! Cross-platform rendering end-to-end tests for the list Prompts.
+//! Cross-platform rendering end-to-end tests for the list prompts.
 //!
-//! These drive the real render + erase code paths and replay their byte output
-//! through the in-repo `vterm` terminal emulator, then assert on the resulting
-//! screen grid. Because `vterm` is pure logic, these run identically on Linux,
-//! macOS, and Windows (they're part of `zig build test-prompts`, which Windows CI
-//! runs) — unlike the PTY harness, which is POSIX-only.
+//! These drive the prompts' frame components through a `ui.App` with a fixed
+//! terminal size and replay the real escape stream through the in-repo
+//! `vterm` emulator, then assert on the resulting screen grid. Because vterm
+//! is pure logic, these run identically on Linux, macOS, and Windows
+//! (they're part of `zig build test-prompts`, which Windows CI runs) —
+//! unlike the PTY harness, which is POSIX-only.
 //!
-//! The central invariant is the fix for the original bug: navigating a list
-//! whose options wrap must leave **no debris**. We assert that by comparing two
-//! screens that must be identical — a fresh render of the target frame, versus
-//! rendering the first frame, erasing it, then rendering the target frame. Any
-//! leftover character from the wider/taller previous frame makes them differ.
+//! The central invariant survives the engine port: navigating a list whose
+//! options wrap must leave **no debris**. Under the old hand-rolled
+//! erase/redraw this guarded the row bookkeeping; now it checks the engine's
+//! frame diff end-to-end — a screen reached by diffing from a previous frame
+//! must be identical to a fresh full paint of the target frame.
 
 const std = @import("std");
 const Prompts = @import("prompts");
 const vterm = @import("vterm");
+const ui = @import("ui");
 
 const Winsize = Prompts.terminal.Winsize;
 const testing = std.testing;
 
-/// Replay `bytes` through a fresh `cols`x`rows` emulator and return the visible
-/// grid as text (caller frees).
-fn screenOf(alloc: std.mem.Allocator, cols: u16, rows: u16, bytes: []const u8) ![]u8 {
-    var term = try vterm.VTerm.init(alloc, cols, rows);
-    defer term.deinit();
-    term.write(bytes);
-    return term.getAllText(alloc);
-}
+/// An App painting into a capture buffer, replayed through vterm on demand.
+const Harness = struct {
+    aw: std.Io.Writer.Allocating,
+    vt: vterm.VTerm,
+    app: ui.App,
+    fed: usize = 0,
+
+    fn init(ws: Winsize) !*Harness {
+        const self = try testing.allocator.create(Harness);
+        errdefer testing.allocator.destroy(self);
+        self.* = .{
+            .aw = std.Io.Writer.Allocating.init(testing.allocator),
+            .vt = try vterm.VTerm.init(testing.allocator, ws.col, ws.row),
+            .app = undefined,
+        };
+        self.app = try ui.App.init(testing.allocator, &self.aw.writer, .{
+            .term_size = .{ .w = ws.col, .h = ws.row },
+        });
+        return self;
+    }
+
+    fn deinit(self: *Harness) void {
+        self.app.deinit();
+        self.vt.deinit();
+        self.aw.deinit();
+        testing.allocator.destroy(self);
+    }
+
+    fn replay(self: *Harness) void {
+        self.vt.write(self.aw.written()[self.fed..]);
+        self.fed = self.aw.written().len;
+    }
+
+    fn screen(self: *Harness, alloc: std.mem.Allocator) ![]u8 {
+        self.replay();
+        return self.vt.getAllText(alloc);
+    }
+};
 
 // ---------------------------------------------------------------------------
 // multi_select
 // ---------------------------------------------------------------------------
 
-fn multiFrame(buf: []u8, config: Prompts.MultiSelectConfig, selected: []const bool, cursor: usize, ws: Winsize) ![]const u8 {
-    var w: std.Io.Writer = .fixed(buf);
-    _ = try Prompts.multi_select_prompt.renderList(&w, Prompts.default_style, config, selected, cursor, ws);
-    return w.buffered();
-}
-
-fn multiNavScreen(alloc: std.mem.Allocator, config: Prompts.MultiSelectConfig, selected: []const bool, from: usize, to: usize, ws: Winsize) ![]u8 {
-    var buf: [16384]u8 = undefined;
-    var w: std.Io.Writer = .fixed(&buf);
-    const r0 = try Prompts.multi_select_prompt.renderList(&w, Prompts.default_style, config, selected, from, ws);
-    try Prompts.list_render.eraseRegion(&w, r0);
-    _ = try Prompts.multi_select_prompt.renderList(&w, Prompts.default_style, config, selected, to, ws);
-    return screenOf(alloc, ws.col, ws.row, w.buffered());
+fn multiFrame(h: *Harness, config: Prompts.MultiSelectConfig, selected: []const bool, cursor: usize, ws: Winsize) !void {
+    try h.app.frame(try Prompts.multi_select_prompt.frameNode(
+        h.app.arena(),
+        Prompts.default_style,
+        config,
+        selected,
+        cursor,
+        ws,
+    ));
 }
 
 test "emulator: multi_select navigation leaves no debris when options wrap" {
@@ -57,16 +85,22 @@ test "emulator: multi_select navigation leaves no debris when options wrap" {
     } };
     const selected = [_]bool{ false, false, false };
 
-    // Fresh render of the target frame (cursor on the long, wrapping option).
-    var cbuf: [16384]u8 = undefined;
-    const clean = try screenOf(alloc, ws.col, ws.row, try multiFrame(&cbuf, config, &selected, 1, ws));
+    // Fresh paint of the target frame (cursor on the long, wrapping option).
+    var fresh = try Harness.init(ws);
+    defer fresh.deinit();
+    try multiFrame(fresh, config, &selected, 1, ws);
+    const clean = try fresh.screen(alloc);
     defer alloc.free(clean);
 
-    // Same frame reached by rendering frame 0, erasing it, then rendering frame 1.
-    const nav = try multiNavScreen(alloc, config, &selected, 0, 1, ws);
-    defer alloc.free(nav);
+    // Same frame reached by painting frame 0, then diffing to frame 1.
+    var nav = try Harness.init(ws);
+    defer nav.deinit();
+    try multiFrame(nav, config, &selected, 0, ws);
+    try multiFrame(nav, config, &selected, 1, ws);
+    const stepped = try nav.screen(alloc);
+    defer alloc.free(stepped);
 
-    try testing.expectEqualStrings(clean, nav);
+    try testing.expectEqualStrings(clean, stepped);
 }
 
 test "emulator: multi_select wraps wide CJK options without debris" {
@@ -79,19 +113,35 @@ test "emulator: multi_select wraps wide CJK options without debris" {
     } };
     const selected = [_]bool{ false, true, false };
 
-    var cbuf: [16384]u8 = undefined;
-    const clean = try screenOf(alloc, ws.col, ws.row, try multiFrame(&cbuf, config, &selected, 2, ws));
+    var fresh = try Harness.init(ws);
+    defer fresh.deinit();
+    try multiFrame(fresh, config, &selected, 2, ws);
+    const clean = try fresh.screen(alloc);
     defer alloc.free(clean);
 
-    const nav = try multiNavScreen(alloc, config, &selected, 1, 2, ws);
-    defer alloc.free(nav);
+    var nav = try Harness.init(ws);
+    defer nav.deinit();
+    try multiFrame(nav, config, &selected, 1, ws);
+    try multiFrame(nav, config, &selected, 2, ws);
+    const stepped = try nav.screen(alloc);
+    defer alloc.free(stepped);
 
-    try testing.expectEqualStrings(clean, nav);
+    try testing.expectEqualStrings(clean, stepped);
 }
 
 // ---------------------------------------------------------------------------
 // select
 // ---------------------------------------------------------------------------
+
+fn selectFrame(h: *Harness, config: Prompts.SelectConfig, cursor: usize, ws: Winsize) !void {
+    try h.app.frame(try Prompts.select_prompt.frameNode(
+        h.app.arena(),
+        Prompts.default_style,
+        config,
+        cursor,
+        ws,
+    ));
+}
 
 test "emulator: select navigation leaves no debris when options wrap" {
     const alloc = testing.allocator;
@@ -102,21 +152,20 @@ test "emulator: select navigation leaves no debris when options wrap" {
         "two",
     } };
 
-    var cbuf: [16384]u8 = undefined;
-    var cw: std.Io.Writer = .fixed(&cbuf);
-    _ = try Prompts.select_prompt.renderList(&cw, Prompts.default_style, config, 1, ws);
-    const clean = try screenOf(alloc, ws.col, ws.row, cw.buffered());
+    var fresh = try Harness.init(ws);
+    defer fresh.deinit();
+    try selectFrame(fresh, config, 1, ws);
+    const clean = try fresh.screen(alloc);
     defer alloc.free(clean);
 
-    var nbuf: [16384]u8 = undefined;
-    var nw: std.Io.Writer = .fixed(&nbuf);
-    const r0 = try Prompts.select_prompt.renderList(&nw, Prompts.default_style, config, 0, ws);
-    try Prompts.list_render.eraseRegion(&nw, r0);
-    _ = try Prompts.select_prompt.renderList(&nw, Prompts.default_style, config, 1, ws);
-    const nav = try screenOf(alloc, ws.col, ws.row, nw.buffered());
-    defer alloc.free(nav);
+    var nav = try Harness.init(ws);
+    defer nav.deinit();
+    try selectFrame(nav, config, 0, ws);
+    try selectFrame(nav, config, 1, ws);
+    const stepped = try nav.screen(alloc);
+    defer alloc.free(stepped);
 
-    try testing.expectEqualStrings(clean, nav);
+    try testing.expectEqualStrings(clean, stepped);
 }
 
 test "emulator: select hang-indents wrapped continuation lines on screen" {
@@ -127,24 +176,42 @@ test "emulator: select hang-indents wrapped continuation lines on screen" {
         "alpha bravo charlie delta echo",
     } };
 
-    var term = try vterm.VTerm.init(alloc, ws.col, ws.row);
-    defer term.deinit();
-    var buf: [16384]u8 = undefined;
-    var w: std.Io.Writer = .fixed(&buf);
-    _ = try Prompts.select_prompt.renderList(&w, Prompts.default_style, config, 0, ws);
-    term.write(w.buffered());
+    var h = try Harness.init(ws);
+    defer h.deinit();
+    try selectFrame(h, config, 0, ws);
+    h.replay();
 
     // Row 0: "? Pick" header. Row 1: first option line (prefix "  > "/"  ❯ ").
     // Row 2: a wrapped continuation, hang-indented to the 4-column prefix width.
-    const row1 = try term.getLine(alloc, 1);
+    const row1 = try h.vt.getLine(alloc, 1);
     defer alloc.free(row1);
-    const row2 = try term.getLine(alloc, 2);
+    const row2 = try h.vt.getLine(alloc, 2);
     defer alloc.free(row2);
 
     try testing.expect(std.mem.indexOf(u8, row1, "alpha") != null);
     // Continuation aligns under the label (4 leading spaces), not the bullet.
     try testing.expect(std.mem.startsWith(u8, row2, "    "));
     try testing.expect(std.mem.trim(u8, row2, " ").len > 0);
+}
+
+test "emulator: select answer persists as one static line, region gone" {
+    const alloc = testing.allocator;
+    const ws = Winsize{ .row = 24, .col = 40 };
+    const config = Prompts.SelectConfig{ .message = "Choose", .choices = &.{ "alpha", "beta" } };
+
+    var h = try Harness.init(ws);
+    defer h.deinit();
+    try selectFrame(h, config, 1, ws);
+    // What select() does on Enter: clear the region, emit the styled answer.
+    try h.app.clear();
+    try h.app.emit("  {s}", .{config.choices[1]});
+    h.replay();
+
+    const line0 = try h.vt.getLine(alloc, 0);
+    defer alloc.free(line0);
+    try testing.expect(std.mem.indexOf(u8, line0, "beta") != null);
+    try testing.expect(!h.vt.containsText("Choose"));
+    try testing.expect(!h.vt.containsText("alpha"));
 }
 
 // ---------------------------------------------------------------------------
@@ -184,6 +251,18 @@ test "emulator: backspace-erase clears a wide char's both cells" {
 // search
 // ---------------------------------------------------------------------------
 
+fn searchFrame(h: *Harness, config: Prompts.SearchConfig, query: []const u8, filtered: []const usize, cursor: usize, ws: Winsize) !void {
+    try h.app.frame(try Prompts.search_prompt.frameNode(
+        h.app.arena(),
+        Prompts.default_style,
+        config,
+        query,
+        filtered,
+        cursor,
+        ws,
+    ));
+}
+
 test "emulator: search navigation leaves no debris when results wrap" {
     const alloc = testing.allocator;
     const ws = Winsize{ .row = 24, .col = 28 };
@@ -195,19 +274,44 @@ test "emulator: search navigation leaves no debris when results wrap" {
     const filtered = [_]usize{ 0, 1, 2 };
     const query = "";
 
-    var cbuf: [16384]u8 = undefined;
-    var cw: std.Io.Writer = .fixed(&cbuf);
-    _ = try Prompts.search_prompt.renderSearch(&cw, Prompts.default_style, config, query, &filtered, 1, ws);
-    const clean = try screenOf(alloc, ws.col, ws.row, cw.buffered());
+    var fresh = try Harness.init(ws);
+    defer fresh.deinit();
+    try searchFrame(fresh, config, query, &filtered, 1, ws);
+    const clean = try fresh.screen(alloc);
     defer alloc.free(clean);
 
-    var nbuf: [16384]u8 = undefined;
-    var nw: std.Io.Writer = .fixed(&nbuf);
-    const r0 = try Prompts.search_prompt.renderSearch(&nw, Prompts.default_style, config, query, &filtered, 0, ws);
-    try Prompts.list_render.eraseRegion(&nw, r0);
-    _ = try Prompts.search_prompt.renderSearch(&nw, Prompts.default_style, config, query, &filtered, 1, ws);
-    const nav = try screenOf(alloc, ws.col, ws.row, nw.buffered());
-    defer alloc.free(nav);
+    var nav = try Harness.init(ws);
+    defer nav.deinit();
+    try searchFrame(nav, config, query, &filtered, 0, ws);
+    try searchFrame(nav, config, query, &filtered, 1, ws);
+    const stepped = try nav.screen(alloc);
+    defer alloc.free(stepped);
 
-    try testing.expectEqualStrings(clean, nav);
+    try testing.expectEqualStrings(clean, stepped);
+}
+
+test "emulator: search filtering shrinks the list without debris" {
+    const alloc = testing.allocator;
+    const ws = Winsize{ .row = 24, .col = 28 };
+    const config = Prompts.SearchConfig{ .message = "Find", .choices = &.{
+        "apple",
+        "a very long result entry that will wrap across more than one row",
+        "cherry",
+    } };
+
+    var fresh = try Harness.init(ws);
+    defer fresh.deinit();
+    try searchFrame(fresh, config, "ap", &.{0}, 0, ws);
+    const clean = try fresh.screen(alloc);
+    defer alloc.free(clean);
+
+    // The same screen reached by filtering down from the full (taller) list.
+    var nav = try Harness.init(ws);
+    defer nav.deinit();
+    try searchFrame(nav, config, "", &.{ 0, 1, 2 }, 0, ws);
+    try searchFrame(nav, config, "ap", &.{0}, 0, ws);
+    const stepped = try nav.screen(alloc);
+    defer alloc.free(stepped);
+
+    try testing.expectEqualStrings(clean, stepped);
 }

--- a/packages/ui/src/app.zig
+++ b/packages/ui/src/app.zig
@@ -129,18 +129,23 @@ pub const App = struct {
     /// never repainted in place. Line-oriented (see module docs). The block
     /// is retained in source form while it may still be visible, so a width
     /// resize can reflow the visible tail (ADR-0013 resize tier 2).
+    ///
+    /// Interactive output terminates lines with CRLF: prompts run the
+    /// terminal in raw mode, where a bare `\n` moves down without returning
+    /// the column (no ONLCR post-processing), and CRLF is harmless in
+    /// cooked mode. Piped output keeps plain `\n`.
     pub fn emit(self: *App, comptime fmt: []const u8, args: anytype) !void {
-        const line_fmt = comptime if (std.mem.endsWith(u8, fmt, "\n")) fmt else fmt ++ "\n";
+        const base = comptime std.mem.trimEnd(u8, fmt, "\r\n");
         if (!self.options.interactive) {
             // Plain line output: no live region exists, nothing to retain.
-            try self.writer.print(line_fmt, args);
+            try self.writer.print(base ++ "\n", args);
             try self.writer.flush();
             return;
         }
         const ts = self.termSize();
         self.last_width = ts.w;
 
-        const text = try std.fmt.allocPrint(self.gpa, line_fmt, args);
+        const text = try std.fmt.allocPrint(self.gpa, base ++ "\r\n", args);
         errdefer self.gpa.free(text);
 
         const had_live = self.live_rows > 0;
@@ -256,7 +261,9 @@ pub const App = struct {
         std.debug.assert(self.live_rows == 0);
         try self.writer.writeByte('\r');
         var i: u16 = 1;
-        while (i < rows) : (i += 1) try self.writer.writeAll("\n");
+        // CRLF, not LF: under raw mode (prompts) there is no ONLCR
+        // post-processing, and the explicit CR is harmless in cooked mode.
+        while (i < rows) : (i += 1) try self.writer.writeAll("\r\n");
         if (rows > 1) try self.writer.print("\x1b[{d}A", .{rows - 1});
         self.live_rows = rows;
     }
@@ -345,7 +352,7 @@ pub const App = struct {
     /// desync this — emit output is expected tab-free.)
     fn textRows(text: []const u8, width: u16) u16 {
         const w: u32 = @max(width, 1);
-        const body = if (std.mem.endsWith(u8, text, "\n")) text[0 .. text.len - 1] else text;
+        const body = std.mem.trimEnd(u8, text, "\r\n");
         var rows: u32 = 0;
         var it = std.mem.splitScalar(u8, body, '\n');
         while (it.next()) |line| {


### PR DESCRIPTION
## What

PR 2a of the migration plan: `select`, `multi_select`, and `search` render through the engine. Each interaction paints one frame of a node tree — navigating diffs in place (moving the cursor repaints two prefix cells, not the list), and the answer is emitted as a static line flowing into scrollback. Input is untouched: raw mode, `readEvent`, `ResizeWatcher`, and filter state stay in the prompts; the App is display-only.

The hand-computed hang indent falls out of the layout: an item is a row of `[fixed-width prefix cell, wrapped label]`, and the label's continuation lines get blank cells under the prefix for free. `renderList`/`renderSearch` become pure, size-explicit `frameNode()` component functions; `list_render` keeps `viewport()` and gains the node builders (the imperative path remains for the line prompts until 2b).

## Two engine lessons this surfaced

- **Raw mode**: prompts run the terminal raw, where `\n` has no ONLCR post-processing — App interactive output now terminates lines with CRLF (harmless in cooked mode); piped output keeps plain `\n`.
- **Measure vs fill**: item labels use explicit `.len` widths, not `.fill` — a fill child contributes nothing at measure time (ADR-0013 §5), which would under-reserve the live region for wrapped labels.

## Split

2b (text/password/number/confirm/editor) follows: the line editors need App cursor placement (`showCursorAt`) for the real insertion point — the list trio hides the cursor, so it wasn't needed here.

## Testing

- `frameNode` measure/render unit tests replace the old writer-based render tests (row counts including wraps, theme tokens asserted on cells, hang-indent cell checks).
- `render_e2e` now drives components through an App with a fixed terminal size into vterm: the **no-debris invariant** (diff path == fresh paint, including CJK wraps) checks the engine's frame diff end-to-end, plus new answer-persists and filter-shrink tests.
- Full repo suite green — including the POSIX PTY and Windows ConPTY interactive e2e tiers driving the real prompts through the tasks-example wizard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)