### PR TITLE
core: zcli.ui on the umbrella + context.ui() (migration plan PR 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to zcli are documented here.
 
 **Versioning policy:** zcli follows [semver](https://semver.org). Until 1.0, breaking changes may land in minor versions and are called out below; patch versions are always safe to take. Releases target **stable Zig** — moving to a new Zig version is at least a minor bump and is stated in the entry. Each release is tagged twice in lockstep: `vX.Y.Z` is the framework library (the tag for your `build.zig.zon`), `zcli-vX.Y.Z` carries the prebuilt meta-CLI binaries.
 
+## Unreleased
+
+The terminal-native layout engine (ADR-0013) and the migration of the interactive packages onto it.
+
+### Added
+- **`zcli.ui`** — a terminal-native layout engine for CLI/TUI hybrid apps: a static stream flowing into scrollback plus a diffed live region (`app.emit()` / `app.frame(node)`). Immediate-mode node trees (box/text/spacer/custom, `fit`/`len`/`fill` sizing), viewport clamping, resize re-layout including reflow of the visible static tail, real-cursor placement for line editors, and plain-line degradation when piped. `context.ui()` returns a pre-wired `ui.App`.
+- **`progress.MultiBar`** — stacked labeled bars for parallel work with thread-safe updates.
+- vterm supports DECAWM (private mode 7).
+
+### Changed (breaking)
+- **progress**: `spinner()`/`progressBar()` take an allocator and return errors; types are no longer writer-generic; `setText` → `setMessage`, `stopAndPersist` → `persist`; `SpinnerConfig.hide_cursor` removed (the engine owns the cursor); piped bars print one finish summary line instead of a line per update; indicators gained idempotent `deinit()`.
+- **prompts**: the `text` Preview callback returns one line of plain text from the prompt's frame arena (was: writes raw styled bytes) and is styled with the theme's hint token; `number`'s range errors render inside the prompt frame instead of scrolling past it. Rendering is engine-based throughout — navigation repaints only changed cells, long input wraps correctly, and answered lines persist as static output.
+
 ## v0.19.0 — 2026-07-05
 
 Hardening and tooling release. Requires Zig 0.16.0.

--- a/README.md
+++ b/README.md
@@ -219,6 +219,23 @@ bar.finish();
 
 Nine spinner styles, plus stacked multi-bars for parallel work; animations auto-disable when not a TTY, symbols adapt to unicode support. Details in [packages/progress](packages/progress/).
 
+## The CLI/TUI hybrid
+
+Prompts and progress render on `zcli.ui` — a terminal-native layout engine, and it's yours to use directly. Output splits into a static stream that flows into scrollback and a live region that repaints in place at the bottom edge: the shape of modern agent-style CLIs. A component is just a function returning a node; frames are diffed, so an animation repaints one cell, not the screen.
+
+```zig
+var app = try context.ui();
+defer app.deinit(); // restores the terminal; the final frame persists
+
+try app.emit("compiled {s}", .{name});            // static → scrollback
+try app.frame(try ui.column(app.arena(), .{ .border = .rounded }, &.{
+    ui.widgets.spinner(.{}, state.tick),
+    try ui.widgets.multiBar(app.arena(), .{}, &bars),
+}));                                              // live → diffed repaint
+```
+
+Boxes, wrapped text, spacers, and custom leaves; `fit`/`len`/`fill` sizing; viewport-clamped, resize-aware (the live region re-lays-out and the visible scrollback tail reflows), and piped output degrades to plain lines. Design in [ADR-0013](docs/adr/0013-terminal-native-layout-engine.md), API in [packages/ui](packages/ui/).
+
 ## Theming
 
 Declare a theme once in your root source file and the whole CLI follows it — help output, styled text, prompts, spinners, and progress bars:

--- a/build.zig
+++ b/build.zig
@@ -19,8 +19,6 @@ pub fn build(b: *std.Build) void {
     const prompts_dep = b.dependency("prompts", .{ .target = target, .optimize = optimize });
     const progress_dep = b.dependency("progress", .{ .target = target, .optimize = optimize });
     const theme_dep = b.dependency("theme", .{ .target = target, .optimize = optimize });
-    // Not exposed on the public umbrella yet: the layout engine (ADR-0013) is
-    // pre-stabilization; it joins the surface once the node/App API lands.
     const ui_dep = b.dependency("ui", .{ .target = target, .optimize = optimize });
 
     // The public module surface of the zcli package — what consumers (external
@@ -33,6 +31,9 @@ pub fn build(b: *std.Build) void {
     expose(b, "terminal", terminal_dep.module("terminal"));
     expose(b, "progress", progress_dep.module("progress"));
     expose(b, "prompts", prompts_dep.module("prompts"));
+    // The terminal-native layout engine (ADR-0013) — the substrate progress
+    // and prompts render on, exposed for hybrid CLI/TUI apps.
+    expose(b, "ui", ui_dep.module("ui"));
     // The unit-testing tier for scaffolded projects (see `zcli.addCommandTests`):
     // in-process command execution plus vterm-rendered assertions. Lazy — costs
     // nothing unless a consumer imports it.

--- a/docs/adr/0013-terminal-native-layout-engine.md
+++ b/docs/adr/0013-terminal-native-layout-engine.md
@@ -1,6 +1,6 @@
 # Terminal-native layout engine: an immediate-mode UI core for the CLI/TUI hybrid
 
-Status: proposed
+Status: accepted
 
 The line between CLI and TUI has blurred. The tools defining the category (Claude Code
 and the agent CLIs, most built on ink.js) feel like CLIs — output flows into scrollback

--- a/packages/core/build.zig
+++ b/packages/core/build.zig
@@ -19,6 +19,10 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    const ui_dep = b.dependency("ui", .{
+        .target = target,
+        .optimize = optimize,
+    });
     const prompts_dep = b.dependency("prompts", .{
         .target = target,
         .optimize = optimize,
@@ -35,6 +39,7 @@ pub fn build(b: *std.Build) void {
         .{ .name = "markdown", .module = markdown_dep.module("markdown") },
         .{ .name = "progress", .module = progress_dep.module("progress") },
         .{ .name = "prompts", .module = prompts_dep.module("prompts") },
+        .{ .name = "ui", .module = ui_dep.module("ui") },
         .{ .name = "serde", .module = serde_dep.module("serde") },
     };
 

--- a/packages/core/build.zig.zon
+++ b/packages/core/build.zig.zon
@@ -40,6 +40,7 @@
         .theme = .{ .path = "../theme" },
         .progress = .{ .path = "../progress" },
         .prompts = .{ .path = "../prompts" },
+        .ui = .{ .path = "../ui" },
         // See `zig fetch --save <url>` for a command-line interface for adding dependencies.
         //.example = .{
         //    // When updating this field to a new URL, be sure to delete the corresponding

--- a/packages/core/src/context.zig
+++ b/packages/core/src/context.zig
@@ -166,6 +166,20 @@ pub fn ContextFor(comptime plugins: []const type) type {
             };
         }
 
+        /// A `ui.App` pre-wired to this command's environment: stdout, the
+        /// arena-per-command allocator, the detected terminal capability, and
+        /// unicode/TTY detection. The entry point for hybrid CLI/TUI output —
+        /// `app.emit()` for static lines that flow into scrollback,
+        /// `app.frame()` for the diffed live region below. `defer app.deinit()`
+        /// (idempotent) restores the terminal and persists the final frame.
+        pub fn ui(self: *Self) !zcli.ui.App {
+            return zcli.ui.App.init(self.allocator, self.stdout(), .{
+                .capability = self.theme.capability(),
+                .unicode = zcli.ui.unicodeSupported(self.environ),
+                .interactive = self.theme.caps.is_tty,
+            });
+        }
+
         /// Get command description by path (for plugins)
         pub fn getCommandDescription(self: *Self, command_path_query: []const []const u8) ?[]const u8 {
             for (self.plugin_command_info) |cmd_info| {

--- a/packages/core/src/zcli.zig
+++ b/packages/core/src/zcli.zig
@@ -15,6 +15,12 @@ pub const progress = @import("progress");
 /// command, prefer `context.prompts()`, which returns a pre-wired instance.
 pub const Prompts = @import("prompts");
 
+/// The terminal-native layout engine (ADR-0013): a static stream that flows
+/// into scrollback plus a diffed live region at the bottom edge — the
+/// CLI/TUI hybrid. In a command, prefer `context.ui()`, which returns a
+/// pre-wired `ui.App`. progress and prompts render on this engine.
+pub const ui = @import("ui");
+
 /// A complete CLI theme; apps declare `pub const zcli_theme: zcli.Theme` in
 /// their root source file to customize how the CLI looks everywhere.
 pub const Theme = theme.Theme;
@@ -590,6 +596,23 @@ test "Context creation" {
     _ = context.stdout();
     _ = context.stderr();
     _ = context.stdin();
+}
+
+test "context.ui() returns an App wired to the detected environment" {
+    const allocator = testing.allocator;
+    var stdio: Stdio = undefined;
+    stdio.init(std.testing.io);
+
+    const test_environ = std.process.Environ.Map.init(allocator);
+    var context = Context.init(allocator, std.testing.io, &stdio, &test_environ);
+    defer context.deinit();
+
+    var app = try context.ui();
+    defer app.deinit();
+    // Tests never run on a TTY: the App must come back non-interactive, so
+    // frame() is a no-op and emit() prints plain lines.
+    try testing.expect(!app.options.interactive);
+    try testing.expect(app.options.capability == context.theme.capability());
 }
 
 test "Context is one generic: base and TestContext instantiations unify" {

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -2,12 +2,9 @@
 
 The terminal-native layout engine behind zcli's CLI/TUI hybrid ([ADR-0013](../../docs/adr/0013-terminal-native-layout-engine.md)).
 
-> **Status: pre-stabilization.** The ADR's build order is complete: surface +
-> diff renderer, node tree + layout, `App` static/live loop, the three-tier
-> resize model, and the progress widget vocabulary (`ui.widgets`). Migrating
-> the shipped `progress`/`prompts` packages onto the engine is a separate,
-> breaking decision. Until it's made, this package is not exported on the
-> zcli umbrella and its API may change freely.
+> **Status: shipped.** ADR-0013 is accepted and both interactive packages
+> (`progress`, `prompts`) render on this engine. Exposed on the zcli umbrella
+> as `zcli.ui`; in a command, `context.ui()` returns a pre-wired `App`.
 
 ## The model
 

--- a/packages/ui/src/ui.zig
+++ b/packages/ui/src/ui.zig
@@ -12,6 +12,7 @@
 //! hand its parent dangling children.
 
 const std = @import("std");
+const terminal = @import("terminal");
 
 const surface = @import("surface.zig");
 pub const Surface = surface.Surface;
@@ -24,6 +25,10 @@ pub const styleEql = surface.styleEql;
 pub const Renderer = @import("diff.zig").Renderer;
 pub const App = @import("app.zig").App;
 pub const widgets = @import("widgets.zig");
+
+/// Whether the terminal supports unicode glyphs (re-exported from `terminal`
+/// for App/RenderCtx configuration — `App.Options.unicode`).
+pub const unicodeSupported = terminal.unicodeSupported;
 
 const node_mod = @import("node.zig");
 pub const Node = node_mod.Node;

--- a/projects/zcli/src/commands/guide.zig
+++ b/projects/zcli/src/commands/guide.zig
@@ -246,6 +246,39 @@ const topics = [_]Topic{
         ,
     },
     .{
+        .name = "ui",
+        .summary = "hybrid CLI/TUI output",
+        .body =
+        \\ui — the CLI/TUI hybrid (live frames over scrolling output)
+        \\
+        \\`context.ui()` returns a `zcli.ui.App` pre-wired to the command's
+        \\stdout, allocator, theme capability, and TTY detection. Two verbs:
+        \\  app.emit(fmt, args)   static line -> flows into scrollback
+        \\  app.frame(node)       live region -> diffed repaint at the bottom
+        \\
+        \\Build each frame's node tree from `app.arena()` (reset per frame).
+        \\A component is just a function returning a `ui.Node`; state (ticks,
+        \\selections) lives in your own structs.
+        \\
+        \\  var app = try context.ui();
+        \\  defer app.deinit(); // restores terminal, final frame persists
+        \\
+        \\  try app.emit("compiled {s}", .{name});
+        \\  try app.frame(try ui.row(app.arena(), .{ .gap = 1 }, &.{
+        \\      ui.widgets.spinner(.{}, tick),
+        \\      ui.text(.{}, "building..."),
+        \\  }));
+        \\
+        \\Vocabulary: row/column boxes (gap, padding, border), text (wrap/
+        \\truncate/clip), spacer (right-align = put one before), and custom
+        \\leaves. Sizing: fit | len(n) | fill(weight). `ui.widgets` has
+        \\spinner/bar/multiBar. Piped output degrades to plain lines
+        \\automatically; resize re-lays-out the live region and reflows the
+        \\visible static tail. progress and prompts render on this engine.
+        \\
+        ,
+    },
+    .{
         .name = "http",
         .summary = "HTTP requests with safe defaults",
         .body =


### PR DESCRIPTION
## What

PR 3 of the migration plan — the engine becomes public API.

- **`zcli.ui`**: the root umbrella exposes the `ui` module and core re-exports it, same pattern as theme/progress/prompts.
- **`context.ui()`**: returns a pre-wired `ui.App` — stdout, arena-per-command allocator, capability from the theme context, unicode from the environment, `interactive` from detected TTY state. The hybrid-CLI entry point, mirroring `context.prompts()`.
- **Docs**: `zcli guide ui` topic (verified through the built CLI), a "CLI/TUI hybrid" section in the root README, an Unreleased CHANGELOG section covering the engine plus the breaking progress/prompts changes from PRs 1–2b, and the ui package README updated to shipped status.
- **ADR-0013: proposed → accepted.** The build order and consumer migration it planned are complete.

## Notes

- `context.ui()` is covered by a wiring test — Zig compiles generic fns lazily, so without a caller, breakage would hide until user code instantiated it.
- The website page for the hybrid model is deferred to the docs pass (Zine toolchain is its own workflow); flagged in the plan doc.

## Testing

Full repo suite green and the zcli e2e suite green locally (lesson learned last time). Remaining after this: PR 4, the dead-code sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)