### PR TITLE
refactor(markdown)!: capability-aware Formatter + context.markdown() (ADR-0014)

### DIFF
--- a/packages/core/src/context.zig
+++ b/packages/core/src/context.zig
@@ -179,6 +179,13 @@ pub fn ContextFor(comptime plugins: []const type) type {
             };
         }
 
+        /// A markdown `Formatter` pre-wired to stdout, the detected terminal
+        /// capability, and the app's palette (baked at comptime). Call
+        /// `.write(fmt, args)` / `.print(alloc, fmt, args)` on the result.
+        pub fn markdown(self: *Self) zcli.markdown.Formatter(zcli.appTheme().palette) {
+            return .{ .writer = self.stdout(), .capability = self.theme.capability() };
+        }
+
         /// Get command description by path (for plugins)
         pub fn getCommandDescription(self: *Self, command_path_query: []const []const u8) ?[]const u8 {
             for (self.plugin_command_info) |cmd_info| {
@@ -230,4 +237,12 @@ pub fn ContextFor(comptime plugins: []const type) type {
             return error.CommandFailed;
         }
     };
+}
+
+test "context accessors type-check" {
+    // Core itself never calls prompts()/progress()/markdown() — Zig skips
+    // unreferenced methods, so force analysis here to catch a broken accessor
+    // signature (e.g. a stale bundle field) at build time rather than only when
+    // an example happens to use it.
+    std.testing.refAllDecls(ContextFor(&.{}));
 }

--- a/packages/core/src/plugins/zcli_help/plugin.zig
+++ b/packages/core/src/plugins/zcli_help/plugin.zig
@@ -142,7 +142,7 @@ pub fn onError(
 /// Unified help display function that handles all help scenarios
 fn showHelp(context: anytype, help_type: HelpType) !void {
     var writer = context.stderr();
-    var fmt = md.capabilityFormatterWithPalette(writer, context.theme.capability(), app_palette);
+    var fmt = md.formatterWithPalette(writer, context.theme.capability(), app_palette);
     const app_name = context.app_name;
     const app_version = context.app_version;
     const app_description = context.app_description;
@@ -534,7 +534,7 @@ fn generateUsage(context: anytype) ![]const u8 {
     var aw: std.Io.Writer.Allocating = .init(context.allocator);
     errdefer aw.deinit();
     const buf_writer = &aw.writer;
-    var fmt = md.capabilityFormatterWithPalette(buf_writer, context.theme.capability(), app_palette);
+    var fmt = md.formatterWithPalette(buf_writer, context.theme.capability(), app_palette);
 
     // Start with app name and command path
     try fmt.write("<command>{s}</command>", .{context.app_name});
@@ -717,7 +717,7 @@ fn generateArgsHelp(module_info: zcli.CommandModuleInfo, context: anytype) !?[]u
     var aw: std.Io.Writer.Allocating = .init(context.allocator);
     errdefer aw.deinit();
     const buf_writer = &aw.writer;
-    var buf_fmt = md.capabilityFormatterWithPalette(buf_writer, context.theme.capability(), app_palette);
+    var buf_fmt = md.formatterWithPalette(buf_writer, context.theme.capability(), app_palette);
 
     // Generate basic help from field names
     for (module_info.args_fields) |field_info| {
@@ -736,7 +736,7 @@ fn generateOptionsHelp(module_info: zcli.CommandModuleInfo, context: anytype) !?
     var aw: std.Io.Writer.Allocating = .init(context.allocator);
     errdefer aw.deinit();
     const buf_writer = &aw.writer;
-    var buf_fmt = md.capabilityFormatterWithPalette(buf_writer, context.theme.capability(), app_palette);
+    var buf_fmt = md.formatterWithPalette(buf_writer, context.theme.capability(), app_palette);
 
     // Generate help from field info with metadata
     for (module_info.options_fields) |field_info| {

--- a/packages/markdown/README.md
+++ b/packages/markdown/README.md
@@ -5,7 +5,7 @@
 ```zig
 const md = @import("markdown");
 
-const fmt = md.formatter(stdout);
+const fmt = md.formatter(stdout, .true_color);
 try fmt.write("<error>**{s}**</error> failed at <path>{s}</path>", .{test_name, file});
 ```
 
@@ -59,7 +59,7 @@ pub fn main(init: std.process.Init) !void {
     var stdout_writer = std.Io.File.stdout().writer(io, &stdout_buf);
     const stdout = &stdout_writer.interface;
 
-    const fmt = md.formatter(stdout);
+    const fmt = md.formatter(stdout, .true_color);
 
     // Headers
     try fmt.write(
@@ -115,19 +115,32 @@ pub fn main(init: std.process.Init) !void {
 
 ### Recommended: Formatter API
 
-Create a formatter once, use it many times without passing the writer:
+Create a formatter once — bundling the writer and the terminal's capability —
+then use it many times. The formatter pre-compiles all four capability variants
+(`no_color`/`ansi_16`/`ansi_256`/`true_color`) of each format string at comptime
+and selects one at runtime, so styling still costs nothing at run time and
+respects `NO_COLOR`. Pass the detected capability (`.true_color` here for a
+standalone example):
 
 ```zig
 // With default palette
-const fmt = md.formatter(stdout);
+const fmt = md.formatter(stdout, .true_color);
 try fmt.write("## Status: <error>**{s}**</error>", .{status});
 
 // With custom palette
 const custom_palette = md.Palette{
     .err = .{ .foreground = .{ .rgb = .{ .r = 255, .g = 0, .b = 0 } }, .bold = true },
 };
-const fmt = md.formatterWithPalette(stdout, custom_palette);
+const fmt = md.formatterWithPalette(stdout, .true_color, custom_palette);
 try fmt.write("<error>Custom colors!</error>", .{});
+```
+
+In a zcli command, prefer `context.markdown()` — it wires stdout, the detected
+capability, and the app's palette for you:
+
+```zig
+var fmt = context.markdown();
+try fmt.write("<success>**{d}** tests passed</success>", .{count});
 ```
 
 **Formatter Methods:**
@@ -169,7 +182,7 @@ const fmt_string = comptime md.parse("## Header\n\n**Error:** Failed to load *{s
 **Note:** Semantic tags work with inline markdown only. For block-level documents (headers, lists, code blocks), use pure markdown.
 
 ```zig
-const fmt = md.formatter(stdout);
+const fmt = md.formatter(stdout, .true_color);
 
 // Status messages (inline only)
 try fmt.write("<success>Build succeeded</success>\n", .{});
@@ -280,7 +293,7 @@ try fmt.write(
 ### CLI Error Messages
 
 ```zig
-const fmt = md.formatter(stderr);
+const fmt = md.formatter(stderr, .true_color);
 
 try fmt.write(
     \\<error>**Error:**</error> Failed to parse <path>{s}</path> at line ~{d}~
@@ -291,7 +304,7 @@ try fmt.write(
 ### Build Reports with Markdown
 
 ```zig
-const fmt = md.formatter(stdout);
+const fmt = md.formatter(stdout, .true_color);
 
 try fmt.write(
     \\# Build Report
@@ -311,7 +324,7 @@ try fmt.write(
 ### CLI Help Text
 
 ````zig
-const fmt = md.formatter(stdout);
+const fmt = md.formatter(stdout, .true_color);
 
 try fmt.write(
     \\# myapp - A demonstration CLI
@@ -388,7 +401,7 @@ const custom_palette = md.Palette{
     .code = .{ .foreground = .{ .rgb = .{ .r = 200, .g = 200, .b = 255 } } },
 };
 
-const fmt = md.formatterWithPalette(stdout, custom_palette);
+const fmt = md.formatterWithPalette(stdout, .true_color, custom_palette);
 try fmt.write("<success>Custom colors!</success>", .{});
 ```
 

--- a/packages/markdown/examples/demo.zig
+++ b/packages/markdown/examples/demo.zig
@@ -6,9 +6,10 @@ pub fn main(init: std.process.Init) !void {
     var stdout_buffer: [4096]u8 = undefined;
     var stdout_writer = std.Io.File.stdout().writer(init.io, &stdout_buffer);
 
-    // Create a formatter - configure once, use many times
-    // Pass the address of the writer's interface
-    var fmt = md.formatter(&stdout_writer.interface);
+    // Create a formatter - configure once, use many times. Pass the address of
+    // the writer's interface and the terminal capability (here, full color;
+    // detect it or use `context.theme.capability()` in a zcli command).
+    var fmt = md.formatter(&stdout_writer.interface, .true_color);
 
     try stdout_writer.interface.writeAll("\n╔═══════════════════════════════════════════════════════════╗\n");
     try stdout_writer.interface.writeAll("║         markdown: Comprehensive Feature Demo          ║\n");
@@ -67,7 +68,7 @@ pub fn main(init: std.process.Init) !void {
         \\## Fenced Code Blocks
         \\
         \\```zig
-        \\const fmt = md.formatter(stdout);
+        \\const fmt = md.formatter(stdout, .true_color);
         \\try fmt.write("**Hello** World!", .{});
         \\```
         \\
@@ -199,7 +200,7 @@ pub fn main(init: std.process.Init) !void {
         .err = .{ .foreground = .{ .rgb = .{ .r = 255, .g = 50, .b = 50 } }, .bold = true }, // Bright red
     };
 
-    var custom_fmt = md.formatterWithPalette(&stdout_writer.interface, custom_palette);
+    var custom_fmt = md.formatterWithPalette(&stdout_writer.interface, .true_color, custom_palette);
 
     try custom_fmt.write(
         \\<success>Custom success color!</success>
@@ -211,7 +212,7 @@ pub fn main(init: std.process.Init) !void {
     try stdout_writer.interface.writeAll("\n╔═══════════════════════════════════════════════════════════╗\n");
     try stdout_writer.interface.writeAll("║                    FORMATTER API                          ║\n");
     try stdout_writer.interface.writeAll("╠═══════════════════════════════════════════════════════════╣\n");
-    try stdout_writer.interface.writeAll("║  const fmt = md.formatter(writer);                        ║\n");
+    try stdout_writer.interface.writeAll("║  const fmt = md.formatter(writer, cap);                        ║\n");
     try stdout_writer.interface.writeAll("║  try fmt.write(\"**{s}**\", .{\"text\"});                     ║\n");
     try stdout_writer.interface.writeAll("║                                                           ║\n");
     try stdout_writer.interface.writeAll("║  ✨ Comptime parsing • Zero runtime overhead • Pure Zig   ║\n");

--- a/packages/markdown/src/main.zig
+++ b/packages/markdown/src/main.zig
@@ -49,7 +49,7 @@ pub fn parseWithPalette(comptime markdown: []const u8, comptime palette: Palette
 /// This is the core parsing function that threads capability through the entire pipeline
 pub fn parseForCapability(comptime markdown: []const u8, comptime palette: Palette, comptime capability: TerminalCapability) []const u8 {
     comptime {
-        @setEvalBranchQuota(100000); // High quota needed for CapabilityFormatter (4x comptime parsing)
+        @setEvalBranchQuota(100000); // High quota needed for Formatter (4x comptime parsing)
 
         // First, check if there are semantic tags - handle those with semantic parser
         if (containsSemanticTags(markdown)) {
@@ -223,58 +223,33 @@ fn parseWithSemanticTags(comptime markdown: []const u8, comptime palette: Palett
     }
 }
 
-/// Create a formatter with default color palette (true_color output)
-pub fn formatter(writer: anytype) Formatter(@TypeOf(writer), Palette{}) {
-    return .{ .writer = writer };
-}
-
-/// Create a formatter with custom color palette (true_color output)
-pub fn formatterWithPalette(writer: anytype, comptime palette: Palette) Formatter(@TypeOf(writer), palette) {
-    return .{ .writer = writer };
-}
-
-/// Formatter with writer and compile-time color palette (always true_color)
-/// This is the simple API for when you don't need capability detection
-pub fn Formatter(comptime Writer: type, comptime palette: Palette) type {
-    return struct {
-        writer: Writer,
-
-        const Self = @This();
-
-        /// Write formatted markdown to the writer
-        pub fn write(self: *Self, comptime markdown: []const u8, args: anytype) !void {
-            const fmt_string = comptime parseWithPalette(markdown, palette);
-            try self.writer.print(fmt_string, args);
-        }
-
-        /// Format markdown and return allocated string
-        pub fn print(_: Self, allocator: std.mem.Allocator, comptime markdown: []const u8, args: anytype) ![]const u8 {
-            const fmt_string = comptime parseWithPalette(markdown, palette);
-            return std.fmt.allocPrint(allocator, fmt_string, args);
-        }
-    };
-}
-
-/// Create a capability-aware formatter that adapts output to terminal capabilities
-pub fn capabilityFormatter(writer: anytype, capability: TerminalCapability) CapabilityFormatter(@TypeOf(writer), Palette{}) {
+/// Create a capability-aware formatter with the default palette. Pass the
+/// terminal's capability (`context.theme.capability()` in a zcli command); in a
+/// command, prefer `context.markdown()`, which wires stdout + capability + the
+/// app palette.
+pub fn formatter(writer: *std.Io.Writer, capability: TerminalCapability) Formatter(Palette{}) {
     return .{ .writer = writer, .capability = capability };
 }
 
-/// Create a capability-aware formatter with custom palette
-pub fn capabilityFormatterWithPalette(writer: anytype, capability: TerminalCapability, comptime palette: Palette) CapabilityFormatter(@TypeOf(writer), palette) {
+/// Create a capability-aware formatter with a custom (comptime) palette — e.g.
+/// the app's palette, `zcli.appTheme().palette`.
+pub fn formatterWithPalette(writer: *std.Io.Writer, capability: TerminalCapability, comptime palette: Palette) Formatter(palette) {
     return .{ .writer = writer, .capability = capability };
 }
 
-/// Capability-aware formatter that pre-compiles 4 versions of each markdown string
-/// at comptime and selects the appropriate one at runtime based on terminal capability.
-pub fn CapabilityFormatter(comptime Writer: type, comptime palette: Palette) type {
+/// A capability-aware markdown formatter: a writer paired with the terminal's
+/// capability. All four capability variants (no_color/16/256/true_color) of
+/// each format string are compiled at comptime and one is selected at runtime,
+/// so styling still costs nothing at run time (ADR-0012). The palette is a
+/// comptime parameter — role colors bake into the format string.
+pub fn Formatter(comptime palette: Palette) type {
     return struct {
-        writer: Writer,
+        writer: *std.Io.Writer,
         capability: TerminalCapability,
 
         const Self = @This();
 
-        /// Write formatted markdown to the writer, adapting to terminal capability
+        /// Write formatted markdown to the writer, adapting to terminal capability.
         pub fn write(self: *Self, comptime markdown: []const u8, args: anytype) !void {
             switch (self.capability) {
                 .no_color => try self.writer.print(comptime parseForCapability(markdown, palette, .no_color), args),
@@ -284,7 +259,7 @@ pub fn CapabilityFormatter(comptime Writer: type, comptime palette: Palette) typ
             }
         }
 
-        /// Format markdown and return allocated string
+        /// Format markdown and return an allocated string.
         pub fn print(self: Self, allocator: std.mem.Allocator, comptime markdown: []const u8, args: anytype) ![]const u8 {
             return switch (self.capability) {
                 .no_color => std.fmt.allocPrint(allocator, comptime parseForCapability(markdown, palette, .no_color), args),
@@ -406,7 +381,7 @@ test "formatter basic usage" {
     var buf: [256]u8 = undefined;
     var writer: std.Io.Writer = .fixed(&buf);
 
-    var fmt = formatter(&writer);
+    var fmt = formatter(&writer, .true_color);
     try fmt.write("Build **{s}** in *{d}s*", .{ "completed", 12 });
 
     const output = writer.buffer[0..writer.end];
@@ -419,7 +394,7 @@ test "formatter with semantic tags" {
     var buf: [256]u8 = undefined;
     var writer: std.Io.Writer = .fixed(&buf);
 
-    var fmt = formatter(&writer);
+    var fmt = formatter(&writer, .true_color);
     try fmt.write("<success>**{d}** tests passed</success>", .{42});
 
     const output = writer.buffer[0..writer.end];
@@ -436,7 +411,7 @@ test "formatter with custom palette" {
         .success = .{ .foreground = .{ .rgb = .{ .r = 255, .g = 0, .b = 0 } } }, // Red instead of green
     };
 
-    var fmt = formatterWithPalette(&writer, custom_palette);
+    var fmt = formatterWithPalette(&writer, .true_color, custom_palette);
     try fmt.write("<success>Custom color</success>", .{});
 
     const output = writer.buffer[0..writer.end];
@@ -449,7 +424,7 @@ test "formatter print method" {
     var buf: [256]u8 = undefined;
     var writer: std.Io.Writer = .fixed(&buf);
 
-    const fmt = formatter(&writer);
+    const fmt = formatter(&writer, .true_color);
     const result = try fmt.print(allocator, "<error>**{s}**</error>", .{"failed"});
     defer allocator.free(result);
 
@@ -461,7 +436,7 @@ test "capability formatter no color" {
     var buf: [256]u8 = undefined;
     var writer: std.Io.Writer = .fixed(&buf);
 
-    var fmt = capabilityFormatter(&writer, .no_color);
+    var fmt = formatter(&writer, .no_color);
     try fmt.write("<success>**{d}** tests passed</success>", .{42});
 
     const output = writer.buffer[0..writer.end];
@@ -473,7 +448,7 @@ test "capability formatter ansi 16" {
     var buf: [256]u8 = undefined;
     var writer: std.Io.Writer = .fixed(&buf);
 
-    var fmt = capabilityFormatter(&writer, .ansi_16);
+    var fmt = formatter(&writer, .ansi_16);
     try fmt.write("<success>passed</success>", .{});
 
     const output = writer.buffer[0..writer.end];
@@ -486,7 +461,7 @@ test "capability formatter true color" {
     var buf: [256]u8 = undefined;
     var writer: std.Io.Writer = .fixed(&buf);
 
-    var fmt = capabilityFormatter(&writer, .true_color);
+    var fmt = formatter(&writer, .true_color);
     try fmt.write("<success>passed</success>", .{});
 
     const output = writer.buffer[0..writer.end];
@@ -755,7 +730,7 @@ test "formatter with complex document" {
     var buf: [2048]u8 = undefined;
     var writer: std.Io.Writer = .fixed(&buf);
 
-    var fmt = formatter(&writer);
+    var fmt = formatter(&writer, .true_color);
 
     const markdown =
         \\# Status: **{s}**


### PR DESCRIPTION
Second package in the [ADR-0014](../blob/main/docs/adr/0014-consistent-output-package-construction.md) construction-unification sequence (after #171 progress). Brings `markdown` to the same `context.X()` front-door shape.

## What changed
- **Collapsed four formatter constructors into one capability-aware pair.** `Formatter(comptime palette)` now bundles `{ writer, capability }` over a concrete `*std.Io.Writer` and supersedes both the old true-color `Formatter` and `CapabilityFormatter`:
  - `formatter(writer, capability)` — default palette
  - `formatterWithPalette(writer, capability, comptime palette)` — custom palette
- **Removed** the capability-blind `Formatter(Writer, palette)`, `capabilityFormatter`, and `capabilityFormatterWithPalette` (no back-compat, per project convention).
- **Added `context.markdown()`** — wires stdout, the detected capability, and the app palette (`Formatter(appTheme().palette)`), matching `context.prompts()` / `context.progress()`.

## What deliberately did *not* change (ADR §4)
markdown stays comptime. The **palette remains a comptime parameter** and the **capability drives a runtime select among four comptime-compiled variants** — the zero-runtime-cost help pipeline (ADR-0012) is untouched. markdown is a namespace (not import-is-the-type) because it's palette-parameterized, same category as `theme`. The comptime `parse`/`write`/`print` primitives are unchanged.

## Blast radius
The only external consumer of the formatter API was the `zcli_help` plugin (4 identical sites), updated to `formatterWithPalette`. README + demo updated.

## Testing
- markdown package tests + demo run clean; core tests + `projects/zcli` build clean; `zcli --help` renders correctly through the updated help plugin.
- Added a `refAllDecls` test in `context.zig` so the accessors type-check even when nothing references them — verified it catches a deliberately-broken `markdown()` signature (Zig skips unreferenced methods, which is why `context.progress()` was only ever checked via the examples).

## Notes on the migration overlap
The parallel ui-engine migration (#170/#172/#173) does **not** touch markdown (it stays comptime), so no conflict. Its PR 3 covers `zcli.ui` + `context.ui()` — that's ADR-0014 §3 (the ui alignment), so I'm leaving the ui piece to that plan rather than duplicating it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)