### PR TITLE
sweep: delete the pre-engine render machinery (migration plan PR 4)

### DIFF
--- a/packages/prompts/src/Prompts.zig
+++ b/packages/prompts/src/Prompts.zig
@@ -70,8 +70,7 @@ pub fn closeSeq(open: []const u8) []const u8 {
     return if (open.len > 0) "\x1b[0m" else "";
 }
 
-/// Shared rendering machinery for the list-style prompts (wrapping, viewport,
-/// resize-safe erase).
+/// Shared rendering machinery for the prompts (viewport + frame node builders).
 pub const list_render = @import("list_render.zig");
 
 pub const text_prompt = @import("text.zig");
@@ -106,23 +105,10 @@ pub fn appendCodepoint(allocator: std.mem.Allocator, buf: *std.ArrayList(u8), c:
 }
 
 /// Shrink `buf` by its trailing grapheme cluster — one *visible* character,
-/// however many codepoints compose it. No-op on an empty buffer. For prompts
-/// that repaint their whole line; `eraseTrailingGrapheme` also erases in place.
+/// however many codepoints compose it. No-op on an empty buffer. The line
+/// editors call this on backspace and repaint the frame from the new buffer.
 pub fn popTrailingGrapheme(buf: *std.ArrayList(u8)) void {
     buf.items.len -= terminal.trailingGraphemeLen(buf.items);
-}
-
-/// Remove the trailing grapheme cluster from `buf` and erase it from the
-/// terminal line: backspace, space, backspace — once per display column, so a
-/// double-width CJK char or emoji clears both of its cells.
-pub fn eraseTrailingGrapheme(writer: anytype, buf: *std.ArrayList(u8)) !void {
-    if (buf.items.len == 0) return;
-    const tail = buf.items[buf.items.len - terminal.trailingGraphemeLen(buf.items) ..];
-    const cols = terminal.displayWidth(tail);
-    buf.items.len -= tail.len;
-    for (0..cols) |_| try writer.writeAll("\x08");
-    for (0..cols) |_| try writer.writeAll(" ");
-    for (0..cols) |_| try writer.writeAll("\x08");
 }
 
 /// Region-relative cursor position at the end of `content` as the engine
@@ -202,26 +188,4 @@ test "popTrailingGrapheme removes whole clusters, not bytes" {
     try std.testing.expectEqualStrings("", buf.items);
     popTrailingGrapheme(&buf); // no-op on empty
     try std.testing.expectEqualStrings("", buf.items);
-}
-
-test "eraseTrailingGrapheme erases one column per display cell" {
-    const allocator = std.testing.allocator;
-    var buf = std.ArrayList(u8).empty;
-    defer buf.deinit(allocator);
-    var out: [64]u8 = undefined;
-
-    // ASCII: one cell.
-    try buf.appendSlice(allocator, "ab");
-    var w1: std.Io.Writer = .fixed(&out);
-    try eraseTrailingGrapheme(&w1, &buf);
-    try std.testing.expectEqualStrings("a", buf.items);
-    try std.testing.expectEqualStrings("\x08 \x08", w1.buffered());
-
-    // Wide CJK: two cells, so two backspace/space pairs.
-    buf.clearRetainingCapacity();
-    try buf.appendSlice(allocator, "你");
-    var w2: std.Io.Writer = .fixed(&out);
-    try eraseTrailingGrapheme(&w2, &buf);
-    try std.testing.expectEqualStrings("", buf.items);
-    try std.testing.expectEqualStrings("\x08\x08  \x08\x08", w2.buffered());
 }

--- a/packages/prompts/src/list_render.zig
+++ b/packages/prompts/src/list_render.zig
@@ -1,9 +1,7 @@
-//! Shared rendering machinery for the list-style prompts (select, multi_select,
-//! search): physical-row-accurate wrapping with a hang indent, a viewport that
-//! scrolls to keep the cursor visible, and region erase that survives terminal
-//! resize. Prompts supply their own per-item prefixes/colors via `ItemStyle`
-//! and drive their own key loops; everything about *how many rows* get painted
-//! and *how to wipe them* lives here.
+//! Shared rendering machinery for the prompts: the viewport that scrolls to
+//! keep the cursor visible, and the node builders every prompt frame is
+//! assembled from. Prompts drive their own key loops and build frames with
+//! these; painting, erasing, and row bookkeeping are the ui engine's job.
 
 const std = @import("std");
 const terminal = @import("terminal");
@@ -12,61 +10,6 @@ const terminal = @import("terminal");
 /// (e.g. output isn't a console).
 pub fn windowSize() terminal.Winsize {
     return terminal.getWindowSize(std.Io.File.stdout().handle) catch .{ .row = 24, .col = 80 };
-}
-
-/// Styling for one rendered item. `first_prefix` is printed on the item's first
-/// physical line (the bullet/marker) and must have a display width equal to
-/// `prefix_w`; continuation lines are padded to `prefix_w` so wrapped text
-/// hang-indents under the label. `line_open`/`line_close` wrap every physical
-/// line, letting a prompt colour the whole row (open) or just the marker
-/// (baked into `first_prefix`) as it prefers.
-pub const ItemStyle = struct {
-    line_open: []const u8 = "",
-    first_prefix: []const u8,
-    prefix_w: usize,
-    line_close: []const u8 = "",
-};
-
-/// Render `label` wrapped to `avail` display columns using `style`, returning
-/// the number of physical rows emitted. `first_line` tracks whether a CRLF
-/// separator is needed; rows are CRLF-*separated*, not terminated, so the
-/// caller's cursor ends at the end of the last row (see `eraseRegion`).
-pub fn renderItem(
-    writer: anytype,
-    first_line: *bool,
-    style: ItemStyle,
-    label: []const u8,
-    avail: usize,
-) !usize {
-    const Ctx = struct {
-        w: @TypeOf(writer),
-        first_line: *bool,
-        style: ItemStyle,
-        seg: usize = 0,
-        rows: usize = 0,
-
-        fn emit(self: *@This(), line: []const u8) anyerror!void {
-            if (!self.first_line.*) try self.w.writeAll("\r\n");
-            self.first_line.* = false;
-            try self.w.writeAll(self.style.line_open);
-            if (self.seg == 0) {
-                try self.w.writeAll(self.style.first_prefix);
-            } else {
-                try writePad(self.w, self.style.prefix_w);
-            }
-            try self.w.writeAll(line);
-            try self.w.writeAll(self.style.line_close);
-            self.seg += 1;
-            self.rows += 1;
-        }
-    };
-    var ctx = Ctx{ .w = writer, .first_line = first_line, .style = style };
-    try terminal.wrapForEach(label, avail, &ctx, Ctx.emit);
-    return ctx.rows;
-}
-
-pub fn writePad(writer: anytype, n: usize) !void {
-    for (0..n) |_| try writer.writeAll(" ");
 }
 
 /// A contiguous window of items to display, chosen so the cursor stays visible
@@ -103,16 +46,6 @@ pub fn viewport(
     return .{ .start = start, .end = end };
 }
 
-/// Erase the previously rendered region. The cursor is at the end of the last
-/// row (rows are CRLF-separated, not terminated), so return to column 0, move up
-/// to the first row, and clear to the end of the display.
-pub fn eraseRegion(writer: anytype, rows: usize) !void {
-    if (rows == 0) return;
-    try writer.writeAll("\r");
-    if (rows > 1) try writer.print("\x1b[{d}A", .{rows - 1});
-    try writer.writeAll("\x1b[0J");
-}
-
 const testing = std.testing;
 
 const CountSlice = struct {
@@ -136,29 +69,8 @@ test "viewport shows everything when it fits" {
     try testing.expectEqual(@as(usize, 3), win.end);
 }
 
-test "eraseRegion is a no-op for zero rows" {
-    var buf: [64]u8 = undefined;
-    var w: std.Io.Writer = .fixed(&buf);
-    try eraseRegion(&w, 0);
-    try testing.expectEqual(@as(usize, 0), w.buffered().len);
-}
-
-test "renderItem hang-indents continuation lines under the label" {
-    var buf: [512]u8 = undefined;
-    var w: std.Io.Writer = .fixed(&buf);
-    var first = true;
-    // 4-column prefix; a label that must wrap at width 12 (avail 8).
-    const rows = try renderItem(&w, &first, .{ .first_prefix = "  > ", .prefix_w = 4 }, "alpha bravo charlie", 8);
-    try testing.expect(rows >= 2);
-    // First line carries the prefix; a continuation line is padded to 4 spaces.
-    try testing.expect(std.mem.indexOf(u8, w.buffered(), "  > alpha") != null);
-    try testing.expect(std.mem.indexOf(u8, w.buffered(), "\r\n    ") != null);
-}
-
 // ---------------------------------------------------------------------------
-// Node builders for the ui-engine render path (ADR-0013 migration). The
-// imperative renderItem/eraseRegion machinery above remains until the line
-// prompts migrate too, then gets swept.
+// Node builders for the prompt frames.
 // ---------------------------------------------------------------------------
 
 pub const ui = @import("ui");

--- a/packages/prompts/test/render_e2e.zig
+++ b/packages/prompts/test/render_e2e.zig
@@ -215,39 +215,6 @@ test "emulator: select answer persists as one static line, region gone" {
 }
 
 // ---------------------------------------------------------------------------
-// text input: echo + backspace-erase (grapheme/width aware)
-// ---------------------------------------------------------------------------
-
-test "emulator: backspace-erase clears a wide char's both cells" {
-    const alloc = testing.allocator;
-    var buf = std.ArrayList(u8).empty;
-    defer buf.deinit(alloc);
-    var out: [256]u8 = undefined;
-    var w: std.Io.Writer = .fixed(&out);
-
-    // Type "ab" then 你 (2 cells), then backspace 你 away and type "c" — the
-    // screen must read exactly "abc" with no half-glyph debris in the cells the
-    // wide char occupied. A byte- or single-column erase fails this.
-    try w.writeAll(try Prompts.appendCodepoint(alloc, &buf, 'a'));
-    try w.writeAll(try Prompts.appendCodepoint(alloc, &buf, 'b'));
-    try w.writeAll(try Prompts.appendCodepoint(alloc, &buf, '你'));
-    try Prompts.eraseTrailingGrapheme(&w, &buf);
-    try w.writeAll(try Prompts.appendCodepoint(alloc, &buf, 'c'));
-
-    try testing.expectEqualStrings("abc", buf.items);
-
-    var term = try vterm.VTerm.init(alloc, 20, 4);
-    defer term.deinit();
-    term.write(w.buffered());
-    const line = try term.getLine(alloc, 0);
-    defer alloc.free(line);
-    try testing.expectEqualStrings("abc", std.mem.trimEnd(u8, line, " "));
-    // Cursor sits right after the 'c' — erase walked back exactly two cells.
-    try testing.expectEqual(@as(u32, 3), term.cursor.x);
-    try testing.expectEqual(@as(u32, 0), term.cursor.y);
-}
-
-// ---------------------------------------------------------------------------
 // search
 // ---------------------------------------------------------------------------
 

--- a/packages/terminal/README.md
+++ b/packages/terminal/README.md
@@ -31,17 +31,15 @@ exe.root_module.addImport("terminal", terminal_dep.module("terminal"));
 
 ## Quick start
 
-An interactive read loop that survives resizes (this is how prompts's prompts are built):
+An interactive read loop that survives resizes (this is how prompts's prompts are built — rendering goes through the `ui` engine, which owns the cursor):
 
 ```zig
 const terminal = @import("terminal");
 
 const stdin = std.Io.File.stdin().handle;
 const raw = try terminal.enableRawMode(stdin);
-try writer.writeAll(terminal.ansi.hide_cursor);
 var watcher = terminal.ResizeWatcher.init();
 defer {
-    writer.writeAll(terminal.ansi.show_cursor) catch {};
     watcher.deinit();
     raw.disable();
 }

--- a/packages/terminal/src/terminal.zig
+++ b/packages/terminal/src/terminal.zig
@@ -138,24 +138,6 @@ pub const symbols = struct {
 // ANSI escape helpers
 // ============================================================================
 
-pub const ansi = struct {
-    pub const hide_cursor = "\x1b[?25l";
-    pub const show_cursor = "\x1b[?25h";
-    pub const clear_line = "\r\x1b[K";
-    pub const clear_to_end = "\x1b[J";
-    pub const reset = "\x1b[0m";
-    pub const bold = "\x1b[1m";
-    pub const dim = "\x1b[2m";
-
-    pub fn cursorUp(comptime n: usize) []const u8 {
-        return std.fmt.comptimePrint("\x1b[{d}A", .{n});
-    }
-
-    pub fn cursorDown(comptime n: usize) []const u8 {
-        return std.fmt.comptimePrint("\x1b[{d}B", .{n});
-    }
-};
-
 // ============================================================================
 // Tests
 // ============================================================================
@@ -173,10 +155,7 @@ test "Key type works" {
     try std.testing.expect(c.char == 'a');
 }
 
-test "ANSI helpers" {
-    try std.testing.expectEqualStrings("\x1b[?25l", ansi.hide_cursor);
-    try std.testing.expectEqualStrings("\r\x1b[K", ansi.clear_line);
-}
+test "ANSI helpers" {}
 
 test "TTY detection runs" {
     _ = isStdinTty();


### PR DESCRIPTION
## What

The final PR of the migration plan — deleting everything the engine replaced, now that nothing calls it:

- **`list_render`**: `ItemStyle`/`renderItem`/`writePad` (hand-computed hang indents) and `eraseRegion` (erase-count bookkeeping). List prompts build frame nodes; the engine paints, diffs, and erases. `viewport()` and the node builders remain.
- **`Prompts.eraseTrailingGrapheme`**: the backspace-space-backspace echo erase — line editors repaint frames from the buffer now. `popTrailingGrapheme` (buffer-side) stays.
- **`terminal.ansi`** escape constants: zero callers remained; the engine owns cursor/erase sequences. The terminal README's raw-mode example updated accordingly.
- The render_e2e helper test for the deleted erase helper went with it — grapheme integrity is covered by the surface wide-char tests and the zcli UTF-8 e2e.

Net **−180 lines**, all of it the hand-rolled escape machinery ADR-0013 set out to dissolve.

## Testing

Full repo suite and the zcli e2e suite green locally. This closes out the migration plan (PRs #170, #172, #173, #174, and this) — the plan doc in `.context/` is marked complete and retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)