### PR TITLE
docs: sync docs + website to the ui layout-engine migration

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -780,7 +780,48 @@ never on the commands — so the back-reference resolves cleanly. The build wire
 Plugin hooks stay `anytype` because a plugin is compiled independently of the
 app that hosts it.
 
-## 13. Developer Experience
+## 13. Terminal Output & Rendering
+
+Beyond command dispatch, zcli ships a family of terminal-output packages that a
+command reaches through its `context`:
+
+- **`theme`** — semantic styling. A comptime `Palette` maps roles
+  (`success`, `command`, `path`, …) to styles; component tokens
+  (`prompts.cursor`, `progress.spinner`) default to those roles. Everything
+  resolves against the detected terminal capability, from true color down to
+  `NO_COLOR`. See ADR-0012.
+- **`prompts`** — eight interactive prompt types (`text`, `select`,
+  `multiSelect`, `search`, …) with grapheme-aware line editing, falling back to
+  line input when stdin is not a TTY.
+- **`progress`** — spinners for indeterminate work and progress/multi-bars for
+  known totals; animations on a TTY, plain lines when piped.
+- **`markdown`** — comptime-baked ANSI formatting used by the help pipeline
+  (zero runtime cost; ADR-0012).
+
+**The layout engine (`packages/ui`, ADR-0013).** `prompts` and `progress` do
+not hand-roll cursor movement or repainting — they render on a shared
+terminal-native layout engine. Output splits into a **static stream** that flows
+into scrollback (`app.emit`) and a **live region** pinned to the bottom edge
+that repaints in place (`app.frame`). The live region is immediate-mode: a
+component is a function returning a `Node`; each frame the tree is rebuilt into a
+per-frame arena, measured, painted onto a cell `Surface`, and diffed against the
+previous frame, so only changed cells reach the terminal. Four node kinds
+(`box`, `text`, `spacer`, `custom`) and three sizing words (`fit`, `len`,
+`fill`) cover the vocabulary; the region re-measures against the terminal each
+frame, so it re-lays-out on resize and clamps to the viewport. This is the
+CLI/TUI hybrid — the shape of modern agent-style CLIs — and it is exposed
+directly as `zcli.ui` / `context.ui()`.
+
+**Construction idiom (ADR-0014).** `context.X()` is the single front door for
+every output capability: `context.theme`, `context.prompts()`,
+`context.progress()`, `context.markdown()`, `context.ui()` each hand back an
+instance already wired to the command's streams, allocator, io, and theme. The
+stateless packages (`prompts`, `progress`, `markdown`) are value bundles — the
+import *is* the type — so standalone use fills the same fields by hand;
+stateful ones (`ui.App`) keep `init`/`deinit`. Each package also works without
+the framework and is published independently.
+
+## 14. Developer Experience
 
 **Zero-Cost Dispatch:**
 

--- a/docs/adr/0014-consistent-output-package-construction.md
+++ b/docs/adr/0014-consistent-output-package-construction.md
@@ -1,6 +1,6 @@
 # Consistent construction across the core output packages
 
-Status: proposed
+Status: accepted
 
 Every package that writes to the terminal — `prompts`, `progress`, `markdown`,
 `theme`, `ui` — needs some subset of the same five environment inputs: a

--- a/packages/terminal/README.md
+++ b/packages/terminal/README.md
@@ -10,7 +10,7 @@ Cross-platform terminal primitives for interactive Zig CLIs: raw mode, event-dri
 - **Width & wrapping**: `displayWidth` handles CJK double-width, emoji (ZWJ sequences, flags, modifiers), combining marks, and skips ANSI sequences; `wrapToWidth` / `wrapForEach` / `wrapCount` wrap to a column budget (allocating, streaming, and counting variants)
 - **Grapheme editing**: `trailingGraphemeLen` and `graphemeCount` make backspace/cursor logic correct for user-perceived characters
 - **Portability**: libc-free on POSIX (`std.posix` directly — static musl builds work); on Windows, virtual-terminal mode makes the console speak the same ANSI dialect, so the escape parsing is fully shared
-- **Helpers**: `ansi.*` escape constants (`hide_cursor`, `clear_line`, …), `symbols.*` Unicode/ASCII indicator pairs, `isTty` / `isStdinTty` / `isStdoutTty`, `unicodeSupported(environ)`
+- **Helpers**: `symbols.*` Unicode/ASCII indicator pairs, `isTty` / `isStdinTty` / `isStdoutTty`, `unicodeSupported(environ)` — cursor and screen escapes live in the [`ui`](../ui/) engine, which owns all repainting
 
 ## Installation
 

--- a/website/content/ui/index.smd
+++ b/website/content/ui/index.smd
@@ -1,0 +1,7 @@
+---
+.title = "zcli — The CLI/TUI hybrid",
+.description = "zcli.ui is a terminal-native layout engine: a static stream that flows into scrollback plus a diffed live region that repaints in place — the shape of modern agent-style CLIs. Immediate-mode node trees, viewport-clamped and resize-aware, degrading to plain lines when piped.",
+.date = @date("2026-07-08"),
+.author = "Ryan Hair",
+.layout = "ui.shtml",
+---

--- a/website/layouts/docs.shtml
+++ b/website/layouts/docs.shtml
@@ -67,6 +67,7 @@
         <a href="#context">The context</a>
         <a href="#prompts">Prompts</a>
         <a href="#progress">Progress & theming</a>
+        <a href="#hybrid">CLI/TUI hybrid</a>
         <a href="#config">Config files</a>
         <h4>Plugins</h4>
         <a href="#plugins">Using plugins</a>
@@ -270,11 +271,14 @@ exe.root_module.<span class="fn">addImport</span>(<span class="str">"command_reg
           <p>The <code>progress</code> package provides spinners (9 styles) and progress bars with ETA; animations auto-disable when not a TTY.</p>
           <div class="code">
             <div class="code-head"><span class="fname">progress</span><span class="lang">zig</span></div>
-<pre><span class="kw">var</span> spinner = progress.<span class="fn">spinner</span>(io, .{ .style = .dots });
+<pre><span class="cm">// Pre-wired to the command's stdout, io, allocator, and theme.</span>
+<span class="kw">const</span> p = context.<span class="fn">progress</span>();
+
+<span class="kw">var</span> spinner = <span class="kw">try</span> p.<span class="fn">spinner</span>(.{ .style = .dots });
 spinner.<span class="fn">start</span>(<span class="str">"Connecting to server..."</span>);
 spinner.<span class="fn">succeed</span>(<span class="str">"Synced successfully"</span>);  <span class="cm">// or .fail() / .warn() / .info()</span>
 
-<span class="kw">var</span> bar = progress.<span class="fn">progressBar</span>(io, .{ .total = items.len, .show_eta = <span class="num">true</span> });
+<span class="kw">var</span> bar = <span class="kw">try</span> p.<span class="fn">progressBar</span>(.{ .total = items.len, .show_eta = <span class="num">true</span> });
 <span class="kw">for</span> (items, <span class="num">0</span>..) |item, i| { <span class="fn">process</span>(item); bar.<span class="fn">update</span>(i + <span class="num">1</span>, <span class="kw">null</span>); }</pre>
           </div>
           <h3>Theming</h3>
@@ -292,6 +296,24 @@ spinner.<span class="fn">succeed</span>(<span class="str">"Synced successfully"<
 <span class="kw">try</span> <span class="fn">styled</span>(<span class="str">"Synced"</span>).<span class="fn">success</span>().<span class="fn">render</span>(writer, &context.theme);</pre>
           </div>
           <p>The full role list, component tokens, and how each surface consumes the theme: see the <a href="$site.page('theming').link()">theming guide</a>.</p>
+        </section>
+
+        <!-- ============ CLI/TUI HYBRID ============ -->
+        <section id="hybrid">
+          <h2>CLI/TUI hybrid</h2>
+          <p>Prompts and progress both render on <code>zcli.ui</code> — a terminal-native layout engine — and it's yours to use directly. Output splits into a static stream that flows into scrollback and a live region that repaints in place at the bottom edge: the shape of modern agent-style CLIs. A component is just a function returning a node; frames are diffed, so an animation repaints one cell, not the screen.</p>
+          <div class="code">
+            <div class="code-head"><span class="fname">src/commands/deploy.zig</span><span class="lang">zig</span></div>
+<pre><span class="kw">var</span> app = <span class="kw">try</span> context.<span class="fn">ui</span>();
+<span class="kw">defer</span> app.<span class="fn">deinit</span>(); <span class="cm">// restores the terminal; the final frame persists</span>
+
+<span class="kw">try</span> app.<span class="fn">emit</span>(<span class="str">"compiled {s}"</span>, .{name});            <span class="cm">// static -> scrollback</span>
+<span class="kw">try</span> app.<span class="fn">frame</span>(<span class="kw">try</span> ui.<span class="fn">row</span>(app.<span class="fn">arena</span>(), .{ .gap = <span class="num">1</span> }, &.{
+    ui.widgets.<span class="fn">spinner</span>(.{}, state.tick),
+    ui.<span class="fn">text</span>(.{ .bold = <span class="num">true</span> }, <span class="str">"building..."</span>),
+}));                                          <span class="cm">// live -> diffed repaint</span></pre>
+          </div>
+          <p>Boxes, wrapped text, spacers, and custom leaves; <code>fit</code>/<code>len</code>/<code>fill</code> sizing; viewport-clamped and resize-aware, degrading to plain lines when piped. The model, the node vocabulary, and the widgets: see the <a href="$site.page('ui').link()">CLI/TUI hybrid guide</a>.</p>
         </section>
 
         <!-- ============ CONFIG ============ -->

--- a/website/layouts/templates/base.shtml
+++ b/website/layouts/templates/base.shtml
@@ -63,6 +63,7 @@
                 <h4>Packages</h4>
                 <a href="$site.page('docs').link().suffix('#prompts')">prompts</a>
                 <a href="$site.page('docs').link().suffix('#progress')">progress</a>
+                <a href="$site.page('ui').link()">ui</a>
                 <a href="https://github.com/ryanhair/zcli/blob/main/LICENSE" target="_blank" rel="noopener">License (MIT)</a>
             </div>
         </div>

--- a/website/layouts/theming.shtml
+++ b/website/layouts/theming.shtml
@@ -175,7 +175,8 @@
           <p>Spinners animate in the <code>progress.spinner</code> token (accent by default); result symbols — <code>succeed</code>, <code>fail</code>, <code>warn</code>, <code>info</code> — render through the matching palette roles; progress bars color their fill and track via <code>bar_fill</code>/<code>bar_empty</code> on TTYs and stay plain when piped:</p>
           <div class="code">
             <div class="code-head"><span class="fname">progress</span><span class="lang">zig</span></div>
-<pre><span class="kw">var</span> spinner = zcli.progress.<span class="fn">spinner</span>(io, .{ .theme = context.theme });
+<pre><span class="cm">// context.progress() carries the app theme, so the spinner is themed.</span>
+<span class="kw">var</span> spinner = <span class="kw">try</span> context.<span class="fn">progress</span>().<span class="fn">spinner</span>(.{});
 spinner.<span class="fn">start</span>(<span class="str">"Deploying..."</span>);
 spinner.<span class="fn">succeed</span>(<span class="str">"Deployed"</span>);  <span class="cm">// ✔ in your palette's success style</span></pre>
           </div>

--- a/website/layouts/ui.shtml
+++ b/website/layouts/ui.shtml
@@ -1,0 +1,199 @@
+<extend template="base.shtml">
+
+<head id="head">
+<style>
+  .layout { display: grid; grid-template-columns: 240px 1fr; gap: 56px; padding: 56px 0 96px; align-items: start; }
+  .layout > * { min-width: 0; }   /* let code blocks scroll instead of widening the page */
+  .table-scroll { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+  .toc { position: sticky; top: 84px; font-family: var(--mono); font-size: 13px; }
+  .toc .toc-label { font-size: 11px; font-weight: 500; letter-spacing: 0.14em; text-transform: uppercase; color: var(--faint); margin: 20px 0 10px; }
+  .toc .toc-label:first-child { margin-top: 0; }
+  .toc a { display: block; color: var(--muted); padding: 5px 0 5px 12px; border-left: 1px solid var(--border); transition: all .15s; }
+  .toc a:hover, .toc a.active { color: var(--accent); border-left-color: var(--accent); }
+
+  .doc { max-width: 760px; }
+  .doc > section { padding: 0 0 56px; border: none; }
+  .doc h1 { font-size: 40px; margin-bottom: 12px; }
+  .doc .sub { color: var(--muted); font-size: 18px; margin-bottom: 8px; }
+  .doc h2 { font-size: 26px; margin: 44px 0 14px; padding-top: 12px; }
+  .doc h3 { font-size: 18px; margin: 30px 0 10px; color: var(--fg); }
+  .doc p { color: var(--muted); margin-bottom: 14px; }
+  .doc ul { color: var(--muted); margin: 0 0 16px 20px; }
+  .doc li { padding: 4px 0; }
+  .doc code { font-family: var(--mono); font-size: 0.88em; background: var(--surface2); border: 1px solid var(--border); border-radius: 5px; padding: 1px 6px; color: var(--accent); }
+  .doc .code code { background: none; border: none; padding: 0; color: inherit; }
+  .doc .code { margin: 16px 0 22px; }
+  .callout { background: rgba(247,164,29,0.06); border: 1px solid rgba(247,164,29,0.25); border-radius: 9px; padding: 14px 18px; margin: 18px 0; color: var(--muted); font-size: 14.5px; }
+  .callout b { color: var(--accent); font-family: var(--mono); font-size: 12px; letter-spacing: 0.08em; text-transform: uppercase; display: block; margin-bottom: 4px; }
+
+  .ptable { width: 100%; border-collapse: collapse; font-size: 14.5px; margin: 8px 0 8px; }
+  .ptable th { text-align: left; font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--faint); padding: 0 14px 12px; border-bottom: 1px solid var(--border); font-weight: 500; }
+  .ptable td { padding: 13px 14px; border-bottom: 1px solid var(--border); vertical-align: top; }
+  .ptable td.name { font-family: var(--mono); color: var(--accent); white-space: nowrap; }
+  .ptable td.desc { color: var(--muted); }
+
+  .nextlinks { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 16px; }
+  .nextlinks a { display: block; background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 18px 20px; transition: border-color .15s; }
+  .nextlinks a:hover { border-color: var(--accent); }
+  .nextlinks .k { display: block; font-family: var(--mono); font-size: 12px; color: var(--accent); }
+  .nextlinks .t { display: block; color: var(--fg); font-size: 15px; margin-top: 4px; }
+  @media (max-width: 860px) { .layout { grid-template-columns: 1fr; } .toc { display: none; } .nextlinks { grid-template-columns: 1fr; } }
+</style>
+</head>
+
+<main id="main">
+  <div class="wrap">
+    <div class="layout">
+      <nav class="toc" aria-label="On this page">
+        <p class="toc-label">The engine</p>
+        <a href="#intro">Overview</a>
+        <a href="#model">The frame model</a>
+        <a href="#nodes">Nodes &amp; sizing</a>
+        <p class="toc-label">Using it</p>
+        <a href="#app">The App</a>
+        <a href="#widgets">Widgets</a>
+        <a href="#resize">Resize &amp; piping</a>
+        <p class="toc-label">Details</p>
+        <a href="#standalone">Standalone use</a>
+        <a href="#try">Try it</a>
+      </nav>
+
+      <article class="doc">
+        <section id="intro">
+          <h1>The CLI/TUI hybrid</h1>
+          <p class="sub">Prompts and progress render on <code>zcli.ui</code> — a terminal-native layout engine — and it's yours to use directly. Stream lines into scrollback while a live region repaints in place at the bottom edge: the shape of modern agent-style CLIs.</p>
+          <p>A full-screen TUI takes the terminal over; a plain CLI can't paint. The hybrid is the third shape — the one Claude Code, modern installers, and deploy tools use. zcli's engine gives you both halves at once:</p>
+          <ul>
+            <li><b>A static stream</b> flows upward into scrollback, one line at a time, exactly like normal output — copy-pasteable, greppable, permanent.</li>
+            <li><b>A live region</b> sits pinned to the bottom edge and repaints in place — a spinner, a status frame, a stack of progress bars — without disturbing the scrollback above it.</li>
+            <li><b>Immediate mode</b> means a component is just a function returning a node. You rebuild the tree every frame from your own state; the engine diffs it and sends only the cells that changed.</li>
+          </ul>
+          <div class="callout"><b>Built on it</b> The <a href="$site.page('docs').link().suffix('#prompts')">prompts</a> and <a href="$site.page('docs').link().suffix('#progress')">progress</a> packages both render on this engine — so cursor hygiene, diffed repaints, and resize re-layout are solved once, in one place.</div>
+        </section>
+
+        <section id="model">
+          <h2>The frame model</h2>
+          <p>The live region is rebuilt from scratch every frame: the node tree is allocated into a per-frame arena, measured (constraints down, sizes up), painted onto a cell surface, and diffed against the previous surface. An unchanged frame writes <em>zero</em> bytes; a ticking spinner repaints one cell, not the screen.</p>
+          <p>Two verbs drive it. <code>emit</code> writes a static line that scrolls up and away; <code>frame</code> replaces the live region with a new node tree. <code>emit</code> is the only way to write while a region is up — it erases the region, prints the line into scrollback, and repaints the region below it.</p>
+          <div class="code">
+            <div class="code-head"><span class="fname">a component is just a function</span><span class="lang">zig</span></div>
+<pre><span class="cm">// State lives in your structs; the frame is a pure function of it.</span>
+<span class="kw">fn</span> <span class="fn">statusLine</span>(a: std.mem.Allocator, s: *<span class="kw">const</span> State) !ui.Node {
+    <span class="kw">return</span> ui.<span class="fn">row</span>(a, .{ .gap = <span class="num">1</span> }, &.{
+        ui.widgets.<span class="fn">spinner</span>(.{}, s.tick),     <span class="cm">// animation = your tick</span>
+        ui.<span class="fn">text</span>(.{ .bold = <span class="num">true</span> }, s.message),
+        ui.<span class="fn">spacer</span>(),                        <span class="cm">// push the rest to the right edge</span>
+        ui.<span class="fn">text</span>(.{ .dim = <span class="num">true</span> }, s.elapsed),
+    });
+}</pre>
+          </div>
+        </section>
+
+        <section id="nodes">
+          <h2>Nodes &amp; sizing</h2>
+          <p>The whole vocabulary is four node kinds and three sizing words — small enough to hold in your head, expressive enough for a bordered, multi-column status frame.</p>
+          <div class="table-scroll">
+          <table class="ptable">
+            <thead><tr><th>Node</th><th>What it is</th></tr></thead>
+            <tbody>
+              <tr><td class="name">box</td><td class="desc">the only container — <code>row</code> and <code>column</code> are boxes with a direction; carries <code>gap</code>, <code>padding</code>, and an optional <code>border</code></td></tr>
+              <tr><td class="name">text</td><td class="desc">a styled string; <code>ui.textOpts</code> chooses <code>wrap</code> / <code>truncate</code> / <code>clip</code> and a fixed width</td></tr>
+              <tr><td class="name">spacer</td><td class="desc">flexible empty space; put one before a node to right-align it, one on each side to center</td></tr>
+              <tr><td class="name">custom</td><td class="desc">the escape hatch — a leaf that draws its own cells (this is how the progress bar is built)</td></tr>
+            </tbody>
+          </table>
+          </div>
+          <p>Every dimension is one of three words. <code>fit</code> shrinks to content, <code>len(n)</code> pins an exact column count, and <code>fill(weight)</code> shares leftover space by weight — so percentages are fill weights and right-alignment is a spacer, not special-cased geometry.</p>
+          <div class="callout"><b>Whitespace</b> The default <code>.wrap</code> mode word-wraps and drops break spaces. Labels with significant whitespace — padded numbers, aligned columns — want <code>.clip</code> or <code>.truncate</code> via <code>ui.textOpts</code>.</div>
+        </section>
+
+        <section id="app">
+          <h2>The App</h2>
+          <p>In a command, <code>context.ui()</code> returns a <code>zcli.ui.App</code> pre-wired to the command's stdout, allocator, theme capability, and TTY detection. The <code>App</code> owns everything stateful — the frame arena (<code>app.arena()</code>, reset when <code>frame()</code> returns), the live region's rows, the double-buffered surfaces, and the cursor (hidden while a region is up, parked at its top-left between calls, restored on <code>deinit</code>).</p>
+          <div class="code">
+            <div class="code-head"><span class="fname">src/commands/deploy.zig</span><span class="lang">zig</span></div>
+<pre><span class="kw">var</span> app = <span class="kw">try</span> context.<span class="fn">ui</span>();
+<span class="kw">defer</span> app.<span class="fn">deinit</span>(); <span class="cm">// restores the terminal; the final frame persists in scrollback</span>
+
+<span class="kw">try</span> app.<span class="fn">emit</span>(<span class="str">"compiled {s}"</span>, .{name});               <span class="cm">// static -> scrollback</span>
+<span class="kw">try</span> app.<span class="fn">frame</span>(<span class="kw">try</span> <span class="fn">statusLine</span>(app.<span class="fn">arena</span>(), &state)); <span class="cm">// live  -> diffed repaint</span></pre>
+          </div>
+          <p>Builders copy their child slices into the arena, so component functions compose freely — no dangling-temporary hazards from returning a node built over a stack array. Styles on the nodes are <code>theme.Style</code> values, and the diff renderer emits them capability-aware, from <code>NO_COLOR</code> through true color.</p>
+        </section>
+
+        <section id="widgets">
+          <h2>Widgets</h2>
+          <p><code>ui.widgets</code> is the progress vocabulary as component functions: a spinner is a <code>text</code> node, a bar is one <code>custom</code> leaf, a multi-bar is a column of rows. No widget owns a repaint loop or hidden state — animation is your tick, progress is your fraction, the frame diff does the rest. Styling flows through the theme's <code>progress</code> tokens, the same ones the progress package reads.</p>
+          <div class="code">
+            <div class="code-head"><span class="fname">a bordered status frame</span><span class="lang">zig</span></div>
+<pre><span class="kw">const</span> a = app.<span class="fn">arena</span>();
+<span class="kw">try</span> app.<span class="fn">frame</span>(<span class="kw">try</span> ui.<span class="fn">column</span>(a, .{ .border = .rounded, .padding = .<span class="fn">symmetric</span>(<span class="num">1</span>, <span class="num">0</span>) }, &.{
+    <span class="kw">try</span> ui.<span class="fn">row</span>(a, .{ .gap = <span class="num">1</span> }, &.{
+        ui.widgets.<span class="fn">spinner</span>(.{}, state.tick),
+        ui.<span class="fn">text</span>(.{ .bold = <span class="num">true</span> }, <span class="str">"Reading dependencies"</span>),
+        ui.<span class="fn">spacer</span>(),
+        ui.<span class="fn">text</span>(.{ .dim = <span class="num">true</span> }, state.elapsed),
+    }),
+    <span class="kw">try</span> ui.widgets.<span class="fn">multiBar</span>(a, .{}, &.{
+        .{ .label = <span class="str">"src/parser.zig"</span>,    .fraction = <span class="num">0.6</span> },
+        .{ .label = <span class="str">"src/formatter.zig"</span>, .fraction = <span class="num">0.9</span> },
+    }),
+}));</pre>
+          </div>
+        </section>
+
+        <section id="resize">
+          <h2>Resize &amp; piping</h2>
+          <p>The live region re-measures against the terminal on every frame, so it re-lays-out on resize for free; its height clamps to the viewport and clips from the bottom. Scrollback is the terminal's authority — but the engine retains the source text of the visible static tail and, on a width change, synchronously rewraps it so the seam between the reflowed tail and the live frame stays clean.</p>
+          <ul>
+            <li><b>Live region</b> — full relayout against the new width, every frame.</li>
+            <li><b>Visible static tail</b> — retained in source form and repainted to rewrap with the new width.</li>
+            <li><b>Scrollback above the fold</b> — left to the terminal; reflow there is the terminal's job, not the app's.</li>
+          </ul>
+          <p>When stdout is not a TTY — a pipe, a file, a CI log — there is no live region to repaint: <code>emit</code> lines print as normal, and a frame degrades to the plain lines it would draw. The same code path produces an interactive frame and a clean log.</p>
+        </section>
+
+        <section id="standalone">
+          <h2>Standalone use</h2>
+          <p>Like every zcli package, <code>ui</code> works without the framework. Outside a command there's no <code>context</code>, so construct the <code>App</code> yourself — it owns heap state (surfaces, retained scrollback), so it takes an explicit <code>init</code>/<code>deinit</code> rather than the value-bundle shape of the stateless packages:</p>
+          <div class="code">
+            <div class="code-head"><span class="fname">standalone</span><span class="lang">zig</span></div>
+<pre><span class="kw">const</span> ui = <span class="fn">@import</span>(<span class="str">"ui"</span>);
+
+<span class="kw">var</span> app = <span class="kw">try</span> ui.App.<span class="fn">init</span>(gpa, writer, .{ .capability = .ansi_256 });
+<span class="kw">defer</span> app.<span class="fn">deinit</span>();
+
+<span class="kw">try</span> app.<span class="fn">emit</span>(<span class="str">"✓ built {s}"</span>, .{name});
+<span class="kw">try</span> app.<span class="fn">frame</span>(<span class="kw">try</span> <span class="fn">statusLine</span>(app.<span class="fn">arena</span>(), &state));</pre>
+          </div>
+        </section>
+
+        <section id="try">
+          <h2>Try it</h2>
+          <p>Two runnable examples live in the <code>ui</code> package — both want a real terminal. Resize the window while either runs and watch the live frame re-lay-out as the visible static tail rewraps with it.</p>
+          <div class="code">
+            <div class="code-head"><span class="fname">packages/ui</span><span class="lang">sh</span></div>
+<pre>zig build run-demo     <span class="cm"># deploy-style task frame: spinner, task list, live gauges</span>
+zig build run-hybrid   <span class="cm"># the Claude-Code shape: streaming prose + a live multi-bar</span></pre>
+          </div>
+          <div class="nextlinks">
+            <a href="https://github.com/ryanhair/zcli/blob/main/docs/adr/0013-terminal-native-layout-engine.md" target="_blank" rel="noopener"><span class="k">→ design</span><span class="t">ADR-0013: the layout engine</span></a>
+            <a href="https://github.com/ryanhair/zcli/tree/main/packages/ui" target="_blank" rel="noopener"><span class="k">→ source</span><span class="t">The ui package</span></a>
+          </div>
+        </section>
+      </article>
+    </div>
+  </div>
+
+<script>
+  var links = document.querySelectorAll('.toc a');
+  var secs = Array.prototype.map.call(links, function (a) { return document.querySelector(a.getAttribute('href')); });
+  function onScroll() {
+    var y = window.scrollY + 120, cur = 0;
+    secs.forEach(function (s, i) { if (s && s.offsetTop <= y) cur = i; });
+    links.forEach(function (a, i) { a.classList.toggle('active', i === cur); });
+  }
+  window.addEventListener('scroll', onScroll, { passive: true }); onScroll();
+</script>
+
+</main>


### PR DESCRIPTION
Closes the docs/website gap left by the terminal-native layout engine migration (packages/ui, ADR-0013) and the interactive-package port onto it (ADR-0014), which shipped across #166–#176. The website page for the CLI/TUI hybrid was explicitly deferred during the migration PRs; this is that pass.

## Website
- **New CLI/TUI hybrid guide** — `website/content/ui/index.smd` + `website/layouts/ui.shtml`, modeled on the theming page (sticky TOC, section layout, highlighted Zig, next-links). Covers the frame model, the four-node / `fit`·`len`·`fill` vocabulary, `context.ui()` + the App, `ui.widgets`, three-tier resize + piped degradation, standalone use, and `run-demo`/`run-hybrid`. Sourced from `packages/ui/README.md`, ADR-0013, `zcli guide ui`, and the two runnable examples.
- **Wired for discoverability** — a `#hybrid` section + TOC entry on the docs guide (links to `/ui/`), and a `ui` link in the shared footer's Packages column.
- **Dead API fixes** — `docs.shtml` and `theming.shtml` still showed the pre-migration free-function progress API (`progress.spinner(io, …)`); updated to `context.progress()`. (Both were split by HTML `<span>` tags, so they slipped past the migration PRs' greps.)

## docs/ + package READMEs
- `packages/terminal/README.md` — dropped the `ansi.*` constants bullet (deleted in #176); notes cursor/screen escapes now live in the `ui` engine.
- `docs/DESIGN.md` — added §13 "Terminal Output & Rendering" (the doc previously covered only command dispatch): the output-package family, the layout engine, and the `context.X()` construction idiom. DevEx → §14.
- `docs/adr/0014` — status `proposed → accepted` (shipped via #171/#175).

Root README hybrid/progress sections, the `prompts`/`progress`/`ui` READMEs, the docs prompts section, CHANGELOG, BUILD.md, and COMMANDS.md were already current — verified, no change.

## Verification
- Website builds clean via prebuilt **zine v0.11.3** — 11 pages, exit 0, no SuperHTML warnings; new page renders with all template exprs resolved and `/ui/` links resolving from docs + footer.
- `zig build test` (root) — green. (e2e skipped intentionally: docs-only diff, no prompt/render code touched.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)