### PR TITLE
docs: clarify the ui live region is a full layout area, not a bottom strip

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Nine spinner styles, plus stacked multi-bars for parallel work; animations auto-
 
 ## The CLI/TUI hybrid
 
-Prompts and progress render on `zcli.ui` — a terminal-native layout engine, and it's yours to use directly. Output splits into a static stream that flows into scrollback and a live region that repaints in place at the bottom edge: the shape of modern agent-style CLIs. A component is just a function returning a node; frames are diffed, so an animation repaints one cell, not the screen.
+Prompts and progress render on `zcli.ui` — a terminal-native layout engine, and it's yours to use directly. Output splits into a static stream that flows into scrollback and a live region that repaints in place just above it — a full layout, from a single line up to the whole viewport, not a fixed bottom strip. Unlike a full-screen TUI it never takes the terminal over, so your scrollback stays intact. This is the shape of modern agent-style CLIs: a component is just a function returning a node, and frames are diffed, so an animation repaints one cell, not the screen.
 
 ```zig
 var app = try context.ui();

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -801,16 +801,22 @@ command reaches through its `context`:
 **The layout engine (`packages/ui`, ADR-0013).** `prompts` and `progress` do
 not hand-roll cursor movement or repainting — they render on a shared
 terminal-native layout engine. Output splits into a **static stream** that flows
-into scrollback (`app.emit`) and a **live region** pinned to the bottom edge
-that repaints in place (`app.frame`). The live region is immediate-mode: a
+into scrollback (`app.emit`) and a **live region** that repaints in place just
+above it (`app.frame`) — a full layout area, from a single line up to the whole
+viewport, positioned above committed scrollback rather than a fixed bottom strip.
+This is the same static-above / live-below split as Ink's `<Static>` and dynamic
+render: the engine shares the screen instead of taking it over (no alternate
+screen buffer), so scrollback is preserved — the deliberate trade against a
+full-screen TUI (ADR-0013). The live region is immediate-mode: a
 component is a function returning a `Node`; each frame the tree is rebuilt into a
 per-frame arena, measured, painted onto a cell `Surface`, and diffed against the
 previous frame, so only changed cells reach the terminal. Four node kinds
 (`box`, `text`, `spacer`, `custom`) and three sizing words (`fit`, `len`,
 `fill`) cover the vocabulary; the region re-measures against the terminal each
-frame, so it re-lays-out on resize and clamps to the viewport. This is the
-CLI/TUI hybrid — the shape of modern agent-style CLIs — and it is exposed
-directly as `zcli.ui` / `context.ui()`.
+frame, so it re-lays-out on resize and clamps to the viewport. A full-screen app
+is just a root sized `fill`, not a separate mode. This is the CLI/TUI hybrid —
+the shape of modern agent-style CLIs — exposed directly as `zcli.ui` /
+`context.ui()`.
 
 **Construction idiom (ADR-0014).** `context.X()` is the single front door for
 every output capability: `context.theme`, `context.prompts()`,

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -9,7 +9,11 @@ The terminal-native layout engine behind zcli's CLI/TUI hybrid ([ADR-0013](../..
 ## The model
 
 Output splits into a **static** stream that flows into scrollback and a
-**live region** at the bottom edge that repaints in place. The live region is
+**live region** that repaints in place just above it — a full layout area,
+from a single line up to the whole viewport, positioned above committed
+scrollback rather than a fixed bottom strip. Like Ink's static/dynamic split,
+it shares the terminal instead of taking it over (no alternate screen buffer),
+so your scrollback survives. The live region is
 immediate-mode: a component is any function returning a `Node`; the tree is
 rebuilt into a frame arena every frame, measured (constraints down, sizes
 up), painted onto a cell `Surface`, and diffed — only changed cells reach the

--- a/website/layouts/docs.shtml
+++ b/website/layouts/docs.shtml
@@ -301,7 +301,7 @@ spinner.<span class="fn">succeed</span>(<span class="str">"Synced successfully"<
         <!-- ============ CLI/TUI HYBRID ============ -->
         <section id="hybrid">
           <h2>CLI/TUI hybrid</h2>
-          <p>Prompts and progress both render on <code>zcli.ui</code> — a terminal-native layout engine — and it's yours to use directly. Output splits into a static stream that flows into scrollback and a live region that repaints in place at the bottom edge: the shape of modern agent-style CLIs. A component is just a function returning a node; frames are diffed, so an animation repaints one cell, not the screen.</p>
+          <p>Prompts and progress both render on <code>zcli.ui</code> — a terminal-native layout engine — and it's yours to use directly. Output splits into a static stream that flows into scrollback and a live region that repaints in place just above it — a full layout, from a single line up to the whole viewport, not a fixed bottom strip. Unlike a full-screen TUI it never takes the terminal over, so your scrollback stays intact. This is the shape of modern agent-style CLIs: a component is just a function returning a node, and frames are diffed, so an animation repaints one cell, not the screen.</p>
           <div class="code">
             <div class="code-head"><span class="fname">src/commands/deploy.zig</span><span class="lang">zig</span></div>
 <pre><span class="kw">var</span> app = <span class="kw">try</span> context.<span class="fn">ui</span>();

--- a/website/layouts/ui.shtml
+++ b/website/layouts/ui.shtml
@@ -61,11 +61,11 @@
       <article class="doc">
         <section id="intro">
           <h1>The CLI/TUI hybrid</h1>
-          <p class="sub">Prompts and progress render on <code>zcli.ui</code> — a terminal-native layout engine — and it's yours to use directly. Stream lines into scrollback while a live region repaints in place at the bottom edge: the shape of modern agent-style CLIs.</p>
+          <p class="sub">Prompts and progress render on <code>zcli.ui</code> — a terminal-native layout engine — and it's yours to use directly. Stream lines into scrollback while a live region — a full layout, from one line up to the whole viewport — repaints in place just above them: the shape of modern agent-style CLIs.</p>
           <p>A full-screen TUI takes the terminal over; a plain CLI can't paint. The hybrid is the third shape — the one Claude Code, modern installers, and deploy tools use. zcli's engine gives you both halves at once:</p>
           <ul>
             <li><b>A static stream</b> flows upward into scrollback, one line at a time, exactly like normal output — copy-pasteable, greppable, permanent.</li>
-            <li><b>A live region</b> sits pinned to the bottom edge and repaints in place — a spinner, a status frame, a stack of progress bars — without disturbing the scrollback above it.</li>
+            <li><b>A live region</b> repaints in place just above the scrollback — anything from a one-line spinner to a full-viewport layout. It's positioned above committed output, not a fixed strip, and shares the screen rather than taking it over, so your scrollback survives.</li>
             <li><b>Immediate mode</b> means a component is just a function returning a node. You rebuild the tree every frame from your own state; the engine diffs it and sends only the cells that changed.</li>
           </ul>
           <div class="callout"><b>Built on it</b> The <a href="$site.page('docs').link().suffix('#prompts')">prompts</a> and <a href="$site.page('docs').link().suffix('#progress')">progress</a> packages both render on this engine — so cursor hygiene, diffed repaints, and resize re-layout are solved once, in one place.</div>
@@ -75,6 +75,7 @@
           <h2>The frame model</h2>
           <p>The live region is rebuilt from scratch every frame: the node tree is allocated into a per-frame arena, measured (constraints down, sizes up), painted onto a cell surface, and diffed against the previous surface. An unchanged frame writes <em>zero</em> bytes; a ticking spinner repaints one cell, not the screen.</p>
           <p>Two verbs drive it. <code>emit</code> writes a static line that scrolls up and away; <code>frame</code> replaces the live region with a new node tree. <code>emit</code> is the only way to write while a region is up — it erases the region, prints the line into scrollback, and repaints the region below it.</p>
+          <div class="callout"><b>Not a full-screen TUI</b> "Above the scrollback" describes where the live region sits, not how big it is — it's a full layout tree, one line to the whole viewport (a full-screen app is just a root sized <code>fill</code>). This is the same static-above / live-below split as Ink's <code>&lt;Static&gt;</code> and dynamic render: the engine shares the terminal and never switches to the alternate screen, so scrollback is preserved. The trade is that there's one live region and it's always the bottom-most live content — top-anchored or multiple independent live regions would need the alt-screen model this deliberately avoids.</div>
           <div class="code">
             <div class="code-head"><span class="fname">a component is just a function</span><span class="lang">zig</span></div>
 <pre><span class="cm">// State lives in your structs; the frame is a pure function of it.</span>


### PR DESCRIPTION
Follow-up to #177. The migration docs described the live region as sitting "at the bottom edge," which reads like a thin bottom strip and undersells the model.

The correction, applied consistently across the user-facing docs:

- The live region is a **full layout area** — one line up to the whole viewport (a full-screen app is just a root sized `fill`), not a fixed strip.
- "Above the scrollback" describes **where it sits, not how big it is**.
- It's the same **static-above / live-below split as Ink's `<Static>`** and dynamic render: the engine **shares the screen rather than switching to the alternate buffer**, so scrollback is preserved — the deliberate trade against a full-screen TUI (ADR-0013).
- The trade is explicit: one live region, always the bottom-most live content; top-anchored or multiple independent regions would require the alt-screen model this avoids.

## Changed
- `README.md` + `website/layouts/docs.shtml` — the hybrid one-liner
- `packages/ui/README.md` — "The model" section (+ Ink parallel, no alt-screen)
- `docs/DESIGN.md` §13 — reframed with the Ink split and the full-screen-TUI trade
- `website/layouts/ui.shtml` — sub + live-region bullet reworded, plus a new **"Not a full-screen TUI"** callout that spells out the whole mental model

ADR-0013 left untouched as the historical decision record.

## Verification
Website rebuilds clean via prebuilt zine v0.11.3 (exit 0, callout renders, all template exprs resolved); no "bottom edge"/"pinned to the bottom" phrasing remains in the user-facing docs. Docs-only, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)