### PR TITLE
feat(ui)!: opt-in full-screen (alt-screen) TUI mode (ADR-0015, steps 1/2/4)

### DIFF
--- a/packages/core/src/context.zig
+++ b/packages/core/src/context.zig
@@ -188,15 +188,22 @@ pub fn ContextFor(comptime plugins: []const type) type {
 
         /// A `ui.App` pre-wired to this command's environment: stdout, the
         /// arena-per-command allocator, the detected terminal capability, and
-        /// unicode/TTY detection. The entry point for hybrid CLI/TUI output —
+        /// unicode/TTY detection. The entry point for CLI/TUI output —
         /// `app.emit()` for static lines that flow into scrollback,
         /// `app.frame()` for the diffed live region below. `defer app.deinit()`
         /// (idempotent) restores the terminal and persists the final frame.
-        pub fn ui(self: *Self) !zcli.ui.App {
+        ///
+        /// Pass `.{ .mode = .full_screen }` for an opt-in alt-screen TUI
+        /// (ADR-0015): the App takes the screen over, owns raw mode, and reads
+        /// input through `app.nextEvent()`; stdin is wired automatically.
+        pub fn ui(self: *Self, options: zcli.ui.App.SessionOptions) !zcli.ui.App {
             return zcli.ui.App.init(self.allocator, self.stdout(), .{
                 .capability = self.theme.capability(),
                 .unicode = zcli.ui.unicodeSupported(self.environ),
                 .interactive = self.theme.caps.is_tty,
+                .mode = options.mode,
+                .sync = options.sync,
+                .stdin = if (options.mode == .full_screen) self.stdin() else null,
             });
         }
 

--- a/packages/core/src/zcli.zig
+++ b/packages/core/src/zcli.zig
@@ -611,7 +611,7 @@ test "context.ui() returns an App wired to the detected environment" {
     var context = Context.init(allocator, std.testing.io, &stdio, &test_environ);
     defer context.deinit();
 
-    var app = try context.ui();
+    var app = try context.ui(.{});
     defer app.deinit();
     // Tests never run on a TTY: the App must come back non-interactive, so
     // frame() is a no-op and emit() prints plain lines.

--- a/packages/terminal/src/backend.zig
+++ b/packages/terminal/src/backend.zig
@@ -56,3 +56,7 @@ pub const ResizeWatcher = impl.ResizeWatcher;
 
 /// Result of `ResizeWatcher.wait`: either input is ready or a resize occurred.
 pub const InputWait = impl.InputWait;
+
+/// Result of `ResizeWatcher.waitTimeout`: input ready, a resize, or the
+/// caller's deadline elapsed with neither.
+pub const WaitResult = impl.WaitResult;

--- a/packages/terminal/src/backend_posix.zig
+++ b/packages/terminal/src/backend_posix.zig
@@ -83,6 +83,10 @@ pub fn waitReadable(fd: Handle, timeout_ms: i32) bool {
 /// Whether a `wait` returned because input is ready or the terminal resized.
 pub const InputWait = enum { input, resize };
 
+/// Result of `waitTimeout`: input ready, a resize, or the caller's deadline
+/// elapsed with neither.
+pub const WaitResult = enum { input, resize, timeout };
+
 /// Backstop poll interval. A SIGWINCH interrupts the poll (EINTR) and is caught
 /// immediately; this only bounds the tiny race where the signal lands between
 /// the flag check and the poll entering the kernel — at worst that resize is
@@ -125,17 +129,41 @@ pub const ResizeWatcher = struct {
     /// raw `poll` (not `std.posix.poll`, which retries EINTR internally and
     /// would hide the SIGWINCH wakeup).
     pub fn wait(self: *ResizeWatcher, fd: Handle) InputWait {
+        return switch (self.waitTimeout(fd, null)) {
+            .input => .input,
+            .resize => .resize,
+            .timeout => unreachable, // a null timeout never expires
+        };
+    }
+
+    /// Like `wait`, but return `.timeout` if neither input nor a resize
+    /// arrives within `timeout_ms`. `null` blocks indefinitely (never
+    /// returns `.timeout`) — the classic prompt behavior. A finite timeout is
+    /// what lets a full-screen loop repaint on a tick with no input.
+    ///
+    /// The deadline is honored one backstop interval at a time: each poll
+    /// waits at most `poll_backstop_ms` so a SIGWINCH that raced the poll is
+    /// noticed promptly, and the remaining budget is decremented by the
+    /// interval actually waited.
+    pub fn waitTimeout(self: *ResizeWatcher, fd: Handle, timeout_ms: ?u32) WaitResult {
         _ = self;
+        var remaining: ?u32 = timeout_ms;
         while (true) {
             if (resize_pending.swap(false, .seq_cst)) return .resize;
 
+            const wait_ms: i32 = if (remaining) |r| blk: {
+                if (r == 0) return .timeout;
+                break :blk @intCast(@min(r, @as(u32, poll_backstop_ms)));
+            } else poll_backstop_ms;
+
             var fds = [_]posix.pollfd{.{ .fd = fd, .events = posix.POLL.IN, .revents = 0 }};
-            const rc = posix.system.poll(&fds, 1, poll_backstop_ms);
+            const rc = posix.system.poll(&fds, 1, wait_ms);
             if (resize_pending.swap(false, .seq_cst)) return .resize;
             switch (posix.errno(rc)) {
                 .SUCCESS => if (rc > 0 and fds[0].revents & posix.POLL.IN != 0) return .input,
                 else => {}, // EINTR / EAGAIN — loop and re-check the flag
             }
+            if (remaining) |*r| r.* -|= @intCast(wait_ms);
         }
     }
 };

--- a/packages/terminal/src/backend_windows.zig
+++ b/packages/terminal/src/backend_windows.zig
@@ -136,6 +136,10 @@ pub fn waitReadable(handle: Handle, timeout_ms: i32) bool {
 /// Whether a `wait` returned because input is ready or the terminal resized.
 pub const InputWait = enum { input, resize };
 
+/// Result of `waitTimeout`: input ready, a resize, or the caller's deadline
+/// elapsed with neither.
+pub const WaitResult = enum { input, resize, timeout };
+
 /// How often `wait` re-checks the window size while blocked on input. With
 /// `ENABLE_VIRTUAL_TERMINAL_INPUT`, resize events are not delivered through the
 /// byte stream (`ReadFile`), so rather than rewire input reading to consume
@@ -161,14 +165,34 @@ pub const ResizeWatcher = struct {
 
     /// Block until stdin (`handle`) has input or the console window resizes.
     pub fn wait(self: *ResizeWatcher, handle: Handle) InputWait {
+        return switch (self.waitTimeout(handle, null)) {
+            .input => .input,
+            .resize => .resize,
+            .timeout => unreachable, // a null timeout never expires
+        };
+    }
+
+    /// Like `wait`, but return `.timeout` if neither input nor a resize
+    /// arrives within `timeout_ms`. `null` blocks indefinitely (never
+    /// returns `.timeout`). A finite timeout lets a full-screen loop repaint
+    /// on a tick with no input; the size poll runs at most one
+    /// `resize_poll_ms` interval past the deadline.
+    pub fn waitTimeout(self: *ResizeWatcher, handle: Handle, timeout_ms: ?u32) WaitResult {
+        var remaining: ?u32 = timeout_ms;
         while (true) {
-            const ready = WaitForSingleObject(handle, @intCast(resize_poll_ms)) == WAIT_OBJECT_0;
+            const wait_ms: DWORD = if (remaining) |r| blk: {
+                if (r == 0) return .timeout;
+                break :blk @intCast(@min(r, @as(u32, @intCast(resize_poll_ms))));
+            } else @intCast(resize_poll_ms);
+
+            const ready = WaitForSingleObject(handle, wait_ms) == WAIT_OBJECT_0;
             const sz = getWindowSize(self.out) catch self.last;
             if (sz.row != self.last.row or sz.col != self.last.col) {
                 self.last = sz;
                 return .resize;
             }
             if (ready) return .input;
+            if (remaining) |*r| r.* -|= wait_ms;
         }
     }
 };

--- a/packages/terminal/src/event.zig
+++ b/packages/terminal/src/event.zig
@@ -22,11 +22,24 @@ pub const Event = union(enum) {
 /// disambiguation and by the watcher's poll. Bytes already buffered in `reader`
 /// are consumed before polling, so no keypress is missed.
 pub fn readEvent(reader: anytype, handle: backend.Handle, watcher: *backend.ResizeWatcher) !Event {
-    while (true) {
-        if (key.bufferedLen(reader) > 0) return .{ .key = try key.readKeyOpt(reader, handle) };
-        switch (watcher.wait(handle)) {
-            .resize => return .resize,
-            .input => return .{ .key = try key.readKeyOpt(reader, handle) },
-        }
-    }
+    return (try readEventTimeout(reader, handle, watcher, null)).?;
+}
+
+/// Like `readEvent`, but return `null` if neither a key nor a resize arrives
+/// within `timeout_ms`. `null` blocks indefinitely (never times out). The
+/// finite-timeout form is what lets a full-screen App repaint on a tick with
+/// no input — a `top`-style refresh — without a background thread.
+pub fn readEventTimeout(
+    reader: anytype,
+    handle: backend.Handle,
+    watcher: *backend.ResizeWatcher,
+    timeout_ms: ?u32,
+) !?Event {
+    // Bytes already buffered are input regardless of the deadline.
+    if (key.bufferedLen(reader) > 0) return Event{ .key = try key.readKeyOpt(reader, handle) };
+    return switch (watcher.waitTimeout(handle, timeout_ms)) {
+        .resize => .resize,
+        .input => Event{ .key = try key.readKeyOpt(reader, handle) },
+        .timeout => null,
+    };
 }

--- a/packages/terminal/src/terminal.zig
+++ b/packages/terminal/src/terminal.zig
@@ -16,6 +16,7 @@ pub const readKeyOpt = key.readKeyOpt;
 pub const event = @import("event.zig");
 pub const Event = event.Event;
 pub const readEvent = event.readEvent;
+pub const readEventTimeout = event.readEventTimeout;
 
 /// Watches for terminal resizes; construct for the lifetime of a prompt.
 pub const ResizeWatcher = backend.ResizeWatcher;

--- a/packages/ui/build.zig
+++ b/packages/ui/build.zig
@@ -42,7 +42,7 @@ pub fn build(b: *std.Build) void {
 
     // Runnable examples — `zig build run-<name>` (they animate, so they need
     // a real terminal). Each is compiled by `test` so it can't bitrot.
-    const example_names = [_][]const u8{ "demo", "hybrid" };
+    const example_names = [_][]const u8{ "demo", "hybrid", "fullscreen" };
     for (example_names) |name| {
         const exe = b.addExecutable(.{
             .name = b.fmt("ui-{s}", .{name}),

--- a/packages/ui/examples/fullscreen.zig
+++ b/packages/ui/examples/fullscreen.zig
@@ -1,0 +1,144 @@
+//! A `top`-style full-screen TUI (ADR-0015 step 4): the whole viewport is a
+//! live table of processes whose CPU/MEM jitter on a 250ms tick, with an
+//! arrow-key selection. It validates the loop shape the ADR proposes —
+//!
+//!     frame(view(state))            paint the whole screen
+//!     nextEvent(250) orelse tick()  block for a key/resize, or refresh
+//!
+//! — reusing the same layout engine as the hybrid, just in alt-screen mode.
+//! On exit (q or Ctrl-C) the shell's screen and scrollback come back exactly
+//! as they were: the final frame does not persist (that is the feature).
+//!
+//! Run with: zig build run-fullscreen   (from packages/ui, needs a real TTY)
+
+const std = @import("std");
+const ui = @import("ui");
+const terminal = @import("terminal");
+
+const tick_ms: u32 = 250;
+
+const proc_names = [_][]const u8{
+    "zig",         "zls",     "kernel_task", "WindowServer",
+    "Terminal",    "firefox", "Slack",       "node",
+    "zcli",        "git",     "ripgrep",     "ssh",
+};
+
+const Proc = struct { pid: u16, name: []const u8, cpu: f32, mem: f32 };
+
+const State = struct {
+    tick: u32 = 0,
+    selected: usize = 0,
+    procs: [proc_names.len]Proc = undefined,
+
+    fn init() State {
+        var s = State{};
+        for (proc_names, 0..) |n, i| {
+            s.procs[i] = .{ .pid = @intCast(1000 + i * 137), .name = n, .cpu = 0, .mem = 0 };
+        }
+        s.refresh();
+        return s;
+    }
+
+    /// Cheap deterministic per-cell jitter — no RNG dependency, just a hash of
+    /// (tick, row) so the table visibly churns each refresh.
+    fn refresh(self: *State) void {
+        for (&self.procs, 0..) |*p, i| {
+            const seed = self.tick *% 2654435761 +% @as(u32, @intCast(i)) *% 40503 +% 1;
+            p.cpu = @as(f32, @floatFromInt(seed % 1000)) / 10.0;
+            p.mem = @as(f32, @floatFromInt((seed >> 7) % 5000)) / 10.0;
+        }
+    }
+
+    fn advance(self: *State) void {
+        self.tick += 1;
+        self.refresh();
+    }
+};
+
+fn view(a: std.mem.Allocator, state: *const State) !ui.Node {
+    var rows = std.ArrayList(ui.Node).empty;
+
+    const elapsed = try std.fmt.allocPrint(a, "{d:.1}s", .{
+        @as(f32, @floatFromInt(state.tick * tick_ms)) / 1000.0,
+    });
+    try rows.append(a, try ui.row(a, .{ .gap = 1 }, &.{
+        ui.text(.{ .bold = true }, "zcli top"),
+        ui.spacer(),
+        ui.text(.{ .dim = true }, elapsed),
+    }));
+
+    try rows.append(a, ui.textOpts(
+        .{ .style = .{ .bold = true, .underline = true }, .wrap = .clip },
+        "  PID   CPU%    MEM%  COMMAND",
+    ));
+
+    for (state.procs, 0..) |p, i| {
+        const line = try std.fmt.allocPrint(a, "{d:>5} {d:>6.1} {d:>7.1}  {s}", .{
+            p.pid, p.cpu, p.mem, p.name,
+        });
+        const style: ui.Style = if (i == state.selected) .{ .reverse = true } else .{};
+        try rows.append(a, ui.textOpts(.{ .style = style, .wrap = .clip }, line));
+    }
+
+    try rows.append(a, ui.spacer());
+    try rows.append(a, ui.text(.{ .dim = true }, "↑/↓ select   q quit"));
+
+    return ui.column(
+        a,
+        .{ .width = .{ .fill = 1 }, .height = .{ .fill = 1 }, .padding = .all(1) },
+        rows.items,
+    );
+}
+
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+    const gpa = init.gpa;
+
+    if (!terminal.isStdoutTty()) {
+        var err_buf: [256]u8 = undefined;
+        var stderr = std.Io.File.stderr().writer(io, &err_buf);
+        try stderr.interface.writeAll("fullscreen: needs an interactive terminal\n");
+        try stderr.interface.flush();
+        return;
+    }
+
+    var out_buf: [1 << 14]u8 = undefined;
+    var stdout = std.Io.File.stdout().writer(io, &out_buf);
+    var in_buf: [256]u8 = undefined;
+    var stdin = std.Io.File.stdin().reader(io, &in_buf);
+
+    var app = try ui.App.init(gpa, &stdout.interface, .{
+        .capability = .ansi_256,
+        .mode = .full_screen,
+        .stdin = &stdin.interface,
+    });
+    defer app.deinit(); // leaves alt-screen, restores cooked mode + cursor
+
+    var state = State.init();
+    var running = true;
+    while (running) {
+        try app.frame(try view(app.arena(), &state));
+        const ev = try app.nextEvent(tick_ms) orelse {
+            state.advance(); // timeout: refresh the table
+            continue;
+        };
+        switch (ev) {
+            .key => |k| switch (k) {
+                .char => |c| if (c == 'q') {
+                    running = false;
+                },
+                .ctrl => |c| if (c == 'c') {
+                    running = false; // Ctrl-C is a key here (raw mode cleared ISIG)
+                },
+                .up => if (state.selected > 0) {
+                    state.selected -= 1;
+                },
+                .down => if (state.selected + 1 < state.procs.len) {
+                    state.selected += 1;
+                },
+                else => {},
+            },
+            .resize => {}, // next frame re-anchors and re-measures
+        }
+    }
+}

--- a/packages/ui/examples/fullscreen.zig
+++ b/packages/ui/examples/fullscreen.zig
@@ -18,9 +18,9 @@ const terminal = @import("terminal");
 const tick_ms: u32 = 250;
 
 const proc_names = [_][]const u8{
-    "zig",         "zls",     "kernel_task", "WindowServer",
-    "Terminal",    "firefox", "Slack",       "node",
-    "zcli",        "git",     "ripgrep",     "ssh",
+    "zig",      "zls",     "kernel_task", "WindowServer",
+    "Terminal", "firefox", "Slack",       "node",
+    "zcli",     "git",     "ripgrep",     "ssh",
 };
 
 const Proc = struct { pid: u16, name: []const u8, cpu: f32, mem: f32 };

--- a/packages/ui/src/app.zig
+++ b/packages/ui/src/app.zig
@@ -1,9 +1,17 @@
-//! App: the static/live frame loop (ADR-0013 step 3).
+//! App: the static/live frame loop (ADR-0013 step 3), in two modes (ADR-0015).
 //!
 //! Owns everything the demo used to hand-roll: the frame arena, the
 //! double-buffered surfaces, reserving the live region's rows, parking the
 //! cursor at the region's top-left (the diff renderer's addressing
 //! contract), and cursor hide/restore.
+//!
+//! The default is `hybrid`: a static stream (`emit`) flowing into scrollback
+//! with a live region (`frame`) pinned above it, sharing the screen. Opting
+//! into `full_screen` (ADR-0015) takes the screen over via the alternate-screen
+//! buffer, grants the frame the whole viewport, owns raw mode for the session,
+//! and reads input through `nextEvent` — `emit` is unavailable there (no
+//! scrollback). The measure/render/diff core is identical between the two;
+//! full-screen is a mode, not a fork.
 //!
 //! The two verbs:
 //!
@@ -39,7 +47,24 @@ const Size = node_mod.Size;
 const Limits = node_mod.Limits;
 const RenderCtx = node_mod.RenderCtx;
 
+/// An input event surfaced by `nextEvent` in full-screen mode: a parsed key
+/// press or a terminal resize (re-exported from `terminal`). Mouse/focus/paste
+/// events join here when they land (ADR-0015 deferred).
+pub const Event = terminal.Event;
+
 pub const App = struct {
+    /// How the App shares the terminal (ADR-0015).
+    ///
+    /// - `hybrid` (default, ADR-0013): a static stream flowing into scrollback
+    ///   with a live region pinned above it. `emit` + `frame`, shared screen.
+    /// - `full_screen`: takes the screen over via the alternate-screen buffer
+    ///   (the shell and its scrollback are saved on enter, restored on exit),
+    ///   owns raw mode for the session, and reads input through `nextEvent`.
+    ///   The static stream goes unused — `emit` is an error — and the frame is
+    ///   granted the whole viewport. The layout/measure/render/diff core is
+    ///   identical; full-screen is a mode, not a fork.
+    pub const Mode = enum { hybrid, full_screen };
+
     pub const Options = struct {
         capability: theme.TerminalCapability = .ansi_16,
         /// Chooses border/ellipsis glyphs (`terminal.unicodeSupported`).
@@ -54,8 +79,25 @@ pub const App = struct {
         /// `terminal.isStdoutTty()`). When false — piped to a file, CI —
         /// the App degrades to plain line output: `frame` is a no-op,
         /// `emit` prints without escapes or retention, the cursor is never
-        /// touched.
+        /// touched. A `full_screen` App on a non-TTY is an error at `init` —
+        /// a TUI into a pipe is meaningless.
         interactive: bool = true,
+        /// Hybrid (default) or full-screen (alt-screen) mode (ADR-0015).
+        mode: Mode = .hybrid,
+        /// Stdin reader for full-screen input. Required in `full_screen` (the
+        /// App owns raw mode and drives `nextEvent`); unused in `hybrid`,
+        /// where input ownership stays with the caller (e.g. `prompts`).
+        stdin: ?*std.Io.Reader = null,
+    };
+
+    /// The caller-facing subset of `Options` for `context.ui()`: the
+    /// environment-derived fields (capability, unicode, interactive, stdin)
+    /// are wired by the context, so these are the choices left to the app
+    /// author.
+    pub const SessionOptions = struct {
+        mode: Mode = .hybrid,
+        /// Wrap paints in synchronized output (DECSET 2026).
+        sync: bool = true,
     };
 
     /// A static block kept for the resize tail repaint (ADR-0013 resize
@@ -93,11 +135,16 @@ pub const App = struct {
     placed: ?CursorPos = null,
     /// Guard for idempotent deinit (finish paths may close the App early).
     deinited: bool = false,
+    /// Session-owned raw mode, in full-screen only (the App reads input via
+    /// `nextEvent`). `null` in hybrid, where input ownership stays external.
+    raw: ?terminal.RawMode = null,
+    /// Resize watcher backing `nextEvent`, full-screen only.
+    watcher: ?terminal.ResizeWatcher = null,
 
     pub const CursorPos = struct { x: u16, y: u16 };
 
     pub fn init(gpa: std.mem.Allocator, writer: *std.Io.Writer, options: Options) !App {
-        return .{
+        var self: App = .{
             .writer = writer,
             .gpa = gpa,
             .options = options,
@@ -105,6 +152,54 @@ pub const App = struct {
             .front = try Surface.init(gpa, 0, 0),
             .back = try Surface.init(gpa, 0, 0),
         };
+        errdefer {
+            self.front.deinit();
+            self.back.deinit();
+            self.frame_arena.deinit();
+        }
+        if (options.mode == .full_screen) try self.enterFullScreen();
+        return self;
+    }
+
+    /// Take the terminal over: enable session raw mode, switch to the
+    /// alternate-screen buffer (saving the shell's screen + scrollback), hide
+    /// the cursor, and anchor at the origin — `?1049h` clears the alt buffer
+    /// but carries the cursor position over from the main screen, so the diff
+    /// renderer's "cursor parked at the region's top-left" contract must be
+    /// established explicitly before the first paint (ADR-0015 choice 2).
+    fn enterFullScreen(self: *App) !void {
+        if (!self.options.interactive) return error.NotATerminal;
+        // Restore terminal state if any step below fails — same bytes/order as
+        // deinit, so a half-entered session never strands the terminal.
+        errdefer {
+            self.writer.writeAll("\x1b[?25h\x1b[?1049l") catch {};
+            self.writer.flush() catch {};
+            if (self.watcher) |*w| w.deinit();
+            if (self.raw) |r| r.disable();
+        }
+        // A fixed `term_size` is the headless-harness path (tests): there is
+        // no real terminal to put in raw mode or watch for resizes. Still emit
+        // the alt-screen takeover so the byte stream is exercised; live input
+        // (`nextEvent`) is a real-terminal-only affair.
+        if (self.options.term_size == null) {
+            self.raw = try terminal.enableRawMode(std.Io.File.stdin().handle);
+            self.watcher = terminal.ResizeWatcher.init();
+        }
+        self.started = true; // cursor hidden, terminal owned
+        try self.writer.writeAll("\x1b[?1049h\x1b[?25l");
+        try self.anchor();
+        try self.writer.flush();
+    }
+
+    /// Park the cursor at the screen origin (the diff renderer's addressing
+    /// anchor in full-screen). One relative sequence — CR plus a
+    /// viewport-height CUU that clamps at the top row — so the renderer stays
+    /// CUP-free and shared byte-for-byte with the hybrid. Used on entry and
+    /// after a resize, the two moments the parked position is invalidated.
+    fn anchor(self: *App) !void {
+        const h = self.termSize().h;
+        try self.writer.writeByte('\r');
+        if (h > 0) try self.writer.print("\x1b[{d}A", .{h});
     }
 
     /// Restores the terminal (cursor shown, parked on a fresh line below the
@@ -113,15 +208,27 @@ pub const App = struct {
     pub fn deinit(self: *App) void {
         if (self.deinited) return;
         self.deinited = true;
-        if (self.started) {
+        if (self.options.mode == .full_screen) {
+            // Restore in strict reverse of enter (ADR-0015 choice 5): show
+            // cursor → leave alt-screen (restores the shell's screen and
+            // scrollback; the final frame is discarded by design) → disable
+            // raw mode. The alt-screen leave must precede the raw-mode
+            // restore so its bytes still go out while we own the terminal.
+            if (self.started) self.writer.writeAll("\x1b[?25h\x1b[?1049l") catch {};
+            self.writer.flush() catch {};
+            if (self.watcher) |*w| w.deinit();
+            if (self.raw) |r| r.disable();
+        } else if (self.started) {
             self.unplace() catch {};
             if (self.live_rows > 1) {
                 self.writer.print("\x1b[{d}B", .{self.live_rows - 1}) catch {};
             }
             if (self.live_rows > 0) self.writer.writeAll("\r\n") catch {};
             self.writer.writeAll("\x1b[?25h") catch {};
+            self.writer.flush() catch {};
+        } else {
+            self.writer.flush() catch {};
         }
-        self.writer.flush() catch {};
         for (self.retained.items) |b| self.gpa.free(b.text);
         self.retained.deinit(self.gpa);
         self.front.deinit();
@@ -174,6 +281,10 @@ pub const App = struct {
     /// the column (no ONLCR post-processing), and CRLF is harmless in
     /// cooked mode. Piped output keeps plain `\n`.
     pub fn emit(self: *App, comptime fmt: []const u8, args: anytype) !void {
+        // Full-screen owns the whole viewport — there is no scrollback for a
+        // static line to flow into (ADR-0015). Code that wants both a
+        // scrollback log and a live frame is, by definition, the hybrid.
+        if (self.options.mode == .full_screen) return error.EmitInFullScreen;
         const base = comptime std.mem.trimEnd(u8, fmt, "\r\n");
         if (!self.options.interactive) {
             // Plain line output: no live region exists, nothing to retain.
@@ -208,6 +319,7 @@ pub const App = struct {
     pub fn frame(self: *App, node: Node) !void {
         defer _ = self.frame_arena.reset(.retain_capacity);
         if (!self.options.interactive) return;
+        if (self.options.mode == .full_screen) return self.frameFullScreen(node);
         try self.unplace();
 
         const ts = self.termSize();
@@ -224,8 +336,9 @@ pub const App = struct {
         };
 
         var size = node_mod.measure(&rctx, &node, limits);
-        // A root with `.fill` stretches to the terminal edge (a full-screen
-        // app is just a root with `height = fill`, not a separate mode).
+        // A root with `.fill` stretches to the terminal edge. Full-screen
+        // (ADR-0015) reuses the same measure/render, but grants the whole
+        // viewport and takes the alt-screen — see `frameFullScreen`.
         if (node.width == .fill) size.w = limits.max_w;
         if (node.height == .fill) size.h = limits.max_h;
 
@@ -272,6 +385,83 @@ pub const App = struct {
         self.front_valid = true;
         if (tail_repaint and self.options.sync) try self.writer.writeAll("\x1b[?2026l");
         try self.writer.flush();
+    }
+
+    /// Full-screen frame (ADR-0015). The alt-screen buffer is ours end to
+    /// end, so this is markedly simpler than the hybrid `frame`: no row
+    /// reservation (the buffer starts blank), no scrollback seam, no tail
+    /// reflow. The surface is always the whole viewport — the root is granted
+    /// the full terminal rect (a `fill`×`fill` root is the norm; centering or
+    /// margins are the root's own layout, via spacers/alignment) — and the
+    /// diff renderer addresses it relative to the origin, where the cursor is
+    /// parked between paints.
+    ///
+    /// Resize is just: re-anchor the parked cursor (the one piece of state the
+    /// terminal silently invalidates) and force a full repaint. A viewport
+    /// change already resizes the surface, which forces the repaint on its
+    /// own; the re-anchor is the resize-specific step.
+    fn frameFullScreen(self: *App, node: Node) !void {
+        const ts = self.termSize();
+        const size = Size{ .w = ts.w, .h = ts.h };
+        if (size.w == 0 or size.h == 0) return;
+
+        // A width or height change invalidates the parked cursor and the
+        // surface both. Re-anchor, then let the surface-size mismatch below
+        // force the full repaint.
+        const resized = self.last_width != null and
+            (self.last_width.? != ts.w or self.live_rows != ts.h);
+        self.last_width = ts.w;
+        if (resized) try self.anchor();
+
+        const rctx = RenderCtx{
+            .allocator = self.frame_arena.allocator(),
+            .unicode = self.options.unicode,
+        };
+
+        if (size.w != self.back.width or size.h != self.back.height) {
+            try self.back.resize(size.w, size.h);
+            try self.front.resize(size.w, size.h);
+            self.front_valid = false;
+        }
+        self.live_rows = size.h;
+
+        self.back.clear();
+        try node_mod.render(&rctx, &node, self.back.root());
+
+        const prev: ?*const Surface = if (self.front_valid) &self.front else null;
+        const renderer = diff_mod.Renderer{
+            .capability = self.options.capability,
+            .sync = self.options.sync,
+        };
+        try renderer.paint(self.writer, prev, &self.back);
+        std.mem.swap(Surface, &self.front, &self.back);
+        self.front_valid = true;
+        try self.writer.flush();
+    }
+
+    /// Full-screen input (ADR-0015). Block for the next key or resize, or
+    /// return `null` when `timeout_ms` elapses first — the timeout is what
+    /// lets a loop repaint on a tick with no input (`nextEvent(250) orelse
+    /// tick()`), no background thread. `null` blocks indefinitely.
+    ///
+    /// Flushes the App's writer before blocking: the frame just built must
+    /// reach the terminal before we wait on the user (the flush-before-read
+    /// discipline `prompts` learned, enforced here in one place). Ctrl-C
+    /// arrives as an ordinary `.key` — raw mode cleared `ISIG` — so whether
+    /// it quits, cancels, or is ignored is the caller's `update`.
+    pub fn nextEvent(self: *App, timeout_ms: ?u32) !?Event {
+        std.debug.assert(self.options.mode == .full_screen);
+        const reader = self.options.stdin orelse return error.NoInput;
+        // No watcher means the headless-harness path (`term_size` set): there
+        // is no real terminal to read from.
+        if (self.watcher == null) return error.NoInput;
+        try self.writer.flush();
+        return terminal.readEventTimeout(
+            reader,
+            std.Io.File.stdin().handle,
+            &self.watcher.?,
+            timeout_ms,
+        );
     }
 
     /// Erase the live region and leave nothing in its place — the ending

--- a/packages/ui/src/app_test.zig
+++ b/packages/ui/src/app_test.zig
@@ -17,6 +17,10 @@ const Harness = struct {
     fed: usize = 0,
 
     fn init(w: u16, h: u16) !*Harness {
+        return initMode(w, h, .hybrid);
+    }
+
+    fn initMode(w: u16, h: u16, mode: ui.App.Mode) !*Harness {
         const self = try testing.allocator.create(Harness);
         errdefer testing.allocator.destroy(self);
         self.* = .{
@@ -26,6 +30,7 @@ const Harness = struct {
         };
         self.app = try ui.App.init(testing.allocator, &self.aw.writer, .{
             .term_size = .{ .w = w, .h = h },
+            .mode = mode,
         });
         return self;
     }
@@ -398,4 +403,86 @@ test "deinit is idempotent" {
     app.deinit();
     app.deinit(); // second call must be a no-op, not a double free
     try testing.expect(std.mem.endsWith(u8, aw.written(), "\x1b[?25h"));
+}
+
+// ----------------------------------------------------------------------
+// Full-screen mode (ADR-0015). A fixed term_size keeps these headless: the
+// alt-screen takeover byte stream runs, but raw mode / input do not (those
+// need a real terminal, exercised by the example + e2e).
+// ----------------------------------------------------------------------
+
+/// A `fill`×`fill` root — the shape a full-screen app uses to take the
+/// whole viewport.
+fn fullRoot(a: std.mem.Allocator, msg: []const u8) !ui.Node {
+    return ui.column(a, .{ .width = .{ .fill = 1 }, .height = .{ .fill = 1 } }, &.{ui.text(.{}, msg)});
+}
+
+test "full_screen enters the alt-screen and paints the whole viewport" {
+    var h = try Harness.initMode(20, 6, .full_screen);
+    defer h.deinit();
+    // init already switched to the alternate screen and hid the cursor.
+    h.replay();
+    try testing.expect(h.vt.alt_screen);
+    try testing.expect(!h.vt.cursor_visible);
+
+    try h.app.frame(try fullRoot(h.app.arena(), "dashboard"));
+    h.replay();
+
+    try testing.expect(h.vt.containsText("dashboard"));
+    // The frame is granted the full viewport height (no held-back row).
+    try testing.expectEqual(@as(u16, 6), h.app.live_rows);
+    // Parked at the origin (the diff renderer's anchor), still hidden.
+    try testing.expect(h.vt.cursorAt(0, 0));
+    try testing.expect(!h.vt.cursor_visible);
+}
+
+test "full_screen deinit leaves the alt-screen and shows the cursor" {
+    var h = try Harness.initMode(20, 6, .full_screen);
+    defer h.deinit();
+
+    try h.app.frame(try fullRoot(h.app.arena(), "bye"));
+    h.app.deinit();
+    // Re-init (hybrid, non-interactive so it touches nothing) so Harness.deinit's
+    // second app.deinit is a harmless no-op.
+    h.app = try ui.App.init(testing.allocator, &h.aw.writer, .{ .interactive = false });
+    h.replay();
+
+    try testing.expect(!h.vt.alt_screen);
+    try testing.expect(h.vt.cursor_visible);
+}
+
+test "emit is unavailable in full_screen" {
+    var h = try Harness.initMode(20, 6, .full_screen);
+    defer h.deinit();
+    try testing.expectError(error.EmitInFullScreen, h.app.emit("nope", .{}));
+}
+
+test "full_screen on a non-TTY is an error at init" {
+    var aw = std.Io.Writer.Allocating.init(testing.allocator);
+    defer aw.deinit();
+    try testing.expectError(error.NotATerminal, ui.App.init(testing.allocator, &aw.writer, .{
+        .term_size = .{ .w = 20, .h = 6 },
+        .mode = .full_screen,
+        .interactive = false,
+    }));
+}
+
+test "full_screen resize repaints the whole new viewport" {
+    var h = try Harness.initMode(20, 6, .full_screen);
+    defer h.deinit();
+
+    try h.app.frame(try fullRoot(h.app.arena(), "before"));
+    h.replay();
+    try testing.expectEqual(@as(u16, 6), h.app.live_rows);
+
+    // Grow the viewport (as a SIGWINCH would) and repaint.
+    h.app.options.term_size = .{ .w = 30, .h = 10 };
+    try h.vt.resize(30, 10);
+    try h.app.frame(try fullRoot(h.app.arena(), "after"));
+    h.replay();
+
+    try testing.expectEqual(@as(u16, 10), h.app.live_rows);
+    try testing.expect(h.vt.containsText("after"));
+    try testing.expect(!h.vt.containsText("before"));
+    try testing.expect(h.vt.cursorAt(0, 0));
 }

--- a/packages/ui/src/ui.zig
+++ b/packages/ui/src/ui.zig
@@ -24,6 +24,8 @@ pub const styleEql = surface.styleEql;
 
 pub const Renderer = @import("diff.zig").Renderer;
 pub const App = @import("app.zig").App;
+/// Full-screen input event (`App.nextEvent`) — a key press or a resize.
+pub const Event = @import("app.zig").Event;
 pub const widgets = @import("widgets.zig");
 
 /// Whether the terminal supports unicode glyphs (re-exported from `terminal`

--- a/projects/zcli/src/commands/guide.zig
+++ b/projects/zcli/src/commands/guide.zig
@@ -260,7 +260,7 @@ const topics = [_]Topic{
         \\A component is just a function returning a `ui.Node`; state (ticks,
         \\selections) lives in your own structs.
         \\
-        \\  var app = try context.ui();
+        \\  var app = try context.ui(.{});
         \\  defer app.deinit(); // restores terminal, final frame persists
         \\
         \\  try app.emit("compiled {s}", .{name});


### PR DESCRIPTION
Implements the first increment of [ADR-0015](docs/adr/0015-full-screen-tui-mode.md) — an opt-in full-screen (alt-screen) TUI mode on the **existing** layout engine. `node`/`measure`/`render`/`diff` are untouched: full-screen is a mode flag, not a fork.

Scoped to the ADR's build order **steps 1, 2, and 4**. Step 3 (teardown hardening) is a deliberate follow-up — see below.

## What's here

**`terminal` — timeout-capable input**
- `waitTimeout`/`readEventTimeout` on both POSIX and Windows backends, plus `WaitResult{input,resize,timeout}`. The existing `wait`/`readEvent` are now null-timeout wrappers. A finite timeout is what lets a loop repaint on a tick with no input (no background thread).

**`ui/App` — full-screen mode**
- `Mode{hybrid, full_screen}` + `Options.mode`/`.stdin` + a caller-facing `SessionOptions`.
- Enter (in `init`): raw mode + alt-screen (`?1049h`) + hide cursor + **origin anchor** — `?1049h` doesn't home the cursor, so the diff renderer's "parked at top-left" contract is established explicitly.
- `frameFullScreen`: grants the whole viewport; resize just re-anchors + full-repaints (no row reservation, scrollback seam, or tail reflow).
- `nextEvent(timeout_ms)`: flush-before-read; `null` blocks, a timeout returns `null`.
- Guards: `emit` → `error.EmitInFullScreen`; full-screen on a non-TTY → `error.NotATerminal` at init.
- `deinit`: restores **show-cursor → leave-alt-screen → disable-raw** (strict reverse of enter).

**`context.ui()` — breaking signature change (per project policy)**
- Now takes `zcli.ui.App.SessionOptions` (`.{ .mode = .full_screen }`); wires stdin automatically in full-screen. Updated the one call site + `guide.zig`.

**Example + tests**
- `packages/ui/examples/fullscreen.zig` — a `top`-style live table on a `nextEvent(250)` tick.
- **Live PTY smoke-test passes**: clean enter → paint → arrow-key input → `q` → teardown in the correct order at the very end of the stream.
- 5 headless full-screen tests (a fixed `term_size` skips real raw-mode but still emits the alt-screen byte stream for vterm golden assertions). All package tests + e2e green.

## Deferred: step 3 (teardown hardening)

Async-signal-safe global restore + POSIX/Windows signal handlers + panic hook. The normal Ctrl-C-as-key → `deinit` path already restores fully; step 3 only hardens external termination (`kill`) and panics.

⚠️ One discrepancy to resolve first: the ADR says the panic hook goes in *"generated `main.zig`"*, but there is **no generated `main.zig`** — each app authors its own entry point importing the generated `command_registry`. Since Zig's panic handler is a root-module declaration, `packages/ui` can't install it; step 3 needs a design decision (a `pub const panic` consumers add, vs. exposing it via the registry) before implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)