### PR TITLE
fix(ui): schedule full-screen tick against a deadline (no input starvation)

### DIFF
--- a/packages/ui/examples/fullscreen.zig
+++ b/packages/ui/examples/fullscreen.zig
@@ -9,6 +9,13 @@
 //! On exit (q or Ctrl-C) the shell's screen and scrollback come back exactly
 //! as they were: the final frame does not persist (that is the feature).
 //!
+//! The tick is scheduled against an absolute DEADLINE, not a fresh
+//! `nextEvent(250)` each pass: a burst of key input (holding an arrow repeats
+//! every ~30ms) must not keep resetting the timeout and starve the refresh.
+//! Each early wakeup shrinks the remaining window instead of restarting it, so
+//! the table keeps churning on wall-clock time no matter how fast keys arrive —
+//! one thread, no timer, exactly the loop shape the ADR intended.
+//!
 //! Run with: zig build run-fullscreen   (from packages/ui, needs a real TTY)
 
 const std = @import("std");
@@ -54,6 +61,13 @@ const State = struct {
         self.refresh();
     }
 };
+
+/// Monotonic milliseconds — the clock the deadline loop schedules against
+/// (the same `std.Io.Clock` source `progress` uses for its animation timing).
+fn nowMs(io: std.Io) u64 {
+    const ns = std.Io.Clock.Timestamp.now(io, .awake).raw.nanoseconds;
+    return @intCast(@divTrunc(ns, std.time.ns_per_ms));
+}
 
 fn view(a: std.mem.Allocator, state: *const State) !ui.Node {
     var rows = std.ArrayList(ui.Node).empty;
@@ -116,10 +130,22 @@ pub fn main(init: std.process.Init) !void {
 
     var state = State.init();
     var running = true;
+    var next_tick = nowMs(io) + tick_ms;
     while (running) {
         try app.frame(try view(app.arena(), &state));
-        const ev = try app.nextEvent(tick_ms) orelse {
-            state.advance(); // timeout: refresh the table
+
+        // Wait only until the next scheduled tick — not a full `tick_ms` — so
+        // continuous key input can't keep pushing the refresh out (see the
+        // module header). A wakeup at or past the deadline is itself a tick.
+        const now = nowMs(io);
+        if (now >= next_tick) {
+            state.advance();
+            next_tick = now + tick_ms;
+            continue;
+        }
+        const ev = try app.nextEvent(@intCast(next_tick - now)) orelse {
+            state.advance(); // deadline reached with no input: refresh the table
+            next_tick = nowMs(io) + tick_ms;
             continue;
         };
         switch (ev) {


### PR DESCRIPTION
Follow-up to #180 (ADR-0015). Fixes the tick-starvation @ryanhair hit: **holding an arrow froze the table churn and the elapsed clock** in the `top`-style example.

## Cause

The example fused two independent clocks into one. `state.advance()` (the table churn + clock) fired **only** on the `nextEvent` timeout branch, and each keypress returned early and started a **fresh** `nextEvent(tick_ms)` window. Key-repeat (~30 ms) meant the 250 ms timeout never elapsed → the refresh starved for as long as a key was held. (Selection still moved — that path repaints — but the animation, the obvious part, froze.)

## Fix: deadline, not fixed timeout

Track the next tick's absolute time and pass `next_tick - now` as the timeout. An early key wakeup **shrinks** the remaining window instead of resetting it, so ticks keep firing on wall-clock time regardless of input rate. Keys still repaint instantly.

```zig
var next_tick = nowMs(io) + tick_ms;
while (running) {
    try app.frame(try view(app.arena(), &state));
    const now = nowMs(io);
    if (now >= next_tick) { state.advance(); next_tick = now + tick_ms; continue; }
    const ev = try app.nextEvent(@intCast(next_tick - now)) orelse {
        state.advance(); next_tick = nowMs(io) + tick_ms; continue;
    };
    switch (ev) { ... }
}
```

**Still one thread, no timer** — this is the loop shape the ADR intended; the fixed `nextEvent(250)` was the naive first cut. A background thread was considered and rejected: the terminal writer, frame arena, and surfaces are single-owner, so a second thread could only *read input* (which already wakes the poll) and would re-introduce the same tick/event multiplexing plus a queue and lock.

## Scope

- **Example-only.** No `App`/engine API change.
- Uses the monotonic `std.Io.Clock.Timestamp` source (same clock `progress` animates against).
- Builds clean; `zig fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)