### PR TITLE
feat(ui)!: robust full-screen teardown — restore guard + signal/panic hooks (ADR-0015 step 3)

### DIFF
--- a/packages/core/src/context.zig
+++ b/packages/core/src/context.zig
@@ -193,17 +193,31 @@ pub fn ContextFor(comptime plugins: []const type) type {
         /// `app.frame()` for the diffed live region below. `defer app.deinit()`
         /// (idempotent) restores the terminal and persists the final frame.
         ///
-        /// Pass `.{ .mode = .full_screen }` for an opt-in alt-screen TUI
-        /// (ADR-0015): the App takes the screen over, owns raw mode, and reads
-        /// input through `app.nextEvent()`; stdin is wired automatically.
+        /// For an opt-in alt-screen TUI, use `uiFullScreen` instead.
         pub fn ui(self: *Self, options: zcli.ui.App.SessionOptions) !zcli.ui.App {
             return zcli.ui.App.init(self.allocator, self.stdout(), .{
                 .capability = self.theme.capability(),
                 .unicode = zcli.ui.unicodeSupported(self.environ),
                 .interactive = self.theme.caps.is_tty,
-                .mode = options.mode,
                 .sync = options.sync,
-                .stdin = if (options.mode == .full_screen) self.stdin() else null,
+            });
+        }
+
+        /// A full-screen (alt-screen) `ui.App` pre-wired to this command's
+        /// environment, with stdin wired for input (ADR-0015): the App takes the
+        /// screen over, owns raw mode, and reads input through `app.nextEvent()`.
+        ///
+        /// Requires a panic handler in your root source file so a panic can't
+        /// strand the terminal in the alt-screen — enforced at compile time:
+        ///
+        ///     pub const panic = zcli.ui.panic;
+        pub fn uiFullScreen(self: *Self, options: zcli.ui.App.SessionOptions) !zcli.ui.App {
+            return zcli.ui.App.initFullScreen(self.allocator, self.stdout(), .{
+                .capability = self.theme.capability(),
+                .unicode = zcli.ui.unicodeSupported(self.environ),
+                .interactive = self.theme.caps.is_tty,
+                .sync = options.sync,
+                .stdin = self.stdin(),
             });
         }
 

--- a/packages/terminal/src/guard.zig
+++ b/packages/terminal/src/guard.zig
@@ -1,0 +1,170 @@
+//! Process-global terminal restore guard (ADR-0015 choice 5).
+//!
+//! A full-screen App — and, more mildly, a hybrid one — takes over process-global
+//! terminal state (raw mode, the alternate screen, a hidden cursor) that outlives
+//! the process: the kernel does not undo it on exit. `App.deinit` restores it on
+//! the normal path, but two exits skip `deinit`:
+//!
+//! - **External termination** — `SIGTERM`/`SIGINT`/`SIGHUP` from a `kill`, or a
+//!   console-close on Windows. Caught by the handlers installed here.
+//! - **A panic** — Zig panics do not run `defer`, so `defer app.deinit()` never
+//!   fires. Caught by the `ui.panic` hook, which calls `restore` before the
+//!   default handler prints (so the trace lands on the restored screen).
+//!
+//! The mechanism is mode-agnostic: whoever takes over registers a precomputed
+//! restore blob (escape bytes + an optional saved raw mode) via `arm`; the signal
+//! handlers and the panic hook replay it via `restore`, which just writes back
+//! whatever was registered — hybrid registers "show cursor", full-screen registers
+//! "show cursor + leave alt-screen + restore termios".
+//!
+//! Process-global because a signal handler and the panic hook cannot reach the App
+//! instance — the same one-active-takeover assumption the SIGWINCH watcher already
+//! makes.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const backend = @import("backend.zig");
+
+const Handle = backend.Handle;
+const RawMode = backend.RawMode;
+
+/// The restore blob is short and bounded: show cursor (`\x1b[?25h`, 6B) plus, in
+/// full-screen, leave the alt-screen (`\x1b[?1049l`, 8B). 32B is ample headroom.
+const blob_max = 32;
+
+/// Set last by `arm` (release) and cleared first by `disarm` — so a handler that
+/// fires mid-`arm` either sees `false` (does nothing) or a fully written `g`.
+var armed = std.atomic.Value(bool).init(false);
+
+var g: struct {
+    out: Handle = undefined,
+    blob: [blob_max]u8 = undefined,
+    blob_len: usize = 0,
+    raw: ?RawMode = null,
+} = .{};
+
+/// Register the restore blob and install the external-termination handlers.
+/// `out` is the tty the escape bytes are written to; `raw`, when present, is the
+/// saved terminal mode to `disable()` on an abnormal exit. Called on takeover,
+/// from the main thread.
+pub fn arm(out: Handle, blob: []const u8, raw: ?RawMode) void {
+    std.debug.assert(blob.len <= blob_max);
+    g.out = out;
+    @memcpy(g.blob[0..blob.len], blob);
+    g.blob_len = blob.len;
+    g.raw = raw;
+    impl.install();
+    armed.store(true, .release);
+}
+
+/// Remove the handlers and stop replaying. Idempotent — a no-op if not armed, so
+/// `deinit` can call it unconditionally (including on the headless path that
+/// never armed).
+pub fn disarm() void {
+    if (!armed.swap(false, .acq_rel)) return;
+    impl.remove();
+}
+
+/// Replay the registered restore blob: write the escape bytes, then restore the
+/// saved raw mode. Async-signal-safe — a raw `write`/`WriteFile` plus
+/// `tcsetattr`/`SetConsoleMode`, no buffered writer and no allocator — so it is
+/// safe from both a signal handler and the panic hook. A no-op if not armed.
+pub fn restore() void {
+    if (!armed.load(.acquire)) return;
+    impl.writeRaw(g.out, g.blob[0..g.blob_len]);
+    if (g.raw) |r| r.disable();
+}
+
+const impl = if (builtin.os.tag == .windows) struct {
+    const windows = std.os.windows;
+    const DWORD = windows.DWORD;
+    const HANDLE = windows.HANDLE;
+
+    extern "kernel32" fn SetConsoleCtrlHandler(
+        handler: ?*const fn (DWORD) callconv(.winapi) c_int,
+        add: c_int,
+    ) callconv(.winapi) c_int;
+    extern "kernel32" fn WriteFile(
+        hFile: HANDLE,
+        lpBuffer: [*]const u8,
+        nNumberOfBytesToWrite: DWORD,
+        lpNumberOfBytesWritten: *DWORD,
+        lpOverlapped: ?*anyopaque,
+    ) callconv(.winapi) c_int;
+
+    /// Runs on a thread the console spawns for Ctrl-C / close / logoff / shutdown.
+    /// Returning FALSE lets the default handler run next, which terminates the
+    /// process — so we restore first, then fall through to the normal death.
+    fn ctrlHandler(_: DWORD) callconv(.winapi) c_int {
+        restore();
+        return 0; // FALSE
+    }
+
+    fn install() void {
+        _ = SetConsoleCtrlHandler(ctrlHandler, 1);
+    }
+    fn remove() void {
+        _ = SetConsoleCtrlHandler(ctrlHandler, 0);
+    }
+    fn writeRaw(h: Handle, bytes: []const u8) void {
+        var written: DWORD = 0;
+        _ = WriteFile(h, bytes.ptr, @intCast(bytes.len), &written, null);
+    }
+} else struct {
+    const posix = std.posix;
+
+    /// The external-termination signals. Raw mode clears `ISIG`, so an in-session
+    /// Ctrl-C is a key, not `SIGINT`; these fire only for an actual `kill`.
+    const sigs = .{ posix.SIG.INT, posix.SIG.TERM, posix.SIG.HUP };
+    var old: [sigs.len]posix.Sigaction = undefined;
+
+    fn install() void {
+        inline for (sigs, 0..) |signo, i| {
+            var act = posix.Sigaction{
+                .handler = .{ .handler = handlerFor(signo) },
+                .mask = posix.sigemptyset(),
+                .flags = 0,
+            };
+            posix.sigaction(signo, &act, &old[i]);
+        }
+    }
+    fn remove() void {
+        inline for (sigs, 0..) |signo, i| posix.sigaction(signo, &old[i], null);
+    }
+    /// The raw `write(2)` syscall — `std.posix.write` is gone in 0.16's IO model,
+    /// and a signal handler can't use a buffered writer anyway. Best-effort: a
+    /// short escape blob to a tty won't partial-write in practice, and the
+    /// process is dying regardless.
+    fn writeRaw(h: Handle, bytes: []const u8) void {
+        var off: usize = 0;
+        while (off < bytes.len) {
+            const rc = posix.system.write(h, bytes.ptr + off, bytes.len - off);
+            const n: isize = @bitCast(rc); // usize (linux) or isize (darwin)
+            if (n <= 0) return;
+            off += @intCast(n);
+        }
+    }
+
+    /// A distinct handler per signal so each knows its own number without reading
+    /// the (platform-varying) handler argument. Restore, then exit `128 + signo`
+    /// — the conventional signal-death code. (We exit rather than re-raise the
+    /// default disposition: `std.posix.raise` is unimplemented libc-free on macOS,
+    /// and for an interactive TUI the exit code is cosmetic — the restore is the
+    /// point.)
+    fn handlerFor(comptime signo: anytype) fn (posix.SIG) callconv(.c) void {
+        return struct {
+            fn h(_: posix.SIG) callconv(.c) void {
+                restore();
+                std.process.exit(128 +| sigNum(signo));
+            }
+        }.h;
+    }
+
+    /// The `SIG` constants are an `enum(u32)` on Darwin and plain ints elsewhere.
+    fn sigNum(comptime signo: anytype) u8 {
+        return switch (@typeInfo(@TypeOf(signo))) {
+            .@"enum" => @intCast(@intFromEnum(signo)),
+            else => @intCast(signo),
+        };
+    }
+};

--- a/packages/terminal/src/terminal.zig
+++ b/packages/terminal/src/terminal.zig
@@ -21,6 +21,12 @@ pub const readEventTimeout = event.readEventTimeout;
 /// Watches for terminal resizes; construct for the lifetime of a prompt.
 pub const ResizeWatcher = backend.ResizeWatcher;
 
+/// Process-global terminal restore guard (ADR-0015): replays a registered
+/// restore blob on external termination (signals / console-close) and, via the
+/// `ui.panic` hook, on a panic. `arm` on takeover, `disarm` on clean teardown,
+/// `restore` from a handler.
+pub const guard = @import("guard.zig");
+
 /// Display-width measurement and word-wrapping (grapheme- and ANSI-aware).
 pub const wrap = @import("wrap.zig");
 pub const displayWidth = wrap.displayWidth;

--- a/packages/ui/examples/fullscreen.zig
+++ b/packages/ui/examples/fullscreen.zig
@@ -22,6 +22,11 @@ const std = @import("std");
 const ui = @import("ui");
 const terminal = @import("terminal");
 
+/// Restore the terminal on a panic before the trace prints — required for
+/// full-screen (a panic doesn't run `defer app.deinit()`, and would otherwise
+/// strand the alt-screen). `App.initFullScreen` won't compile without it.
+pub const panic = ui.panic;
+
 const tick_ms: u32 = 250;
 
 const proc_names = [_][]const u8{
@@ -121,9 +126,8 @@ pub fn main(init: std.process.Init) !void {
     var in_buf: [256]u8 = undefined;
     var stdin = std.Io.File.stdin().reader(io, &in_buf);
 
-    var app = try ui.App.init(gpa, &stdout.interface, .{
+    var app = try ui.App.initFullScreen(gpa, &stdout.interface, .{
         .capability = .ansi_256,
-        .mode = .full_screen,
         .stdin = &stdin.interface,
     });
     defer app.deinit(); // leaves alt-screen, restores cooked mode + cursor

--- a/packages/ui/src/app.zig
+++ b/packages/ui/src/app.zig
@@ -82,20 +82,17 @@ pub const App = struct {
         /// touched. A `full_screen` App on a non-TTY is an error at `init` —
         /// a TUI into a pipe is meaningless.
         interactive: bool = true,
-        /// Hybrid (default) or full-screen (alt-screen) mode (ADR-0015).
-        mode: Mode = .hybrid,
-        /// Stdin reader for full-screen input. Required in `full_screen` (the
-        /// App owns raw mode and drives `nextEvent`); unused in `hybrid`,
-        /// where input ownership stays with the caller (e.g. `prompts`).
+        /// Stdin reader for full-screen input, wired by `initFullScreen` (the
+        /// App owns raw mode and drives `nextEvent`). Unused in hybrid, where
+        /// input ownership stays with the caller (e.g. `prompts`).
         stdin: ?*std.Io.Reader = null,
     };
 
-    /// The caller-facing subset of `Options` for `context.ui()`: the
-    /// environment-derived fields (capability, unicode, interactive, stdin)
-    /// are wired by the context, so these are the choices left to the app
-    /// author.
+    /// The caller-facing subset of `Options` for `context.ui()` /
+    /// `context.uiFullScreen()`: the environment-derived fields (capability,
+    /// unicode, interactive, stdin) are wired by the context, so this is the
+    /// choice left to the app author.
     pub const SessionOptions = struct {
-        mode: Mode = .hybrid,
         /// Wrap paints in synchronized output (DECSET 2026).
         sync: bool = true,
     };
@@ -112,6 +109,11 @@ pub const App = struct {
     writer: *std.Io.Writer,
     gpa: std.mem.Allocator,
     options: Options,
+    /// How the App shares the terminal — set by the constructor (`init` →
+    /// hybrid, `initFullScreen` → full-screen), not a caller option, so the
+    /// full-screen path (and its compile-time panic-hook requirement) rides on
+    /// a distinct constructor rather than a runtime flag.
+    mode: Mode = .hybrid,
 
     frame_arena: std.heap.ArenaAllocator,
     /// What the terminal currently shows (diff source) / the paint target.
@@ -143,23 +145,74 @@ pub const App = struct {
 
     pub const CursorPos = struct { x: u16, y: u16 };
 
+    /// A hybrid App (ADR-0013): a static stream flowing into scrollback with a
+    /// live region pinned above it. Shares the screen, stays in cooked mode,
+    /// input ownership is the caller's.
     pub fn init(gpa: std.mem.Allocator, writer: *std.Io.Writer, options: Options) !App {
-        var self: App = .{
+        return .{
             .writer = writer,
             .gpa = gpa,
             .options = options,
+            .mode = .hybrid,
             .frame_arena = std.heap.ArenaAllocator.init(gpa),
             .front = try Surface.init(gpa, 0, 0),
             .back = try Surface.init(gpa, 0, 0),
         };
+    }
+
+    /// A full-screen App (ADR-0015): takes the screen over via the
+    /// alternate-screen buffer, owns raw mode for the session, and reads input
+    /// through `nextEvent`. Pass a stdin reader in `options.stdin`.
+    ///
+    /// A distinct constructor, not a `mode` option, for one reason: full-screen
+    /// hands the terminal to the alt-screen in raw mode, so a panic (which does
+    /// not run `defer app.deinit()`) would strand it — the app MUST install the
+    /// restore panic hook. Because `mode` is comptime-known here (unlike a
+    /// runtime flag), `assertPanicInstalled` can turn a forgotten hook into a
+    /// build error instead of a wedged terminal, and only for full-screen apps.
+    pub fn initFullScreen(gpa: std.mem.Allocator, writer: *std.Io.Writer, options: Options) !App {
+        comptime assertPanicInstalled();
+        var self = try init(gpa, writer, options);
+        self.mode = .full_screen;
         errdefer {
             self.front.deinit();
             self.back.deinit();
             self.frame_arena.deinit();
         }
-        if (options.mode == .full_screen) try self.enterFullScreen();
+        try self.enterFullScreen();
         return self;
     }
+
+    /// Compile-time guard on `initFullScreen`: full-screen needs a panic handler
+    /// (see the constructor). Zig resolves the handler as `@import("root").panic`
+    /// — a root-module decl an imported module can't provide — so this checks the
+    /// root source file for it. Hybrid carries no such requirement (cooked mode,
+    /// cursor-only), which is why the check lives here and not in `init`.
+    fn assertPanicInstalled() void {
+        // `zig test` roots at the test runner (no panic hook) and constructs
+        // full-screen Apps only headlessly (fixed `term_size`, no real terminal
+        // to strand), so the requirement doesn't apply there.
+        if (@import("builtin").is_test) return;
+        if (!@hasDecl(@import("root"), "panic")) @compileError(
+            "full-screen ui.App requires a panic handler, so a panic can't strand the " ++
+                "terminal in the alt-screen. Add to your root source file (main.zig):\n\n" ++
+                "    pub const panic = zcli.ui.panic;\n\n" ++
+                "(standalone ui users: `pub const panic = ui.panic;`)",
+        );
+    }
+
+    /// Panic handler that restores the terminal (replays the `terminal.guard`
+    /// blob) *before* the default handler prints — so the stack trace lands on
+    /// the shell's real screen, not the discarded alt-screen. Install in your
+    /// root source file: `pub const panic = zcli.ui.panic;`. Required for
+    /// full-screen (enforced by `initFullScreen`); optional but recommended for
+    /// hybrid, where it re-shows the hidden cursor.
+    pub const panic = std.debug.FullPanic(struct {
+        fn call(msg: []const u8, first_trace_addr: ?usize) noreturn {
+            terminal.guard.restore();
+            std.debug.defaultPanic(msg, first_trace_addr);
+        }
+    }.call);
 
     /// Take the terminal over: enable session raw mode, switch to the
     /// alternate-screen buffer (saving the shell's screen + scrollback), hide
@@ -172,18 +225,26 @@ pub const App = struct {
         // Restore terminal state if any step below fails — same bytes/order as
         // deinit, so a half-entered session never strands the terminal.
         errdefer {
+            terminal.guard.disarm();
             self.writer.writeAll("\x1b[?25h\x1b[?1049l") catch {};
             self.writer.flush() catch {};
             if (self.watcher) |*w| w.deinit();
             if (self.raw) |r| r.disable();
         }
         // A fixed `term_size` is the headless-harness path (tests): there is
-        // no real terminal to put in raw mode or watch for resizes. Still emit
-        // the alt-screen takeover so the byte stream is exercised; live input
-        // (`nextEvent`) is a real-terminal-only affair.
+        // no real terminal to put in raw mode, watch for resizes, or arm the
+        // restore guard against (tests must not grab process signals). Still
+        // emit the alt-screen takeover so the byte stream is exercised; live
+        // input (`nextEvent`) is a real-terminal-only affair.
         if (self.options.term_size == null) {
             self.raw = try terminal.enableRawMode(std.Io.File.stdin().handle);
             self.watcher = terminal.ResizeWatcher.init();
+            // Register the full restore (show cursor → leave alt-screen →
+            // restore termios) for the signal/panic paths that skip deinit.
+            // Armed before the alt-screen bytes go out so a signal in the gap
+            // still restores; leaving an alt-screen we haven't entered is a
+            // harmless no-op.
+            terminal.guard.arm(std.Io.File.stdout().handle, "\x1b[?25h\x1b[?1049l", self.raw);
         }
         self.started = true; // cursor hidden, terminal owned
         try self.writer.writeAll("\x1b[?1049h\x1b[?25l");
@@ -208,7 +269,11 @@ pub const App = struct {
     pub fn deinit(self: *App) void {
         if (self.deinited) return;
         self.deinited = true;
-        if (self.options.mode == .full_screen) {
+        // Clean teardown owns the restore from here — disarm so a racing signal
+        // doesn't also replay, and to put the old signal dispositions back.
+        // Idempotent: a no-op on the headless path that never armed.
+        if (self.started) terminal.guard.disarm();
+        if (self.mode == .full_screen) {
             // Restore in strict reverse of enter (ADR-0015 choice 5): show
             // cursor → leave alt-screen (restores the shell's screen and
             // scrollback; the final frame is discarded by design) → disable
@@ -284,7 +349,7 @@ pub const App = struct {
         // Full-screen owns the whole viewport — there is no scrollback for a
         // static line to flow into (ADR-0015). Code that wants both a
         // scrollback log and a live frame is, by definition, the hybrid.
-        if (self.options.mode == .full_screen) return error.EmitInFullScreen;
+        if (self.mode == .full_screen) return error.EmitInFullScreen;
         const base = comptime std.mem.trimEnd(u8, fmt, "\r\n");
         if (!self.options.interactive) {
             // Plain line output: no live region exists, nothing to retain.
@@ -319,7 +384,7 @@ pub const App = struct {
     pub fn frame(self: *App, node: Node) !void {
         defer _ = self.frame_arena.reset(.retain_capacity);
         if (!self.options.interactive) return;
-        if (self.options.mode == .full_screen) return self.frameFullScreen(node);
+        if (self.mode == .full_screen) return self.frameFullScreen(node);
         try self.unplace();
 
         const ts = self.termSize();
@@ -450,7 +515,7 @@ pub const App = struct {
     /// arrives as an ordinary `.key` — raw mode cleared `ISIG` — so whether
     /// it quits, cancels, or is ignored is the caller's `update`.
     pub fn nextEvent(self: *App, timeout_ms: ?u32) !?Event {
-        std.debug.assert(self.options.mode == .full_screen);
+        std.debug.assert(self.mode == .full_screen);
         const reader = self.options.stdin orelse return error.NoInput;
         // No watcher means the headless-harness path (`term_size` set): there
         // is no real terminal to read from.
@@ -594,10 +659,17 @@ pub const App = struct {
         return @intCast(@min(rows, std.math.maxInt(u16)));
     }
 
+    /// Hybrid takeover: hide the cursor (the only process-global state hybrid
+    /// touches). Arm the guard to re-show it on a signal/panic that skips
+    /// deinit — the mode-agnostic restore, minus the alt-screen and termios
+    /// full-screen also registers. Only on a real terminal (`term_size` null);
+    /// the headless harness must not grab process signals.
     fn start(self: *App) !void {
         if (self.started) return;
         self.started = true;
         try self.writer.writeAll("\x1b[?25l");
+        if (self.options.term_size == null)
+            terminal.guard.arm(std.Io.File.stdout().handle, "\x1b[?25h", null);
     }
 
     fn termSize(self: *App) Size {

--- a/packages/ui/src/app_test.zig
+++ b/packages/ui/src/app_test.zig
@@ -28,10 +28,11 @@ const Harness = struct {
             .vt = try VTerm.init(testing.allocator, w, h),
             .app = undefined,
         };
-        self.app = try ui.App.init(testing.allocator, &self.aw.writer, .{
-            .term_size = .{ .w = w, .h = h },
-            .mode = mode,
-        });
+        const opts = ui.App.Options{ .term_size = .{ .w = w, .h = h } };
+        self.app = switch (mode) {
+            .hybrid => try ui.App.init(testing.allocator, &self.aw.writer, opts),
+            .full_screen => try ui.App.initFullScreen(testing.allocator, &self.aw.writer, opts),
+        };
         return self;
     }
 
@@ -460,9 +461,8 @@ test "emit is unavailable in full_screen" {
 test "full_screen on a non-TTY is an error at init" {
     var aw = std.Io.Writer.Allocating.init(testing.allocator);
     defer aw.deinit();
-    try testing.expectError(error.NotATerminal, ui.App.init(testing.allocator, &aw.writer, .{
+    try testing.expectError(error.NotATerminal, ui.App.initFullScreen(testing.allocator, &aw.writer, .{
         .term_size = .{ .w = 20, .h = 6 },
-        .mode = .full_screen,
         .interactive = false,
     }));
 }

--- a/packages/ui/src/ui.zig
+++ b/packages/ui/src/ui.zig
@@ -28,6 +28,12 @@ pub const App = @import("app.zig").App;
 pub const Event = @import("app.zig").Event;
 pub const widgets = @import("widgets.zig");
 
+/// Root-module panic handler that restores the terminal before the default
+/// handler prints (ADR-0015). Install in your `main.zig`:
+/// `pub const panic = zcli.ui.panic;`. Required for `App.initFullScreen` /
+/// `context.uiFullScreen` (enforced at compile time); optional for hybrid.
+pub const panic = App.panic;
+
 /// Whether the terminal supports unicode glyphs (re-exported from `terminal`
 /// for App/RenderCtx configuration — `App.Options.unicode`).
 pub const unicodeSupported = terminal.unicodeSupported;


### PR DESCRIPTION
Completes [ADR-0015](docs/adr/0015-full-screen-tui-mode.md) — **step 3, teardown hardening**. Follows #180 (steps 1/2/4) and #181 (tick fix).

Full-screen takes over process-global terminal state (raw mode, alt-screen, hidden cursor) that outlives the process. `App.deinit` restores it on the normal path, but **two exits skip `deinit`** and would strand the terminal — a wedged session needing `reset`:

- **External termination** (`kill` → SIGTERM/SIGINT/SIGHUP; Windows console-close)
- **Panic** — Zig panics don't run `defer`, so `defer app.deinit()` never fires

This closes both, on the mode-agnostic design we discussed.

## What's here

**`terminal.guard` — process-global restore singleton**
- `arm` registers a precomputed restore blob (escape bytes + optional saved `RawMode`) on takeover; `restore` replays it; `disarm` on clean teardown.
- `restore` is **async-signal-safe**: a raw `write(2)`/`WriteFile` + `tcsetattr`/`SetConsoleMode`, no buffered writer, no allocator.
- POSIX installs SIGINT/SIGTERM/SIGHUP handlers (restore → `exit(128+signo)` — `std.posix.raise` is unimplemented libc-free on macOS, and the exit code is cosmetic; the restore is the point). Windows uses `SetConsoleCtrlHandler`.
- Same process-global / one-active-session assumption the SIGWINCH watcher already makes.

**`ui.panic` — the panic hook**
- A `FullPanic` wrapper that runs `guard.restore()` **before** the default handler prints, so the stack trace lands on the restored screen instead of the discarded alt-screen. Install `pub const panic = zcli.ui.panic;` in `main.zig`.

**Mode-agnostic mechanism (hybrid rides along)**
- Full-screen arms `show cursor → leave alt-screen → restore termios`; hybrid arms just `show cursor` in `start()`. So hybrid gets cursor-restore on kill/panic **with no user action** and no panic-hook requirement. Both `disarm` in `deinit`. Only on a real terminal (`term_size == null`) — the headless test path never grabs signals.

**Constructor split + compile-time guard**
- `App.init` (hybrid) / `App.initFullScreen` (full-screen); `mode` leaves the public `Options` (now an internal field set by the constructor). `context.ui` / `context.uiFullScreen` likewise.
- `initFullScreen` runs `comptime assertPanicInstalled()` — `@hasDecl(@import("root"), "panic")`, the same decl `std.builtin` resolves. **A full-screen app that forgets the hook is a build error, not a wedged terminal** — and only full-screen apps, because `mode` is comptime at the distinct constructor (no `comptime` params on `context.ui`, per your ask). `zig test` roots are exempt via `builtin.is_test`.

## Validated live under a PTY

| Exit | alt-screen left | cursor shown | exit code |
|------|:---:|:---:|---|
| normal quit (`q`) | ✅ | ✅ | 0 |
| SIGTERM | ✅ | ✅ | 143 |
| SIGINT | ✅ | ✅ | 130 |
| `@panic` | ✅ | ✅ | abort — **restore precedes the trace** |

All package tests + e2e green; `zig fmt` clean.

## Note vs the ADR text

The ADR says the panic hook lives in *"generated `main.zig`"*, but there is no generated `main.zig` (apps author their own entry point importing `command_registry`). Since Zig requires `pub const panic` in the root module, this ships the one-line opt-in **enforced at compile time for full-screen** — the honest fit for the actual entry-point model, decided in discussion. Generating `main.zig` to make it fully automatic remains a possible future ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)