### PR TITLE
fix(terminal)!: die by the signal on external termination + finish ADR-0015 docs

### DIFF
--- a/docs/adr/0015-full-screen-tui-mode.md
+++ b/docs/adr/0015-full-screen-tui-mode.md
@@ -1,6 +1,15 @@
 # Full-screen mode: opt-in alt-screen TUI on the same layout engine
 
-Status: proposed
+Status: accepted
+
+> Shipped across PRs #180 (steps 1/2/4), #181 (deadline-scheduled tick), and
+> #182 (step 3 teardown). One deviation from the text below: there is no
+> generated `main.zig` (apps author their own entry point), so the panic hook
+> ships as a one-line opt-in — `pub const panic = zcli.ui.panic;` — enforced at
+> compile time for full-screen apps via `App.initFullScreen`, rather than
+> emitted by codegen. `mode` also became a constructor split
+> (`init`/`initFullScreen`, `context.ui`/`context.uiFullScreen`) instead of a
+> runtime `Options.mode` flag, to make that compile-time check possible.
 
 The layout engine (ADR-0013) was built CLI-first: a static stream flowing into
 scrollback plus a live region pinned above it. But the engine that paints the

--- a/packages/terminal/src/guard.zig
+++ b/packages/terminal/src/guard.zig
@@ -123,7 +123,12 @@ const impl = if (builtin.os.tag == .windows) struct {
             var act = posix.Sigaction{
                 .handler = .{ .handler = handlerFor(signo) },
                 .mask = posix.sigemptyset(),
-                .flags = 0,
+                // RESETHAND: the disposition is back to default on entry, so the
+                // handler's re-raise finds SIG_DFL (no recursion). NODEFER: the
+                // signal isn't blocked during the handler, so the re-raise is
+                // delivered synchronously and terminates us then and there —
+                // together, the "clean up, then die BY the signal" idiom.
+                .flags = posix.SA.RESETHAND | posix.SA.NODEFER,
             };
             posix.sigaction(signo, &act, &old[i]);
         }
@@ -146,15 +151,17 @@ const impl = if (builtin.os.tag == .windows) struct {
     }
 
     /// A distinct handler per signal so each knows its own number without reading
-    /// the (platform-varying) handler argument. Restore, then exit `128 + signo`
-    /// — the conventional signal-death code. (We exit rather than re-raise the
-    /// default disposition: `std.posix.raise` is unimplemented libc-free on macOS,
-    /// and for an interactive TUI the exit code is cosmetic — the restore is the
-    /// point.)
+    /// the (platform-varying) handler argument. Restore, then re-raise the signal
+    /// so the process dies BY it — the parent sees `WIFSIGNALED`/`WTERMSIG`, not a
+    /// plain exit. `posix.raise` is reachable on every target this branch compiles
+    /// for (macOS always links libSystem; libc-free Linux uses `tkill`; Windows
+    /// takes the other `impl`), so no libc dependency is added. The `exit` is a
+    /// fallback for the practically-impossible case where `raise` returns.
     fn handlerFor(comptime signo: anytype) fn (posix.SIG) callconv(.c) void {
         return struct {
             fn h(_: posix.SIG) callconv(.c) void {
                 restore();
+                posix.raise(signo) catch {};
                 std.process.exit(128 +| sigNum(signo));
             }
         }.h;

--- a/projects/zcli/src/commands/guide.zig
+++ b/projects/zcli/src/commands/guide.zig
@@ -276,6 +276,29 @@ const topics = [_]Topic{
         \\automatically; resize re-lays-out the live region and reflows the
         \\visible static tail. progress and prompts render on this engine.
         \\
+        \\Full-screen (alt-screen TUI): `context.uiFullScreen()` takes the whole
+        \\screen over on the same engine, owns raw mode, and reads input. Write
+        \\your own loop — `app.frame(view(state))` then `app.nextEvent(timeout)`;
+        \\a null timeout blocks, a number returns null on expiry (for a tick).
+        \\Ctrl-C arrives as a key. `emit` is unavailable; leaving restores the
+        \\shell exactly (the final frame does not persist).
+        \\
+        \\  // main.zig — required, else a panic strands the alt-screen:
+        \\  pub const panic = zcli.ui.panic;
+        \\
+        \\  var app = try context.uiFullScreen(.{});
+        \\  defer app.deinit();
+        \\  while (running) {
+        \\      try app.frame(try view(app.arena(), &state));
+        \\      switch (try app.nextEvent(250) orelse { tick(&state); continue; }) {
+        \\          .key => |k| update(&state, k),
+        \\          .resize => {},
+        \\      }
+        \\  }
+        \\
+        \\Runnable example: packages/ui/examples/fullscreen.zig (a top-style
+        \\table on a nextEvent tick). Kill/panic restore the terminal too.
+        \\
         ,
     },
     .{


### PR DESCRIPTION
Follow-up to #182. Two things that didn't make the merge:

## 1. Signal death instead of `exit(128+n)` (`packages/terminal/src/guard.zig`)

The full-screen restore guard restored the terminal on `kill`, then called `exit(128+signo)`. Cleanup was correct, but the process **exited normally** — a supervisor, `timeout`, or shell `$?` saw exit 143/130, not a signal death.

Now it re-raises: handlers install with `SA.RESETHAND | SA.NODEFER` and call `posix.raise(signo)` after `restore()`, so the re-delivered signal terminates the process with the **default disposition** — the parent sees `WIFSIGNALED` / `WTERMSIG = signo`. The `exit(128+signo)` remains only as a fallback for the impossible case where `raise` returns.

This also corrects the assumption behind the original code: `raise` is **not** unavailable libc-free. It's reachable on every target the POSIX branch compiles for — macOS always links libSystem, libc-free Linux uses `tkill`/`gettid`, and Windows takes the other `impl`. No libc dependency is added.

**Verified under a PTY:**

| signal | terminal restored | death |
|---|:---:|---|
| SIGTERM | ✅ | `WIFSIGNALED` 15 |
| SIGINT | ✅ | `WIFSIGNALED` 2 |
| SIGHUP | ✅ | `WIFSIGNALED` 1 |
| quit (`q`) | ✅ | exit 0 |

## 2. ADR-0015 wrap-up docs (held back from #182)

- `docs/adr/0015-full-screen-tui-mode.md`: `proposed` → **accepted**, with a note on the two shipped deviations from the text (compile-enforced panic one-liner instead of a generated `main.zig`; constructor split instead of a runtime `mode` flag).
- `zcli guide ui`: a full-screen section — `context.uiFullScreen()`, the `nextEvent` loop shape, the required `pub const panic = zcli.ui.panic;`, and a pointer to `examples/fullscreen.zig`.

All package tests + e2e green; `zig fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)