### PR TITLE
feat(ui): App.run — the full-screen loop driver (ADR-0015 deferred sugar)

### DIFF
--- a/packages/ui/examples/fullscreen.zig
+++ b/packages/ui/examples/fullscreen.zig
@@ -1,20 +1,18 @@
-//! A `top`-style full-screen TUI (ADR-0015 step 4): the whole viewport is a
-//! live table of processes whose CPU/MEM jitter on a 250ms tick, with an
-//! arrow-key selection. It validates the loop shape the ADR proposes —
+//! A `top`-style full-screen TUI (ADR-0015): the whole viewport is a live table
+//! of processes whose CPU/MEM jitter on a 250ms tick, with an arrow-key
+//! selection. It drives the `App.run(state, tick_ms, view, update)` loop —
 //!
-//!     frame(view(state))            paint the whole screen
-//!     nextEvent(250) orelse tick()  block for a key/resize, or refresh
+//!     view(state)           render the whole screen from state
+//!     update(state, ev)      handle a key/resize, or a `null` tick; -> keep|quit
 //!
-//! — reusing the same layout engine as the hybrid, just in alt-screen mode.
-//! On exit (q or Ctrl-C) the shell's screen and scrollback come back exactly
-//! as they were: the final frame does not persist (that is the feature).
+//! — reusing the same layout engine as the hybrid, just in alt-screen mode. On
+//! exit (q or Ctrl-C) the shell's screen and scrollback come back exactly as
+//! they were: the final frame does not persist (that is the feature).
 //!
-//! The tick is scheduled against an absolute DEADLINE, not a fresh
-//! `nextEvent(250)` each pass: a burst of key input (holding an arrow repeats
-//! every ~30ms) must not keep resetting the timeout and starve the refresh.
-//! Each early wakeup shrinks the remaining window instead of restarting it, so
-//! the table keeps churning on wall-clock time no matter how fast keys arrive —
-//! one thread, no timer, exactly the loop shape the ADR intended.
+//! `run` owns the loop and schedules the tick against a deadline (a burst of
+//! keys shrinks the wait rather than resetting it, so input can't starve the
+//! refresh). The explicit `frame`/`nextEvent` loop `run` wraps is still there
+//! if you need it — see `App.run`'s doc comment.
 //!
 //! Run with: zig build run-fullscreen   (from packages/ui, needs a real TTY)
 
@@ -67,14 +65,7 @@ const State = struct {
     }
 };
 
-/// Monotonic milliseconds — the clock the deadline loop schedules against
-/// (the same `std.Io.Clock` source `progress` uses for its animation timing).
-fn nowMs(io: std.Io) u64 {
-    const ns = std.Io.Clock.Timestamp.now(io, .awake).raw.nanoseconds;
-    return @intCast(@divTrunc(ns, std.time.ns_per_ms));
-}
-
-fn view(a: std.mem.Allocator, state: *const State) !ui.Node {
+fn view(a: std.mem.Allocator, state: *State) !ui.Node {
     var rows = std.ArrayList(ui.Node).empty;
 
     const elapsed = try std.fmt.allocPrint(a, "{d:.1}s", .{
@@ -109,6 +100,31 @@ fn view(a: std.mem.Allocator, state: *const State) !ui.Node {
     );
 }
 
+/// A `null` event is the tick (advance the jittering table); keys drive
+/// selection and quitting. Ctrl-C is an ordinary key here (raw mode cleared
+/// ISIG). Resize needs nothing — `run` re-renders every pass.
+fn update(state: *State, ev: ?ui.Event) !ui.Flow {
+    const e = ev orelse {
+        state.advance();
+        return .keep;
+    };
+    switch (e) {
+        .key => |k| switch (k) {
+            .char => |c| if (c == 'q') return .quit,
+            .ctrl => |c| if (c == 'c') return .quit,
+            .up => if (state.selected > 0) {
+                state.selected -= 1;
+            },
+            .down => if (state.selected + 1 < state.procs.len) {
+                state.selected += 1;
+            },
+            else => {},
+        },
+        .resize => {},
+    }
+    return .keep;
+}
+
 pub fn main(init: std.process.Init) !void {
     const io = init.io;
     const gpa = init.gpa;
@@ -133,42 +149,5 @@ pub fn main(init: std.process.Init) !void {
     defer app.deinit(); // leaves alt-screen, restores cooked mode + cursor
 
     var state = State.init();
-    var running = true;
-    var next_tick = nowMs(io) + tick_ms;
-    while (running) {
-        try app.frame(try view(app.arena(), &state));
-
-        // Wait only until the next scheduled tick — not a full `tick_ms` — so
-        // continuous key input can't keep pushing the refresh out (see the
-        // module header). A wakeup at or past the deadline is itself a tick.
-        const now = nowMs(io);
-        if (now >= next_tick) {
-            state.advance();
-            next_tick = now + tick_ms;
-            continue;
-        }
-        const ev = try app.nextEvent(@intCast(next_tick - now)) orelse {
-            state.advance(); // deadline reached with no input: refresh the table
-            next_tick = nowMs(io) + tick_ms;
-            continue;
-        };
-        switch (ev) {
-            .key => |k| switch (k) {
-                .char => |c| if (c == 'q') {
-                    running = false;
-                },
-                .ctrl => |c| if (c == 'c') {
-                    running = false; // Ctrl-C is a key here (raw mode cleared ISIG)
-                },
-                .up => if (state.selected > 0) {
-                    state.selected -= 1;
-                },
-                .down => if (state.selected + 1 < state.procs.len) {
-                    state.selected += 1;
-                },
-                else => {},
-            },
-            .resize => {}, // next frame re-anchors and re-measures
-        }
-    }
+    try app.run(io, &state, tick_ms, view, update);
 }

--- a/packages/ui/src/app.zig
+++ b/packages/ui/src/app.zig
@@ -529,6 +529,65 @@ pub const App = struct {
         );
     }
 
+    /// `update`'s verdict: keep looping, or stop `run`.
+    pub const Flow = enum { keep, quit };
+
+    /// The full-screen driver (ADR-0015): own the `frame → nextEvent → update`
+    /// loop so callers don't hand-roll it. Each pass renders `view(state)`,
+    /// blocks for the next event, and routes it to `update`; loop until `update`
+    /// returns `.quit`. Sugar over the explicit loop — state stays caller-owned
+    /// and mutable (immediate mode), `view` should treat it as read-only.
+    ///
+    /// `tick_ms` drives a periodic refresh with no input (a `top`-style clock):
+    /// the tick is delivered to `update` as a `null` event, and it is scheduled
+    /// against a DEADLINE — a burst of keys shrinks the wait rather than
+    /// resetting it, so input can't starve the tick. `null` disables ticking
+    /// (block on input only — a form or menu). `io` is only the monotonic clock
+    /// the deadline reads (`std.Io.Clock`). Full-screen only.
+    pub fn run(
+        self: *App,
+        io: std.Io,
+        state: anytype,
+        tick_ms: ?u32,
+        comptime view: fn (std.mem.Allocator, @TypeOf(state)) anyerror!Node,
+        comptime update: fn (@TypeOf(state), ?Event) anyerror!Flow,
+    ) !void {
+        std.debug.assert(self.mode == .full_screen);
+        const ns_per_ms = std.time.ns_per_ms;
+        var next_tick: u64 = if (tick_ms) |ms| nowNs(io) + @as(u64, ms) * ns_per_ms else 0;
+
+        while (true) {
+            try self.frame(try view(self.arena(), state));
+
+            // How long until the next tick — the remaining window, not a fresh
+            // `tick_ms`, so early key wakeups can't push the tick out forever.
+            var timeout: ?u32 = null;
+            if (tick_ms) |ms| {
+                const now = nowNs(io);
+                if (now >= next_tick) {
+                    if (try update(state, null) == .quit) return;
+                    next_tick = nowNs(io) + @as(u64, ms) * ns_per_ms;
+                    continue; // re-render, then re-arm the wait
+                }
+                timeout = @intCast((next_tick - now) / ns_per_ms);
+            }
+
+            const ev = try self.nextEvent(timeout) orelse {
+                // Deadline reached with no input: a tick.
+                if (try update(state, null) == .quit) return;
+                if (tick_ms) |ms| next_tick = nowNs(io) + @as(u64, ms) * ns_per_ms;
+                continue;
+            };
+            if (try update(state, ev) == .quit) return;
+        }
+    }
+
+    /// Monotonic nanoseconds — the deadline source for `run`'s tick, via the
+    /// `.awake` clock `progress` also animates against.
+    fn nowNs(io: std.Io) u64 {
+        return @intCast(std.Io.Clock.Timestamp.now(io, .awake).raw.nanoseconds);
+    }
+
     /// Erase the live region and leave nothing in its place — the ending
     /// for a widget whose result is an `emit`ted line (or no output at
     /// all), as opposed to `deinit`'s leave-the-final-frame-visible.

--- a/packages/ui/src/ui.zig
+++ b/packages/ui/src/ui.zig
@@ -26,6 +26,8 @@ pub const Renderer = @import("diff.zig").Renderer;
 pub const App = @import("app.zig").App;
 /// Full-screen input event (`App.nextEvent`) — a key press or a resize.
 pub const Event = @import("app.zig").Event;
+/// `update`'s verdict for the `App.run` loop — keep looping, or quit.
+pub const Flow = App.Flow;
 pub const widgets = @import("widgets.zig");
 
 /// Root-module panic handler that restores the terminal before the default


### PR DESCRIPTION
First of the ADR-0015 deferred items. `run(update, view)` was deferred as "optional sugar over the loop… added later without changing anything" — now that the loop shape has proven out (steps 1–3 shipped), here it is.

## Why it earns its place

It's not *only* cosmetic: the explicit `while → frame → nextEvent → route` loop is boilerplate every full-screen app rewrites, and **re-deriving the deadline-scheduled tick is exactly what regressed in #181**. `run` owns that logic in one place so no consumer can get it wrong again.

## API

```zig
pub const Flow = enum { keep, quit };

pub fn run(
    self: *App,
    io: std.Io,                 // monotonic clock for the tick deadline only
    state: anytype,             // *State — caller-owned, mutable
    tick_ms: ?u32,              // null = block on input; N = top-style refresh
    comptime view:   fn (std.mem.Allocator, @TypeOf(state)) anyerror!Node,
    comptime update: fn (@TypeOf(state), ?Event) anyerror!Flow,   // null event = tick
) !void
```

- `view` renders from state; `update` handles an event (or a `null` tick) and returns `.keep`/`.quit`. Immediate-mode contract preserved — state lives with the caller.
- The tick is **deadline-scheduled**: a key burst shrinks the remaining wait instead of resetting it, so input can't starve the refresh (#181's fix, baked in).
- `io` is only the clock (`std.Io.Clock` — `std.time.Timer` was removed in 0.16). Full-screen only; the explicit loop it wraps is unchanged and still available.

## Example

`examples/fullscreen.zig` converted — the ~20-line hand-rolled loop collapses to one `run` call plus an `update` fn (the raw loop is documented on `App.run` for anyone who needs it).

## Validation

No headless unit test — the harness can't feed `nextEvent` (no input source → `error.NoInput`), and `run` is thin over already-tested pieces. **PTY-validated** instead (as agreed):

| check | result |
|---|---|
| tick fires on the deadline | 7 paints / 2.0s idle @ 250ms ✅ |
| tick not starved by input | 18 paints under key spam ✅ |
| input renders (selection moves) | reverse-video present ✅ |
| q / Ctrl-C quit + teardown | restored, exit 0 ✅ |

ui tests (69/69) + `zig fmt` green.

## Design decisions (agreed up front)
- **Tick as a `null` event** (not a separate `tick` callback) — closest to the raw loop, mirrors `nextEvent`'s own `?Event`, avoids a struct-of-fn-pointers.
- **`Flow{keep,quit}`** for readable returns.
- **Converted the example** rather than keeping a second raw-loop demo.

Next in the deferred queue (in order, per your call): mouse/focus/paste events → overlays/z-layers → scroll viewports → focusable widget library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)