### PR TITLE
feat(ui): mouse + focus events (ADR-0015 deferred)

### DIFF
--- a/packages/core/src/context.zig
+++ b/packages/core/src/context.zig
@@ -218,6 +218,8 @@ pub fn ContextFor(comptime plugins: []const type) type {
                 .interactive = self.theme.caps.is_tty,
                 .sync = options.sync,
                 .stdin = self.stdin(),
+                .mouse = options.mouse,
+                .focus = options.focus,
             });
         }
 

--- a/packages/prompts/src/multi_select.zig
+++ b/packages/prompts/src/multi_select.zig
@@ -132,6 +132,7 @@ pub fn multiSelect(p: Prompts, config: MultiSelectConfig) ![]usize {
                 },
                 else => {},
             },
+            else => {}, // mouse/focus never arrive — prompts don't enable them
         }
     }
 }

--- a/packages/prompts/src/search.zig
+++ b/packages/prompts/src/search.zig
@@ -108,6 +108,7 @@ pub fn search(p: Prompts, config: SearchConfig) !usize {
                 },
                 else => {},
             },
+            else => {}, // mouse/focus never arrive — prompts don't enable them
         }
     }
 }

--- a/packages/prompts/src/select.zig
+++ b/packages/prompts/src/select.zig
@@ -100,6 +100,7 @@ pub fn select(p: Prompts, config: SelectConfig) !usize {
                     else => {},
                 }
             },
+            else => {}, // mouse/focus never arrive — prompts don't enable them
         }
     }
 }

--- a/packages/terminal/src/event.zig
+++ b/packages/terminal/src/event.zig
@@ -11,11 +11,24 @@
 const key = @import("key.zig");
 const backend = @import("backend.zig");
 
-/// An input event: a parsed key press or a terminal resize.
+/// An input event: a key press, a terminal resize, or — when their modes are
+/// enabled — a mouse report or a focus change. Resize is out-of-band (from the
+/// watcher); the rest are parsed from the byte stream by `key.readInput`.
 pub const Event = union(enum) {
     key: key.Key,
     resize,
+    mouse: key.Mouse,
+    focus: key.Focus,
 };
+
+/// Lift a byte-parsed `Input` into an `Event`.
+fn fromInput(input: key.Input) Event {
+    return switch (input) {
+        .key => |v| .{ .key = v },
+        .mouse => |v| .{ .mouse = v },
+        .focus => |v| .{ .focus = v },
+    };
+}
 
 /// Block until a key is read from `reader` or the terminal is resized, reported
 /// via `watcher`. `handle` is the stdin handle — used both for escape-sequence
@@ -36,10 +49,10 @@ pub fn readEventTimeout(
     timeout_ms: ?u32,
 ) !?Event {
     // Bytes already buffered are input regardless of the deadline.
-    if (key.bufferedLen(reader) > 0) return Event{ .key = try key.readKeyOpt(reader, handle) };
+    if (key.bufferedLen(reader) > 0) return fromInput(try key.readInput(reader, handle));
     return switch (watcher.waitTimeout(handle, timeout_ms)) {
         .resize => .resize,
-        .input => Event{ .key = try key.readKeyOpt(reader, handle) },
+        .input => fromInput(try key.readInput(reader, handle)),
         .timeout => null,
     };
 }

--- a/packages/terminal/src/guard.zig
+++ b/packages/terminal/src/guard.zig
@@ -28,9 +28,10 @@ const backend = @import("backend.zig");
 const Handle = backend.Handle;
 const RawMode = backend.RawMode;
 
-/// The restore blob is short and bounded: show cursor (`\x1b[?25h`, 6B) plus, in
-/// full-screen, leave the alt-screen (`\x1b[?1049l`, 8B). 32B is ample headroom.
-const blob_max = 32;
+/// The restore blob is short and bounded: show cursor (`\x1b[?25h`, 6B), leave
+/// the alt-screen (`\x1b[?1049l`, 8B), and disable any opt-in input modes
+/// (mouse `?1002l?1006l`, focus `?1004l`). 48B covers all of them at once.
+const blob_max = 48;
 
 /// Set last by `arm` (release) and cleared first by `disarm` — so a handler that
 /// fires mid-`arm` either sees `false` (does nothing) or a fully written `g`.

--- a/packages/terminal/src/key.zig
+++ b/packages/terminal/src/key.zig
@@ -47,6 +47,35 @@ pub const Key = union(enum) {
     }
 };
 
+/// A mouse report (SGR encoding, DECSET 1006). Coordinates are 1-based cells,
+/// as the terminal reports them — subtract 1 to index a 0-based surface.
+pub const Mouse = struct {
+    pub const Button = enum { left, middle, right, wheel_up, wheel_down, none };
+    /// `drag` is motion with a button held (needs DECSET 1002); `move` is motion
+    /// with no button (hover — needs 1003, not enabled by default, so it does not
+    /// occur in the current full-screen wiring).
+    pub const Action = enum { press, release, drag, move };
+    pub const Mods = struct { shift: bool = false, alt: bool = false, ctrl: bool = false };
+
+    x: u16,
+    y: u16,
+    button: Button,
+    action: Action,
+    mods: Mods = .{},
+};
+
+/// A focus change (DECSET 1004): the terminal window gained or lost focus.
+pub const Focus = enum { in, out };
+
+/// A single parsed input token from the byte stream. `readEvent` lifts this into
+/// an `Event` (adding the out-of-band `resize`); `readKey` projects it back to
+/// just the key case. Mouse/focus only arrive when their modes are enabled.
+pub const Input = union(enum) {
+    key: Key,
+    mouse: Mouse,
+    focus: Focus,
+};
+
 /// Read a single byte from a reader.
 /// Supports std.Io.Reader (pointer with readSliceAll) and GenericReader (value with readByte).
 pub fn readByteFn(reader: anytype) !u8 {
@@ -85,20 +114,33 @@ pub fn readKeyOpt(reader: anytype, esc_handle: backend.Handle) !Key {
     return readKeyImpl(reader, esc_handle);
 }
 
-fn readKeyImpl(reader: anytype, esc_handle: ?backend.Handle) !Key {
+/// Read one input token — a key, or (when their modes are enabled) a mouse or
+/// focus event. The single byte→token parser; `readKey` and the event
+/// multiplexer both funnel through it.
+pub fn readInput(reader: anytype, esc_handle: ?backend.Handle) !Input {
     const byte = try readByteFn(reader);
 
     return switch (byte) {
-        '\r', '\n' => .enter,
-        '\t' => .tab,
-        127 => .backspace,
+        '\r', '\n' => .{ .key = .enter },
+        '\t' => .{ .key = .tab },
+        127 => .{ .key = .backspace },
         '\x1b' => parseEscapeSequence(reader, esc_handle),
         // Ctrl+A through Ctrl+Z (1-26, excluding 9=tab, 10=newline, 13=cr, 27=esc)
-        1...8, 11...12, 14...26 => .{ .ctrl = byte + 'a' - 1 },
+        1...8, 11...12, 14...26 => .{ .key = .{ .ctrl = byte + 'a' - 1 } },
         // Lead byte of a multibyte UTF-8 sequence
-        0x80...0xff => .{ .char = readUtf8Tail(reader, byte) },
+        0x80...0xff => .{ .key = .{ .char = readUtf8Tail(reader, byte) } },
         // Printable ASCII (plus the few remaining C0 codes callers ignore)
-        else => .{ .char = byte },
+        else => .{ .key = .{ .char = byte } },
+    };
+}
+
+/// Key-only projection of `readInput`. Mouse/focus tokens (which arrive only if
+/// those modes are enabled — key-only callers like `prompts` never enable them)
+/// collapse to `.escape`, harmlessly ignored.
+fn readKeyImpl(reader: anytype, esc_handle: ?backend.Handle) !Key {
+    return switch (try readInput(reader, esc_handle)) {
+        .key => |k| k,
+        .mouse, .focus => .escape,
     };
 }
 
@@ -118,45 +160,123 @@ fn readUtf8Tail(reader: anytype, lead: u8) u21 {
     return std.unicode.utf8Decode(seq[0..len]) catch replacement_char;
 }
 
-fn parseEscapeSequence(reader: anytype, esc_handle: ?backend.Handle) !Key {
+/// A key token wrapped as an `Input` — the common escape-parse result.
+fn keyIn(key: Key) Input {
+    return .{ .key = key };
+}
+
+fn parseEscapeSequence(reader: anytype, esc_handle: ?backend.Handle) !Input {
     // A lone ESC has no following bytes. Arrow keys, etc. arrive as one chunk, so
     // their bytes are already buffered; if nothing is buffered, only the poll
     // (when a handle is given) decides — otherwise treat it as a lone Escape
     // rather than block.
-    if (!escapeSequenceFollows(reader, esc_handle)) return .escape;
+    if (!escapeSequenceFollows(reader, esc_handle)) return keyIn(.escape);
 
     // Try to read the next byte — if it's '[', this is a CSI sequence
-    const next = readByteFn(reader) catch return .escape;
+    const next = readByteFn(reader) catch return keyIn(.escape);
 
     if (next == '[') {
         // CSI sequence: ESC [ ...
-        const code = readByteFn(reader) catch return .escape;
+        const code = readByteFn(reader) catch return keyIn(.escape);
         return switch (code) {
-            'A' => .up,
-            'B' => .down,
-            'C' => .right,
-            'D' => .left,
-            'H' => .home,
-            'F' => .end,
+            'A' => keyIn(.up),
+            'B' => keyIn(.down),
+            'C' => keyIn(.right),
+            'D' => keyIn(.left),
+            'H' => keyIn(.home),
+            'F' => keyIn(.end),
+            // Focus in/out (DECSET 1004). `ESC [ O` is distinct from the SS3
+            // `ESC O …` below (no intervening `[`).
+            'I' => .{ .focus = .in },
+            'O' => .{ .focus = .out },
+            // SGR mouse (DECSET 1006): ESC [ < Cb ; Cx ; Cy (M|m).
+            '<' => parseMouseSgr(reader),
             '3' => blk: {
                 // ESC [ 3 ~ = Delete
-                const tilde = readByteFn(reader) catch break :blk .escape;
-                if (tilde == '~') break :blk .delete;
-                break :blk .escape;
+                const tilde = readByteFn(reader) catch break :blk keyIn(.escape);
+                if (tilde == '~') break :blk keyIn(.delete);
+                break :blk keyIn(.escape);
             },
-            else => .escape,
+            else => keyIn(.escape),
         };
     } else if (next == 'O') {
         // SS3 sequence: ESC O ...
-        const code = readByteFn(reader) catch return .escape;
+        const code = readByteFn(reader) catch return keyIn(.escape);
         return switch (code) {
-            'H' => .home,
-            'F' => .end,
-            else => .escape,
+            'H' => keyIn(.home),
+            'F' => keyIn(.end),
+            else => keyIn(.escape),
         };
     }
 
-    return .escape;
+    return keyIn(.escape);
+}
+
+/// Parse the tail of an SGR mouse report (`ESC [ <` already consumed):
+/// `Cb ; Cx ; Cy` then `M` (press) or `m` (release). Any malformed byte
+/// collapses to `.escape` rather than desyncing the stream.
+fn parseMouseSgr(reader: anytype) !Input {
+    const cb = readCsiNum(reader) catch return keyIn(.escape);
+    if (cb.term != ';') return keyIn(.escape);
+    const cx = readCsiNum(reader) catch return keyIn(.escape);
+    if (cx.term != ';') return keyIn(.escape);
+    const cy = readCsiNum(reader) catch return keyIn(.escape);
+    if (cy.term != 'M' and cy.term != 'm') return keyIn(.escape);
+    return .{ .mouse = decodeMouse(cb.val, cx.val, cy.val, cy.term == 'M') };
+}
+
+const CsiNum = struct { val: u16, term: u8 };
+
+/// Read a decimal parameter and the non-digit byte that terminated it.
+fn readCsiNum(reader: anytype) !CsiNum {
+    var val: u16 = 0;
+    var any = false;
+    while (true) {
+        const b = try readByteFn(reader);
+        if (b >= '0' and b <= '9') {
+            val = val *% 10 +% (b - '0');
+            any = true;
+        } else {
+            if (!any) return error.InvalidMouse;
+            return .{ .val = val, .term = b };
+        }
+    }
+}
+
+/// Decode an SGR button code into a `Mouse`. Low 2 bits pick the button; bit 6
+/// (64) marks a wheel; bit 5 (32) marks motion (drag with a button, else move);
+/// bits 2/3/4 are shift/alt/ctrl.
+fn decodeMouse(cb: u16, x: u16, y: u16, press: bool) Mouse {
+    const wheel = (cb & 64) != 0;
+    const motion = (cb & 32) != 0;
+    const low = cb & 3;
+
+    var button: Mouse.Button = .none;
+    var action: Mouse.Action = if (press) .press else .release;
+    if (wheel) {
+        button = if (low == 0) .wheel_up else .wheel_down;
+        action = .press;
+    } else {
+        button = switch (low) {
+            0 => .left,
+            1 => .middle,
+            2 => .right,
+            else => .none,
+        };
+        if (motion) action = if (button == .none) .move else .drag;
+    }
+
+    return .{
+        .x = x,
+        .y = y,
+        .button = button,
+        .action = action,
+        .mods = .{
+            .shift = (cb & 4) != 0,
+            .alt = (cb & 8) != 0,
+            .ctrl = (cb & 16) != 0,
+        },
+    };
 }
 
 /// Whether more of an escape sequence follows the ESC byte: true if bytes are
@@ -288,4 +408,66 @@ test "readKey parses delete" {
     var reader: std.Io.Reader = .fixed(&buf);
     const k = try readKey(&reader);
     try std.testing.expect(k == .delete);
+}
+
+fn parseInput(comptime bytes: []const u8) !Input {
+    var buf: [bytes.len]u8 = undefined;
+    @memcpy(&buf, bytes);
+    var reader: std.Io.Reader = .fixed(&buf);
+    return readInput(&reader, null);
+}
+
+test "readInput parses an SGR mouse press" {
+    // ESC [ < 0 ; 10 ; 5 M — left button press at (10, 5).
+    const i = try parseInput("\x1b[<0;10;5M");
+    try std.testing.expectEqual(Mouse{
+        .x = 10,
+        .y = 5,
+        .button = .left,
+        .action = .press,
+        .mods = .{},
+    }, i.mouse);
+}
+
+test "readInput distinguishes press (M) from release (m)" {
+    try std.testing.expectEqual(Mouse.Action.press, (try parseInput("\x1b[<2;1;1M")).mouse.action);
+    const rel = (try parseInput("\x1b[<2;1;1m")).mouse;
+    try std.testing.expectEqual(Mouse.Action.release, rel.action);
+    try std.testing.expectEqual(Mouse.Button.right, rel.button);
+}
+
+test "readInput decodes wheel, drag, and modifiers" {
+    // 64 = wheel bit, low 2 bits 0 -> wheel up.
+    const wheel = (try parseInput("\x1b[<64;3;3M")).mouse;
+    try std.testing.expectEqual(Mouse.Button.wheel_up, wheel.button);
+    try std.testing.expectEqual(Mouse.Action.press, wheel.action);
+
+    // 32 = motion bit, low 2 bits 0 (left held) -> left drag.
+    const drag = (try parseInput("\x1b[<32;5;5M")).mouse;
+    try std.testing.expectEqual(Mouse.Button.left, drag.button);
+    try std.testing.expectEqual(Mouse.Action.drag, drag.action);
+
+    // 16 = ctrl modifier on a left press.
+    const ctrl = (try parseInput("\x1b[<16;1;1M")).mouse;
+    try std.testing.expect(ctrl.mods.ctrl and !ctrl.mods.shift and !ctrl.mods.alt);
+}
+
+test "readInput handles multi-digit mouse coordinates" {
+    const m = (try parseInput("\x1b[<0;120;48M")).mouse;
+    try std.testing.expectEqual(@as(u16, 120), m.x);
+    try std.testing.expectEqual(@as(u16, 48), m.y);
+}
+
+test "readInput parses focus in/out" {
+    try std.testing.expectEqual(Focus.in, (try parseInput("\x1b[I")).focus);
+    try std.testing.expectEqual(Focus.out, (try parseInput("\x1b[O")).focus);
+}
+
+test "readInput still parses keys" {
+    try std.testing.expectEqual(Key.up, (try parseInput("\x1b[A")).key);
+    try std.testing.expectEqual(Key{ .char = 'a' }, (try parseInput("a")).key);
+}
+
+test "malformed mouse sequence degrades to escape, not a desync" {
+    try std.testing.expectEqual(Key.escape, (try parseInput("\x1b[<0;xM")).key);
 }

--- a/packages/terminal/src/terminal.zig
+++ b/packages/terminal/src/terminal.zig
@@ -9,6 +9,8 @@ const backend = @import("backend.zig");
 
 pub const key = @import("key.zig");
 pub const Key = key.Key;
+pub const Mouse = key.Mouse;
+pub const Focus = key.Focus;
 pub const readKey = key.readKey;
 pub const readKeyOpt = key.readKeyOpt;
 

--- a/packages/ui/examples/fullscreen.zig
+++ b/packages/ui/examples/fullscreen.zig
@@ -39,6 +39,8 @@ const State = struct {
     tick: u32 = 0,
     selected: usize = 0,
     procs: [proc_names.len]Proc = undefined,
+    last_mouse: ?ui.Mouse = null,
+    focused: bool = true,
 
     fn init() State {
         var s = State{};
@@ -91,7 +93,15 @@ fn view(a: std.mem.Allocator, state: *State) !ui.Node {
     }
 
     try rows.append(a, ui.spacer());
-    try rows.append(a, ui.text(.{ .dim = true }, "↑/↓ select   q quit"));
+    const mouse = if (state.last_mouse) |m|
+        try std.fmt.allocPrint(a, "{s} @ {d},{d}", .{ @tagName(m.button), m.x, m.y })
+    else
+        "—";
+    const status = try std.fmt.allocPrint(a, "↑/↓ select   click a cell   q quit    focus:{s}  mouse:{s}", .{
+        if (state.focused) "on" else "off",
+        mouse,
+    });
+    try rows.append(a, ui.text(.{ .dim = true }, status));
 
     return ui.column(
         a,
@@ -120,6 +130,15 @@ fn update(state: *State, ev: ?ui.Event) !ui.Flow {
             },
             else => {},
         },
+        .mouse => |m| {
+            state.last_mouse = m;
+            // Left-click a table row (rows start at y=3: padding + title + header).
+            if (m.button == .left and m.action == .press and m.y >= 3) {
+                const row = m.y - 3;
+                if (row < state.procs.len) state.selected = row;
+            }
+        },
+        .focus => |f| state.focused = f == .in,
         .resize => {},
     }
     return .keep;
@@ -145,6 +164,8 @@ pub fn main(init: std.process.Init) !void {
     var app = try ui.App.initFullScreen(gpa, &stdout.interface, .{
         .capability = .ansi_256,
         .stdin = &stdin.interface,
+        .mouse = true,
+        .focus = true,
     });
     defer app.deinit(); // leaves alt-screen, restores cooked mode + cursor
 

--- a/packages/ui/src/app.zig
+++ b/packages/ui/src/app.zig
@@ -47,10 +47,20 @@ const Size = node_mod.Size;
 const Limits = node_mod.Limits;
 const RenderCtx = node_mod.RenderCtx;
 
-/// An input event surfaced by `nextEvent` in full-screen mode: a parsed key
-/// press or a terminal resize (re-exported from `terminal`). Mouse/focus/paste
-/// events join here when they land (ADR-0015 deferred).
+/// An input event surfaced by `nextEvent` in full-screen mode: a key press, a
+/// terminal resize, or (when enabled) a mouse or focus event (re-exported from
+/// `terminal`). Bracketed paste joins here when it lands (ADR-0015 deferred).
 pub const Event = terminal.Event;
+
+// Full-screen takeover/restore escape sequences. The `*_on`/`*_off` pairs are
+// DECSET enable/disable for the opt-in input modes; `restore_tail` shows the
+// cursor and leaves the alt-screen. Restore order is the reverse of enter:
+// disable input modes, then cursor, then alt-screen.
+const mouse_on = "\x1b[?1002h\x1b[?1006h"; // button+drag tracking, SGR encoding
+const mouse_off = "\x1b[?1002l\x1b[?1006l";
+const focus_on = "\x1b[?1004h";
+const focus_off = "\x1b[?1004l";
+const restore_tail = "\x1b[?25h\x1b[?1049l";
 
 pub const App = struct {
     /// How the App shares the terminal (ADR-0015).
@@ -86,6 +96,12 @@ pub const App = struct {
         /// App owns raw mode and drives `nextEvent`). Unused in hybrid, where
         /// input ownership stays with the caller (e.g. `prompts`).
         stdin: ?*std.Io.Reader = null,
+        /// Report mouse press/release/drag as `Event.mouse` (full-screen only).
+        /// Off by default — mouse reporting overrides the terminal's own text
+        /// selection, so it's opt-in.
+        mouse: bool = false,
+        /// Report window focus in/out as `Event.focus` (full-screen only).
+        focus: bool = false,
     };
 
     /// The caller-facing subset of `Options` for `context.ui()` /
@@ -95,6 +111,10 @@ pub const App = struct {
     pub const SessionOptions = struct {
         /// Wrap paints in synchronized output (DECSET 2026).
         sync: bool = true,
+        /// Report mouse events (full-screen only; see `Options.mouse`).
+        mouse: bool = false,
+        /// Report focus in/out (full-screen only; see `Options.focus`).
+        focus: bool = false,
     };
 
     /// A static block kept for the resize tail repaint (ADR-0013 resize
@@ -226,7 +246,7 @@ pub const App = struct {
         // deinit, so a half-entered session never strands the terminal.
         errdefer {
             terminal.guard.disarm();
-            self.writer.writeAll("\x1b[?25h\x1b[?1049l") catch {};
+            self.writeRestore();
             self.writer.flush() catch {};
             if (self.watcher) |*w| w.deinit();
             if (self.raw) |r| r.disable();
@@ -239,17 +259,45 @@ pub const App = struct {
         if (self.options.term_size == null) {
             self.raw = try terminal.enableRawMode(std.Io.File.stdin().handle);
             self.watcher = terminal.ResizeWatcher.init();
-            // Register the full restore (show cursor → leave alt-screen →
-            // restore termios) for the signal/panic paths that skip deinit.
-            // Armed before the alt-screen bytes go out so a signal in the gap
-            // still restores; leaving an alt-screen we haven't entered is a
-            // harmless no-op.
-            terminal.guard.arm(std.Io.File.stdout().handle, "\x1b[?25h\x1b[?1049l", self.raw);
+            // Register the full restore (disable input modes → show cursor →
+            // leave alt-screen → restore termios) for the signal/panic paths
+            // that skip deinit. Armed before the takeover bytes go out so a
+            // signal in the gap still restores; disabling modes / leaving an
+            // alt-screen we haven't entered yet is a harmless no-op.
+            var blob: [64]u8 = undefined;
+            terminal.guard.arm(std.Io.File.stdout().handle, self.restoreBlob(&blob), self.raw);
         }
         self.started = true; // cursor hidden, terminal owned
         try self.writer.writeAll("\x1b[?1049h\x1b[?25l");
+        if (self.options.mouse) try self.writer.writeAll(mouse_on);
+        if (self.options.focus) try self.writer.writeAll(focus_on);
         try self.anchor();
         try self.writer.flush();
+    }
+
+    /// The restore blob for the signal/panic guard: disable whichever input
+    /// modes are on, then `restore_tail` (show cursor + leave alt-screen). Same
+    /// bytes `writeRestore` emits on the normal path, packed into `buf`.
+    fn restoreBlob(self: *App, buf: []u8) []const u8 {
+        var n: usize = 0;
+        const put = struct {
+            fn f(dst: []u8, at: *usize, s: []const u8) void {
+                @memcpy(dst[at.*..][0..s.len], s);
+                at.* += s.len;
+            }
+        }.f;
+        if (self.options.mouse) put(buf, &n, mouse_off);
+        if (self.options.focus) put(buf, &n, focus_off);
+        put(buf, &n, restore_tail);
+        return buf[0..n];
+    }
+
+    /// Emit the restore sequence to the writer (normal teardown / errdefer):
+    /// disable input modes, then show cursor and leave the alt-screen.
+    fn writeRestore(self: *App) void {
+        if (self.options.mouse) self.writer.writeAll(mouse_off) catch {};
+        if (self.options.focus) self.writer.writeAll(focus_off) catch {};
+        self.writer.writeAll(restore_tail) catch {};
     }
 
     /// Park the cursor at the screen origin (the diff renderer's addressing
@@ -274,12 +322,12 @@ pub const App = struct {
         // Idempotent: a no-op on the headless path that never armed.
         if (self.started) terminal.guard.disarm();
         if (self.mode == .full_screen) {
-            // Restore in strict reverse of enter (ADR-0015 choice 5): show
-            // cursor → leave alt-screen (restores the shell's screen and
-            // scrollback; the final frame is discarded by design) → disable
-            // raw mode. The alt-screen leave must precede the raw-mode
+            // Restore in strict reverse of enter (ADR-0015 choice 5): disable
+            // input modes → show cursor → leave alt-screen (restores the shell's
+            // screen and scrollback; the final frame is discarded by design) →
+            // disable raw mode. The alt-screen leave must precede the raw-mode
             // restore so its bytes still go out while we own the terminal.
-            if (self.started) self.writer.writeAll("\x1b[?25h\x1b[?1049l") catch {};
+            if (self.started) self.writeRestore();
             self.writer.flush() catch {};
             if (self.watcher) |*w| w.deinit();
             if (self.raw) |r| r.disable();

--- a/packages/ui/src/app_test.zig
+++ b/packages/ui/src/app_test.zig
@@ -467,6 +467,36 @@ test "full_screen on a non-TTY is an error at init" {
     }));
 }
 
+test "full_screen enables mouse + focus on enter and disables them on deinit" {
+    var aw = std.Io.Writer.Allocating.init(testing.allocator);
+    defer aw.deinit();
+    var app = try ui.App.initFullScreen(testing.allocator, &aw.writer, .{
+        .term_size = .{ .w = 20, .h = 6 },
+        .mouse = true,
+        .focus = true,
+    });
+    // Enter emitted the DECSET enables (SGR mouse + drag tracking, focus).
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "\x1b[?1002h") != null);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "\x1b[?1006h") != null);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "\x1b[?1004h") != null);
+
+    app.deinit();
+    const out = aw.written();
+    // Teardown disabled them before leaving the alt-screen (the disables precede
+    // the `?1049l` in the stream).
+    const mouse_off = std.mem.indexOf(u8, out, "\x1b[?1002l").?;
+    const focus_off = std.mem.indexOf(u8, out, "\x1b[?1004l").?;
+    const alt_off = std.mem.lastIndexOf(u8, out, "\x1b[?1049l").?;
+    try testing.expect(mouse_off < alt_off and focus_off < alt_off);
+}
+
+test "full_screen leaves mouse/focus modes untouched when not requested" {
+    var h = try Harness.initMode(20, 6, .full_screen);
+    defer h.deinit();
+    try testing.expect(std.mem.indexOf(u8, h.aw.written(), "\x1b[?1002h") == null);
+    try testing.expect(std.mem.indexOf(u8, h.aw.written(), "\x1b[?1004h") == null);
+}
+
 test "full_screen resize repaints the whole new viewport" {
     var h = try Harness.initMode(20, 6, .full_screen);
     defer h.deinit();

--- a/packages/ui/src/ui.zig
+++ b/packages/ui/src/ui.zig
@@ -24,8 +24,11 @@ pub const styleEql = surface.styleEql;
 
 pub const Renderer = @import("diff.zig").Renderer;
 pub const App = @import("app.zig").App;
-/// Full-screen input event (`App.nextEvent`) — a key press or a resize.
+/// Full-screen input event (`App.nextEvent`) — a key, resize, mouse, or focus.
 pub const Event = @import("app.zig").Event;
+/// Mouse report / focus change carried by `Event` (full-screen, when enabled).
+pub const Mouse = terminal.Mouse;
+pub const Focus = terminal.Focus;
 /// `update`'s verdict for the `App.run` loop — keep looping, or quit.
 pub const Flow = App.Flow;
 pub const widgets = @import("widgets.zig");

--- a/projects/zcli/src/commands/guide.zig
+++ b/projects/zcli/src/commands/guide.zig
@@ -277,27 +277,37 @@ const topics = [_]Topic{
         \\visible static tail. progress and prompts render on this engine.
         \\
         \\Full-screen (alt-screen TUI): `context.uiFullScreen()` takes the whole
-        \\screen over on the same engine, owns raw mode, and reads input. Write
-        \\your own loop — `app.frame(view(state))` then `app.nextEvent(timeout)`;
-        \\a null timeout blocks, a number returns null on expiry (for a tick).
-        \\Ctrl-C arrives as a key. `emit` is unavailable; leaving restores the
-        \\shell exactly (the final frame does not persist).
+        \\screen over on the same engine, owns raw mode, and reads input. Ctrl-C
+        \\arrives as a key; `emit` is unavailable; leaving restores the shell
+        \\exactly (the final frame does not persist). Opt into mouse/focus with
+        \\`.{ .mouse = true, .focus = true }` — they surface as `Event.mouse` /
+        \\`Event.focus`.
+        \\
+        \\`app.run` owns the loop for you (tick delivered as a null event,
+        \\deadline-scheduled); `update` returns `.keep` or `.quit`:
         \\
         \\  // main.zig — required, else a panic strands the alt-screen:
         \\  pub const panic = zcli.ui.panic;
         \\
         \\  var app = try context.uiFullScreen(.{});
         \\  defer app.deinit();
-        \\  while (running) {
-        \\      try app.frame(try view(app.arena(), &state));
-        \\      switch (try app.nextEvent(250) orelse { tick(&state); continue; }) {
-        \\          .key => |k| update(&state, k),
-        \\          .resize => {},
+        \\  try app.run(context.io, &state, 250, view, update);
+        \\
+        \\  fn update(s: *State, ev: ?ui.Event) !ui.Flow {
+        \\      const e = ev orelse { tick(s); return .keep; };  // null = tick
+        \\      switch (e) {
+        \\          .key => |k| if (k == .char and k.char == 'q') return .quit,
+        \\          .mouse => |m| s.cursor = .{ m.x, m.y },
+        \\          else => {},
         \\      }
+        \\      return .keep;
         \\  }
         \\
-        \\Runnable example: packages/ui/examples/fullscreen.zig (a top-style
-        \\table on a nextEvent tick). Kill/panic restore the terminal too.
+        \\Prefer the explicit loop? `app.frame(view(state))` +
+        \\`app.nextEvent(timeout)` (null blocks; a number returns null on expiry)
+        \\is what `run` wraps. Runnable example:
+        \\packages/ui/examples/fullscreen.zig (a top-style table, mouse + focus).
+        \\Kill/panic restore the terminal too.
         \\
         ,
     },


### PR DESCRIPTION
Second of the ADR-0015 deferred input items. Mouse reports and focus in/out **join the `Event` union** (the ADR's named home — "mouse and focus/paste events join `Event`; `event.zig` already reserves the spot"). Paste stays deferred — its buffer-lifetime is a separate design, and it's next in the queue.

## Parsing (`terminal`)

`key.readInput` parses one input token → `Input{ key, mouse, focus }`:
- **SGR mouse** (`ESC[<Cb;Cx;Cy` + `M`/`m`) → `Mouse{ x, y, button, action, mods }`. Decodes left/middle/right, wheel up/down, press/release/drag, and shift/alt/ctrl. Coords are 1-based (as the terminal reports — subtract 1 for a 0-based surface).
- **Focus** (`ESC[I` / `ESC[O`) → `Focus{ in, out }`.
- Malformed mouse **degrades to `.escape`**, never desyncs the stream.

`Event` gains `.mouse`/`.focus`; `readEvent` lifts `Input` (adding out-of-band `resize`). `readKey` projects back to keys (mouse/focus → ignored `.escape`), so **prompts are unchanged in behavior** — one `else => {}` each in the 3 that `switch` on `Event`, for exhaustiveness (never fires; they don't enable the modes).

## Opt-in + guard safety (`ui/App`)

Mouse reporting overrides the terminal's own text selection, so it's off by default: `Options.mouse` / `.focus` (+ `SessionOptions`, `context.uiFullScreen(.{ .mouse = true, .focus = true })`). On enter, the DECSET enables go out (`?1002h?1006h` for SGR mouse+drag, `?1004h` for focus). Critically, the **disables are prepended to the `terminal.guard` restore blob** (and emitted on `deinit`), so a `kill`/panic can't strand the terminal spewing `ESC[<…` on every click. `blob_max` 32→48.

## Example + docs

`examples/fullscreen.zig` now showcases it — click a row to select, wheel, and a live focus/mouse status line — and `zcli guide ui` is refreshed for `run` + mouse/focus.

## Tests

- **Unit** (headless, real `zig build test`): SGR mouse press/release/wheel/drag/mods/multi-digit/malformed + focus in/out parsing; App enable-on-enter / disable-on-deinit byte-stream assertions; "modes untouched when not requested".
- **PTY e2e**: fed real SGR/focus sequences — click and wheel reach `update`, focus-out flips state, enter enables + quit disables, clean teardown (exit 0). (Fought the diff renderer's changed-cells-only output a couple times; confirmed via the actual repainted tail.)

All packages + `zig fmt` green.

Next: **bracketed paste** — I'll bring the buffer-lifetime design (the option (b) gpa-allocated slice we discussed) before implementing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)