### PR TITLE
feat(ui): bracketed paste events (ADR-0015 deferred)

### DIFF
--- a/packages/core/src/context.zig
+++ b/packages/core/src/context.zig
@@ -220,6 +220,8 @@ pub fn ContextFor(comptime plugins: []const type) type {
                 .stdin = self.stdin(),
                 .mouse = options.mouse,
                 .focus = options.focus,
+                .paste = options.paste,
+                .paste_max = options.paste_max,
             });
         }
 

--- a/packages/terminal/src/event.zig
+++ b/packages/terminal/src/event.zig
@@ -12,14 +12,22 @@ const key = @import("key.zig");
 const backend = @import("backend.zig");
 
 /// An input event: a key press, a terminal resize, or — when their modes are
-/// enabled — a mouse report or a focus change. Resize is out-of-band (from the
-/// watcher); the rest are parsed from the byte stream by `key.readInput`.
+/// enabled — a mouse report, focus change, or bracketed paste. Resize is
+/// out-of-band (from the watcher); the rest are parsed from the byte stream by
+/// `key.readInput`.
 pub const Event = union(enum) {
     key: key.Key,
     resize,
     mouse: key.Mouse,
     focus: key.Focus,
+    /// Bracketed-paste content, borrowed from the `PasteSink` (valid until the
+    /// next read — copy it if you need it longer).
+    paste: []const u8,
 };
+
+/// Where paste content is accumulated; passed by `App.nextEvent` when paste
+/// mode is on. `null` (e.g. `prompts` via `readEvent`) discards any paste.
+pub const PasteSink = key.PasteSink;
 
 /// Lift a byte-parsed `Input` into an `Event`.
 fn fromInput(input: key.Input) Event {
@@ -27,6 +35,7 @@ fn fromInput(input: key.Input) Event {
         .key => |v| .{ .key = v },
         .mouse => |v| .{ .mouse = v },
         .focus => |v| .{ .focus = v },
+        .paste => |v| .{ .paste = v },
     };
 }
 
@@ -35,7 +44,7 @@ fn fromInput(input: key.Input) Event {
 /// disambiguation and by the watcher's poll. Bytes already buffered in `reader`
 /// are consumed before polling, so no keypress is missed.
 pub fn readEvent(reader: anytype, handle: backend.Handle, watcher: *backend.ResizeWatcher) !Event {
-    return (try readEventTimeout(reader, handle, watcher, null)).?;
+    return (try readEventTimeout(reader, handle, watcher, null, null)).?;
 }
 
 /// Like `readEvent`, but return `null` if neither a key nor a resize arrives
@@ -47,12 +56,13 @@ pub fn readEventTimeout(
     handle: backend.Handle,
     watcher: *backend.ResizeWatcher,
     timeout_ms: ?u32,
+    paste: ?PasteSink,
 ) !?Event {
     // Bytes already buffered are input regardless of the deadline.
-    if (key.bufferedLen(reader) > 0) return fromInput(try key.readInput(reader, handle));
+    if (key.bufferedLen(reader) > 0) return fromInput(try key.readInput(reader, handle, paste));
     return switch (watcher.waitTimeout(handle, timeout_ms)) {
         .resize => .resize,
-        .input => fromInput(try key.readInput(reader, handle)),
+        .input => fromInput(try key.readInput(reader, handle, paste)),
         .timeout => null,
     };
 }

--- a/packages/terminal/src/key.zig
+++ b/packages/terminal/src/key.zig
@@ -67,13 +67,26 @@ pub const Mouse = struct {
 /// A focus change (DECSET 1004): the terminal window gained or lost focus.
 pub const Focus = enum { in, out };
 
+/// Where bracketed-paste content is accumulated. The caller owns `buf` (the App
+/// reuses one across pastes); the parser clears it, appends the content up to
+/// `max` bytes (a pathological multi-MB paste is truncated, not an OOM), and
+/// returns a slice of it as `Input.paste`. Borrowed — valid until the next read.
+pub const PasteSink = struct {
+    buf: *std.ArrayList(u8),
+    allocator: std.mem.Allocator,
+    max: usize,
+};
+
 /// A single parsed input token from the byte stream. `readEvent` lifts this into
 /// an `Event` (adding the out-of-band `resize`); `readKey` projects it back to
-/// just the key case. Mouse/focus only arrive when their modes are enabled.
+/// just the key case. Mouse/focus/paste only arrive when their modes are enabled.
 pub const Input = union(enum) {
     key: Key,
     mouse: Mouse,
     focus: Focus,
+    /// Bracketed-paste content (DECSET 2004), borrowed from the `PasteSink`'s
+    /// buffer — copy it if you need it past the next read.
+    paste: []const u8,
 };
 
 /// Read a single byte from a reader.
@@ -117,14 +130,14 @@ pub fn readKeyOpt(reader: anytype, esc_handle: backend.Handle) !Key {
 /// Read one input token — a key, or (when their modes are enabled) a mouse or
 /// focus event. The single byte→token parser; `readKey` and the event
 /// multiplexer both funnel through it.
-pub fn readInput(reader: anytype, esc_handle: ?backend.Handle) !Input {
+pub fn readInput(reader: anytype, esc_handle: ?backend.Handle, paste: ?PasteSink) !Input {
     const byte = try readByteFn(reader);
 
     return switch (byte) {
         '\r', '\n' => .{ .key = .enter },
         '\t' => .{ .key = .tab },
         127 => .{ .key = .backspace },
-        '\x1b' => parseEscapeSequence(reader, esc_handle),
+        '\x1b' => parseEscapeSequence(reader, esc_handle, paste),
         // Ctrl+A through Ctrl+Z (1-26, excluding 9=tab, 10=newline, 13=cr, 27=esc)
         1...8, 11...12, 14...26 => .{ .key = .{ .ctrl = byte + 'a' - 1 } },
         // Lead byte of a multibyte UTF-8 sequence
@@ -134,13 +147,13 @@ pub fn readInput(reader: anytype, esc_handle: ?backend.Handle) !Input {
     };
 }
 
-/// Key-only projection of `readInput`. Mouse/focus tokens (which arrive only if
-/// those modes are enabled — key-only callers like `prompts` never enable them)
-/// collapse to `.escape`, harmlessly ignored.
+/// Key-only projection of `readInput`. Mouse/focus/paste tokens (which arrive
+/// only if those modes are enabled — key-only callers like `prompts` never
+/// enable them) collapse to `.escape`, harmlessly ignored.
 fn readKeyImpl(reader: anytype, esc_handle: ?backend.Handle) !Key {
-    return switch (try readInput(reader, esc_handle)) {
+    return switch (try readInput(reader, esc_handle, null)) {
         .key => |k| k,
-        .mouse, .focus => .escape,
+        .mouse, .focus, .paste => .escape,
     };
 }
 
@@ -165,7 +178,7 @@ fn keyIn(key: Key) Input {
     return .{ .key = key };
 }
 
-fn parseEscapeSequence(reader: anytype, esc_handle: ?backend.Handle) !Input {
+fn parseEscapeSequence(reader: anytype, esc_handle: ?backend.Handle, paste: ?PasteSink) !Input {
     // A lone ESC has no following bytes. Arrow keys, etc. arrive as one chunk, so
     // their bytes are already buffered; if nothing is buffered, only the poll
     // (when a handle is given) decides — otherwise treat it as a lone Escape
@@ -195,6 +208,14 @@ fn parseEscapeSequence(reader: anytype, esc_handle: ?backend.Handle) !Input {
                 // ESC [ 3 ~ = Delete
                 const tilde = readByteFn(reader) catch break :blk keyIn(.escape);
                 if (tilde == '~') break :blk keyIn(.delete);
+                break :blk keyIn(.escape);
+            },
+            '2' => blk: {
+                // ESC [ 200 ~ = bracketed-paste start (DECSET 2004). Only that
+                // exact prefix; any other ESC[2… is an unhandled CSI.
+                var m: [3]u8 = undefined;
+                for (&m) |*c| c.* = readByteFn(reader) catch break :blk keyIn(.escape);
+                if (std.mem.eql(u8, &m, "00~")) break :blk readPasteBody(reader, paste);
                 break :blk keyIn(.escape);
             },
             else => keyIn(.escape),
@@ -277,6 +298,65 @@ fn decodeMouse(cb: u16, x: u16, y: u16, press: bool) Mouse {
             .ctrl = (cb & 16) != 0,
         },
     };
+}
+
+/// The bracketed-paste terminator (`ESC [ 2 0 1 ~`). Scanned for byte-by-byte so
+/// paste content may itself contain lone ESC bytes or partial markers.
+const paste_end = "\x1b[201~";
+
+/// Read paste content (the `ESC [ 200 ~` start already consumed) up to the
+/// `ESC [ 201 ~` terminator, into `paste.buf`. Bytes matching a prefix of the
+/// terminator are held back — flushed as content only if the match breaks — so
+/// the terminator is never appended and content is preserved verbatim. Over
+/// `paste.max` bytes are dropped (scanning continues, so the terminator is still
+/// found). With no sink, the sequence is consumed and discarded (defensive: a
+/// caller that didn't enable 2004 shouldn't receive one, but must not desync).
+fn readPasteBody(reader: anytype, paste: ?PasteSink) !Input {
+    const sink = paste orelse {
+        discardPaste(reader);
+        return keyIn(.escape);
+    };
+    sink.buf.clearRetainingCapacity();
+
+    var matched: usize = 0; // bytes of `paste_end` matched so far (held back)
+    while (true) {
+        const b = readByteFn(reader) catch break; // EOF: return what we have
+        if (b == paste_end[matched]) {
+            matched += 1;
+            if (matched == paste_end.len) break; // full terminator consumed
+            continue;
+        }
+        // Match broke: the held prefix was real content. Emit it, then classify
+        // `b` (it may itself restart a match).
+        if (matched > 0) {
+            appendCapped(sink, paste_end[0..matched]);
+            matched = 0;
+        }
+        if (b == paste_end[0]) matched = 1 else appendCapped(sink, &.{b});
+    }
+    return .{ .paste = sink.buf.items };
+}
+
+/// Append `bytes` to the sink, clamped so the buffer never exceeds `max`.
+fn appendCapped(sink: PasteSink, bytes: []const u8) void {
+    const room = sink.max -| sink.buf.items.len;
+    const n = @min(room, bytes.len);
+    if (n > 0) sink.buf.appendSlice(sink.allocator, bytes[0..n]) catch {};
+}
+
+/// Consume a paste body without keeping it (no sink) — still scan to the
+/// terminator so the byte stream stays in sync.
+fn discardPaste(reader: anytype) void {
+    var matched: usize = 0;
+    while (true) {
+        const b = readByteFn(reader) catch return;
+        if (b == paste_end[matched]) {
+            matched += 1;
+            if (matched == paste_end.len) return;
+        } else {
+            matched = if (b == paste_end[0]) 1 else 0;
+        }
+    }
 }
 
 /// Whether more of an escape sequence follows the ESC byte: true if bytes are
@@ -414,7 +494,15 @@ fn parseInput(comptime bytes: []const u8) !Input {
     var buf: [bytes.len]u8 = undefined;
     @memcpy(&buf, bytes);
     var reader: std.Io.Reader = .fixed(&buf);
-    return readInput(&reader, null);
+    return readInput(&reader, null, null);
+}
+
+/// Parse `bytes` with a paste sink backed by `list` (caller owns/deinits it).
+fn parseInputPaste(comptime bytes: []const u8, list: *std.ArrayList(u8), max: usize) !Input {
+    var buf: [bytes.len]u8 = undefined;
+    @memcpy(&buf, bytes);
+    var reader: std.Io.Reader = .fixed(&buf);
+    return readInput(&reader, null, .{ .buf = list, .allocator = std.testing.allocator, .max = max });
 }
 
 test "readInput parses an SGR mouse press" {
@@ -470,4 +558,45 @@ test "readInput still parses keys" {
 
 test "malformed mouse sequence degrades to escape, not a desync" {
     try std.testing.expectEqual(Key.escape, (try parseInput("\x1b[<0;xM")).key);
+}
+
+test "readInput parses bracketed paste content" {
+    var list: std.ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    const i = try parseInputPaste("\x1b[200~hello\nworld\x1b[201~", &list, 1024);
+    try std.testing.expectEqualStrings("hello\nworld", i.paste);
+}
+
+test "paste content may contain lone ESC and partial terminators" {
+    var list: std.ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    // An ESC that isn't the terminator, and "\x1b[201" without the closing '~'.
+    const i = try parseInputPaste("\x1b[200~a\x1bb\x1b[201x\x1b[201~", &list, 1024);
+    try std.testing.expectEqualStrings("a\x1bb\x1b[201x", i.paste);
+}
+
+test "paste is truncated at max, terminator still found" {
+    var list: std.ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    const i = try parseInputPaste("\x1b[200~abcdefgh\x1b[201~", &list, 3);
+    try std.testing.expectEqualStrings("abc", i.paste); // capped, no desync
+}
+
+test "paste sink is reused across pastes (borrowed slice)" {
+    var buf = "\x1b[200~one\x1b[201~\x1b[200~two!\x1b[201~".*;
+    var reader: std.Io.Reader = .fixed(&buf);
+    var list: std.ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    const sink = PasteSink{ .buf = &list, .allocator = std.testing.allocator, .max = 1024 };
+    try std.testing.expectEqualStrings("one", (try readInput(&reader, null, sink)).paste);
+    try std.testing.expectEqualStrings("two!", (try readInput(&reader, null, sink)).paste);
+}
+
+test "paste with no sink is consumed, not desynced" {
+    // ESC[200~…ESC[201~ then a real key: the paste is discarded (escape) and the
+    // following key parses cleanly.
+    var buf = "\x1b[200~junk\x1b[201~a".*;
+    var reader: std.Io.Reader = .fixed(&buf);
+    try std.testing.expectEqual(Key.escape, (try readInput(&reader, null, null)).key);
+    try std.testing.expectEqual(Key{ .char = 'a' }, (try readInput(&reader, null, null)).key);
 }

--- a/packages/terminal/src/terminal.zig
+++ b/packages/terminal/src/terminal.zig
@@ -17,6 +17,7 @@ pub const readKeyOpt = key.readKeyOpt;
 /// Input event multiplexing: a key press or a terminal resize.
 pub const event = @import("event.zig");
 pub const Event = event.Event;
+pub const PasteSink = event.PasteSink;
 pub const readEvent = event.readEvent;
 pub const readEventTimeout = event.readEventTimeout;
 

--- a/packages/ui/examples/fullscreen.zig
+++ b/packages/ui/examples/fullscreen.zig
@@ -41,6 +41,11 @@ const State = struct {
     procs: [proc_names.len]Proc = undefined,
     last_mouse: ?ui.Mouse = null,
     focused: bool = true,
+    // A printable preview of the last paste (copied out — `Event.paste` is only
+    // borrowed for the current event).
+    paste_len: usize = 0,
+    paste_head: [24]u8 = undefined,
+    paste_head_len: usize = 0,
 
     fn init() State {
         var s = State{};
@@ -97,9 +102,14 @@ fn view(a: std.mem.Allocator, state: *State) !ui.Node {
         try std.fmt.allocPrint(a, "{s} @ {d},{d}", .{ @tagName(m.button), m.x, m.y })
     else
         "—";
-    const status = try std.fmt.allocPrint(a, "↑/↓ select   click a cell   q quit    focus:{s}  mouse:{s}", .{
+    const paste = if (state.paste_len > 0)
+        try std.fmt.allocPrint(a, "{d}b \"{s}\"", .{ state.paste_len, state.paste_head[0..state.paste_head_len] })
+    else
+        "—";
+    const status = try std.fmt.allocPrint(a, "↑/↓ select   click a cell   paste   q quit    focus:{s}  mouse:{s}  paste:{s}", .{
         if (state.focused) "on" else "off",
         mouse,
+        paste,
     });
     try rows.append(a, ui.text(.{ .dim = true }, status));
 
@@ -139,6 +149,13 @@ fn update(state: *State, ev: ?ui.Event) !ui.Flow {
             }
         },
         .focus => |f| state.focused = f == .in,
+        .paste => |p| {
+            state.paste_len = p.len;
+            state.paste_head_len = @min(p.len, state.paste_head.len);
+            for (p[0..state.paste_head_len], 0..) |c, i| {
+                state.paste_head[i] = if (c >= 0x20 and c < 0x7f) c else ' ';
+            }
+        },
         .resize => {},
     }
     return .keep;
@@ -166,6 +183,7 @@ pub fn main(init: std.process.Init) !void {
         .stdin = &stdin.interface,
         .mouse = true,
         .focus = true,
+        .paste = true,
     });
     defer app.deinit(); // leaves alt-screen, restores cooked mode + cursor
 

--- a/packages/ui/src/app.zig
+++ b/packages/ui/src/app.zig
@@ -60,6 +60,8 @@ const mouse_on = "\x1b[?1002h\x1b[?1006h"; // button+drag tracking, SGR encoding
 const mouse_off = "\x1b[?1002l\x1b[?1006l";
 const focus_on = "\x1b[?1004h";
 const focus_off = "\x1b[?1004l";
+const paste_on = "\x1b[?2004h"; // bracketed paste
+const paste_off = "\x1b[?2004l";
 const restore_tail = "\x1b[?25h\x1b[?1049l";
 
 pub const App = struct {
@@ -102,6 +104,12 @@ pub const App = struct {
         mouse: bool = false,
         /// Report window focus in/out as `Event.focus` (full-screen only).
         focus: bool = false,
+        /// Deliver bracketed paste as `Event.paste` (full-screen only). Off by
+        /// default; the borrowed slice is valid until the next `nextEvent`.
+        paste: bool = false,
+        /// Cap on a single paste's buffered bytes — a pathological multi-MB
+        /// paste is truncated to this, not an OOM. Only meaningful with `paste`.
+        paste_max: usize = 5 << 20, // 5 MiB
     };
 
     /// The caller-facing subset of `Options` for `context.ui()` /
@@ -115,6 +123,10 @@ pub const App = struct {
         mouse: bool = false,
         /// Report focus in/out (full-screen only; see `Options.focus`).
         focus: bool = false,
+        /// Deliver bracketed paste as `Event.paste` (see `Options.paste`).
+        paste: bool = false,
+        /// Cap on a single paste's buffered bytes (see `Options.paste_max`).
+        paste_max: usize = 5 << 20, // 5 MiB
     };
 
     /// A static block kept for the resize tail repaint (ADR-0013 resize
@@ -162,6 +174,9 @@ pub const App = struct {
     raw: ?terminal.RawMode = null,
     /// Resize watcher backing `nextEvent`, full-screen only.
     watcher: ?terminal.ResizeWatcher = null,
+    /// Reused accumulator for bracketed-paste content (full-screen, `paste`
+    /// enabled). `Event.paste` borrows its bytes until the next `nextEvent`.
+    paste_buf: std.ArrayList(u8) = .empty,
 
     pub const CursorPos = struct { x: u16, y: u16 };
 
@@ -271,6 +286,7 @@ pub const App = struct {
         try self.writer.writeAll("\x1b[?1049h\x1b[?25l");
         if (self.options.mouse) try self.writer.writeAll(mouse_on);
         if (self.options.focus) try self.writer.writeAll(focus_on);
+        if (self.options.paste) try self.writer.writeAll(paste_on);
         try self.anchor();
         try self.writer.flush();
     }
@@ -288,6 +304,7 @@ pub const App = struct {
         }.f;
         if (self.options.mouse) put(buf, &n, mouse_off);
         if (self.options.focus) put(buf, &n, focus_off);
+        if (self.options.paste) put(buf, &n, paste_off);
         put(buf, &n, restore_tail);
         return buf[0..n];
     }
@@ -297,6 +314,7 @@ pub const App = struct {
     fn writeRestore(self: *App) void {
         if (self.options.mouse) self.writer.writeAll(mouse_off) catch {};
         if (self.options.focus) self.writer.writeAll(focus_off) catch {};
+        if (self.options.paste) self.writer.writeAll(paste_off) catch {};
         self.writer.writeAll(restore_tail) catch {};
     }
 
@@ -344,6 +362,7 @@ pub const App = struct {
         }
         for (self.retained.items) |b| self.gpa.free(b.text);
         self.retained.deinit(self.gpa);
+        self.paste_buf.deinit(self.gpa);
         self.front.deinit();
         self.back.deinit();
         self.frame_arena.deinit();
@@ -569,11 +588,19 @@ pub const App = struct {
         // is no real terminal to read from.
         if (self.watcher == null) return error.NoInput;
         try self.writer.flush();
+        // The paste sink borrows `paste_buf` (reused each call); the returned
+        // `Event.paste` is valid only until the next `nextEvent`.
+        const sink: ?terminal.PasteSink = if (self.options.paste) .{
+            .buf = &self.paste_buf,
+            .allocator = self.gpa,
+            .max = self.options.paste_max,
+        } else null;
         return terminal.readEventTimeout(
             reader,
             std.Io.File.stdin().handle,
             &self.watcher.?,
             timeout_ms,
+            sink,
         );
     }
 

--- a/packages/ui/src/app_test.zig
+++ b/packages/ui/src/app_test.zig
@@ -490,11 +490,27 @@ test "full_screen enables mouse + focus on enter and disables them on deinit" {
     try testing.expect(mouse_off < alt_off and focus_off < alt_off);
 }
 
-test "full_screen leaves mouse/focus modes untouched when not requested" {
+test "full_screen leaves mouse/focus/paste modes untouched when not requested" {
     var h = try Harness.initMode(20, 6, .full_screen);
     defer h.deinit();
     try testing.expect(std.mem.indexOf(u8, h.aw.written(), "\x1b[?1002h") == null);
     try testing.expect(std.mem.indexOf(u8, h.aw.written(), "\x1b[?1004h") == null);
+    try testing.expect(std.mem.indexOf(u8, h.aw.written(), "\x1b[?2004h") == null);
+}
+
+test "full_screen enables paste on enter and disables it on deinit" {
+    var aw = std.Io.Writer.Allocating.init(testing.allocator);
+    defer aw.deinit();
+    var app = try ui.App.initFullScreen(testing.allocator, &aw.writer, .{
+        .term_size = .{ .w = 20, .h = 6 },
+        .paste = true,
+    });
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "\x1b[?2004h") != null);
+    app.deinit();
+    const out = aw.written();
+    const paste_off = std.mem.indexOf(u8, out, "\x1b[?2004l").?;
+    const alt_off = std.mem.lastIndexOf(u8, out, "\x1b[?1049l").?;
+    try testing.expect(paste_off < alt_off);
 }
 
 test "full_screen resize repaints the whole new viewport" {

--- a/projects/zcli/src/commands/guide.zig
+++ b/projects/zcli/src/commands/guide.zig
@@ -279,9 +279,10 @@ const topics = [_]Topic{
         \\Full-screen (alt-screen TUI): `context.uiFullScreen()` takes the whole
         \\screen over on the same engine, owns raw mode, and reads input. Ctrl-C
         \\arrives as a key; `emit` is unavailable; leaving restores the shell
-        \\exactly (the final frame does not persist). Opt into mouse/focus with
-        \\`.{ .mouse = true, .focus = true }` — they surface as `Event.mouse` /
-        \\`Event.focus`.
+        \\exactly (the final frame does not persist). Opt into mouse/focus/paste
+        \\with `.{ .mouse = true, .focus = true, .paste = true }` — they surface
+        \\as `Event.mouse` / `.focus` / `.paste` (paste content is borrowed until
+        \\the next event; `paste_max` caps it, default 5 MiB).
         \\
         \\`app.run` owns the loop for you (tick delivered as a null event,
         \\deadline-scheduled); `update` returns `.keep` or `.quit`:


### PR DESCRIPTION
Third and last of the ADR-0015 deferred input items. Bracketed paste (DECSET 2004) joins `Event` as **`.paste: []const u8`** — pasted text arrives as one event instead of a burst of fake keystrokes, and can't be misinterpreted as commands.

## Lifetime (the design we settled)

The App owns a **reused `paste_buf`**; `Event.paste` **borrows** it, valid until the next `nextEvent` — the same immediate-mode contract as `app.arena()` (copy it if you need it longer). No per-paste alloc/free, no ownership handoff. `paste_max` caps a single paste (**5 MiB default, user-configurable**) so a pathological multi-MB paste truncates instead of OOMing.

## Parsing (`terminal`)

`key.readInput` reads `ESC[200~` … `ESC[201~` into a `PasteSink { buf, allocator, max }`. The terminator is matched byte-by-byte with **held-back prefix matching**, so content may contain lone `ESC` bytes or partial `ESC[201` sequences **verbatim**; bytes past `max` are dropped while scanning continues (no desync, no OOM). A `null` sink consumes-and-discards (defensive — a caller that didn't enable 2004 shouldn't get one, but mustn't desync).

## Plumbing — still no prompt churn

`readEventTimeout` threads `?PasteSink`; `readEvent` (what prompts call) passes `null` internally, and prompts' existing `else => {}` arm already absorbs the new variant. `App.nextEvent` passes `.{ &paste_buf, gpa, paste_max }` when enabled.

## Opt-in + guard

`Options.paste` / `.paste_max` (+ `SessionOptions`, `context.uiFullScreen`). `?2004h` on enter; `?2004l` in the `terminal.guard` restore blob **and** on `deinit`, so a kill/panic can't leave paste mode on. Fits `blob_max` 48.

## Tests

- **Unit** (headless, real `zig build test`): content incl. `\n`; embedded `ESC` / partial terminator preserved; truncation-at-max; buffer reuse across two pastes; no-sink consume-and-discard.
- **App**: enable-on-enter / disable-on-deinit byte-stream; "untouched when not requested".
- **PTY e2e**: a real bracketed paste reaches `update`; enter enables, quit disables, clean teardown (exit 0).

Example + `zcli guide ui` showcase paste (byte count + preview). All packages + `zig fmt` green.

---

**This completes ADR-0015's deferred input events** — mouse (#185), focus (#185), paste (here). Remaining ADR deferrals are the non-input ones: overlays/z-layers, scrollable viewports, focusable widget library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)