### PR TITLE
feat(ui): overlays via a stack z-layer (ADR-0016)

### DIFF
--- a/docs/adr/0016-overlays-z-layers.md
+++ b/docs/adr/0016-overlays-z-layers.md
@@ -1,0 +1,98 @@
+# Overlays: z-layers by surface-compositing, no absolute addressing
+
+Status: accepted
+
+ADR-0013 and ADR-0015 both named overlays / z-layers as a clean deferral — "a
+fifth node variant or an absolute-addressed overlay pass" — and both tied it to
+the one piece of machinery the layout engine deliberately does *not* have: an
+absolute-`CUP` diff renderer. The live region floats in scrollback, so the
+renderer (`diff.zig`) addresses cells relative to the frame's top-left and never
+with `CUP`; ADR-0015 §2 spelled out that absolute addressing buys "cheap
+out-of-flow drawing (overlays/popups)" and deferred the renderer rewrite until a
+feature needed it.
+
+Overlays are that feature. This ADR records how they landed — and why the
+renderer rewrite turned out **not** to be needed after all.
+
+## The realization: compositing happens in the cell buffer, not on the terminal
+
+An overlay draws out of flow: a modal in the middle of the screen, a toast in a
+corner, a dim over content. "Out of flow" reads like it needs absolute
+addressing. It does — but only *within the surface*, which is plain array
+indexing (`Surface.idx`), not on the terminal.
+
+Every frame already renders into one back `Surface`, then the diff renderer
+compares it against the front surface and emits the minimal relative byte stream.
+An overlay is just *more cells painted into that back surface, on top of the base
+tree, before the diff runs*. The diff then diffs the **final composite** and
+emits its usual relative moves; it never learns an overlay existed.
+
+So overlays add **zero terminal I/O, zero new escape sequences, and no `diff.zig`
+change**. The absolute-`CUP` rewrite ADR-0015 deferred stays deferred — correctly,
+because overlays don't need it. The only place addressing had to become absolute
+was inside the cell buffer, where it was already trivial.
+
+## Decisions
+
+### 1. A `stack` is a third box arrangement, not a fifth node kind
+
+`Direction` gains `stack` alongside `row`/`column`. A `row`/`column` distributes
+its main axis among children; a `stack` overlaps them in one region — declaration
+order is z-order, later children composite over earlier ones. Measure maxes both
+axes (a stack is as big as its largest layer) where a flow box sums its main axis.
+
+Making it a `Direction` rather than a new `Kind` means a stack reuses the entire
+`Box` struct and its chrome — border, padding, background, the inner-region math —
+so a bordered modal container or a padded overlay panel is just a stack with the
+`BoxOpts` every other box takes. A fifth `Kind` would have re-implemented that
+chrome. "Direction" stretches slightly to mean "arrangement," which is the honest
+generalization: stacking is a third way to arrange children.
+
+### 2. Each layer fills the stack; position with composition, not new fields
+
+A stack grants every child the **full** inner region — it does not size or place
+layers. A bare layer therefore fills the stack. To float a smaller layer (a
+modal), wrap it in the existing layout vocabulary: `ui.center` is
+`column{ spacer, row{ spacer, child, spacer }, spacer }`, which sizes the child to
+its content and pushes it to the middle with transparent spacers. Corners, edges,
+and margins fall out of the same spacer/`align_self`/`len` toolkit.
+
+This adds **no positioning primitive and no new node fields** — 2D placement is
+composition, consistent with how the engine already right-aligns (a leading
+spacer) and centers on the cross axis (`align_self`).
+
+### 3. A style-less box is transparent
+
+Compositing needs a notion of "this layer didn't touch this cell, so the layer
+beneath shows through." The engine gets it for free from one rule: **a box paints
+its background only when it has a style.** `renderBox` fills its region only when
+`b.style` is non-default; a style-less box (a `center` scaffold, a plain
+container) paints nothing and lets lower layers show through its gaps, while a box
+with a background is opaque and erases the base beneath it. Spacers already paint
+nothing; text paints only its glyphs.
+
+This is invisible to flow layout — the back surface is cleared every frame, so a
+style-less box skipping its blank-fill paints the same blanks it would have. It
+only changes behavior *under a stack*, where an earlier layer has already painted.
+No transparent-cell sentinel, no separate compositing pass, no `Cell` change.
+
+## Consequences
+
+- **The renderer is untouched.** No `CUP`, no absolute addressing, no second paint
+  pass. Overlays ride the existing relative diff, so they work byte-for-byte the
+  same in hybrid and full-screen — compositing is upstream of the mode split.
+- **No PTY validation needed.** Overlays add no terminal I/O, so the headless
+  layout tests plus vterm golden-frame tests (compositing survives the real diff
+  renderer; closing an overlay repaints the base) cover them fully.
+- **Opacity is `.style`, not alpha.** A layer is transparent (no style),
+  glyph-transparent (text — gaps show through), or opaque (a background). There is
+  no partial transparency; a dim-the-background overlay is a full-region layer
+  whose style is the dim, not an alpha blend.
+- **Anchored popups are the next deferral, with the same clean home.** A dropdown
+  pinned to a specific widget's computed (x, y) needs layout to expose measured
+  positions or an anchor system — genuinely more than a stack, and with no
+  consumer yet. `stack` + composition covers modals, toasts, and full-region
+  overlays (the bread and butter); anchored popups are a follow-up when a consumer
+  needs one.
+- **`emit`/scrollback is unaffected.** Stacks are a node-tree feature; they change
+  neither the static stream nor the live-region bookkeeping.

--- a/packages/ui/examples/fullscreen.zig
+++ b/packages/ui/examples/fullscreen.zig
@@ -1,6 +1,8 @@
 //! A `top`-style full-screen TUI (ADR-0015): the whole viewport is a live table
 //! of processes whose CPU/MEM jitter on a 250ms tick, with an arrow-key
-//! selection. It drives the `App.run(state, tick_ms, view, update)` loop —
+//! selection and a `?`-toggled help overlay (a centered modal composited over
+//! the table — ADR-0016). It drives the `App.run(state, tick_ms, view, update)`
+//! loop —
 //!
 //!     view(state)           render the whole screen from state
 //!     update(state, ev)      handle a key/resize, or a `null` tick; -> keep|quit
@@ -38,6 +40,7 @@ const Proc = struct { pid: u16, name: []const u8, cpu: f32, mem: f32 };
 const State = struct {
     tick: u32 = 0,
     selected: usize = 0,
+    show_help: bool = false,
     procs: [proc_names.len]Proc = undefined,
     last_mouse: ?ui.Mouse = null,
     focused: bool = true,
@@ -106,18 +109,46 @@ fn view(a: std.mem.Allocator, state: *State) !ui.Node {
         try std.fmt.allocPrint(a, "{d}b \"{s}\"", .{ state.paste_len, state.paste_head[0..state.paste_head_len] })
     else
         "—";
-    const status = try std.fmt.allocPrint(a, "↑/↓ select   click a cell   paste   q quit    focus:{s}  mouse:{s}  paste:{s}", .{
+    const status = try std.fmt.allocPrint(a, "↑/↓ select   click a cell   paste   ? help   q quit    focus:{s}  mouse:{s}  paste:{s}", .{
         if (state.focused) "on" else "off",
         mouse,
         paste,
     });
     try rows.append(a, ui.text(.{ .dim = true }, status));
 
-    return ui.column(
+    const base = try ui.column(
         a,
         .{ .width = .{ .fill = 1 }, .height = .{ .fill = 1 }, .padding = .all(1) },
         rows.items,
     );
+    if (!state.show_help) return base;
+
+    // An overlay (ADR-0016): a centered help modal composited over the table.
+    // `stack` overlaps its layers back to front; `center` floats the opaque
+    // modal in the middle while the table shows through the transparent
+    // scaffold around it. No absolute addressing — the modal is just cells
+    // painted on top of the base surface before the frame diff runs.
+    return ui.stack(a, .{}, &.{
+        base,
+        try ui.center(a, try helpModal(a)),
+    });
+}
+
+fn helpModal(a: std.mem.Allocator) !ui.Node {
+    return ui.column(a, .{
+        .border = .rounded,
+        .border_style = .{ .foreground = .bright_cyan },
+        .padding = .symmetric(2, 1),
+        .style = .{ .background = .{ .indexed = 236 } }, // opaque panel
+        .gap = 0,
+    }, &.{
+        ui.text(.{ .bold = true }, "Keys"),
+        ui.text(.{}, ""),
+        ui.text(.{}, "↑ / ↓   select a process"),
+        ui.text(.{}, "click   select a row"),
+        ui.text(.{}, "?       close this help"),
+        ui.text(.{}, "q       quit"),
+    });
 }
 
 /// A `null` event is the tick (advance the jittering table); keys drive
@@ -130,7 +161,11 @@ fn update(state: *State, ev: ?ui.Event) !ui.Flow {
     };
     switch (e) {
         .key => |k| switch (k) {
-            .char => |c| if (c == 'q') return .quit,
+            .char => |c| switch (c) {
+                'q' => return .quit,
+                '?' => state.show_help = !state.show_help, // toggle the overlay
+                else => {},
+            },
             .ctrl => |c| if (c == 'c') return .quit,
             .up => if (state.selected > 0) {
                 state.selected -= 1;

--- a/packages/ui/src/golden_test.zig
+++ b/packages/ui/src/golden_test.zig
@@ -193,3 +193,77 @@ test "style-only change repaints in place" {
     try testing.expectEqual(vterm.Color.yellow, vt.getTextColor(0, 0));
     try testing.expect(vt.hasAttribute(0, 0, .bold));
 }
+
+test "a centered overlay composites over the base through the renderer" {
+    var vt = try VTerm.init(testing.allocator, 9, 3);
+    defer vt.deinit();
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var s = try Surface.init(testing.allocator, 9, 3);
+    defer s.deinit();
+
+    const rctx = ui.RenderCtx{ .allocator = a };
+    const n = try ui.stack(a, .{}, &.{
+        try ui.column(a, .{}, &.{
+            ui.textOpts(.{ .wrap = .clip }, "........."),
+            ui.textOpts(.{ .wrap = .clip }, "........."),
+            ui.textOpts(.{ .wrap = .clip }, "........."),
+        }),
+        try ui.center(a, ui.textOpts(.{ .wrap = .clip }, "MID")),
+    });
+    try ui.render(&rctx, &n, s.root());
+    try paintInto(&vt, .{ .capability = .ansi_16 }, null, &s);
+
+    // The overlay sits on the middle row, base dots on either side of it —
+    // compositing survives the diff renderer and lands where the surface says.
+    try testing.expect(vt.containsText("MID"));
+    try testing.expectEqual(@as(u21, 'M'), vt.getCell(3, 1).char);
+    try testing.expectEqual(@as(u21, '.'), vt.getCell(0, 1).char);
+    try testing.expectEqual(@as(u21, '.'), vt.getCell(8, 1).char);
+    // Rows above and below the overlay stay pure base.
+    try testing.expectEqual(@as(u21, '.'), vt.getCell(4, 0).char);
+    try testing.expectEqual(@as(u21, '.'), vt.getCell(4, 2).char);
+}
+
+test "closing an overlay repaints the base underneath it" {
+    var vt = try VTerm.init(testing.allocator, 9, 3);
+    defer vt.deinit();
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const rctx = ui.RenderCtx{ .allocator = a };
+
+    const baseLayer = struct {
+        fn build(alloc: std.mem.Allocator) !ui.Node {
+            return ui.column(alloc, .{}, &.{
+                ui.textOpts(.{ .wrap = .clip }, "........."),
+                ui.textOpts(.{ .wrap = .clip }, "........."),
+                ui.textOpts(.{ .wrap = .clip }, "........."),
+            });
+        }
+    }.build;
+
+    // Frame 1: base with a centered overlay.
+    var withOverlay = try Surface.init(testing.allocator, 9, 3);
+    defer withOverlay.deinit();
+    const f1 = try ui.stack(a, .{}, &.{
+        try baseLayer(a),
+        try ui.center(a, ui.textOpts(.{ .wrap = .clip }, "MID")),
+    });
+    try ui.render(&rctx, &f1, withOverlay.root());
+    try paintInto(&vt, .{ .capability = .ansi_16 }, null, &withOverlay);
+    try testing.expect(vt.containsText("MID"));
+
+    // Frame 2: overlay removed — the base cells it covered must come back.
+    var baseOnly = try Surface.init(testing.allocator, 9, 3);
+    defer baseOnly.deinit();
+    const f2 = try baseLayer(a);
+    try ui.render(&rctx, &f2, baseOnly.root());
+    try paintInto(&vt, .{ .capability = .ansi_16 }, &withOverlay, &baseOnly);
+
+    try testing.expect(!vt.containsText("MID"));
+    try testing.expectEqual(@as(u21, '.'), vt.getCell(3, 1).char);
+    try testing.expectEqual(@as(u21, '.'), vt.getCell(5, 1).char);
+}

--- a/packages/ui/src/layout_test.zig
+++ b/packages/ui/src/layout_test.zig
@@ -309,3 +309,77 @@ test "component functions compose: children are arena-copied, not borrowed" {
     try renderInto(&h, n, &s);
     try testing.expectEqualStrings("ok        3s", try rowString(&h, &s, 0));
 }
+
+// ============================================================================
+// Stack (z-layers / overlays, ADR-0016)
+// ============================================================================
+
+test "stack measures to its largest child on both axes" {
+    var h = Harness.init();
+    defer h.deinit();
+    const rctx = h.ctx();
+
+    const n = try ui.stack(h.a(), .{}, &.{
+        ui.textOpts(.{ .wrap = .clip }, "wide text"), // 9 x 1
+        try ui.column(h.a(), .{}, &.{ ui.text(.{}, "a"), ui.text(.{}, "b") }), // 1 x 2
+    });
+    // Layers overlap, so the stack is the widest AND the tallest child.
+    try testing.expectEqual(
+        ui.Size{ .w = 9, .h = 2 },
+        ui.measure(&rctx, &n, .{ .max_w = 20, .max_h = 10 }),
+    );
+}
+
+test "stack paints layers back to front; a later layer wins shared cells" {
+    var h = Harness.init();
+    defer h.deinit();
+    var s = try ui.Surface.init(testing.allocator, 4, 1);
+    defer s.deinit();
+
+    const n = try ui.stack(h.a(), .{}, &.{
+        ui.textOpts(.{ .wrap = .clip }, "...."), // base fills the row
+        ui.textOpts(.{ .wrap = .clip }, "AB"), // top layer covers two cells
+    });
+    try renderInto(&h, n, &s);
+    // Top layer wins cols 0-1; its untouched cols 2-3 show the base through.
+    try testing.expectEqualStrings("AB..", try rowString(&h, &s, 0));
+}
+
+test "an opaque layer erases the base beneath while the scaffold stays transparent" {
+    var h = Harness.init();
+    defer h.deinit();
+    var s = try ui.Surface.init(testing.allocator, 3, 3);
+    defer s.deinit();
+
+    const n = try ui.stack(h.a(), .{}, &.{
+        // Base: fills 3x3 with a reverse-styled background.
+        try ui.column(h.a(), .{ .style = .{ .reverse = true } }, &.{}),
+        // Modal: a 1x1 bold cell, centered → lands on the middle cell (1,1).
+        try ui.center(h.a(), try ui.column(h.a(), .{
+            .width = .{ .len = 1 },
+            .height = .{ .len = 1 },
+            .style = .{ .bold = true },
+        }, &.{})),
+    });
+    try renderInto(&h, n, &s);
+    // The opaque modal replaced the base on its own cell...
+    try testing.expect(s.cell(1, 1).style.bold and !s.cell(1, 1).style.reverse);
+    // ...but the style-less centering scaffold left the base intact elsewhere.
+    try testing.expect(s.cell(0, 0).style.reverse and !s.cell(0, 0).style.bold);
+    try testing.expect(s.cell(2, 2).style.reverse);
+}
+
+test "a stack carries box chrome: a border insets its layers" {
+    var h = Harness.init();
+    defer h.deinit();
+    var s = try ui.Surface.init(testing.allocator, 4, 3);
+    defer s.deinit();
+
+    const n = try ui.stack(h.a(), .{ .border = .single }, &.{
+        ui.textOpts(.{ .wrap = .clip }, "XX"),
+    });
+    try renderInto(&h, n, &s);
+    try testing.expectEqualStrings("┌──┐", try rowString(&h, &s, 0));
+    try testing.expectEqualStrings("│XX│", try rowString(&h, &s, 1));
+    try testing.expectEqualStrings("└──┘", try rowString(&h, &s, 2));
+}

--- a/packages/ui/src/node.zig
+++ b/packages/ui/src/node.zig
@@ -48,7 +48,10 @@ pub const Dim = union(enum) {
 };
 
 pub const Align = enum { start, center, end };
-pub const Direction = enum { row, column };
+/// How a box arranges its children. `row`/`column` distribute space along that
+/// axis; `stack` overlaps them in the same region (z-layers, ADR-0016) —
+/// declaration order is z-order, later children composite over earlier ones.
+pub const Direction = enum { row, column, stack };
 pub const WrapMode = enum { wrap, truncate, clip };
 
 pub const BorderStyle = enum { none, single, rounded, double, ascii };
@@ -207,6 +210,22 @@ fn measureBox(ctx: *const RenderCtx, b: *const Box, limits: Limits) Size {
     const chrome_h: u32 = @as(u32, b.padding.top) + b.padding.bottom + borderCols(b) * 2;
     const inner = limits.shrink(chrome_w, chrome_h);
 
+    // A stack's layers overlap, so it wants the LARGEST child on both axes
+    // (a `row`/`column` sums its main axis; a stack maxes both).
+    if (b.dir == .stack) {
+        var w: u32 = 0;
+        var h: u32 = 0;
+        for (b.children) |*child| {
+            const s = measure(ctx, child, inner);
+            w = @max(w, s.w);
+            h = @max(h, s.h);
+        }
+        return .{
+            .w = @intCast(@min(chrome_w + w, limits.max_w)),
+            .h = @intCast(@min(chrome_h + h, limits.max_h)),
+        };
+    }
+
     var main_used: u32 = 0;
     var cross_max: u32 = 0;
     var first = true;
@@ -305,7 +324,12 @@ fn prefixForWidth(text: []const u8, width: u16) usize {
 }
 
 fn renderBox(ctx: *const RenderCtx, b: *const Box, region: Region) !void {
-    region.fill(b.style);
+    // A box paints its background only when it has a style; a style-less box is
+    // transparent, so in a `.stack` the layer beneath shows through its gaps
+    // (ADR-0016). In flow layout the surface is pre-cleared every frame, so
+    // skipping the blank-fill is invisible there — it only matters when an
+    // earlier stack layer already painted underneath.
+    if (!surface_mod.styleEql(b.style, .{})) region.fill(b.style);
     try drawBorder(ctx, b, region);
 
     const bc = borderCols(b);
@@ -316,6 +340,16 @@ fn renderBox(ctx: *const RenderCtx, b: *const Box, region: Region) !void {
         .h = @intCast(region.height() -| (@as(u32, b.padding.top) + b.padding.bottom + bc * 2)),
     });
     if (b.children.len == 0 or inner.width() == 0 or inner.height() == 0) return;
+
+    // Z-layers (ADR-0016): every child is granted the FULL inner region and
+    // painted in declaration order, so a later layer composites over an earlier
+    // one. A bare layer fills the stack; size and position a layer (a modal,
+    // a toast) with `ui.center` or spacer scaffolding — the scaffold boxes are
+    // style-less, hence transparent, so the base shows around the placed layer.
+    if (b.dir == .stack) {
+        for (b.children) |*child| try render(ctx, child, inner);
+        return;
+    }
 
     // --- Distribute the main axis: len, then fit in declaration order, then
     // fill by weight with largest-remainder rounding (ADR-0013 §5).

--- a/packages/ui/src/ui.zig
+++ b/packages/ui/src/ui.zig
@@ -85,6 +85,17 @@ pub fn column(a: std.mem.Allocator, opts: BoxOpts, children: []const Node) !Node
     return box(a, .column, opts, children);
 }
 
+/// Overlapping layers, back to front (ADR-0016). Children share one region and
+/// paint in declaration order, so each composites over the ones before it — the
+/// z-layer / overlay primitive. A style-less layer is transparent (lower layers
+/// show through its gaps); a layer with a background is opaque. Each layer is
+/// granted the whole stack, so a bare layer fills it — place a smaller layer (a
+/// modal, a toast) with `center` or spacer scaffolding. Reuses `BoxOpts`, so a
+/// stack can carry its own border/padding/background like any box.
+pub fn stack(a: std.mem.Allocator, opts: BoxOpts, children: []const Node) !Node {
+    return box(a, .stack, opts, children);
+}
+
 pub fn box(a: std.mem.Allocator, dir: Direction, opts: BoxOpts, children: []const Node) !Node {
     return .{
         .width = opts.width,
@@ -135,6 +146,18 @@ pub fn textOpts(opts: TextOpts, content: []const u8) Node {
 /// by preceding with a spacer; center by surrounding with two.
 pub fn spacer() Node {
     return .{ .kind = .spacer };
+}
+
+/// Center `child` within the region its parent grants — spacer scaffolding for
+/// placing an overlay layer in the middle of a `stack` (a modal, a dialog).
+/// `child` sizes to its content; the surrounding scaffold is style-less, hence
+/// transparent, so in a stack the layer beneath shows around it.
+pub fn center(a: std.mem.Allocator, child: Node) !Node {
+    return column(a, .{}, &.{
+        spacer(),
+        try row(a, .{}, &.{ spacer(), child, spacer() }),
+        spacer(),
+    });
 }
 
 test {


### PR DESCRIPTION
The overlay / z-layer primitive ADR-0013/0015 deferred — modals, toasts, dim-over-content. Adds `stack` as a third box arrangement: children overlap in one region, painted back to front (declaration order = z-order).

## The key realization
Compositing happens in the **cell buffer, not on the terminal**. An overlay is just more cells painted into the back `Surface` on top of the base tree, before the frame diff runs. The diff sees the final composite and emits its usual relative moves — so overlays add **zero terminal I/O, zero new escape sequences, and no `diff.zig` change**. The absolute-`CUP` renderer rewrite ADR-0015 explicitly deferred *stays* deferred, because overlays turn out not to need it (absolute addressing was only ever needed *inside* the surface, which is array indexing).

## Design
- **`Direction.stack`** (not a fifth `Kind`) reuses the whole `Box` struct + chrome — border, padding, background — so a modal container is just a stack with the usual `BoxOpts`.
- **Each layer fills the stack**; position a smaller layer with `ui.center` (spacer scaffolding). No new positioning primitive, no new node fields — 2D placement is composition, like the engine already does for right-align/cross-center.
- **Transparency from one rule:** a box paints its background only when it has a style. A style-less box (a `center` scaffold) is transparent and lets lower layers show through; a styled box is opaque. Invisible to flow layout (the surface is pre-cleared each frame); only matters under a stack.

## API
```zig
pub fn stack(a, opts: BoxOpts, children: []const Node) !Node   // z-layers, back to front
pub fn center(a, child: Node) !Node                            // float a layer in the middle
```
Works byte-for-byte the same in hybrid and full-screen — compositing is upstream of the mode split.

## Tests
- **Layout** (`layout_test.zig`): stack measures to max on both axes; z-order + transparency; opaque-erases-base vs transparent-scaffold; border chrome insets layers.
- **Golden** (`golden_test.zig`): a centered overlay composites correctly through the real diff renderer + vterm; **closing an overlay repaints the base underneath** (the deterministic proof base cells revert).
- **Example**: `examples/fullscreen.zig` gains a `?`-toggled centered help modal, **PTY-validated** (opens with title + rounded border, closes clean with active base repaints).
- No PTY validation needed for the primitive itself — it adds no terminal I/O.

`zig build test` green, `zig fmt` clean. ADR-0016 records the rationale; anchored popups (a dropdown pinned to a widget's computed position) become the next deferral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)