### PR TITLE
feat(ui): scrollable viewport (ADR-0017)

### DIFF
--- a/docs/adr/0017-scrollable-viewports.md
+++ b/docs/adr/0017-scrollable-viewports.md
@@ -1,0 +1,74 @@
+# Scrollable viewports: a windowed blit, content rendered in full
+
+Status: accepted
+
+ADR-0013 and ADR-0015 named scrollable viewports as a clean deferral — "a
+`custom` leaf first, a first-class node if it earns it." This is that leaf: a
+fixed window onto content taller than the space it is granted (a log pane, a
+long list, a tall form), with a caller-owned vertical scroll offset.
+
+## The core problem
+
+To scroll, you must render content at its **full natural height**, then show
+only a window of it offset by `scroll_y`. But the live surface only has cells
+for the *visible* rows — you cannot render 1000 lines into a 20-row surface. The
+diff renderer, deliberately, addresses cells relative to the frame origin
+(ADR-0015 §2); it has no notion of a content offset.
+
+## Decision: render the child in full into a scratch surface, then blit a window
+
+A `viewport` is a `custom` leaf. Its `renderFn`:
+
+1. measures the child at the viewport width and **unbounded height** → the
+   content height,
+2. renders the child in full into a **scratch `Surface`** of
+   `width × content_h`, allocated from the frame arena,
+3. clamps `scroll_y` to `[0, content_h − viewport_h]`,
+4. copies rows `[scroll_y .. scroll_y + viewport_h)` of the scratch into the
+   viewport region (`Region.copyRows`, the one new surface primitive).
+
+`measure`/`render` are **untouched** — the child renders normally into a real
+(taller) surface, so wide graphemes, styles, borders, nested `custom` leaves,
+even nested viewports all work for free. The whole feature is one small copy
+primitive plus a builder.
+
+### Why this over teaching the renderer/Region about a content offset
+
+The alternative — split `Region` into a coordinate origin (which may sit *above*
+the clip, so content scrolls up) and a clip window, and let the child lay out at
+`content_h` while painting clipped — is allocation-free and a more general
+translation primitive. But it touches `Region`'s core: signed coordinates, every
+`writeText`/`fill`/`put` clipping against a separate rect, and the wide-grapheme-
+straddles-the-top-edge case. Bigger diff, higher risk, and no consumer yet needs
+its generality.
+
+The scratch-surface blit is exactly ADR-0013's "a `custom` leaf first." It keeps
+the four-node vocabulary intact (a viewport is a `custom`, not a fifth `Kind`),
+and if profiling ever shows the per-frame scratch alloc matters, the offset-clip
+Region becomes the first-class-node upgrade **with no change to the `viewport`
+API**. That optionality is the reason to start here.
+
+## Consequences
+
+- **Scroll state stays caller-owned** (immediate mode): the app holds `scroll_y`
+  and adjusts it on ↑/↓/PageUp/PageDown, matching "no widget owns state." The
+  viewport only *clamps* it, so an overshoot (PageDown past the end) rests on the
+  last page. A widget that needs "am I at the bottom?" gets a measure helper when
+  one is written — deferred until then.
+- **Content is fully realized each frame.** Fine for the ordinary
+  screenful-or-few; very tall content (a 50k-line log) pays for its full height
+  in scratch cells each frame. That is the accepted cost of "custom leaf first,"
+  and the exact thing the offset-clip Region would later fix.
+- **Vertical scroll only.** Horizontal scroll is rare in TUIs and would double
+  the API; deferred until a consumer needs it.
+- **No scrollbar indicator** in this increment — a thin thumb column is a cheap
+  follow-up on top of the same mechanism.
+- **The renderer is untouched.** Like overlays (ADR-0016), the work happens in
+  the cell buffer, upstream of the terminal: the blitted window is just cells,
+  and the relative diff renderer paints them as usual. Short content leaves the
+  rows below it untouched, so a viewport composites over a lower stack layer the
+  same way any transparent region does.
+- **No PTY validation needed for the primitive** — it adds no terminal I/O.
+  Headless layout tests plus vterm golden-frame tests (styled and wide content
+  survive the blit; the window tracks `scroll_y`) cover correctness; the PTY only
+  smoke-tests the example integration.

--- a/packages/ui/examples/fullscreen.zig
+++ b/packages/ui/examples/fullscreen.zig
@@ -1,8 +1,8 @@
-//! A `top`-style full-screen TUI (ADR-0015): the whole viewport is a live table
-//! of processes whose CPU/MEM jitter on a 250ms tick, with an arrow-key
-//! selection and a `?`-toggled help overlay (a centered modal composited over
-//! the table — ADR-0016). It drives the `App.run(state, tick_ms, view, update)`
-//! loop —
+//! A `top`-style full-screen TUI (ADR-0015): a live table of processes whose
+//! CPU/MEM jitter on a 250ms tick, in a scrolling pane the arrow keys drive
+//! (the selection scrolls into view — ADR-0017), with a `?`-toggled help
+//! overlay (a centered modal composited over the table — ADR-0016). It drives
+//! the `App.run(state, tick_ms, view, update)` loop —
 //!
 //!     view(state)           render the whole screen from state
 //!     update(state, ev)      handle a key/resize, or a `null` tick; -> keep|quit
@@ -29,10 +29,18 @@ pub const panic = ui.panic;
 
 const tick_ms: u32 = 250;
 
+/// Visible rows in the scrolling process pane — a fixed window so `update` can
+/// keep the selection in view without knowing the laid-out height.
+const visible_rows: usize = 8;
+
 const proc_names = [_][]const u8{
-    "zig",      "zls",     "kernel_task", "WindowServer",
-    "Terminal", "firefox", "Slack",       "node",
-    "zcli",     "git",     "ripgrep",     "ssh",
+    "zig",      "zls",        "kernel_task",  "WindowServer",
+    "Terminal", "firefox",    "Slack",        "node",
+    "zcli",     "git",        "ripgrep",      "ssh",
+    "dockerd",  "postgres",   "redis-server", "nginx",
+    "python3",  "rustc",      "cargo",        "go",
+    "vim",      "tmux",       "bash",         "launchd",
+    "mdworker", "spotlightd", "cloudd",       "bluetoothd",
 };
 
 const Proc = struct { pid: u16, name: []const u8, cpu: f32, mem: f32 };
@@ -40,6 +48,7 @@ const Proc = struct { pid: u16, name: []const u8, cpu: f32, mem: f32 };
 const State = struct {
     tick: u32 = 0,
     selected: usize = 0,
+    scroll: u16 = 0, // first visible process row in the viewport
     show_help: bool = false,
     procs: [proc_names.len]Proc = undefined,
     last_mouse: ?ui.Mouse = null,
@@ -92,13 +101,21 @@ fn view(a: std.mem.Allocator, state: *State) !ui.Node {
         "  PID   CPU%    MEM%  COMMAND",
     ));
 
-    for (state.procs, 0..) |p, i| {
+    // The process rows live in a scrolling viewport (ADR-0017): the list is
+    // taller than its fixed window, so `state.scroll` (kept in view by `update`)
+    // slides it. The header above and the status below stay put.
+    const proc_rows = try a.alloc(ui.Node, state.procs.len);
+    for (state.procs, proc_rows, 0..) |p, *row_node, i| {
         const line = try std.fmt.allocPrint(a, "{d:>5} {d:>6.1} {d:>7.1}  {s}", .{
             p.pid, p.cpu, p.mem, p.name,
         });
         const style: ui.Style = if (i == state.selected) .{ .reverse = true } else .{};
-        try rows.append(a, ui.textOpts(.{ .style = style, .wrap = .clip }, line));
+        row_node.* = ui.textOpts(.{ .style = style, .wrap = .clip }, line);
     }
+    try rows.append(a, try ui.viewport(a, .{
+        .scroll_y = state.scroll,
+        .height = .{ .len = @intCast(visible_rows) },
+    }, try ui.column(a, .{}, proc_rows)));
 
     try rows.append(a, ui.spacer());
     const mouse = if (state.last_mouse) |m|
@@ -151,6 +168,16 @@ fn helpModal(a: std.mem.Allocator) !ui.Node {
     });
 }
 
+/// Slide the scroll offset so the selected row stays inside the fixed viewport
+/// window — the immediate-mode analogue of a list widget's "scroll into view".
+fn keepSelectionVisible(state: *State) void {
+    if (state.selected < state.scroll) {
+        state.scroll = @intCast(state.selected);
+    } else if (state.selected >= state.scroll + visible_rows) {
+        state.scroll = @intCast(state.selected - visible_rows + 1);
+    }
+}
+
 /// A `null` event is the tick (advance the jittering table); keys drive
 /// selection and quitting. Ctrl-C is an ordinary key here (raw mode cleared
 /// ISIG). Resize needs nothing — `run` re-renders every pass.
@@ -169,18 +196,24 @@ fn update(state: *State, ev: ?ui.Event) !ui.Flow {
             .ctrl => |c| if (c == 'c') return .quit,
             .up => if (state.selected > 0) {
                 state.selected -= 1;
+                keepSelectionVisible(state);
             },
             .down => if (state.selected + 1 < state.procs.len) {
                 state.selected += 1;
+                keepSelectionVisible(state);
             },
             else => {},
         },
         .mouse => |m| {
             state.last_mouse = m;
-            // Left-click a table row (rows start at y=3: padding + title + header).
+            // Left-click a process row: the viewport starts at y=3 (padding +
+            // title + header), so a click maps through the scroll offset.
             if (m.button == .left and m.action == .press and m.y >= 3) {
-                const row = m.y - 3;
-                if (row < state.procs.len) state.selected = row;
+                const vis = m.y - 3;
+                if (vis < visible_rows) {
+                    const row = @as(usize, state.scroll) + vis;
+                    if (row < state.procs.len) state.selected = row;
+                }
             }
         },
         .focus => |f| state.focused = f == .in,

--- a/packages/ui/src/golden_test.zig
+++ b/packages/ui/src/golden_test.zig
@@ -267,3 +267,33 @@ test "closing an overlay repaints the base underneath it" {
     try testing.expectEqual(@as(u21, '.'), vt.getCell(3, 1).char);
     try testing.expectEqual(@as(u21, '.'), vt.getCell(5, 1).char);
 }
+
+test "a viewport blits styled and wide content through the renderer" {
+    var vt = try VTerm.init(testing.allocator, 6, 2);
+    defer vt.deinit();
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    var s = try Surface.init(testing.allocator, 6, 2);
+    defer s.deinit();
+    const rctx = ui.RenderCtx{ .allocator = a };
+
+    const content = try ui.column(a, .{}, &.{
+        ui.textOpts(.{ .wrap = .clip, .style = .{ .bold = true } }, "top"),
+        ui.textOpts(.{ .wrap = .clip }, "你好"), // wide graphemes
+        ui.textOpts(.{ .wrap = .clip, .style = .{ .underline = true } }, "last"),
+    });
+    // Window rows 1-2: scroll the bold "top" out of view.
+    const vp = try ui.viewport(a, .{ .scroll_y = 1 }, content);
+    try ui.render(&rctx, &vp, s.root());
+    try paintInto(&vt, .{ .capability = .ansi_16 }, null, &s);
+
+    // Wide graphemes survive the blit (head + continuation land intact)...
+    try testing.expectEqual(@as(u21, '你'), vt.getCell(0, 0).char);
+    try testing.expectEqual(@as(u21, '好'), vt.getCell(2, 0).char);
+    // ...and so does per-cell style.
+    try testing.expect(vt.containsText("last"));
+    try testing.expect(vt.hasAttribute(0, 1, .underline));
+    // The scrolled-out row is gone.
+    try testing.expect(!vt.containsText("top"));
+}

--- a/packages/ui/src/layout_test.zig
+++ b/packages/ui/src/layout_test.zig
@@ -383,3 +383,63 @@ test "a stack carries box chrome: a border insets its layers" {
     try testing.expectEqualStrings("│XX│", try rowString(&h, &s, 1));
     try testing.expectEqualStrings("└──┘", try rowString(&h, &s, 2));
 }
+
+// ============================================================================
+// Viewport (scrollable window, ADR-0017)
+// ============================================================================
+
+fn sixLines(a: std.mem.Allocator) !ui.Node {
+    const labels = [_][]const u8{ "L0", "L1", "L2", "L3", "L4", "L5" };
+    var lines: [6]ui.Node = undefined;
+    for (&lines, labels) |*n, lbl| n.* = ui.textOpts(.{ .wrap = .clip }, lbl);
+    return ui.column(a, .{}, &lines);
+}
+
+test "viewport windows tall content at scroll_y" {
+    var h = Harness.init();
+    defer h.deinit();
+
+    var top = try ui.Surface.init(testing.allocator, 4, 3);
+    defer top.deinit();
+    try renderInto(&h, try ui.viewport(h.a(), .{ .scroll_y = 0 }, try sixLines(h.a())), &top);
+    try testing.expectEqualStrings("L0  ", try rowString(&h, &top, 0));
+    try testing.expectEqualStrings("L1  ", try rowString(&h, &top, 1));
+    try testing.expectEqualStrings("L2  ", try rowString(&h, &top, 2));
+
+    var mid = try ui.Surface.init(testing.allocator, 4, 3);
+    defer mid.deinit();
+    try renderInto(&h, try ui.viewport(h.a(), .{ .scroll_y = 2 }, try sixLines(h.a())), &mid);
+    try testing.expectEqualStrings("L2  ", try rowString(&h, &mid, 0));
+    try testing.expectEqualStrings("L3  ", try rowString(&h, &mid, 1));
+    try testing.expectEqualStrings("L4  ", try rowString(&h, &mid, 2));
+}
+
+test "viewport clamps an overscroll to the last page" {
+    var h = Harness.init();
+    defer h.deinit();
+    var s = try ui.Surface.init(testing.allocator, 4, 3);
+    defer s.deinit();
+    // 6 lines, 3-row window, scroll_y way past the end → rests on L3,L4,L5.
+    try renderInto(&h, try ui.viewport(h.a(), .{ .scroll_y = 100 }, try sixLines(h.a())), &s);
+    try testing.expectEqualStrings("L3  ", try rowString(&h, &s, 0));
+    try testing.expectEqualStrings("L4  ", try rowString(&h, &s, 1));
+    try testing.expectEqualStrings("L5  ", try rowString(&h, &s, 2));
+}
+
+test "viewport shorter than its window leaves trailing rows untouched" {
+    var h = Harness.init();
+    defer h.deinit();
+    var s = try ui.Surface.init(testing.allocator, 4, 4);
+    defer s.deinit();
+    _ = try s.root().writeText(0, 3, "ZZ", .{}); // sits beneath the viewport
+
+    const content = try ui.column(h.a(), .{}, &.{
+        ui.textOpts(.{ .wrap = .clip }, "AA"),
+        ui.textOpts(.{ .wrap = .clip }, "BB"),
+    });
+    try renderInto(&h, try ui.viewport(h.a(), .{}, content), &s);
+    try testing.expectEqualStrings("AA  ", try rowString(&h, &s, 0));
+    try testing.expectEqualStrings("BB  ", try rowString(&h, &s, 1));
+    try testing.expectEqualStrings("    ", try rowString(&h, &s, 2)); // no content, untouched
+    try testing.expectEqualStrings("ZZ  ", try rowString(&h, &s, 3)); // shows through
+}

--- a/packages/ui/src/surface.zig
+++ b/packages/ui/src/surface.zig
@@ -162,6 +162,24 @@ pub const Surface = struct {
         };
         if (w == 2) self.cells[i + 1] = .{ .width = 0, .style = style };
     }
+
+    /// Copy `src`'s cell verbatim into (x, y) — text, width, and style — re-
+    /// appending its grapheme bytes into this surface's own store (a cell's
+    /// `text_off` is relative to the surface that owns it). Sets the cell
+    /// directly, without dissolving whatever it overwrites: the callers
+    /// (a viewport blit into its own freshly-cleared rect) copy whole rows,
+    /// so a wide grapheme is always overwritten as a head+continuation pair.
+    fn putCell(self: *Surface, x: u16, y: u16, c: Cell, text: []const u8) !void {
+        const i = self.idx(x, y);
+        if (c.text_len == 0) {
+            // Blank (width 1) or wide-continuation (width 0): no grapheme bytes.
+            self.cells[i] = .{ .width = c.width, .style = c.style };
+            return;
+        }
+        const off: u32 = @intCast(self.bytes.items.len);
+        try self.bytes.appendSlice(self.allocator, text);
+        self.cells[i] = .{ .text_off = off, .text_len = c.text_len, .width = c.width, .style = c.style };
+    }
 };
 
 /// A clipped rectangular view of a surface. All coordinates on the API are
@@ -206,6 +224,28 @@ pub const Region = struct {
             var x: u16 = 0;
             while (x < self.rect.w) : (x += 1) {
                 self.surface.blankAt(self.rect.x + x, self.rect.y + y, style);
+            }
+        }
+    }
+
+    /// Copy `src`'s rows, starting at `src_y`, into this region — top-left
+    /// aligned, one source column per region column. Cells are copied verbatim
+    /// (text, width, style). This is the viewport's windowed blit: a child is
+    /// rendered into a full-height scratch surface, then the visible slice is
+    /// copied here (ADR-0017). Fewer available source rows than the region is
+    /// tall leaves the remaining region rows untouched — so short content shows
+    /// whatever sits beneath the viewport, consistent with the stack
+    /// transparency model. `src` should be at least the region's width.
+    pub fn copyRows(self: Region, src: *const Surface, src_y: u16) !void {
+        const cols = @min(self.rect.w, src.width);
+        var dy: u16 = 0;
+        while (dy < self.rect.h) : (dy += 1) {
+            const sy = src_y + dy;
+            if (sy >= src.height) break;
+            var x: u16 = 0;
+            while (x < cols) : (x += 1) {
+                const c = src.cell(x, sy);
+                try self.surface.putCell(self.rect.x + x, self.rect.y + dy, c, src.cellText(c));
             }
         }
     }

--- a/packages/ui/src/ui.zig
+++ b/packages/ui/src/ui.zig
@@ -160,6 +160,68 @@ pub fn center(a: std.mem.Allocator, child: Node) !Node {
     });
 }
 
+pub const ViewportOpts = struct {
+    /// Caller-owned vertical scroll offset, in rows (immediate mode — the app
+    /// holds it in state and adjusts it on ↑/↓/PageUp/PageDown). Clamped to the
+    /// content, so overshooting (PageDown past the end) rests on the last page.
+    scroll_y: u16 = 0,
+    /// A viewport is a fixed window; it fills what it's granted by default and
+    /// its content scrolls behind it. `.fit` height is meaningless (there would
+    /// be nothing to scroll) — use `.fill` or `.len`.
+    width: Dim = .{ .fill = 1 },
+    height: Dim = .{ .fill = 1 },
+};
+
+/// A scrolling window onto content taller than the space it's granted (ADR-0017):
+/// a log pane, a long list, a tall form. `child` is measured at the viewport
+/// width and its natural (unbounded) height, rendered in full into a scratch
+/// surface, and the slice at `scroll_y` is copied into the viewport. Vertical
+/// scroll only. Scroll state stays caller-owned (immediate mode); the viewport
+/// only clamps it. Content is fully realized each frame — fine for the ordinary
+/// screenful-or-few; very tall content pays for its full height in scratch.
+pub fn viewport(a: std.mem.Allocator, opts: ViewportOpts, child: Node) !Node {
+    const ctx = try a.create(ViewportCtx);
+    ctx.* = .{ .child = child, .scroll_y = opts.scroll_y };
+    return .{
+        .width = opts.width,
+        .height = opts.height,
+        .kind = .{ .custom = .{
+            .context = ctx,
+            .measureFn = ViewportCtx.measureFn,
+            .renderFn = ViewportCtx.renderFn,
+        } },
+    };
+}
+
+const ViewportCtx = struct {
+    child: Node,
+    scroll_y: u16,
+
+    /// A viewport takes the whole offer — it's a fixed window (the node's own
+    /// `.len`/`.fill` dims, applied by `measure` after this, refine it).
+    fn measureFn(_: *anyopaque, _: *const RenderCtx, limits: Limits) Size {
+        return .{ .w = limits.max_w, .h = limits.max_h };
+    }
+
+    fn renderFn(context: *anyopaque, rctx: *const RenderCtx, region: Region) anyerror!void {
+        const self: *const ViewportCtx = @ptrCast(@alignCast(context));
+        const w = region.width();
+        const h = region.height();
+        if (w == 0 or h == 0) return;
+
+        // Measure the child at the viewport width, unbounded height, then paint
+        // it in full into a scratch surface (arena-backed — freed with the frame).
+        const content = measure(rctx, &self.child, .{ .max_w = w, .max_h = std.math.maxInt(u16) });
+        const content_h = @max(content.h, 1);
+        var scratch = try Surface.init(rctx.allocator, w, content_h);
+        try render(rctx, &self.child, scratch.root());
+
+        // Clamp the scroll offset to the content and copy the visible window.
+        const sy = @min(self.scroll_y, content_h -| h);
+        try region.copyRows(&scratch, sy);
+    }
+};
+
 test {
     _ = @import("node.zig");
 }


### PR DESCRIPTION
The scrollable-viewport primitive ADR-0013/0015 deferred as *"a `custom` leaf first."* A `viewport` is a fixed window onto content taller than the space it's granted — a log pane, a long list, a tall form — with a caller-owned vertical scroll offset.

## The core problem
To scroll, you must render content at its **full natural height**, then show only a window of it offset by `scroll_y`. But the live surface only has cells for the *visible* rows, and the diff renderer addresses relative to the frame origin (ADR-0015 §2) — no content-offset concept.

## Approach: windowed blit
A `viewport` is a `custom` leaf. Its `renderFn`:
1. measures the child at the viewport width, **unbounded height** → content height,
2. renders the child in full into a **scratch `Surface`** (frame-arena),
3. clamps `scroll_y` to `[0, content_h − viewport_h]`,
4. copies rows `[scroll_y .. scroll_y+viewport_h)` into the viewport region.

**`measure`/`render` and the diff renderer are untouched** — the child renders normally into a real (taller) surface, so wide graphemes, styles, borders, and nested trees all work for free. The one new surface primitive is `Region.copyRows` (a verbatim windowed cell copy). Like overlays (#187), the work happens in the cell buffer, upstream of the terminal — no absolute addressing.

## API
```zig
pub const ViewportOpts = struct {
    scroll_y: u16 = 0,               // caller-owned (immediate mode); viewport only clamps
    width: Dim = .{ .fill = 1 },
    height: Dim = .{ .fill = 1 },
};
pub fn viewport(a, opts: ViewportOpts, child: Node) !Node
```
Scroll state is caller-owned — the app adjusts it on ↑/↓/PageUp/PageDown; the viewport clamps so an overshoot rests on the last page. Short content leaves the rows below untouched, so a viewport composites over a lower `stack` layer like any transparent region.

## Why not teach `Region` a content offset
The offset-clip alternative (a coordinate origin above the clip window, child laid out at `content_h`, painted clipped) is allocation-free and more general, but touches `Region`'s core — signed coords, per-write clipping, wide-grapheme-straddles-top-edge. Bigger diff, higher risk, no consumer yet. The scratch blit keeps the four-node vocabulary intact and, if the per-frame scratch alloc ever matters, the offset-clip Region becomes the first-class-node upgrade **with no `viewport` API change**. ADR-0017 records this.

## Tests
- **Layout** (`layout_test.zig`): windowing + scroll offset; overscroll clamps to the last page; short content leaves trailing rows untouched (transparency-consistent).
- **Golden** (`golden_test.zig`): styled + wide content survives the blit through the real diff renderer; scrolled-out rows disappear.
- **Example**: `examples/fullscreen.zig` gains a scrolling process pane (28 procs, 8-row window) whose selection scrolls into view — **PTY-validated** (late rows come into view on ↓).

`zig build test` green, `zig fmt` clean. **Vertical scroll only**; horizontal scroll and a scrollbar indicator are the named next deferrals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)