### PR TITLE
feat(ui): focusable widgets — TextInput + Checkbox (ADR-0018)

### DIFF
--- a/docs/adr/0018-focusable-widgets.md
+++ b/docs/adr/0018-focusable-widgets.md
@@ -1,0 +1,89 @@
+# Focusable widgets: state structs with `view` + `handle`, caller-owned focus
+
+Status: accepted
+
+> Increment 1 of the widget library: the focus/routing model plus `TextInput`
+> and `Checkbox`. `Select` (a list over a `viewport`) and a `Button` are
+> follow-ups on the same contract.
+
+ADR-0013/0015 named a focusable widget library as a clean deferral. This is the
+first increment, and it settles the one hard question: how do interactive,
+*stateful* widgets live on an engine that is deliberately immediate-mode
+(stateless nodes, caller-owned state, tree rebuilt every frame, "a thin event
+source, not a framework loop" — ADR-0015 §3).
+
+## Decision: a widget is a state struct with `view` + `handle`
+
+A widget is a plain struct the caller embeds in its own `State`. Two methods, by
+convention (not an enforced interface):
+
+- `view(self, a, opts) !Node` — render from current state; `opts.focused` tells
+  it to draw its caret/highlight. Immediate: it returns a `Node` like any
+  component.
+- `handle(self, key) bool` — mutate state on a key, returning whether it was
+  **consumed**.
+
+That bool is the entire routing model. A widget eats the keys it uses (a
+`TextInput` eats char/←/→/Backspace/Home/End) and lets the rest bubble. The loop
+gives the focused widget first crack, and treats an *unconsumed* key as
+form-level navigation:
+
+```zig
+const consumed = switch (state.focus) {
+    .user => state.user.handle(key),
+    .pass => state.pass.handle(key),
+    .remember => state.remember.handle(key),
+};
+if (consumed) return .keep;
+switch (key) {                                   // unconsumed → navigation
+    .tab      => state.focus = ui.widgets.focusNext(Field, state.focus),
+    .back_tab => state.focus = ui.widgets.focusPrev(Field, state.focus),
+    .enter    => submit(state),
+    .escape   => return .quit,
+    else => {},
+}
+```
+
+State stays caller-owned (the widget is a field in `State`), rendering stays
+immediate, behavior is a pure `handle`. No retained widget tree, no ID store, no
+framework loop — the loop is still the plain `App.run`.
+
+**Rejected:** an ImGui-style immediate-mode ID store (a retained context + ID
+management — a different paradigm) and a retained widget tree that owns
+focus/routing (a framework loop, against ADR-0015 §3).
+
+## Focus is caller-owned; the library adds only a ring helper
+
+Focus is a value the app owns — here a `Field` enum. Routing is an explicit
+`switch`, inherent to heterogeneous, type-safe widgets (no dynamic dispatch, no
+IDs). The library contributes only `focusNext`/`focusPrev` (wrap-around over the
+app's focus enum). A library-managed focus *registry* would need widget
+identity — exactly what this avoids.
+
+## Consequences and scoped-out edges
+
+- **Shift-Tab needed a terminal change.** `terminal`'s `Key` had no Shift-Tab
+  (and non-char keys carry no modifiers), so a `.back_tab` variant was added to
+  the parser (recognizing `CSI Z`). It is the one change outside `packages/ui`,
+  and reverse focus navigation is standard form UX.
+- **The caret is a styled cell, not the hardware cursor.** Showing the real
+  cursor would require a focused widget to know its own laid-out screen position
+  — the same "layout doesn't expose measured positions" gap that blocks anchored
+  popups. The caret is a reverse-video cell instead (pure surface content). A
+  hardware cursor is a future enhancement bundled with that position-feedback
+  work.
+- **Editing is codepoint-granular.** Insert/Backspace/Delete/←/→ operate on whole
+  UTF-8 codepoints over a caller-provided buffer (allocation-free; capacity is
+  the caller's). Full grapheme-cluster editing (combining marks, ZWJ emoji) is a
+  later refinement.
+- **Keyboard only.** Click-to-focus and click-to-position-caret need hit-testing
+  (map (x,y) → widget), which again needs exposed widget rects. Deferred with the
+  same position-feedback dependency.
+- **Shared theme with `prompts`.** Widgets style through the existing
+  `PromptTheme` tokens (cursor/selected/marker/hint). `prompts` is the
+  cooked-mode, one-shot, line-oriented interactive layer; this widget library is
+  its full-screen, persistent, node-tree counterpart. They are parallel and
+  share the vocabulary — `prompts` is neither merged nor replaced.
+- **Next:** `Select` (a list rendered inside a `viewport`, ADR-0017 — it owns
+  `highlighted` + `scroll` and scrolls the selection into view) and a `Button`,
+  both on this same `view`/`handle`/`consumed` contract.

--- a/packages/terminal/src/key.zig
+++ b/packages/terminal/src/key.zig
@@ -20,6 +20,8 @@ pub const Key = union(enum) {
     delete,
     escape,
     tab,
+    /// Shift-Tab (CSI Z / "cursor backward tabulation") — reverse focus.
+    back_tab,
     up,
     down,
     left,
@@ -36,6 +38,7 @@ pub const Key = union(enum) {
             .delete => try writer.writeAll("<delete>"),
             .escape => try writer.writeAll("<escape>"),
             .tab => try writer.writeAll("<tab>"),
+            .back_tab => try writer.writeAll("<back_tab>"),
             .up => try writer.writeAll("<up>"),
             .down => try writer.writeAll("<down>"),
             .left => try writer.writeAll("<left>"),
@@ -198,6 +201,8 @@ fn parseEscapeSequence(reader: anytype, esc_handle: ?backend.Handle, paste: ?Pas
             'D' => keyIn(.left),
             'H' => keyIn(.home),
             'F' => keyIn(.end),
+            // Shift-Tab: CSI Z (cursor backward tabulation).
+            'Z' => keyIn(.back_tab),
             // Focus in/out (DECSET 1004). `ESC [ O` is distinct from the SS3
             // `ESC O …` below (no intervening `[`).
             'I' => .{ .focus = .in },
@@ -460,6 +465,13 @@ test "Key format renders a multibyte char" {
     const str = try std.fmt.allocPrint(allocator, "{f}", .{k});
     defer allocator.free(str);
     try std.testing.expectEqualStrings("'你'", str);
+}
+
+test "readKey parses shift-tab as back_tab" {
+    var buf = "\x1b[Z".*;
+    var reader: std.Io.Reader = .fixed(&buf);
+    const k = try readKey(&reader);
+    try std.testing.expect(k == .back_tab);
 }
 
 test "readKey parses arrow up" {

--- a/packages/ui/build.zig
+++ b/packages/ui/build.zig
@@ -42,7 +42,7 @@ pub fn build(b: *std.Build) void {
 
     // Runnable examples — `zig build run-<name>` (they animate, so they need
     // a real terminal). Each is compiled by `test` so it can't bitrot.
-    const example_names = [_][]const u8{ "demo", "hybrid", "fullscreen" };
+    const example_names = [_][]const u8{ "demo", "hybrid", "fullscreen", "form" };
     for (example_names) |name| {
         const exe = b.addExecutable(.{
             .name = b.fmt("ui-{s}", .{name}),

--- a/packages/ui/examples/form.zig
+++ b/packages/ui/examples/form.zig
@@ -1,0 +1,140 @@
+//! A focusable form (ADR-0018): two text fields and a checkbox, with Tab /
+//! Shift-Tab moving focus, Enter submitting, and Esc quitting. It shows the
+//! whole widget contract in one screen:
+//!
+//!   - each widget is a plain struct in `State` (immediate mode — no retained
+//!     widget tree);
+//!   - `update` gives the focused widget first crack at a key via `handle`,
+//!     which returns whether it consumed it. An unconsumed key (Tab, Enter, Esc)
+//!     is form-level navigation. That one bool is the entire routing model.
+//!   - `view` passes `focused` to each widget so it draws its caret/highlight.
+//!
+//! Focus is caller-owned (a `Field` enum); `ui.widgets.focusNext`/`focusPrev`
+//! are the only helpers the library adds.
+//!
+//! Run with: zig build run-form   (from packages/ui, needs a real TTY)
+
+const std = @import("std");
+const ui = @import("ui");
+const terminal = @import("terminal");
+
+pub const panic = ui.panic;
+
+const Field = enum { user, pass, remember };
+
+const State = struct {
+    user_buf: [48]u8 = undefined,
+    pass_buf: [48]u8 = undefined,
+    // `buffer` is wired to the inline buffers by `wire()` once the State has its
+    // final address (a self-referential struct can't do it in the initializer).
+    user: ui.widgets.TextInput = .{ .buffer = &.{} },
+    pass: ui.widgets.TextInput = .{ .buffer = &.{}, .mask = '*' },
+    remember: ui.widgets.Checkbox = .{},
+    focus: Field = .user,
+    submitted: bool = false,
+
+    fn wire(self: *State) void {
+        self.user.buffer = &self.user_buf;
+        self.pass.buffer = &self.pass_buf;
+    }
+};
+
+fn labeled(a: std.mem.Allocator, label: []const u8, field: ui.Node) !ui.Node {
+    return ui.row(a, .{ .gap = 1 }, &.{
+        ui.textOpts(.{ .width = .{ .len = 5 }, .wrap = .clip }, label),
+        field,
+    });
+}
+
+fn view(a: std.mem.Allocator, state: *State) !ui.Node {
+    const status = if (state.submitted)
+        try std.fmt.allocPrint(a, "✓ signed in as \"{s}\"{s}", .{
+            state.user.value(),
+            if (state.remember.checked) " (remembered)" else "",
+        })
+    else
+        "Tab / Shift-Tab move · Enter submit · Esc quit";
+
+    const form = try ui.column(a, .{
+        .border = .rounded,
+        .border_style = .{ .foreground = .bright_cyan },
+        .padding = .symmetric(2, 1),
+        .gap = 1,
+        .width = .{ .len = 46 },
+    }, &.{
+        ui.text(.{ .bold = true }, "Sign in"),
+        try labeled(a, "User", try state.user.view(a, .{
+            .focused = state.focus == .user,
+            .placeholder = "username",
+        })),
+        try labeled(a, "Pass", try state.pass.view(a, .{
+            .focused = state.focus == .pass,
+            .placeholder = "password",
+        })),
+        try state.remember.view(a, .{
+            .focused = state.focus == .remember,
+            .label = "Remember me",
+        }),
+        ui.text(.{ .dim = !state.submitted }, status),
+    });
+
+    // Center the form on the otherwise-blank alt-screen.
+    return ui.center(a, form);
+}
+
+fn update(state: *State, ev: ?ui.Event) !ui.Flow {
+    const e = ev orelse return .keep;
+    const key = switch (e) {
+        .key => |k| k,
+        else => return .keep,
+    };
+
+    // The focused widget gets first crack; an unconsumed key is navigation.
+    const consumed = switch (state.focus) {
+        .user => state.user.handle(key),
+        .pass => state.pass.handle(key),
+        .remember => state.remember.handle(key),
+    };
+    if (consumed) {
+        state.submitted = false; // editing invalidates a prior submit
+        return .keep;
+    }
+
+    switch (key) {
+        .tab => state.focus = ui.widgets.focusNext(Field, state.focus),
+        .back_tab => state.focus = ui.widgets.focusPrev(Field, state.focus),
+        .enter => state.submitted = true,
+        .escape => return .quit,
+        .ctrl => |c| if (c == 'c') return .quit,
+        else => {},
+    }
+    return .keep;
+}
+
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+    const gpa = init.gpa;
+
+    if (!terminal.isStdoutTty()) {
+        var err_buf: [256]u8 = undefined;
+        var stderr = std.Io.File.stderr().writer(io, &err_buf);
+        try stderr.interface.writeAll("form: needs an interactive terminal\n");
+        try stderr.interface.flush();
+        return;
+    }
+
+    var out_buf: [1 << 14]u8 = undefined;
+    var stdout = std.Io.File.stdout().writer(io, &out_buf);
+    var in_buf: [256]u8 = undefined;
+    var stdin = std.Io.File.stdin().reader(io, &in_buf);
+
+    var app = try ui.App.initFullScreen(gpa, &stdout.interface, .{
+        .capability = .ansi_256,
+        .stdin = &stdin.interface,
+    });
+    defer app.deinit();
+
+    var state = State{};
+    state.wire();
+    try app.run(io, &state, null, view, update); // no tick — a form blocks on input
+}

--- a/packages/ui/src/input.zig
+++ b/packages/ui/src/input.zig
@@ -1,0 +1,288 @@
+//! Focusable input widgets (ADR-0018): the interactive counterpart to the
+//! progress widgets in `widgets.zig`. Each widget is a plain struct the caller
+//! embeds in its own state — the immediate-mode contract holds:
+//!
+//!   - `view(self, a, opts) !Node`  — render from current state (opts carries
+//!     `focused`); the caret/highlight is a styled cell, no hardware cursor.
+//!   - `handle(self, key) bool`      — mutate on a key; returns whether it was
+//!     consumed. A widget eats the keys it uses (a text field eats ←/→/char);
+//!     everything else bubbles, so the form treats *unconsumed* keys as
+//!     navigation (Tab/Enter/Escape). That one bool is the whole routing model.
+//!
+//! Focus itself is caller-owned (an index or an enum); the loop routes an event
+//! to the focused widget, and on an unconsumed key does form-level navigation.
+//! `focusNext`/`focusPrev` are the only helpers the library adds. No retained
+//! widget tree, no IDs, no framework loop.
+//!
+//! Styling flows through the theme's prompt tokens (`PromptTheme`: cursor,
+//! selected, marker, hint) — the same tokens the `prompts` package uses, so the
+//! full-screen widgets and the line-oriented prompts share one look.
+
+const std = @import("std");
+const theme_mod = @import("theme");
+const terminal = @import("terminal");
+const node_mod = @import("node.zig");
+const surface_mod = @import("surface.zig");
+
+const Node = node_mod.Node;
+const Dim = node_mod.Dim;
+const Limits = node_mod.Limits;
+const Size = node_mod.Size;
+const RenderCtx = node_mod.RenderCtx;
+const Region = surface_mod.Region;
+const Style = surface_mod.Style;
+const Key = terminal.Key;
+
+pub const Theme = theme_mod.Theme;
+const default_theme = theme_mod.default_theme;
+
+// ============================================================================
+// Focus helpers
+// ============================================================================
+
+/// The next focus target with wrap-around (Tab). `E` is the app's focus enum
+/// whose variants are its focusable fields, in order.
+pub fn focusNext(comptime E: type, current: E) E {
+    const n = @typeInfo(E).@"enum".fields.len;
+    return @enumFromInt((@intFromEnum(current) + 1) % n);
+}
+
+/// The previous focus target with wrap-around (Shift-Tab / `.back_tab`).
+pub fn focusPrev(comptime E: type, current: E) E {
+    const n = @typeInfo(E).@"enum".fields.len;
+    return @enumFromInt((@intFromEnum(current) + n - 1) % n);
+}
+
+// ============================================================================
+// TextInput
+// ============================================================================
+
+/// A single-line text field over a caller-owned buffer (capacity is the
+/// caller's choice — allocation-free). Editing is codepoint-granular: insert,
+/// backspace/delete, ←/→, home/end. The caret and horizontal scroll are derived
+/// from `cursor` each frame, so the only persistent state is the bytes and the
+/// cursor.
+pub const TextInput = struct {
+    /// Caller-owned storage. `value()` is `buffer[0..len]`.
+    buffer: []u8,
+    len: usize = 0,
+    /// Insertion point, as a byte offset into `buffer` (always on a codepoint
+    /// boundary).
+    cursor: usize = 0,
+    /// Render each codepoint as this glyph instead of itself (e.g. `'*'` for a
+    /// password). Editing still operates on the real bytes.
+    mask: ?u8 = null,
+
+    pub const ViewOpts = struct {
+        focused: bool = false,
+        /// Shown dimmed when the field is empty.
+        placeholder: []const u8 = "",
+        width: Dim = .{ .fill = 1 },
+        theme: *const Theme = &default_theme,
+    };
+
+    pub fn value(self: *const TextInput) []const u8 {
+        return self.buffer[0..self.len];
+    }
+
+    /// Handle a key; returns whether it was consumed (so the form knows to treat
+    /// an unconsumed key as navigation). Editing keys are always consumed, even
+    /// when they can't move (←at column 0), because they belong to the field.
+    pub fn handle(self: *TextInput, key: Key) bool {
+        switch (key) {
+            .char => |c| self.insert(c),
+            .backspace => self.deleteBack(),
+            .delete => self.deleteForward(),
+            .left => self.cursor = prevBoundary(self.value(), self.cursor),
+            .right => self.cursor = nextBoundary(self.value(), self.cursor),
+            .home => self.cursor = 0,
+            .end => self.cursor = self.len,
+            else => return false,
+        }
+        return true;
+    }
+
+    fn insert(self: *TextInput, cp: u21) void {
+        var enc: [4]u8 = undefined;
+        const n = std.unicode.utf8Encode(cp, &enc) catch return;
+        if (self.len + n > self.buffer.len) return; // full — drop the keystroke
+        std.mem.copyBackwards(u8, self.buffer[self.cursor + n .. self.len + n], self.buffer[self.cursor..self.len]);
+        @memcpy(self.buffer[self.cursor..][0..n], enc[0..n]);
+        self.len += n;
+        self.cursor += n;
+    }
+
+    fn deleteBack(self: *TextInput) void {
+        if (self.cursor == 0) return;
+        const start = prevBoundary(self.value(), self.cursor);
+        const n = self.cursor - start;
+        std.mem.copyForwards(u8, self.buffer[start .. self.len - n], self.buffer[self.cursor..self.len]);
+        self.len -= n;
+        self.cursor = start;
+    }
+
+    fn deleteForward(self: *TextInput) void {
+        if (self.cursor >= self.len) return;
+        const end = nextBoundary(self.value(), self.cursor);
+        const n = end - self.cursor;
+        std.mem.copyForwards(u8, self.buffer[self.cursor .. self.len - n], self.buffer[end..self.len]);
+        self.len -= n;
+    }
+
+    pub fn view(self: *const TextInput, a: std.mem.Allocator, opts: ViewOpts) !Node {
+        const th = opts.theme;
+        const empty = self.len == 0;
+
+        const ctx = try a.create(FieldView);
+        if (empty) {
+            // Placeholder in hint style; the caret rests at column 0.
+            ctx.* = .{
+                .text = opts.placeholder,
+                .cursor_col = 0,
+                .caret = " ",
+                .focused = opts.focused,
+                .text_style = th.prompts.hint.resolve(th.palette),
+                .caret_style = .{ .reverse = true },
+            };
+        } else {
+            const shown = if (self.mask) |m| try maskOf(a, self.value(), m) else self.value();
+            const before = if (self.mask) |m| try maskOf(a, self.value()[0..self.cursor], m) else self.value()[0..self.cursor];
+            ctx.* = .{
+                .text = shown,
+                .cursor_col = @intCast(terminal.displayWidth(before)),
+                .caret = try caretGlyph(a, self, shown, before.len),
+                .focused = opts.focused,
+                .text_style = .{},
+                .caret_style = .{ .reverse = true },
+            };
+        }
+        return .{
+            .width = opts.width,
+            .kind = .{ .custom = .{
+                .context = ctx,
+                .measureFn = FieldView.measureFn,
+                .renderFn = FieldView.renderFn,
+            } },
+        };
+    }
+};
+
+/// One mask glyph per codepoint of `s`.
+fn maskOf(a: std.mem.Allocator, s: []const u8, m: u8) ![]const u8 {
+    const out = try a.alloc(u8, utf8Count(s));
+    @memset(out, m);
+    return out;
+}
+
+/// The glyph under the caret in the displayed text — a space past the end.
+fn caretGlyph(a: std.mem.Allocator, self: *const TextInput, shown: []const u8, shown_cursor: usize) ![]const u8 {
+    if (self.cursor >= self.len) return " ";
+    const end = nextBoundary(shown, shown_cursor);
+    return a.dupe(u8, shown[shown_cursor..end]);
+}
+
+const FieldView = struct {
+    text: []const u8,
+    cursor_col: u16,
+    caret: []const u8,
+    focused: bool,
+    text_style: Style,
+    caret_style: Style,
+
+    fn measureFn(_: *anyopaque, _: *const RenderCtx, limits: Limits) Size {
+        return .{ .w = limits.max_w, .h = @min(1, limits.max_h) };
+    }
+
+    fn renderFn(context: *anyopaque, _: *const RenderCtx, region: Region) anyerror!void {
+        const self: *const FieldView = @ptrCast(@alignCast(context));
+        const w = region.width();
+        if (w == 0) return;
+        // Scroll horizontally so the caret stays in view (right-anchored once
+        // the text outgrows the field).
+        const scroll: u16 = if (self.cursor_col < w) 0 else self.cursor_col - w + 1;
+        const start = byteAtColumn(self.text, scroll);
+        _ = try region.writeText(0, 0, self.text[start..], self.text_style);
+        if (self.focused) {
+            _ = try region.writeText(self.cursor_col - scroll, 0, self.caret, self.caret_style);
+        }
+    }
+};
+
+// ============================================================================
+// Checkbox
+// ============================================================================
+
+/// A boolean toggle rendered as `[x] label` / `[ ] label`. Space toggles it;
+/// Enter is left for the form (submit), so a checkbox never swallows it.
+pub const Checkbox = struct {
+    checked: bool = false,
+
+    pub const ViewOpts = struct {
+        focused: bool = false,
+        label: []const u8 = "",
+        theme: *const Theme = &default_theme,
+    };
+
+    pub fn handle(self: *Checkbox, key: Key) bool {
+        switch (key) {
+            .char => |c| if (c == ' ') {
+                self.checked = !self.checked;
+                return true;
+            },
+            else => {},
+        }
+        return false;
+    }
+
+    pub fn view(self: *const Checkbox, a: std.mem.Allocator, opts: ViewOpts) !Node {
+        const th = opts.theme;
+        const box: []const u8 = if (self.checked) "[x]" else "[ ]";
+        const label = try std.fmt.allocPrint(a, " {s}", .{opts.label});
+        const label_style: Style = if (opts.focused) th.prompts.selected.resolve(th.palette) else .{};
+        // Built as node literals directly (not via `ui.zig`, which imports this).
+        const children = try a.dupe(Node, &.{
+            .{ .kind = .{ .text = .{ .content = box, .style = th.prompts.marker.resolve(th.palette), .wrap = .clip } } },
+            .{ .kind = .{ .text = .{ .content = label, .style = label_style, .wrap = .clip } } },
+        });
+        return .{ .kind = .{ .box = .{ .dir = .row, .children = children } } };
+    }
+};
+
+// ============================================================================
+// UTF-8 helpers (codepoint boundaries; editing is codepoint-granular)
+// ============================================================================
+
+fn prevBoundary(s: []const u8, i: usize) usize {
+    var j = i;
+    while (j > 0) {
+        j -= 1;
+        if (s[j] & 0xc0 != 0x80) break; // not a UTF-8 continuation byte
+    }
+    return j;
+}
+
+fn nextBoundary(s: []const u8, i: usize) usize {
+    if (i >= s.len) return s.len;
+    const n = std.unicode.utf8ByteSequenceLength(s[i]) catch 1;
+    return @min(i + n, s.len);
+}
+
+fn utf8Count(s: []const u8) usize {
+    var n: usize = 0;
+    var i: usize = 0;
+    while (i < s.len) : (n += 1) i = nextBoundary(s, i);
+    return n;
+}
+
+/// The byte offset in `text` at which the cumulative display width first
+/// reaches `target_col` — the left edge of a horizontally scrolled field.
+fn byteAtColumn(text: []const u8, target_col: u16) usize {
+    var col: u16 = 0;
+    var i: usize = 0;
+    while (i < text.len and col < target_col) {
+        const end = nextBoundary(text, i);
+        col += @intCast(terminal.displayWidth(text[i..end]));
+        i = end;
+    }
+    return i;
+}

--- a/packages/ui/src/input_test.zig
+++ b/packages/ui/src/input_test.zig
@@ -1,0 +1,190 @@
+//! Tests for the focusable input widgets (ADR-0018): `handle` as pure state
+//! transitions (no terminal), and `view` painted onto a surface directly.
+
+const std = @import("std");
+const ui = @import("ui.zig");
+const widgets = @import("widgets.zig");
+
+const testing = std.testing;
+const TextInput = widgets.TextInput;
+const Checkbox = widgets.Checkbox;
+
+// ---- handle: TextInput editing --------------------------------------------
+
+test "TextInput inserts at the cursor and reports consumed" {
+    var buf: [16]u8 = undefined;
+    var ti = TextInput{ .buffer = &buf };
+    try testing.expect(ti.handle(.{ .char = 'h' }));
+    try testing.expect(ti.handle(.{ .char = 'i' }));
+    try testing.expectEqualStrings("hi", ti.value());
+    try testing.expectEqual(@as(usize, 2), ti.cursor);
+}
+
+test "TextInput backspace and delete remove a codepoint" {
+    var buf: [16]u8 = undefined;
+    var ti = TextInput{ .buffer = &buf };
+    for ("abc") |c| _ = ti.handle(.{ .char = c });
+    _ = ti.handle(.backspace); // "ab", cursor 2
+    try testing.expectEqualStrings("ab", ti.value());
+    _ = ti.handle(.home);
+    _ = ti.handle(.delete); // remove 'a' → "b"
+    try testing.expectEqualStrings("b", ti.value());
+    try testing.expectEqual(@as(usize, 0), ti.cursor);
+}
+
+test "TextInput cursor moves and inserts mid-string" {
+    var buf: [16]u8 = undefined;
+    var ti = TextInput{ .buffer = &buf };
+    for ("ac") |c| _ = ti.handle(.{ .char = c });
+    _ = ti.handle(.left); // between a and c
+    _ = ti.handle(.{ .char = 'b' });
+    try testing.expectEqualStrings("abc", ti.value());
+    _ = ti.handle(.end);
+    try testing.expectEqual(@as(usize, 3), ti.cursor);
+}
+
+test "TextInput edits multibyte codepoints whole" {
+    var buf: [16]u8 = undefined;
+    var ti = TextInput{ .buffer = &buf };
+    _ = ti.handle(.{ .char = 'é' }); // 2 bytes
+    _ = ti.handle(.{ .char = '中' }); // 3 bytes
+    try testing.expectEqual(@as(usize, 5), ti.len);
+    _ = ti.handle(.backspace); // removes 中 (all 3 bytes)
+    try testing.expectEqualStrings("é", ti.value());
+    _ = ti.handle(.left); // before é
+    _ = ti.handle(.right); // after é (one codepoint, 2 bytes)
+    try testing.expectEqual(@as(usize, 2), ti.cursor);
+}
+
+test "TextInput drops a keystroke when the buffer is full" {
+    var buf: [2]u8 = undefined;
+    var ti = TextInput{ .buffer = &buf };
+    _ = ti.handle(.{ .char = 'a' });
+    _ = ti.handle(.{ .char = 'b' });
+    try testing.expect(ti.handle(.{ .char = 'c' })); // consumed, but dropped
+    try testing.expectEqualStrings("ab", ti.value());
+}
+
+test "TextInput does not consume navigation keys" {
+    var buf: [16]u8 = undefined;
+    var ti = TextInput{ .buffer = &buf };
+    try testing.expect(!ti.handle(.tab));
+    try testing.expect(!ti.handle(.back_tab));
+    try testing.expect(!ti.handle(.enter));
+    try testing.expect(!ti.handle(.escape));
+}
+
+// ---- handle: Checkbox ------------------------------------------------------
+
+test "Checkbox toggles on space, leaves Enter for the form" {
+    var cb = Checkbox{};
+    try testing.expect(cb.handle(.{ .char = ' ' }));
+    try testing.expect(cb.checked);
+    try testing.expect(cb.handle(.{ .char = ' ' }));
+    try testing.expect(!cb.checked);
+    // Enter is not consumed — the form uses it to submit.
+    try testing.expect(!cb.handle(.enter));
+    try testing.expect(!cb.checked);
+}
+
+// ---- focus helpers ---------------------------------------------------------
+
+test "focusNext and focusPrev wrap around" {
+    const F = enum { a, b, c };
+    try testing.expectEqual(F.b, widgets.focusNext(F, .a));
+    try testing.expectEqual(F.a, widgets.focusNext(F, .c)); // wrap
+    try testing.expectEqual(F.c, widgets.focusPrev(F, .a)); // wrap
+    try testing.expectEqual(F.a, widgets.focusPrev(F, .b));
+}
+
+// ---- view: rendering onto a surface ---------------------------------------
+
+fn rowString(a: std.mem.Allocator, s: *ui.Surface, y: u16) ![]u8 {
+    var list = std.ArrayList(u8).empty;
+    var x: u16 = 0;
+    while (x < s.width) : (x += 1) {
+        const c = s.cell(x, y);
+        if (c.isContinuation()) continue;
+        if (c.text_len == 0) try list.append(a, ' ') else try list.appendSlice(a, s.cellText(c));
+    }
+    return list.items;
+}
+
+fn renderNode(a: std.mem.Allocator, n: ui.Node, s: *ui.Surface) !void {
+    const rctx = ui.RenderCtx{ .allocator = a };
+    try ui.render(&rctx, &n, s.root());
+}
+
+test "focused TextInput shows the caret as a reverse cell" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var buf: [16]u8 = undefined;
+    var ti = TextInput{ .buffer = &buf };
+    for ("hi") |c| _ = ti.handle(.{ .char = c }); // cursor at end (col 2)
+
+    var s = try ui.Surface.init(testing.allocator, 6, 1);
+    defer s.deinit();
+    try renderNode(a, try ti.view(a, .{ .focused = true }), &s);
+
+    try testing.expectEqualStrings("hi    ", try rowString(a, &s, 0));
+    try testing.expect(s.cell(2, 0).style.reverse); // caret rests past the text
+    try testing.expect(!s.cell(0, 0).style.reverse);
+}
+
+test "unfocused TextInput paints no caret" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var buf: [16]u8 = undefined;
+    var ti = TextInput{ .buffer = &buf };
+    for ("hi") |c| _ = ti.handle(.{ .char = c });
+
+    var s = try ui.Surface.init(testing.allocator, 6, 1);
+    defer s.deinit();
+    try renderNode(a, try ti.view(a, .{ .focused = false }), &s);
+    try testing.expect(!s.cell(2, 0).style.reverse);
+}
+
+test "masked TextInput renders the mask glyph, not the text" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var buf: [16]u8 = undefined;
+    var ti = TextInput{ .buffer = &buf, .mask = '*' };
+    for ("pw") |c| _ = ti.handle(.{ .char = c });
+
+    var s = try ui.Surface.init(testing.allocator, 6, 1);
+    defer s.deinit();
+    try renderNode(a, try ti.view(a, .{ .focused = true }), &s);
+    try testing.expectEqualStrings("**    ", try rowString(a, &s, 0));
+}
+
+test "empty TextInput shows its placeholder" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var buf: [16]u8 = undefined;
+    var ti = TextInput{ .buffer = &buf };
+
+    var s = try ui.Surface.init(testing.allocator, 8, 1);
+    defer s.deinit();
+    try renderNode(a, try ti.view(a, .{ .placeholder = "name" }), &s);
+    try testing.expectEqualStrings("name    ", try rowString(a, &s, 0));
+}
+
+test "Checkbox renders its box and label, checked and focused" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var cb = Checkbox{ .checked = true };
+    var s = try ui.Surface.init(testing.allocator, 12, 1);
+    defer s.deinit();
+    try renderNode(a, try cb.view(a, .{ .focused = true, .label = "on" }), &s);
+    try testing.expectEqualStrings("[x] on      ", try rowString(a, &s, 0));
+}

--- a/packages/ui/src/test.zig
+++ b/packages/ui/src/test.zig
@@ -6,6 +6,7 @@ test {
     _ = @import("diff.zig");
     _ = @import("layout_test.zig");
     _ = @import("widgets_test.zig");
+    _ = @import("input_test.zig");
     _ = @import("golden_test.zig");
     _ = @import("app_test.zig");
 }

--- a/packages/ui/src/ui.zig
+++ b/packages/ui/src/ui.zig
@@ -26,6 +26,9 @@ pub const Renderer = @import("diff.zig").Renderer;
 pub const App = @import("app.zig").App;
 /// Full-screen input event (`App.nextEvent`) — a key, resize, mouse, or focus.
 pub const Event = @import("app.zig").Event;
+/// A key press (`Event.key`), re-exported from `terminal` for widget `handle`
+/// signatures (`ui.widgets.TextInput.handle(key)`).
+pub const Key = terminal.Key;
 /// Mouse report / focus change carried by `Event` (full-screen, when enabled).
 pub const Mouse = terminal.Mouse;
 pub const Focus = terminal.Focus;

--- a/packages/ui/src/widgets.zig
+++ b/packages/ui/src/widgets.zig
@@ -167,3 +167,15 @@ pub fn multiBar(a: std.mem.Allocator, opts: MultiBarOpts, items: []const MultiBa
 
     return .{ .kind = .{ .box = .{ .dir = .column, .children = rows } } };
 }
+
+// ============================================================================
+// Focusable input widgets (ADR-0018)
+// ============================================================================
+
+// These live in `input.zig` (interactive widgets, a distinct concern from the
+// progress widgets above) but re-export here so the whole catalog is one
+// namespace: `ui.widgets.TextInput`, `ui.widgets.Checkbox`, `ui.widgets.focusNext`.
+pub const TextInput = @import("input.zig").TextInput;
+pub const Checkbox = @import("input.zig").Checkbox;
+pub const focusNext = @import("input.zig").focusNext;
+pub const focusPrev = @import("input.zig").focusPrev;


### PR DESCRIPTION
The first increment of the focusable widget library ADR-0013/0015 deferred: **the focus/routing model plus `TextInput` and `Checkbox`.** It settles the one hard question — how *stateful*, interactive widgets live on an engine that's deliberately immediate-mode (stateless nodes, caller-owned state, no framework loop).

## The contract
A widget is a plain struct the caller embeds in its own `State`, with two methods:
- `view(self, a, opts) !Node` — render from current state; `opts.focused` draws the caret/highlight. Immediate, returns a `Node` like any component.
- `handle(self, key) bool` — mutate on a key, returning whether **consumed**.

That bool is the whole routing model. A widget eats the keys it uses (a `TextInput` eats char/←/→/Backspace) and lets the rest bubble, so the loop gives the focused widget first crack and treats an *unconsumed* key as form-level navigation:

```zig
const consumed = switch (state.focus) {
    .user => state.user.handle(key),
    .pass => state.pass.handle(key),
    .remember => state.remember.handle(key),
};
if (consumed) return .keep;
switch (key) {
    .tab      => state.focus = ui.widgets.focusNext(Field, state.focus),
    .back_tab => state.focus = ui.widgets.focusPrev(Field, state.focus),
    .enter    => submit(state),
    .escape   => return .quit,
    else => {},
}
```

State stays caller-owned, rendering immediate, behavior a pure `handle` — **no retained widget tree, no IDs, no framework loop.** Focus is caller-owned (an enum); the library adds only `focusNext`/`focusPrev`.

**Rejected:** an ImGui-style ID store (retained context + IDs) and a retained widget tree that owns routing (a framework loop, against ADR-0015 §3).

## Notable decisions
- **`back_tab`** — `terminal`'s `Key` had no Shift-Tab, so a `.back_tab` variant (CSI `Z`) was added to the parser. The one change outside `packages/ui`; reverse focus is standard form UX.
- **Caret is a styled cell**, not the hardware cursor (which would need a widget to know its laid-out position — the same gap that blocks anchored popups).
- **Codepoint-granular editing** over a caller-provided buffer (allocation-free; capacity is the caller's).
- **Shared `PromptTheme`** with `prompts` — the parallel cooked-mode, line-oriented layer. Not merged or replaced.
- **Keyboard only**; click-to-focus deferred (needs hit-testing).

## Layout
Widgets live in `input.zig`, re-exported under `ui.widgets` alongside the progress widgets.

## Tests
- **`handle`** (pure, no terminal): insert at cursor, backspace/delete, ←/→/home/end, multibyte codepoints edited whole, buffer-full drops the keystroke, `consumed` correctness (Tab/Enter/Esc bubble), Checkbox toggles on Space but leaves Enter for the form, focus wrap.
- **`view`**: caret cell (focused vs not), mask glyph, placeholder, checkbox box+label — painted onto a surface.
- **Example**: `examples/form.zig` (two fields + a checkbox, Tab/Shift-Tab nav, submit) — **PTY-validated**: typed input captured, password masked and **never leaked to screen**, checkbox toggled, submit confirmed.

`zig build test` green across the whole workspace (the `terminal` change is dependent-safe), `zig fmt` clean.

## Next (same contract)
`Select` — a list rendered inside a `viewport` (ADR-0017), owning `highlighted` + `scroll` with scroll-into-view — then a `Button`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)