### PR TITLE
feat(ui): Select widget (ADR-0018 increment 2)

### DIFF
--- a/docs/adr/0018-focusable-widgets.md
+++ b/docs/adr/0018-focusable-widgets.md
@@ -3,8 +3,18 @@
 Status: accepted
 
 > Increment 1 of the widget library: the focus/routing model plus `TextInput`
-> and `Checkbox`. `Select` (a list over a `viewport`) and a `Button` are
-> follow-ups on the same contract.
+> and `Checkbox`. `Select` and a `Button` are follow-ups on the same contract.
+>
+> **Increment 2 (landed): `Select`.** A single-select scrollable list on the
+> same `view`/`handle`/`consumed` contract — it holds `highlighted` + a
+> persistent `scroll`, consumes ↑/↓/Home/End, and bubbles Enter/Tab/Esc (the
+> caller reads `options[select.highlighted]`). One refinement to the plan below:
+> `Select` **renders its own visible window directly rather than wrapping a
+> `viewport`.** It already computes which slice is visible (to place the
+> highlight and scroll it into view), so re-rendering every option into a
+> viewport's scratch surface would be wasted work; the `viewport` is the right
+> tool only once options become multi-line (deferred). Options are single-line;
+> overflow indicators (a dim ↑/↓) are the next small follow-up.
 
 ADR-0013/0015 named a focusable widget library as a clean deferral. This is the
 first increment, and it settles the one hard question: how do interactive,
@@ -84,6 +94,9 @@ identity — exactly what this avoids.
   cooked-mode, one-shot, line-oriented interactive layer; this widget library is
   its full-screen, persistent, node-tree counterpart. They are parallel and
   share the vocabulary — `prompts` is neither merged nor replaced.
-- **Next:** `Select` (a list rendered inside a `viewport`, ADR-0017 — it owns
-  `highlighted` + `scroll` and scrolls the selection into view) and a `Button`,
-  both on this same `view`/`handle`/`consumed` contract.
+- **Next:** a `Button` (fires on Enter/Space) on this same contract, plus small
+  polish on `Select` — overflow indicators (a dim ↑/↓) and multi-line options
+  (which would render through a `viewport`, ADR-0017). Still deferred across the
+  library: mouse click-to-focus and a hardware cursor, both of which need layout
+  to expose measured widget positions (the same feedback the anchored-popup
+  deferral waits on).

--- a/packages/ui/examples/form.zig
+++ b/packages/ui/examples/form.zig
@@ -1,6 +1,7 @@
-//! A focusable form (ADR-0018): two text fields and a checkbox, with Tab /
-//! Shift-Tab moving focus, Enter submitting, and Esc quitting. It shows the
-//! whole widget contract in one screen:
+//! A focusable form (ADR-0018): two text fields, a select, and a checkbox, with
+//! Tab / Shift-Tab moving focus, ↑/↓ picking within the select, Enter
+//! submitting, and Esc quitting. It shows the whole widget contract in one
+//! screen:
 //!
 //!   - each widget is a plain struct in `State` (immediate mode — no retained
 //!     widget tree);
@@ -20,7 +21,10 @@ const terminal = @import("terminal");
 
 pub const panic = ui.panic;
 
-const Field = enum { user, pass, remember };
+const Field = enum { user, pass, role, remember };
+
+const roles = [_][]const u8{ "admin", "developer", "viewer" };
+const role_rows: u16 = roles.len;
 
 const State = struct {
     user_buf: [48]u8 = undefined,
@@ -29,6 +33,7 @@ const State = struct {
     // final address (a self-referential struct can't do it in the initializer).
     user: ui.widgets.TextInput = .{ .buffer = &.{} },
     pass: ui.widgets.TextInput = .{ .buffer = &.{}, .mask = '*' },
+    role: ui.widgets.Select = .{},
     remember: ui.widgets.Checkbox = .{},
     focus: Field = .user,
     submitted: bool = false,
@@ -48,12 +53,13 @@ fn labeled(a: std.mem.Allocator, label: []const u8, field: ui.Node) !ui.Node {
 
 fn view(a: std.mem.Allocator, state: *State) !ui.Node {
     const status = if (state.submitted)
-        try std.fmt.allocPrint(a, "✓ signed in as \"{s}\"{s}", .{
+        try std.fmt.allocPrint(a, "✓ signed in as \"{s}\" ({s}){s}", .{
             state.user.value(),
-            if (state.remember.checked) " (remembered)" else "",
+            roles[state.role.highlighted],
+            if (state.remember.checked) " · remembered" else "",
         })
     else
-        "Tab / Shift-Tab move · Enter submit · Esc quit";
+        "Tab / Shift-Tab move · ↑/↓ pick role · Enter submit · Esc quit";
 
     const form = try ui.column(a, .{
         .border = .rounded,
@@ -70,6 +76,11 @@ fn view(a: std.mem.Allocator, state: *State) !ui.Node {
         try labeled(a, "Pass", try state.pass.view(a, .{
             .focused = state.focus == .pass,
             .placeholder = "password",
+        })),
+        try labeled(a, "Role", try state.role.view(a, .{
+            .focused = state.focus == .role,
+            .options = &roles,
+            .height = role_rows,
         })),
         try state.remember.view(a, .{
             .focused = state.focus == .remember,
@@ -93,6 +104,7 @@ fn update(state: *State, ev: ?ui.Event) !ui.Flow {
     const consumed = switch (state.focus) {
         .user => state.user.handle(key),
         .pass => state.pass.handle(key),
+        .role => state.role.handle(key, roles.len, role_rows),
         .remember => state.remember.handle(key),
     };
     if (consumed) {

--- a/packages/ui/src/input.zig
+++ b/packages/ui/src/input.zig
@@ -249,6 +249,91 @@ pub const Checkbox = struct {
 };
 
 // ============================================================================
+// Select
+// ============================================================================
+
+/// A single-select scrollable list. The options are caller-owned and passed in
+/// each frame (immediate mode); the widget holds only the cursor. ↑/↓/Home/End
+/// move the highlight and are consumed; Enter/Tab/Escape bubble to the form,
+/// which reads the choice as `options[select.highlighted]`. Options are
+/// single-line. The list scrolls to keep the highlight within `height` rows —
+/// `scroll` is persistent, so the window stays put and slides only when the
+/// highlight crosses an edge (a stable viewport, not a highlight glued to the
+/// fold). It renders its own window directly rather than wrapping a `viewport`:
+/// it already knows which slice is visible, so re-rendering every option into a
+/// scratch surface would be wasted work.
+pub const Select = struct {
+    highlighted: usize = 0,
+    /// First visible option — persistent, maintained by `handle`.
+    scroll: usize = 0,
+
+    pub const ViewOpts = struct {
+        focused: bool = false,
+        options: []const []const u8,
+        /// Visible rows; the list scrolls within this window.
+        height: u16 = 6,
+        theme: *const Theme = &default_theme,
+    };
+
+    /// Handle a key; returns whether it was consumed. `count` (the option count)
+    /// and `visible` (the window height) are what the caller passes to `view`,
+    /// so the highlight and scroll stay in step with what's rendered.
+    pub fn handle(self: *Select, key: Key, count: usize, visible: u16) bool {
+        if (count == 0) return false;
+        switch (key) {
+            .up => if (self.highlighted > 0) {
+                self.highlighted -= 1;
+            },
+            .down => if (self.highlighted + 1 < count) {
+                self.highlighted += 1;
+            },
+            .home => self.highlighted = 0,
+            .end => self.highlighted = count - 1,
+            else => return false,
+        }
+        self.scroll = scrollFor(self.scroll, self.highlighted, visible, count);
+        return true;
+    }
+
+    pub fn view(self: *const Select, a: std.mem.Allocator, opts: ViewOpts) !Node {
+        const th = opts.theme;
+        const count = opts.options.len;
+        if (count == 0) return .{ .kind = .{ .text = .{ .content = "", .wrap = .clip } } };
+
+        const hi = @min(self.highlighted, count - 1);
+        const visible = @min(@max(@as(usize, opts.height), 1), count);
+        // Persistent scroll, re-derived so the highlight is always in view even
+        // if the caller set `highlighted` directly, bypassing `handle`.
+        const scroll = scrollFor(self.scroll, hi, @intCast(visible), count);
+
+        const rows = try a.alloc(Node, visible);
+        for (rows, 0..) |*row_node, i| {
+            const idx = scroll + i;
+            const is_hi = idx == hi;
+            const marker: []const u8 = if (is_hi and opts.focused) "›" else " ";
+            const line = try std.fmt.allocPrint(a, "{s} {s}", .{ marker, opts.options[idx] });
+            const style: Style = if (is_hi)
+                (if (opts.focused) th.prompts.selected.resolve(th.palette) else th.prompts.hint.resolve(th.palette))
+            else
+                .{};
+            row_node.* = .{ .kind = .{ .text = .{ .content = line, .style = style, .wrap = .clip } } };
+        }
+        return .{ .kind = .{ .box = .{ .dir = .column, .children = rows } } };
+    }
+};
+
+/// Slide `scroll` the minimum needed to keep `hi` within a `visible`-row window
+/// over `count` items — the persistent-scroll rule shared by `handle` (to
+/// update state) and `view` (to correct it).
+fn scrollFor(scroll: usize, hi: usize, visible: u16, count: usize) usize {
+    const v = @max(@as(usize, visible), 1);
+    var s = @min(scroll, count -| v);
+    if (hi < s) s = hi;
+    if (hi >= s + v) s = hi - v + 1;
+    return s;
+}
+
+// ============================================================================
 // UTF-8 helpers (codepoint boundaries; editing is codepoint-granular)
 // ============================================================================
 

--- a/packages/ui/src/input_test.zig
+++ b/packages/ui/src/input_test.zig
@@ -8,6 +8,7 @@ const widgets = @import("widgets.zig");
 const testing = std.testing;
 const TextInput = widgets.TextInput;
 const Checkbox = widgets.Checkbox;
+const Select = widgets.Select;
 
 // ---- handle: TextInput editing --------------------------------------------
 
@@ -85,6 +86,44 @@ test "Checkbox toggles on space, leaves Enter for the form" {
     // Enter is not consumed — the form uses it to submit.
     try testing.expect(!cb.handle(.enter));
     try testing.expect(!cb.checked);
+}
+
+// ---- handle: Select --------------------------------------------------------
+
+test "Select moves the highlight and clamps at the ends" {
+    var sel = Select{};
+    const n = 5;
+    try testing.expect(sel.handle(.down, n, 3));
+    try testing.expectEqual(@as(usize, 1), sel.highlighted);
+    _ = sel.handle(.up, n, 3);
+    _ = sel.handle(.up, n, 3); // clamp at the top
+    try testing.expectEqual(@as(usize, 0), sel.highlighted);
+    _ = sel.handle(.end, n, 3);
+    try testing.expectEqual(@as(usize, 4), sel.highlighted);
+    _ = sel.handle(.down, n, 3); // clamp at the bottom
+    try testing.expectEqual(@as(usize, 4), sel.highlighted);
+    _ = sel.handle(.home, n, 3);
+    try testing.expectEqual(@as(usize, 0), sel.highlighted);
+}
+
+test "Select consumes navigation, bubbles Enter/Tab, ignores an empty list" {
+    var sel = Select{};
+    try testing.expect(sel.handle(.down, 3, 3));
+    try testing.expect(!sel.handle(.enter, 3, 3));
+    try testing.expect(!sel.handle(.tab, 3, 3));
+    try testing.expect(!sel.handle(.down, 0, 3)); // nothing to move
+}
+
+test "Select scrolls to keep the highlight in the window" {
+    var sel = Select{};
+    const n = 6;
+    const vis = 3;
+    for (0..4) |_| _ = sel.handle(.down, n, vis); // highlight 4
+    try testing.expectEqual(@as(usize, 4), sel.highlighted);
+    try testing.expectEqual(@as(usize, 2), sel.scroll); // window [2,5) shows it
+    for (0..3) |_| _ = sel.handle(.up, n, vis); // back to 1
+    try testing.expectEqual(@as(usize, 1), sel.highlighted);
+    try testing.expectEqual(@as(usize, 1), sel.scroll); // window slid up to [1,4)
 }
 
 // ---- focus helpers ---------------------------------------------------------
@@ -187,4 +226,59 @@ test "Checkbox renders its box and label, checked and focused" {
     defer s.deinit();
     try renderNode(a, try cb.view(a, .{ .focused = true, .label = "on" }), &s);
     try testing.expectEqualStrings("[x] on      ", try rowString(a, &s, 0));
+}
+
+const menu_options = [_][]const u8{ "alpha", "bravo", "charlie", "delta", "echo" };
+
+test "focused Select marks and styles the highlighted row" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var sel = Select{};
+    _ = sel.handle(.down, menu_options.len, 3); // highlight 1 (bravo)
+
+    var s = try ui.Surface.init(testing.allocator, 10, 3);
+    defer s.deinit();
+    try renderNode(a, try sel.view(a, .{ .focused = true, .options = &menu_options, .height = 3 }), &s);
+
+    // Window [0,3): the highlight wears the cursor marker; the others don't.
+    try testing.expectEqualStrings("  alpha   ", try rowString(a, &s, 0));
+    try testing.expectEqualStrings("› bravo   ", try rowString(a, &s, 1));
+    try testing.expectEqualStrings("  charlie ", try rowString(a, &s, 2));
+    // The highlighted row is styled (selected token); the others are plain.
+    try testing.expect(!ui.styleEql(s.cell(0, 1).style, .{}));
+    try testing.expect(ui.styleEql(s.cell(0, 0).style, .{}));
+}
+
+test "unfocused Select drops the cursor marker" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var sel = Select{};
+    _ = sel.handle(.down, menu_options.len, 3);
+
+    var s = try ui.Surface.init(testing.allocator, 10, 3);
+    defer s.deinit();
+    try renderNode(a, try sel.view(a, .{ .focused = false, .options = &menu_options, .height = 3 }), &s);
+    try testing.expectEqualStrings("  bravo   ", try rowString(a, &s, 1));
+}
+
+test "Select view slides the window to the highlight" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var sel = Select{};
+    for (0..4) |_| _ = sel.handle(.down, menu_options.len, 3); // highlight 4 (echo)
+
+    var s = try ui.Surface.init(testing.allocator, 10, 3);
+    defer s.deinit();
+    try renderNode(a, try sel.view(a, .{ .focused = true, .options = &menu_options, .height = 3 }), &s);
+
+    // Window slid to [2,5): charlie, delta, echo (highlighted).
+    try testing.expectEqualStrings("  charlie ", try rowString(a, &s, 0));
+    try testing.expectEqualStrings("  delta   ", try rowString(a, &s, 1));
+    try testing.expectEqualStrings("› echo    ", try rowString(a, &s, 2));
 }

--- a/packages/ui/src/widgets.zig
+++ b/packages/ui/src/widgets.zig
@@ -177,5 +177,6 @@ pub fn multiBar(a: std.mem.Allocator, opts: MultiBarOpts, items: []const MultiBa
 // namespace: `ui.widgets.TextInput`, `ui.widgets.Checkbox`, `ui.widgets.focusNext`.
 pub const TextInput = @import("input.zig").TextInput;
 pub const Checkbox = @import("input.zig").Checkbox;
+pub const Select = @import("input.zig").Select;
 pub const focusNext = @import("input.zig").focusNext;
 pub const focusPrev = @import("input.zig").focusPrev;


### PR DESCRIPTION
Increment 2 of the focusable widget library (after #189): **`Select`**, a single-select scrollable list on the same `view` / `handle(consumed:bool)` contract as `TextInput`/`Checkbox`.

## Behaviour
- Holds `highlighted` + a persistent `scroll`; consumes ↑/↓/Home/End, **bubbles Enter/Tab/Esc** (a `Select` is a highlighter — the caller reads `options[select.highlighted]` and decides what Enter means).
- Options are caller-owned, passed to `view`/`handle` each frame (immediate mode); the widget holds only the cursor.
- **Persistent scroll** keeps a stable window that slides only when the highlight crosses an edge — `handle` maintains it, `view` re-derives defensively so a directly-set `highlighted` still renders in view.

## One refinement to the plan
`Select` **renders its own visible window directly rather than wrapping a `viewport`.** It already computes which slice is visible (to place the highlight and scroll it in), so re-rendering *every* option into a viewport's scratch surface would be wasted work. The `viewport` (ADR-0017) is the right tool only once options become multi-line — deferred. Single-line options; overflow indicators (a dim ↑/↓) are the next small follow-up. ADR-0018 updated to record this.

## API
```zig
pub const Select = struct {
    highlighted: usize = 0,
    scroll: usize = 0,
    pub const ViewOpts = struct {
        focused: bool = false,
        options: []const []const u8,
        height: u16 = 6,              // visible rows; the list scrolls within this
        theme: *const Theme = &default_theme,
    };
    pub fn handle(self: *Select, key: Key, count: usize, visible: u16) bool;  // ↑/↓/Home/End
    pub fn view(self: *const Select, a: Allocator, opts: ViewOpts) !Node;
};
```
Styling flows through `PromptTheme` (`selected` for the focused highlight, `hint` when unfocused, a `›` cursor marker) — same tokens as `prompts`.

## Tests
- **`handle`:** move + clamp at the ends, Home/End, scroll-into-view across an edge, `consumed` correctness (Enter/Tab bubble, empty list ignored).
- **`view`:** the highlighted row is marked + styled; the window slides to keep a mid/end highlight visible; unfocused drops the marker.
- **Example:** `examples/form.zig` gains a "Role" `Select` in the Tab rotation — **PTY-validated** (↓↓ picks "viewer", the submit line shows `signed in as "alice" (viewer) · remembered`).

`zig build test` green, `zig fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)