### PR TITLE
feat(ui): Button widget (ADR-0018 increment 3)

### DIFF
--- a/docs/adr/0018-focusable-widgets.md
+++ b/docs/adr/0018-focusable-widgets.md
@@ -15,6 +15,15 @@ Status: accepted
 > viewport's scratch surface would be wasted work; the `viewport` is the right
 > tool only once options become multi-line (deferred). Options are single-line;
 > overflow indicators (a dim ↑/↓) are the next small follow-up.
+>
+> **Increment 3 (landed): `Button`.** A stateless action control (`[ Label ]`)
+> activated by Enter/Space. Being stateless (a terminal has no key-up, so no
+> "pressed" phase), its `handle` returns whether the key *activated* it — the
+> same routing role as the editors' `consumed` (`true` = "this key is mine, not
+> navigation"), but for an action widget "mine" means "fired." The caller runs
+> the action on a `true` return in its focus arm. This is why a `Button` can't
+> share the editors' routing arm in the form example: an editor's consumed key
+> *invalidates* a prior submit, whereas the button's *is* the submit.
 
 ADR-0013/0015 named a focusable widget library as a clean deferral. This is the
 first increment, and it settles the one hard question: how do interactive,
@@ -94,9 +103,9 @@ identity — exactly what this avoids.
   cooked-mode, one-shot, line-oriented interactive layer; this widget library is
   its full-screen, persistent, node-tree counterpart. They are parallel and
   share the vocabulary — `prompts` is neither merged nor replaced.
-- **Next:** a `Button` (fires on Enter/Space) on this same contract, plus small
-  polish on `Select` — overflow indicators (a dim ↑/↓) and multi-line options
-  (which would render through a `viewport`, ADR-0017). Still deferred across the
-  library: mouse click-to-focus and a hardware cursor, both of which need layout
-  to expose measured widget positions (the same feedback the anchored-popup
-  deferral waits on).
+- **Next:** small polish on `Select` — overflow indicators (a dim ↑/↓) and
+  multi-line options (which would render through a `viewport`, ADR-0017). With
+  `TextInput`/`Checkbox`/`Select`/`Button` landed, the widget catalog covers the
+  common form controls. Still deferred across the library: mouse click-to-focus
+  and a hardware cursor, both of which need layout to expose measured widget
+  positions (the same feedback the anchored-popup deferral waits on).

--- a/packages/ui/examples/form.zig
+++ b/packages/ui/examples/form.zig
@@ -1,7 +1,7 @@
-//! A focusable form (ADR-0018): two text fields, a select, and a checkbox, with
-//! Tab / Shift-Tab moving focus, ↑/↓ picking within the select, Enter
-//! submitting, and Esc quitting. It shows the whole widget contract in one
-//! screen:
+//! A focusable form (ADR-0018): two text fields, a select, a checkbox, and a
+//! submit button, with Tab / Shift-Tab moving focus, ↑/↓ picking within the
+//! select, Enter/Space firing the focused button, Enter submitting, and Esc
+//! quitting. It shows the whole widget contract in one screen:
 //!
 //!   - each widget is a plain struct in `State` (immediate mode — no retained
 //!     widget tree);
@@ -21,7 +21,7 @@ const terminal = @import("terminal");
 
 pub const panic = ui.panic;
 
-const Field = enum { user, pass, role, remember };
+const Field = enum { user, pass, role, remember, submit };
 
 const roles = [_][]const u8{ "admin", "developer", "viewer" };
 const role_rows: u16 = roles.len;
@@ -35,6 +35,7 @@ const State = struct {
     pass: ui.widgets.TextInput = .{ .buffer = &.{}, .mask = '*' },
     role: ui.widgets.Select = .{},
     remember: ui.widgets.Checkbox = .{},
+    submit: ui.widgets.Button = .{},
     focus: Field = .user,
     submitted: bool = false,
 
@@ -86,11 +87,21 @@ fn view(a: std.mem.Allocator, state: *State) !ui.Node {
             .focused = state.focus == .remember,
             .label = "Remember me",
         }),
+        try state.submit.view(a, .{
+            .focused = state.focus == .submit,
+            .label = "Sign in",
+        }),
         ui.text(.{ .dim = !state.submitted }, status),
     });
 
     // Center the form on the otherwise-blank alt-screen.
     return ui.center(a, form);
+}
+
+/// An editing widget consumed the key: a prior submit is now stale.
+fn edited(state: *State) ui.Flow {
+    state.submitted = false;
+    return .keep;
 }
 
 fn update(state: *State, ev: ?ui.Event) !ui.Flow {
@@ -100,16 +111,18 @@ fn update(state: *State, ev: ?ui.Event) !ui.Flow {
         else => return .keep,
     };
 
-    // The focused widget gets first crack; an unconsumed key is navigation.
-    const consumed = switch (state.focus) {
-        .user => state.user.handle(key),
-        .pass => state.pass.handle(key),
-        .role => state.role.handle(key, roles.len, role_rows),
-        .remember => state.remember.handle(key),
-    };
-    if (consumed) {
-        state.submitted = false; // editing invalidates a prior submit
-        return .keep;
+    // The focused widget gets first crack; an unconsumed key falls through to
+    // navigation. Editing invalidates a prior submit; the Button *is* the submit
+    // (Enter/Space on it fires), which is why it can't share the editors' arm.
+    switch (state.focus) {
+        .user => if (state.user.handle(key)) return edited(state),
+        .pass => if (state.pass.handle(key)) return edited(state),
+        .role => if (state.role.handle(key, roles.len, role_rows)) return edited(state),
+        .remember => if (state.remember.handle(key)) return edited(state),
+        .submit => if (state.submit.handle(key)) {
+            state.submitted = true;
+            return .keep;
+        },
     }
 
     switch (key) {

--- a/packages/ui/src/input.zig
+++ b/packages/ui/src/input.zig
@@ -334,6 +334,41 @@ fn scrollFor(scroll: usize, hi: usize, visible: u16, count: usize) usize {
 }
 
 // ============================================================================
+// Button
+// ============================================================================
+
+/// A stateless action control: `[ Label ]`, activated by Enter or Space. It
+/// holds no state (a terminal has no key-up, so there is no "pressed" phase),
+/// so `handle` returns whether the key *activated* it — the same routing role
+/// as the editors' `consumed` (`true` = "this key is mine, not navigation"), but
+/// for an action widget "mine" means "fired." The caller runs the action on a
+/// `true` return in its focus arm; unconsumed keys (Tab/arrows) bubble on.
+pub const Button = struct {
+    pub const ViewOpts = struct {
+        focused: bool = false,
+        label: []const u8 = "",
+        theme: *const Theme = &default_theme,
+    };
+
+    pub fn handle(self: *Button, key: Key) bool {
+        _ = self;
+        return switch (key) {
+            .enter => true,
+            .char => |c| c == ' ',
+            else => false,
+        };
+    }
+
+    pub fn view(self: *const Button, a: std.mem.Allocator, opts: ViewOpts) !Node {
+        _ = self;
+        const th = opts.theme;
+        const label = try std.fmt.allocPrint(a, "[ {s} ]", .{opts.label});
+        const style: Style = if (opts.focused) th.prompts.selected.resolve(th.palette) else .{};
+        return .{ .kind = .{ .text = .{ .content = label, .style = style, .wrap = .clip } } };
+    }
+};
+
+// ============================================================================
 // UTF-8 helpers (codepoint boundaries; editing is codepoint-granular)
 // ============================================================================
 

--- a/packages/ui/src/input_test.zig
+++ b/packages/ui/src/input_test.zig
@@ -9,6 +9,7 @@ const testing = std.testing;
 const TextInput = widgets.TextInput;
 const Checkbox = widgets.Checkbox;
 const Select = widgets.Select;
+const Button = widgets.Button;
 
 // ---- handle: TextInput editing --------------------------------------------
 
@@ -124,6 +125,18 @@ test "Select scrolls to keep the highlight in the window" {
     for (0..3) |_| _ = sel.handle(.up, n, vis); // back to 1
     try testing.expectEqual(@as(usize, 1), sel.highlighted);
     try testing.expectEqual(@as(usize, 1), sel.scroll); // window slid up to [1,4)
+}
+
+// ---- handle: Button --------------------------------------------------------
+
+test "Button activates on Enter and Space, ignores other keys" {
+    var b = Button{};
+    try testing.expect(b.handle(.enter));
+    try testing.expect(b.handle(.{ .char = ' ' }));
+    // A non-activating key bubbles (so Tab still navigates off the button).
+    try testing.expect(!b.handle(.tab));
+    try testing.expect(!b.handle(.{ .char = 'x' }));
+    try testing.expect(!b.handle(.left));
 }
 
 // ---- focus helpers ---------------------------------------------------------
@@ -281,4 +294,21 @@ test "Select view slides the window to the highlight" {
     try testing.expectEqualStrings("  charlie ", try rowString(a, &s, 0));
     try testing.expectEqualStrings("  delta   ", try rowString(a, &s, 1));
     try testing.expectEqualStrings("› echo    ", try rowString(a, &s, 2));
+}
+
+test "Button renders its label and styles the focused state" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var b = Button{};
+    var s = try ui.Surface.init(testing.allocator, 12, 1);
+    defer s.deinit();
+    try renderNode(a, try b.view(a, .{ .focused = true, .label = "OK" }), &s);
+    try testing.expectEqualStrings("[ OK ]      ", try rowString(a, &s, 0));
+    try testing.expect(!ui.styleEql(s.cell(0, 0).style, .{})); // focused → styled
+
+    s.clear();
+    try renderNode(a, try b.view(a, .{ .focused = false, .label = "OK" }), &s);
+    try testing.expect(ui.styleEql(s.cell(0, 0).style, .{})); // unfocused → plain
 }

--- a/packages/ui/src/widgets.zig
+++ b/packages/ui/src/widgets.zig
@@ -178,5 +178,6 @@ pub fn multiBar(a: std.mem.Allocator, opts: MultiBarOpts, items: []const MultiBa
 pub const TextInput = @import("input.zig").TextInput;
 pub const Checkbox = @import("input.zig").Checkbox;
 pub const Select = @import("input.zig").Select;
+pub const Button = @import("input.zig").Button;
 pub const focusNext = @import("input.zig").focusNext;
 pub const focusPrev = @import("input.zig").focusPrev;


### PR DESCRIPTION
Increment 3 of the focusable widget library (after #189, #190): **`Button`**, a stateless action control on the same `view`/`handle` contract.

## The one decision — what `handle` returns for a stateless widget
`Button` has no state to read, so activation must be signalled. `handle(key) bool` returns whether the key **activated** it (Enter/Space) — the same routing role as the editors' `consumed` (`true` = "this key is mine, don't navigate"), but for an action widget "mine" means "fired." The caller runs the action on a `true` return in its focus arm; unconsumed keys (Tab/arrows) bubble to navigation.

`Button` is stateless (`struct {}`) — a terminal has no key-up, so there's no "pressed" phase. Styling reuses `PromptTheme.selected` for the focused state, like `Checkbox`.

## API
```zig
pub const Button = struct {
    pub const ViewOpts = struct {
        focused: bool = false,
        label: []const u8 = "",
        theme: *const Theme = &default_theme,
    };
    pub fn handle(self: *Button, key: Key) bool;   // true = activated (Enter/Space)
    pub fn view(self: *const Button, a: Allocator, opts: ViewOpts) !Node;  // [ Label ]
};
```

## Tests
- **`handle`:** activates on Enter and Space, bubbles everything else (so Tab still navigates off the button).
- **`view`:** renders `[ Label ]`; focused → styled, unfocused → plain.
- **Example:** `examples/form.zig` gains a "Sign in" submit button in the Tab rotation — **PTY-validated** (Space on the focused button submits). It also surfaces why a `Button` can't share the editors' routing arm: an editor's consumed key *invalidates* a prior submit, whereas the button's *is* the submit.

## Catalog status
With `TextInput`/`Checkbox`/`Select`/`Button` landed, the widget catalog covers the common form controls. Remaining ADR-0018 deferrals — `Select` overflow indicators / multi-line options, and library-wide mouse click-to-focus + hardware cursor — all wait on layout exposing measured widget positions (the same feedback the anchored-popup deferral needs).

`zig build test` green, `zig fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)