### PR TITLE
feat(ui): probe — position feedback + click-to-focus (ADR-0019)

### DIFF
--- a/docs/adr/0019-position-feedback.md
+++ b/docs/adr/0019-position-feedback.md
@@ -1,0 +1,76 @@
+# Position feedback: recovering where a node rendered, immediate-mode
+
+Status: accepted
+
+> Increment 1: the `ui.probe` primitive plus its first consumer, mouse
+> click-to-focus in the form example. The hardware cursor and anchored popups —
+> the other two features this unblocks — are follow-ups on the same primitive.
+
+The layout engine (ADR-0013) is immediate-mode: `view(state)` builds a fresh,
+anonymous node tree every frame; `measure`+`render` lay it out and paint it; the
+tree is discarded. Nothing persists to tell the caller *where a widget ended up
+on screen*. Three deferred features all need exactly that:
+
+- **mouse click-to-focus** — map a click at (x, y) to the widget under it,
+- **hardware cursor** — place the real terminal cursor at a focused field's caret,
+- **anchored popups** — pin a dropdown under the widget it belongs to.
+
+Each needs the rect a given node occupied after layout — the one thing the
+immediate-mode tree throws away.
+
+## Decision: a `probe` wrapper that reports its child's rendered rect
+
+`ui.probe(a, out: *Rect, child) !Node` wraps a node, lays it out and paints it
+exactly as if the wrapper weren't there, and as a side effect writes the child's
+absolute rendered rect into `out`:
+
+```zig
+try ui.probe(a, &state.rects[i], try widget.view(a, .{ ... }))
+```
+
+A `custom` leaf's `renderFn` already receives its **absolute** `Region.rect`
+(surface coordinates, which in full-screen *are* screen coordinates — the surface
+fills the viewport from the origin). So the wrapper is tiny: write `out.* =
+region.rect`, then render the child into that same region. It copies the child's
+sizing fields so the parent measures and places it identically — a rect report,
+never a layout change.
+
+Because `view` runs *inside* `frame`, before the next event is read, `out`
+reflects the **current** frame — a click is hit-tested against the very layout it
+is reacting to, not a frame behind.
+
+### Why the wrapper over the alternatives
+
+- **A `rect_out` field on every `Node`** — one line in `render()`, but adds a
+  field to `Node` and threads it through every builder's opts. A large surface
+  for a feature only a few nodes use.
+- **An id → rect map collected during render (the Dear ImGui approach)** — scales
+  to thousands of hit-tested items, but needs node identity and a retained map.
+  Overkill for a handful of form widgets.
+- **The wrapper** — **zero changes to `Node`, the builders, or the widgets.**
+  Purely additive (one function), and it composes: wrap anything whose position
+  you want. Its one limit is that probing *N* nodes wraps *N* times; if we ever
+  hit-test a large grid, that's when the id-map earns its keep. For forms, wrap.
+
+## Consequences
+
+- **First consumer — click-to-focus.** The form example wraps each field in a
+  `probe`, stores the rects, and on a left-click hit-tests the point against them
+  to set focus. Pure caller logic on top of the primitive — no widget change. It
+  needs the App's `mouse` mode on (the events were already parsed; ADR-0015).
+- **`out` is written only when the child paints.** A child clipped to zero size
+  never runs its `renderFn`, so `out` keeps its previous value — zero-init or
+  reset it if "not visible this frame" must be distinguishable.
+- **Full-screen is where this is meaningful.** In hybrid, the live region floats
+  in scrollback, so the surface rect isn't a stable screen coordinate; the
+  consumers (mouse, cursor, popups) are full-screen features anyway.
+- **The two deferred consumers ride the same primitive.** *Hardware cursor* needs
+  a `TextInput`-specific caret point (a `cursor_out` in its `ViewOpts`, since the
+  caret is internal) plus App plumbing — a full-screen `showCursorAt` that
+  survives the diff renderer's park-at-origin contract. *Anchored popups* probe
+  the anchor's rect, then render a popup in a `stack` (ADR-0016) positioned there
+  with len-spacers. Both are follow-ups; neither needs a core change.
+- **No renderer or measure change.** `probe` is a `custom` leaf like `viewport`
+  and the widgets — the position feedback is a side effect of the normal render
+  pass, tested headlessly (the rect is deterministic) with the live click path
+  PTY-validated.

--- a/packages/ui/examples/form.zig
+++ b/packages/ui/examples/form.zig
@@ -1,8 +1,8 @@
 //! A focusable form (ADR-0018): two text fields, a select, a checkbox, and a
-//! submit button, with Tab / Shift-Tab (and Enter) moving focus, ↑/↓ picking
-//! within the select, Space toggling the checkbox, the button signing in on
-//! Enter/Space, and Esc quitting. It shows the whole widget contract in one
-//! screen:
+//! submit button, with Tab / Shift-Tab (and Enter) moving focus, a mouse click
+//! focusing a field (ADR-0019), ↑/↓ picking within the select, Space toggling
+//! the checkbox, the button signing in on Enter/Space, and Esc quitting. It
+//! shows the whole widget contract in one screen:
 //!
 //!   - each widget is a plain struct in `State` (immediate mode — no retained
 //!     widget tree);
@@ -23,6 +23,7 @@ const terminal = @import("terminal");
 pub const panic = ui.panic;
 
 const Field = enum { user, pass, role, remember, submit };
+const field_count = @typeInfo(Field).@"enum".fields.len;
 
 const roles = [_][]const u8{ "admin", "developer", "viewer", "auditor", "billing", "support" };
 // Fewer visible rows than roles, so the select scrolls and shows its ↑/↓ gutter.
@@ -40,10 +41,18 @@ const State = struct {
     submit: ui.widgets.Button = .{},
     focus: Field = .user,
     submitted: bool = false,
+    // Where each field last rendered — filled by `ui.probe` in `view`, read by
+    // `update` to map a mouse click to a field (ADR-0019). Click-to-focus needs
+    // nothing more than these rects.
+    rects: [field_count]ui.Rect = [_]ui.Rect{.{ .x = 0, .y = 0, .w = 0, .h = 0 }} ** field_count,
 
     fn wire(self: *State) void {
         self.user.buffer = &self.user_buf;
         self.pass.buffer = &self.pass_buf;
+    }
+
+    fn rect(self: *State, f: Field) *ui.Rect {
+        return &self.rects[@intFromEnum(f)];
     }
 };
 
@@ -62,7 +71,7 @@ fn view(a: std.mem.Allocator, state: *State) !ui.Node {
             if (state.remember.checked) " · remembered" else "",
         })
     else
-        "Tab/Enter next · Shift-Tab back · ↑/↓ pick role · Space toggles · Esc quit";
+        "Tab/Enter next · click a field · ↑/↓ pick role · Space toggles · Esc quit";
 
     const form = try ui.column(a, .{
         .border = .rounded,
@@ -72,27 +81,29 @@ fn view(a: std.mem.Allocator, state: *State) !ui.Node {
         .width = .{ .len = 46 },
     }, &.{
         ui.text(.{ .bold = true }, "Sign in"),
-        try labeled(a, "User", try state.user.view(a, .{
+        // Each field is wrapped in `ui.probe` so its on-screen rect lands in
+        // `state.rects` — that's all click-to-focus needs.
+        try ui.probe(a, state.rect(.user), try labeled(a, "User", try state.user.view(a, .{
             .focused = state.focus == .user,
             .placeholder = "username",
-        })),
-        try labeled(a, "Pass", try state.pass.view(a, .{
+        }))),
+        try ui.probe(a, state.rect(.pass), try labeled(a, "Pass", try state.pass.view(a, .{
             .focused = state.focus == .pass,
             .placeholder = "password",
-        })),
-        try labeled(a, "Role", try state.role.view(a, .{
+        }))),
+        try ui.probe(a, state.rect(.role), try labeled(a, "Role", try state.role.view(a, .{
             .focused = state.focus == .role,
             .options = &roles,
             .height = role_rows,
-        })),
-        try state.remember.view(a, .{
+        }))),
+        try ui.probe(a, state.rect(.remember), try state.remember.view(a, .{
             .focused = state.focus == .remember,
             .label = "Remember me",
-        }),
-        try state.submit.view(a, .{
+        })),
+        try ui.probe(a, state.rect(.submit), try state.submit.view(a, .{
             .focused = state.focus == .submit,
             .label = "Sign in",
-        }),
+        })),
         ui.text(.{ .dim = !state.submitted }, status),
     });
 
@@ -108,6 +119,24 @@ fn edited(state: *State) ui.Flow {
 
 fn update(state: *State, ev: ?ui.Event) !ui.Flow {
     const e = ev orelse return .keep;
+
+    // Click-to-focus (ADR-0019): map a left-click to the field whose probed rect
+    // contains it. Mouse coords are 1-based; the surface is 0-based.
+    if (e == .mouse) {
+        const m = e.mouse;
+        if (m.button == .left and m.action == .press) {
+            const px = m.x -| 1;
+            const py = m.y -| 1;
+            for (state.rects, 0..) |r, i| {
+                if (px >= r.x and px < r.x + r.w and py >= r.y and py < r.y + r.h) {
+                    state.focus = @enumFromInt(i);
+                    break;
+                }
+            }
+        }
+        return .keep;
+    }
+
     const key = switch (e) {
         .key => |k| k,
         else => return .keep,
@@ -160,6 +189,7 @@ pub fn main(init: std.process.Init) !void {
     var app = try ui.App.initFullScreen(gpa, &stdout.interface, .{
         .capability = .ansi_256,
         .stdin = &stdin.interface,
+        .mouse = true, // click-to-focus (ADR-0019)
     });
     defer app.deinit();
 

--- a/packages/ui/src/layout_test.zig
+++ b/packages/ui/src/layout_test.zig
@@ -443,3 +443,52 @@ test "viewport shorter than its window leaves trailing rows untouched" {
     try testing.expectEqualStrings("    ", try rowString(&h, &s, 2)); // no content, untouched
     try testing.expectEqualStrings("ZZ  ", try rowString(&h, &s, 3)); // shows through
 }
+
+// ============================================================================
+// probe (position feedback, ADR-0019)
+// ============================================================================
+
+test "probe reports its child's absolute rendered rect" {
+    var h = Harness.init();
+    defer h.deinit();
+    var s = try ui.Surface.init(testing.allocator, 12, 5);
+    defer s.deinit();
+
+    var rect: ui.Rect = undefined;
+    // Padding offsets the child; the probe must report the absolute rect.
+    const node = try ui.column(h.a(), .{ .padding = .{ .top = 1, .left = 2 } }, &.{
+        try ui.probe(h.a(), &rect, ui.textOpts(
+            .{ .wrap = .clip, .width = .{ .len = 4 }, .height = .{ .len = 1 } },
+            "abcd",
+        )),
+    });
+    try renderInto(&h, node, &s);
+
+    try testing.expectEqual(ui.Rect{ .x = 2, .y = 1, .w = 4, .h = 1 }, rect);
+    // ...and the child still painted where the rect says.
+    try testing.expectEqualStrings("abcd", (try rowString(&h, &s, 1))[2..6]);
+}
+
+test "probe is layout-transparent" {
+    var h = Harness.init();
+    defer h.deinit();
+    var with = try ui.Surface.init(testing.allocator, 10, 2);
+    defer with.deinit();
+    var without = try ui.Surface.init(testing.allocator, 10, 2);
+    defer without.deinit();
+
+    var rect: ui.Rect = undefined;
+    const plain = try ui.row(h.a(), .{ .gap = 1 }, &.{ ui.text(.{}, "hi"), ui.text(.{}, "yo") });
+    const probed = try ui.row(h.a(), .{ .gap = 1 }, &.{ ui.text(.{}, "hi"), try ui.probe(h.a(), &rect, ui.text(.{}, "yo")) });
+
+    try renderInto(&h, plain, &without);
+    try renderInto(&h, probed, &with);
+
+    // The frame renders cell-for-cell identically whether or not the probe is there.
+    var y: u16 = 0;
+    while (y < 2) : (y += 1) {
+        try testing.expectEqualStrings(try rowString(&h, &without, y), try rowString(&h, &with, y));
+    }
+    // The wrapped child sits after "hi" + gap: absolute x = 3.
+    try testing.expectEqual(@as(u16, 3), rect.x);
+}

--- a/packages/ui/src/ui.zig
+++ b/packages/ui/src/ui.zig
@@ -151,6 +151,56 @@ pub fn spacer() Node {
     return .{ .kind = .spacer };
 }
 
+/// Report where `child` lands on screen (ADR-0019). A layout-transparent
+/// wrapper: it lays out and paints `child` exactly as if it weren't here, and as
+/// a side effect writes the child's absolute rendered rect into `out`. Because
+/// `view` runs inside `frame` before the next event, `out` reflects the current
+/// frame — a click can be hit-tested against the very layout it's reacting to.
+///
+/// The rect is in surface coordinates, which in full-screen ARE screen
+/// coordinates (the surface fills the viewport from the origin). This is the
+/// position feedback the immediate-mode tree otherwise discards — the basis for
+/// mouse hit-testing, a hardware cursor, and anchored popups.
+///
+/// `out` is only written when `child` actually paints; a child clipped to zero
+/// size leaves it untouched (so zero-init or reset it if that matters).
+pub fn probe(a: std.mem.Allocator, out: *Rect, child: Node) !Node {
+    const ctx = try a.create(Probe);
+    ctx.* = .{ .child = child, .out = out };
+    // Copy the child's sizing so the parent measures/places the wrapper exactly
+    // as it would the child — the wrapper adds a rect report, never a layout.
+    return .{
+        .width = child.width,
+        .height = child.height,
+        .align_self = child.align_self,
+        .min_width = child.min_width,
+        .max_width = child.max_width,
+        .min_height = child.min_height,
+        .max_height = child.max_height,
+        .kind = .{ .custom = .{
+            .context = ctx,
+            .measureFn = Probe.measureFn,
+            .renderFn = Probe.renderFn,
+        } },
+    };
+}
+
+const Probe = struct {
+    child: Node,
+    out: *Rect,
+
+    fn measureFn(context: *anyopaque, rctx: *const RenderCtx, limits: Limits) Size {
+        const self: *const Probe = @ptrCast(@alignCast(context));
+        return measure(rctx, &self.child, limits);
+    }
+
+    fn renderFn(context: *anyopaque, rctx: *const RenderCtx, region: Region) anyerror!void {
+        const self: *const Probe = @ptrCast(@alignCast(context));
+        self.out.* = region.rect;
+        try render(rctx, &self.child, region);
+    }
+};
+
 /// Center `child` within the region its parent grants — spacer scaffolding for
 /// placing an overlay layer in the middle of a `stack` (a modal, a dialog).
 /// `child` sizes to its content; the surrounding scaffold is style-less, hence


### PR DESCRIPTION
The layout engine is immediate-mode — it discards *where each widget rendered*. Three deferred features all need that geometry back: **mouse click-to-focus**, a **hardware cursor**, and **anchored popups**. This adds the primitive that recovers it, plus the first consumer.

## `ui.probe(a, out: *Rect, child) !Node`
A layout-transparent wrapper: it lays out and paints `child` exactly as if it weren't there, and as a side effect writes the child's **absolute** rendered rect into `out`.

```zig
try ui.probe(a, &state.rects[i], try widget.view(a, .{ ... }))
```

A `custom` leaf's `renderFn` already receives its absolute `Region.rect` (surface coords, which in full-screen *are* screen coords), so the wrapper just writes `out.* = region.rect` and renders the child. Because `view` runs inside `frame` before the next event, `out` reflects the **current** frame — a click is hit-tested against the very layout it's reacting to.

## Why the wrapper (Decision 1)
- **A `rect_out` field on every `Node`** — one line in `render()`, but adds a field to `Node` + threads through every builder's opts. Large surface for a rare need.
- **An id→rect map (the ImGui approach)** — scales to thousands of hit-tested items, but needs node identity + a retained map. Overkill for a few form widgets.
- **The wrapper** — **zero changes to `Node`, the builders, or the widgets.** Purely additive, and it composes. (If we ever hit-test a large grid, that's when the id-map earns its keep.)

## First consumer: click-to-focus
The form example wraps each field in a `probe`, stores the rects, and on a left-click hit-tests the point to set focus (App `mouse` mode enabled). Pure caller logic on top of the primitive — no widget change.

## Tests
- **Layout:** `probe` reports a child's absolute rect (offset by padding), and is **layout-transparent** (the frame renders cell-for-cell identically with/without it).
- **Example:** click-to-focus in `form.zig` — **PTY-validated**: clicking the role select focuses it (a subsequent `↓` advances the submitted role admin→developer, which only happens if the click landed focus there).

## Deferred (same primitive)
- **Hardware cursor** — needs a `TextInput`-specific caret point (`cursor_out` in its `ViewOpts`) + App plumbing (a full-screen `showCursorAt` that survives the diff renderer's park-at-origin contract).
- **Anchored popups** — probe the anchor's rect, then render a popup in a `stack` (ADR-0016) positioned there with len-spacers.

`zig build test` green, `zig fmt` clean. ADR-0019 records the rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)