### PR TITLE
feat(ui): hardware cursor for focused text fields (ADR-0019 increment 2)

### DIFF
--- a/docs/adr/0019-position-feedback.md
+++ b/docs/adr/0019-position-feedback.md
@@ -5,6 +5,20 @@ Status: accepted
 > Increment 1: the `ui.probe` primitive plus its first consumer, mouse
 > click-to-focus in the form example. The hardware cursor and anchored popups —
 > the other two features this unblocks — are follow-ups on the same primitive.
+>
+> **Increment 2 (landed): hardware cursor.** A focused `TextInput` reports its
+> caret's absolute cell through a `cursor_out: ?*?Point` in its `ViewOpts` (the
+> same caller-pointer shape as `probe`, since the caret sits *inside* the field
+> at a scroll-dependent column only the widget's render knows) and draws no block
+> there. The App gained `cursorAt(?Point)` — place the real terminal cursor at a
+> screen cell or hide it — which reuses the hybrid `showCursorAt`/`unplace`
+> machinery (already coordinate-general); `frameFullScreen` now `unplace()`s
+> before painting so the placed cursor returns to the origin the diff addresses
+> against. `App.run` gained an optional **post-frame hook** (`after_frame`, run
+> just before blocking on input) — its home use is `app.cursorAt(state.caret)`,
+> reading a `Point` the field wrote during render. The reporting channel stayed a
+> `ViewOpts` pointer over a `RenderCtx` slot for the same reason increment 1 chose
+> a wrapper over a `Node` field: keep `node.zig` free of a cursor concept.
 
 The layout engine (ADR-0013) is immediate-mode: `view(state)` builds a fresh,
 anonymous node tree every frame; `measure`+`render` lay it out and paint it; the
@@ -64,12 +78,12 @@ is reacting to, not a frame behind.
 - **Full-screen is where this is meaningful.** In hybrid, the live region floats
   in scrollback, so the surface rect isn't a stable screen coordinate; the
   consumers (mouse, cursor, popups) are full-screen features anyway.
-- **The two deferred consumers ride the same primitive.** *Hardware cursor* needs
-  a `TextInput`-specific caret point (a `cursor_out` in its `ViewOpts`, since the
-  caret is internal) plus App plumbing — a full-screen `showCursorAt` that
-  survives the diff renderer's park-at-origin contract. *Anchored popups* probe
-  the anchor's rect, then render a popup in a `stack` (ADR-0016) positioned there
-  with len-spacers. Both are follow-ups; neither needs a core change.
+- **Hardware cursor landed (increment 2); anchored popups remain.** The cursor
+  reuses this position feedback for a point *inside* a widget (the caret) plus
+  App plumbing (`cursorAt` + the `run` post-frame hook + `frameFullScreen`'s
+  pre-paint `unplace`). *Anchored popups* — the last consumer — probe the
+  anchor's rect, then render a popup in a `stack` (ADR-0016) positioned there
+  with len-spacers. A composition of what already exists; no core change.
 - **No renderer or measure change.** `probe` is a `custom` leaf like `viewport`
   and the widgets — the position feedback is a side effect of the normal render
   pass, tested headlessly (the rect is deterministic) with the live click path

--- a/packages/ui/examples/form.zig
+++ b/packages/ui/examples/form.zig
@@ -41,6 +41,9 @@ const State = struct {
     submit: ui.widgets.Button = .{},
     focus: Field = .user,
     submitted: bool = false,
+    // The focused text field reports its caret here during render (ADR-0019);
+    // the post-frame hook places the real terminal cursor there.
+    caret: ?ui.Point = null,
     // Where each field last rendered — filled by `ui.probe` in `view`, read by
     // `update` to map a mouse click to a field (ADR-0019). Click-to-focus needs
     // nothing more than these rects.
@@ -86,10 +89,12 @@ fn view(a: std.mem.Allocator, state: *State) !ui.Node {
         try ui.probe(a, state.rect(.user), try labeled(a, "User", try state.user.view(a, .{
             .focused = state.focus == .user,
             .placeholder = "username",
+            .cursor_out = &state.caret,
         }))),
         try ui.probe(a, state.rect(.pass), try labeled(a, "Pass", try state.pass.view(a, .{
             .focused = state.focus == .pass,
             .placeholder = "password",
+            .cursor_out = &state.caret,
         }))),
         try ui.probe(a, state.rect(.role), try labeled(a, "Role", try state.role.view(a, .{
             .focused = state.focus == .role,
@@ -115,6 +120,14 @@ fn view(a: std.mem.Allocator, state: *State) !ui.Node {
 fn edited(state: *State) ui.Flow {
     state.submitted = false;
     return .keep;
+}
+
+/// Post-frame hook: place the real terminal cursor at the focused field's caret
+/// (a text field filled `state.caret` during render), or hide it when no text
+/// field is focused. Reset the cache so the next frame starts blank.
+fn placeCursor(app: *ui.App, state: *State) !void {
+    try app.cursorAt(state.caret);
+    state.caret = null;
 }
 
 fn update(state: *State, ev: ?ui.Event) !ui.Flow {
@@ -195,5 +208,7 @@ pub fn main(init: std.process.Init) !void {
 
     var state = State{};
     state.wire();
-    try app.run(io, &state, null, view, update); // no tick — a form blocks on input
+    // `placeCursor` runs after each frame — the real terminal cursor tracks the
+    // focused text field's caret (ADR-0019).
+    try app.run(io, &state, null, view, update, placeCursor); // no tick — a form blocks on input
 }

--- a/packages/ui/examples/fullscreen.zig
+++ b/packages/ui/examples/fullscreen.zig
@@ -256,5 +256,5 @@ pub fn main(init: std.process.Init) !void {
     defer app.deinit(); // leaves alt-screen, restores cooked mode + cursor
 
     var state = State.init();
-    try app.run(io, &state, tick_ms, view, update);
+    try app.run(io, &state, tick_ms, view, update, null);
 }

--- a/packages/ui/src/app.zig
+++ b/packages/ui/src/app.zig
@@ -42,6 +42,7 @@ const node_mod = @import("node.zig");
 const diff_mod = @import("diff.zig");
 
 const Surface = surface_mod.Surface;
+const Point = surface_mod.Point;
 const Node = node_mod.Node;
 const Size = node_mod.Size;
 const Limits = node_mod.Limits;
@@ -388,6 +389,22 @@ pub const App = struct {
         self.placed = pos;
     }
 
+    /// Place the real terminal cursor at an absolute screen cell, or hide it
+    /// (`null`) — the full-screen entry point for a focused text field's caret
+    /// (ADR-0019). In full-screen the surface fills the viewport from the origin,
+    /// so a widget's reported cell (`TextInput`'s `cursor_out`) is already a
+    /// screen coordinate. Call it after `frame`, before blocking on input — the
+    /// natural home is `run`'s post-frame hook. `frameFullScreen` returns the
+    /// cursor to the origin before the next diff.
+    pub fn cursorAt(self: *App, p: ?Point) !void {
+        if (p) |pt| {
+            try self.showCursorAt(pt.x, pt.y);
+        } else {
+            try self.unplace();
+            try self.writer.flush();
+        }
+    }
+
     /// Hide the placed cursor and return to the region's top-left, restoring
     /// the parking invariant every other operation assumes.
     fn unplace(self: *App) !void {
@@ -533,6 +550,11 @@ pub const App = struct {
     /// change already resizes the surface, which forces the repaint on its
     /// own; the re-anchor is the resize-specific step.
     fn frameFullScreen(self: *App, node: Node) !void {
+        // A hardware cursor placed after the last frame (`cursorAt`) sits away
+        // from the origin the diff renderer addresses relative to — return it
+        // before painting, mirroring the hybrid `frame`.
+        try self.unplace();
+
         const ts = self.termSize();
         const size = Size{ .w = ts.w, .h = ts.h };
         if (size.w == 0 or size.h == 0) return;
@@ -619,6 +641,13 @@ pub const App = struct {
     /// resetting it, so input can't starve the tick. `null` disables ticking
     /// (block on input only — a form or menu). `io` is only the monotonic clock
     /// the deadline reads (`std.Io.Clock`). Full-screen only.
+    ///
+    /// `after_frame` (optional) runs after each paint, just before blocking on
+    /// input — the post-frame hook for work that depends on the rendered layout.
+    /// Its home use is the hardware cursor: place the focused field's caret with
+    /// `app.cursorAt(...)` (ADR-0019), reading a `Point` the field reported into
+    /// caller state during render. It receives the App and state; keep it to
+    /// terminal side effects (don't re-enter `frame`). Pass `null` for none.
     pub fn run(
         self: *App,
         io: std.Io,
@@ -626,6 +655,7 @@ pub const App = struct {
         tick_ms: ?u32,
         comptime view: fn (std.mem.Allocator, @TypeOf(state)) anyerror!Node,
         comptime update: fn (@TypeOf(state), ?Event) anyerror!Flow,
+        comptime after_frame: ?fn (*App, @TypeOf(state)) anyerror!void,
     ) !void {
         std.debug.assert(self.mode == .full_screen);
         const ns_per_ms = std.time.ns_per_ms;
@@ -646,6 +676,10 @@ pub const App = struct {
                 }
                 timeout = @intCast((next_tick - now) / ns_per_ms);
             }
+
+            // Post-frame hook, right before we block: the frame is painted and
+            // its layout (e.g. a caret position) is settled.
+            if (after_frame) |hook| try hook(self, state);
 
             const ev = try self.nextEvent(timeout) orelse {
                 // Deadline reached with no input: a tick.

--- a/packages/ui/src/input.zig
+++ b/packages/ui/src/input.zig
@@ -31,6 +31,7 @@ const Size = node_mod.Size;
 const RenderCtx = node_mod.RenderCtx;
 const Region = surface_mod.Region;
 const Style = surface_mod.Style;
+const Point = surface_mod.Point;
 const Key = terminal.Key;
 
 pub const Theme = theme_mod.Theme;
@@ -79,6 +80,13 @@ pub const TextInput = struct {
         placeholder: []const u8 = "",
         width: Dim = .{ .fill = 1 },
         theme: *const Theme = &default_theme,
+        /// When set (and focused), the field reports its caret's absolute cell
+        /// here during render and draws NO block cursor — the caller places the
+        /// real terminal cursor there (`App.cursorAt`, ADR-0019). The target is
+        /// an *optional* Point: only a focused field writes it, so the caller
+        /// resets it to null each frame and reads "no caret" when nothing did.
+        /// Left null, the field paints the reverse-video block caret as before.
+        cursor_out: ?*?Point = null,
     };
 
     pub fn value(self: *const TextInput) []const u8 {
@@ -143,6 +151,7 @@ pub const TextInput = struct {
                 .focused = opts.focused,
                 .text_style = th.prompts.hint.resolve(th.palette),
                 .caret_style = .{ .reverse = true },
+                .cursor_out = opts.cursor_out,
             };
         } else {
             const shown = if (self.mask) |m| try maskOf(a, self.value(), m) else self.value();
@@ -154,6 +163,7 @@ pub const TextInput = struct {
                 .focused = opts.focused,
                 .text_style = .{},
                 .caret_style = .{ .reverse = true },
+                .cursor_out = opts.cursor_out,
             };
         }
         return .{
@@ -188,6 +198,7 @@ const FieldView = struct {
     focused: bool,
     text_style: Style,
     caret_style: Style,
+    cursor_out: ?*?Point,
 
     fn measureFn(_: *anyopaque, _: *const RenderCtx, limits: Limits) Size {
         return .{ .w = limits.max_w, .h = @min(1, limits.max_h) };
@@ -202,8 +213,15 @@ const FieldView = struct {
         const scroll: u16 = if (self.cursor_col < w) 0 else self.cursor_col - w + 1;
         const start = byteAtColumn(self.text, scroll);
         _ = try region.writeText(0, 0, self.text[start..], self.text_style);
-        if (self.focused) {
-            _ = try region.writeText(self.cursor_col - scroll, 0, self.caret, self.caret_style);
+        if (!self.focused) return;
+
+        const vis_col = self.cursor_col - scroll;
+        if (self.cursor_out) |out| {
+            // Report the caret's absolute cell for a real terminal cursor; no
+            // block (the App draws the cursor there instead).
+            out.* = .{ .x = region.rect.x + vis_col, .y = region.rect.y };
+        } else {
+            _ = try region.writeText(vis_col, 0, self.caret, self.caret_style);
         }
     }
 };

--- a/packages/ui/src/input_test.zig
+++ b/packages/ui/src/input_test.zig
@@ -363,3 +363,58 @@ test "Button renders its label and styles the focused state" {
     try renderNode(a, try b.view(a, .{ .focused = false, .label = "OK" }), &s);
     try testing.expect(ui.styleEql(s.cell(0, 0).style, .{})); // unfocused → plain
 }
+
+// ---- TextInput hardware-cursor reporting (ADR-0019) -----------------------
+
+test "focused TextInput reports its caret and suppresses the block" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var buf: [16]u8 = undefined;
+    var ti = TextInput{ .buffer = &buf };
+    for ("hi") |c| _ = ti.handle(.{ .char = c }); // caret at col 2
+
+    var caret: ?ui.Point = null;
+    var s = try ui.Surface.init(testing.allocator, 6, 1);
+    defer s.deinit();
+    try renderNode(a, try ti.view(a, .{ .focused = true, .cursor_out = &caret }), &s);
+
+    try testing.expectEqual(ui.Point{ .x = 2, .y = 0 }, caret.?);
+    // The real cursor goes there — no reverse-video block is painted.
+    try testing.expect(!s.cell(2, 0).style.reverse);
+}
+
+test "TextInput caret reports the scrolled column" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var buf: [16]u8 = undefined;
+    var ti = TextInput{ .buffer = &buf };
+    for ("abcdef") |c| _ = ti.handle(.{ .char = c }); // caret at col 6
+
+    var caret: ?ui.Point = null;
+    var s = try ui.Surface.init(testing.allocator, 4, 1); // field only 4 wide → scrolls
+    defer s.deinit();
+    try renderNode(a, try ti.view(a, .{ .focused = true, .cursor_out = &caret }), &s);
+
+    // cursor_col 6, width 4 → scroll 3 → caret visible at column 3.
+    try testing.expectEqual(@as(u16, 3), caret.?.x);
+}
+
+test "unfocused TextInput reports no caret" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var buf: [16]u8 = undefined;
+    var ti = TextInput{ .buffer = &buf };
+    for ("hi") |c| _ = ti.handle(.{ .char = c });
+
+    var caret: ?ui.Point = null;
+    var s = try ui.Surface.init(testing.allocator, 6, 1);
+    defer s.deinit();
+    try renderNode(a, try ti.view(a, .{ .focused = false, .cursor_out = &caret }), &s);
+    try testing.expect(caret == null);
+}

--- a/packages/ui/src/surface.zig
+++ b/packages/ui/src/surface.zig
@@ -63,6 +63,7 @@ fn colorEql(a: ?theme.Color, b: ?theme.Color) bool {
 }
 
 pub const Rect = struct { x: u16, y: u16, w: u16, h: u16 };
+pub const Point = struct { x: u16, y: u16 };
 
 pub const Surface = struct {
     allocator: std.mem.Allocator,

--- a/packages/ui/src/ui.zig
+++ b/packages/ui/src/ui.zig
@@ -18,6 +18,7 @@ const surface = @import("surface.zig");
 pub const Surface = surface.Surface;
 pub const Region = surface.Region;
 pub const Rect = surface.Rect;
+pub const Point = surface.Point;
 pub const Cell = surface.Cell;
 pub const Style = surface.Style;
 pub const styleEql = surface.styleEql;


### PR DESCRIPTION
A focused `TextInput` in full-screen now places the **real terminal cursor** at its insertion point (blinking, IME-friendly) instead of the reverse-video block it drew before.

## Two pieces, both riding ADR-0019 position feedback

**Report the caret (widget → caller).** The caret sits *inside* the field at a scroll-dependent column only the widget's render knows — `probe`'s rect isn't enough. So `TextInput.ViewOpts` gains `cursor_out: ?*?Point` (the same caller-pointer shape as `probe`): when set + focused, the field writes its caret's absolute cell and draws **no block**. The target is an *optional* Point — only a focused field writes it, so the caller resets it each frame and reads "no caret" when nothing did.

**Place it (App).** `App.cursorAt(?Point)` places the real cursor at a screen cell or hides it — reusing the hybrid `showCursorAt`/`unplace` machinery (already coordinate-general). `frameFullScreen` now `unplace()`s before painting, so a placed cursor returns to the origin the diff renderer addresses against.

**Post-frame hook on `App.run`.** `run` gained an optional `after_frame` hook, run just before blocking on input — the natural home for `app.cursorAt(state.caret)`, reading the `Point` the field wrote during render. `run` callers pass `null` for none.

## Decisions
- **`ViewOpts.cursor_out` over a `RenderCtx` slot** — keeps a cursor concept out of `node.zig`'s core render context, the same call increment 1 made choosing a wrapper over a `Node` field.
- **A post-frame hook on `run`** (your call) over the explicit loop — text-editing apps keep `run`'s convenience.

`Point` joins `Rect` in `surface.zig`.

## Verification
- **Unit:** a focused `TextInput` reports the correct absolute caret cell (including when horizontally scrolled) and suppresses the block; unfocused reports nothing.
- **Example:** `form.zig` wires it — the focused text field's caret gets the real cursor; it hides on the select/checkbox/button. **PTY-validated:** cursor shown on the text fields, hidden on the select, shown again when focus wraps back.

`zig build test` green, `zig fmt` clean. ADR-0019 updated. **Anchored popups** are the last remaining consumer of this primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)