### PR TITLE
feat(ui): anchored popups — ui.positioned + dropdown (ADR-0019 increment 3)

### DIFF
--- a/docs/adr/0019-position-feedback.md
+++ b/docs/adr/0019-position-feedback.md
@@ -19,6 +19,20 @@ Status: accepted
 > reading a `Point` the field wrote during render. The reporting channel stayed a
 > `ViewOpts` pointer over a `RenderCtx` slot for the same reason increment 1 chose
 > a wrapper over a `Node` field: keep `node.zig` free of a cursor concept.
+>
+> **Increment 3 (landed): anchored popups.** The last consumer, and pure
+> composition — no new engine capability. A `ui.positioned(a, x, y, child)` helper
+> places a child at an absolute cell via fixed-size `len` gaps (the `center`
+> pattern with offsets; the gaps are style-less, hence transparent, ADR-0016). An
+> anchored popup is then `stack{ base, positioned(anchor.x, anchor.y + anchor.h,
+> popup) }`, where `anchor` is the rect `probe` reported for the anchor widget —
+> no `anchoredPopup` wrapper, the three-line composition reads clearly. The popup
+> reads the *previous* frame's anchor rect (probe fills during render, positioning
+> happens in `view`), which is exact for a stable anchor. Smart placement
+> (flip-when-near-an-edge, horizontal clamp) is deferred — it needs the popup's
+> measured size — and the dumb `positioned` clips gracefully off-screen. Demo: a
+> new `popup.zig` dropdown (button → menu anchored below), integrating probe +
+> stack + positioned + `Select`.
 
 The layout engine (ADR-0013) is immediate-mode: `view(state)` builds a fresh,
 anonymous node tree every frame; `measure`+`render` lay it out and paint it; the
@@ -78,12 +92,13 @@ is reacting to, not a frame behind.
 - **Full-screen is where this is meaningful.** In hybrid, the live region floats
   in scrollback, so the surface rect isn't a stable screen coordinate; the
   consumers (mouse, cursor, popups) are full-screen features anyway.
-- **Hardware cursor landed (increment 2); anchored popups remain.** The cursor
-  reuses this position feedback for a point *inside* a widget (the caret) plus
-  App plumbing (`cursorAt` + the `run` post-frame hook + `frameFullScreen`'s
-  pre-paint `unplace`). *Anchored popups* — the last consumer — probe the
-  anchor's rect, then render a popup in a `stack` (ADR-0016) positioned there
-  with len-spacers. A composition of what already exists; no core change.
+- **All three consumers landed.** Click-to-focus (increment 1), hardware cursor
+  (increment 2, position feedback for a point *inside* a widget plus App
+  plumbing), and anchored popups (increment 3, `probe` + `stack` + `positioned`).
+  The last needed no core change at all — it is composition — which is the
+  clearest evidence that `probe` was the right primitive: with a node's rendered
+  rect in hand, the deferred TUI features fall out of the vocabulary already
+  built. This closes the ADR-0015 full-screen deferral list.
 - **No renderer or measure change.** `probe` is a `custom` leaf like `viewport`
   and the widgets — the position feedback is a side effect of the normal render
   pass, tested headlessly (the rect is deterministic) with the live click path

--- a/packages/ui/build.zig
+++ b/packages/ui/build.zig
@@ -42,7 +42,7 @@ pub fn build(b: *std.Build) void {
 
     // Runnable examples — `zig build run-<name>` (they animate, so they need
     // a real terminal). Each is compiled by `test` so it can't bitrot.
-    const example_names = [_][]const u8{ "demo", "hybrid", "fullscreen", "form" };
+    const example_names = [_][]const u8{ "demo", "hybrid", "fullscreen", "form", "popup" };
     for (example_names) |name| {
         const exe = b.addExecutable(.{
             .name = b.fmt("ui-{s}", .{name}),

--- a/packages/ui/examples/popup.zig
+++ b/packages/ui/examples/popup.zig
@@ -1,0 +1,144 @@
+//! An anchored dropdown (ADR-0019): a button that opens a menu floating directly
+//! below it. It's pure composition of the pieces built across the TUI thread —
+//!
+//!   - `ui.probe` reports the button's on-screen rect (the anchor),
+//!   - `ui.stack` composites the menu over the base (ADR-0016),
+//!   - `ui.positioned` places the menu at the anchor's rect,
+//!   - `ui.widgets.Select` is the menu list itself.
+//!
+//! Space/Enter/click opens the menu; ↑/↓ move the highlight; Enter chooses and
+//! closes; Esc closes (or quits when already closed). No core engine change —
+//! the popup is just cells painted over the base surface at an offset.
+//!
+//! The menu is positioned from the button's rect as probed on the PREVIOUS
+//! frame; the button doesn't move, so that's exact (one frame of lag only on a
+//! resize) — the immediate-mode trade `probe` already documents.
+//!
+//! Run with: zig build run-popup   (from packages/ui, needs a real TTY)
+
+const std = @import("std");
+const ui = @import("ui");
+const terminal = @import("terminal");
+
+pub const panic = ui.panic;
+
+const options = [_][]const u8{ "Name", "Date modified", "Size", "Kind" };
+const menu_rows: u16 = options.len; // short menu — show every option, no scroll
+
+const State = struct {
+    open: bool = false,
+    menu: ui.widgets.Select = .{},
+    // The button's rect, filled by `ui.probe` in `view` — the popup's anchor.
+    button: ui.Rect = .{ .x = 0, .y = 0, .w = 0, .h = 0 },
+};
+
+fn panel(a: std.mem.Allocator, child: ui.Node) !ui.Node {
+    return ui.column(a, .{
+        .border = .rounded,
+        .border_style = .{ .foreground = .bright_cyan },
+        .style = .{ .background = .{ .indexed = 236 } },
+    }, &.{child});
+}
+
+fn view(a: std.mem.Allocator, state: *State) !ui.Node {
+    const caret: []const u8 = if (state.open) "▴" else "▾";
+    const label = try std.fmt.allocPrint(a, "Sort: {s}  {s}", .{ options[state.menu.highlighted], caret });
+
+    // The button is the anchor — probe its rect so the menu can pin under it.
+    const button_label = try ui.row(a, .{ .padding = .symmetric(1, 0) }, &.{
+        ui.textOpts(.{ .wrap = .clip }, label),
+    });
+    const button = try ui.probe(a, &state.button, try panel(a, button_label));
+
+    const base = try ui.column(a, .{
+        .padding = .all(1),
+        .gap = 1,
+        .width = .{ .fill = 1 },
+        .height = .{ .fill = 1 },
+    }, &.{
+        ui.text(.{ .bold = true }, "Anchored dropdown"),
+        button,
+        ui.spacer(),
+        ui.text(.{ .dim = true }, "Space/Enter/click opens · ↑/↓ pick · Enter choose · Esc close · q quit"),
+    });
+
+    if (!state.open) return base;
+
+    // Open: the menu floats in a stack layer, positioned just below the button.
+    const menu = try panel(a, try state.menu.view(a, .{
+        .focused = true,
+        .options = &options,
+        .height = menu_rows,
+    }));
+    return ui.stack(a, .{}, &.{
+        base,
+        try ui.positioned(a, state.button.x, state.button.y + state.button.h, menu),
+    });
+}
+
+fn update(state: *State, ev: ?ui.Event) !ui.Flow {
+    const e = ev orelse return .keep;
+    switch (e) {
+        .key => |k| {
+            if (state.open) {
+                // Menu open: navigation goes to the Select; Enter/Esc close it.
+                if (state.menu.handle(k, options.len, menu_rows)) return .keep;
+                switch (k) {
+                    .enter, .escape => state.open = false, // Enter keeps the highlight
+                    else => {},
+                }
+            } else switch (k) {
+                .char => |c| switch (c) {
+                    ' ' => state.open = true,
+                    'q' => return .quit,
+                    else => {},
+                },
+                .enter => state.open = true,
+                .escape => return .quit,
+                .ctrl => |c| if (c == 'c') return .quit,
+                else => {},
+            }
+        },
+        .mouse => |m| {
+            // Click the button to toggle the menu (hit-test its probed rect).
+            if (m.button == .left and m.action == .press) {
+                const px = m.x -| 1;
+                const py = m.y -| 1;
+                const r = state.button;
+                if (px >= r.x and px < r.x + r.w and py >= r.y and py < r.y + r.h) {
+                    state.open = !state.open;
+                }
+            }
+        },
+        else => {},
+    }
+    return .keep;
+}
+
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+    const gpa = init.gpa;
+
+    if (!terminal.isStdoutTty()) {
+        var err_buf: [256]u8 = undefined;
+        var stderr = std.Io.File.stderr().writer(io, &err_buf);
+        try stderr.interface.writeAll("popup: needs an interactive terminal\n");
+        try stderr.interface.flush();
+        return;
+    }
+
+    var out_buf: [1 << 14]u8 = undefined;
+    var stdout = std.Io.File.stdout().writer(io, &out_buf);
+    var in_buf: [256]u8 = undefined;
+    var stdin = std.Io.File.stdin().reader(io, &in_buf);
+
+    var app = try ui.App.initFullScreen(gpa, &stdout.interface, .{
+        .capability = .ansi_256,
+        .stdin = &stdin.interface,
+        .mouse = true, // click the button to open
+    });
+    defer app.deinit();
+
+    var state = State{};
+    try app.run(io, &state, null, view, update, null); // no tick, no cursor hook
+}

--- a/packages/ui/src/layout_test.zig
+++ b/packages/ui/src/layout_test.zig
@@ -492,3 +492,32 @@ test "probe is layout-transparent" {
     // The wrapped child sits after "hi" + gap: absolute x = 3.
     try testing.expectEqual(@as(u16, 3), rect.x);
 }
+
+// ============================================================================
+// positioned (anchored placement, ADR-0019)
+// ============================================================================
+
+test "positioned places its child at an absolute offset over a transparent base" {
+    var h = Harness.init();
+    defer h.deinit();
+    var s = try ui.Surface.init(testing.allocator, 8, 4);
+    defer s.deinit();
+
+    // A base layer fills the surface with dots; a popup is positioned at (3, 1).
+    const node = try ui.stack(h.a(), .{}, &.{
+        try ui.column(h.a(), .{}, &.{
+            ui.textOpts(.{ .wrap = .clip }, "........"),
+            ui.textOpts(.{ .wrap = .clip }, "........"),
+            ui.textOpts(.{ .wrap = .clip }, "........"),
+            ui.textOpts(.{ .wrap = .clip }, "........"),
+        }),
+        try ui.positioned(h.a(), 3, 1, ui.textOpts(.{ .wrap = .clip }, "POP")),
+    });
+    try renderInto(&h, node, &s);
+
+    // The popup lands at column 3 of row 1; the transparent gaps let the base
+    // show through around it.
+    try testing.expectEqualStrings("........", try rowString(&h, &s, 0));
+    try testing.expectEqualStrings("...POP..", try rowString(&h, &s, 1));
+    try testing.expectEqualStrings("........", try rowString(&h, &s, 2));
+}

--- a/packages/ui/src/ui.zig
+++ b/packages/ui/src/ui.zig
@@ -214,6 +214,23 @@ pub fn center(a: std.mem.Allocator, child: Node) !Node {
     });
 }
 
+/// Place `child`'s top-left at absolute `(x, y)` within the region its parent
+/// grants — the placement half of an anchored popup (ADR-0019): a `stack` layer
+/// `positioned` at a widget's probed rect floats a dropdown/menu over the base.
+/// Uses fixed-size `len` gaps, which are style-less and therefore transparent,
+/// so the base shows through everywhere but the (opaque) `child`. An `(x, y)`
+/// past the region clips gracefully rather than erroring. It's the `center`
+/// pattern with fixed offsets instead of spacers.
+pub fn positioned(a: std.mem.Allocator, x: u16, y: u16, child: Node) !Node {
+    return column(a, .{}, &.{
+        try row(a, .{ .height = .{ .len = y } }, &.{}), // top gap: y rows tall
+        try row(a, .{}, &.{
+            try column(a, .{ .width = .{ .len = x } }, &.{}), // left gap: x cols wide
+            child,
+        }),
+    });
+}
+
 pub const ViewportOpts = struct {
     /// Caller-owned vertical scroll offset, in rows (immediate mode — the app
     /// holds it in state and adjusts it on ↑/↓/PageUp/PageDown). Clamped to the


### PR DESCRIPTION
The last consumer of position feedback — and **pure composition**, no new engine capability. This closes the ADR-0015 full-screen TUI deferral list.

## `ui.positioned(a, x, y, child)`
Places a child at an absolute cell within its region via fixed-size `len` gaps — the `center` pattern with offsets. The gaps are style-less, hence transparent (ADR-0016), so the base shows through everywhere but the opaque child; an out-of-bounds offset clips gracefully.

## An anchored popup is three lines
```zig
const anchor = state.rects[...];             // filled by ui.probe last frame
return ui.stack(a, .{}, &.{
    base_ui,
    try ui.positioned(a, anchor.x, anchor.y + anchor.h, popup),   // opens below the anchor
});
```
No `anchoredPopup` wrapper — the composition reads clearly, and a wrapper would have to bake in below/above and clamping. The popup reads the *previous* frame's anchor rect (probe fills during render, positioning happens in `view`), which is exact for a stable anchor — one frame of lag only on a resize.

## New `popup.zig` example
A dropdown: a button that opens a menu anchored directly below it — integrating the whole toolkit (`probe` anchor + `stack` overlay + `positioned` placement + `Select` list). Space/Enter/click opens, ↑/↓ pick, Enter chooses + closes, Esc closes, click-to-open via the button's probed rect.

## Verification
- **Layout:** `positioned(x, y, child)` places the child at `(x, y)` with transparent gaps (base shows through in a stack; popup opaque at the offset).
- **Example:** **PTY-validated** — menu hidden until opened, options appear below the button, a pick updates the button and closes, re-opening repaints (proving it closed).

`zig build test` green, `zig fmt` clean. ADR-0019 updated.

## Deferred
Smart placement — flip when near the bottom edge, horizontal clamp — needs the popup's measured size; the dumb `positioned` clips off-screen for now, a clean follow-up when a consumer needs it.

## Milestone
With this, all three position-feedback consumers (click-to-focus, hardware cursor, anchored popups) have landed. The fact that the last one needed **zero core change** is the clearest evidence `probe` was the right primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)