### PR TITLE
feat(theme): surface chrome tokens for full-screen panels

### DIFF
--- a/docs/adr/0012-theme-system.md
+++ b/docs/adr/0012-theme-system.md
@@ -21,10 +21,14 @@ The token hierarchy follows design-system practice:
   attributes (errors are bold, links italic, muted is dim). The palette field
   defaults are the single source of truth for the default look.
 - **`StyleRef`** is either a role reference or a literal style. Component
-  tokens — `PromptTheme` (cursor, selected, marker, hint) and `ProgressTheme`
-  (spinner, bar fill/empty) — default to role references, so one palette edit
-  flows through every component, while any single token can still be pinned.
-- **`Theme`** aggregates `{ palette, prompts, progress }`. **`ThemeContext`**
+  tokens — `PromptTheme` (cursor, selected, marker, hint), `ProgressTheme`
+  (spinner, bar fill/empty), and `SurfaceTheme` (panel, border) — default to
+  role references, so one palette edit flows through every component, while any
+  single token can still be pinned. `SurfaceTheme` is the full-screen chrome
+  layer (ADR-0013→0019): `border` follows `accent`; `panel` is a literal fill
+  (`indexed 236`), since no foreground palette role owns a surface background.
+- **`Theme`** aggregates `{ palette, prompts, progress, surface }`.
+  **`ThemeContext`**
   pairs a `*const Theme` with detected `Capabilities` (the struct previously
   misnamed `Theme`) and is the one value render paths consume: it answers both
   "what does this role look like" and "what can this terminal display".
@@ -58,6 +62,11 @@ palette apply to code written before the theme existed.
   the custom color, stays plain when piped, and honors NO_COLOR.
 - Prompts and progress adopt their component tokens in follow-up changes;
   the schema ships with the Theme so the contract is stable.
+- Full-screen surface chrome (panels, overlays, their borders) resolves through
+  `SurfaceTheme` rather than per-node literals; the `ui` core is untouched —
+  callers resolve a token and assign it to `border_style`/`.style`, the same
+  call-site pattern the focusable widgets already use for `PromptTheme`. The
+  border *glyph shape* stays a per-node `BorderStyle` (structure, not palette).
 - Runtime theme *switching* (config file, `--theme` flag) is deliberately out
   of scope: a comptime theme is what keeps help compilation zero-cost. If
   demand appears, help rendering can move to the runtime formatting path.

--- a/packages/theme/src/definition.zig
+++ b/packages/theme/src/definition.zig
@@ -8,6 +8,7 @@
 
 const std = @import("std");
 const Style = @import("core/style.zig").Style;
+const Color = @import("core/color.zig").Color;
 const Capabilities = @import("detection/capability.zig").Capabilities;
 const TerminalCapability = @import("detection/capability.zig").TerminalCapability;
 
@@ -95,11 +96,25 @@ pub const ProgressTheme = struct {
     bar_empty: StyleRef = .{ .role = .muted },
 };
 
+/// Component tokens for full-screen surface chrome (consumed by the ui package's
+/// panels and overlays). `PromptTheme` is the line-oriented layer; this is its
+/// surface-oriented counterpart — the one place an app sets "the panel look" for
+/// a full-screen UI instead of repeating literals.
+pub const SurfaceTheme = struct {
+    /// The base fill behind a panel or overlay's content.
+    panel: StyleRef = .{ .style = .{ .background = .{ .indexed = 236 } } },
+    /// A panel or overlay border's color. The border *glyph shape*
+    /// (`.rounded`/`.single`/…) stays a per-node `BorderStyle` — that's
+    /// structure, not palette.
+    border: StyleRef = .{ .role = .accent },
+};
+
 /// A complete CLI theme: one place to define how an app looks everywhere.
 pub const Theme = struct {
     palette: Palette = .{},
     prompts: PromptTheme = .{},
     progress: ProgressTheme = .{},
+    surface: SurfaceTheme = .{},
 };
 
 pub const default_theme: Theme = .{};
@@ -136,6 +151,11 @@ pub const ThemeContext = struct {
     /// The active theme's progress component tokens
     pub fn progressTokens(self: ThemeContext) ProgressTheme {
         return self.theme.progress;
+    }
+
+    /// The active theme's surface-chrome component tokens
+    pub fn surfaceTokens(self: ThemeContext) SurfaceTheme {
+        return self.theme.surface;
     }
 
     /// The effective terminal capability (no_color when color is disabled)
@@ -184,6 +204,24 @@ test "component tokens default to role references" {
     try testing.expect(std.meta.eql(spinner, theme.palette.accent));
     const marker = theme.prompts.marker.resolve(theme.palette);
     try testing.expect(std.meta.eql(marker, theme.palette.success));
+}
+
+test "surface tokens: border follows accent, panel is a literal fill" {
+    const theme = Theme{};
+    // border defaults to the accent role — recoloring the brand moves the border.
+    const border = theme.surface.border.resolve(theme.palette);
+    try testing.expect(std.meta.eql(border, theme.palette.accent));
+    // panel is a literal background (no palette role owns a surface fill).
+    const panel = theme.surface.panel.resolve(theme.palette);
+    try testing.expect(std.meta.eql(panel.background, Color{ .indexed = 236 }));
+
+    // A custom accent flows through the border token…
+    const custom = Theme{
+        .palette = .{ .accent = .{ .foreground = .{ .rgb = .{ .r = 250, .g = 100, .b = 0 } } } },
+    };
+    try testing.expect(std.meta.eql(custom.surface.border.resolve(custom.palette), custom.palette.accent));
+    // …but the literal panel is unaffected by the palette.
+    try testing.expect(std.meta.eql(custom.surface.panel.resolve(custom.palette).background, Color{ .indexed = 236 }));
 }
 
 test "ThemeContext capability honors color_enabled" {

--- a/packages/theme/src/theme.zig
+++ b/packages/theme/src/theme.zig
@@ -29,6 +29,7 @@ pub const Palette = @import("definition.zig").Palette;
 pub const StyleRef = @import("definition.zig").StyleRef;
 pub const PromptTheme = @import("definition.zig").PromptTheme;
 pub const ProgressTheme = @import("definition.zig").ProgressTheme;
+pub const SurfaceTheme = @import("definition.zig").SurfaceTheme;
 pub const Theme = @import("definition.zig").Theme;
 pub const default_theme = @import("definition.zig").default_theme;
 pub const ThemeContext = @import("definition.zig").ThemeContext;

--- a/packages/ui/examples/form.zig
+++ b/packages/ui/examples/form.zig
@@ -29,6 +29,11 @@ const roles = [_][]const u8{ "admin", "developer", "viewer", "auditor", "billing
 // Fewer visible rows than roles, so the select scrolls and shows its ↑/↓ gutter.
 const role_rows: u16 = 3;
 
+// One theme drives the whole screen's look: the panel border reads from its
+// surface tokens, and every widget's focus highlight from its prompt tokens
+// (widgets default to this same theme). Change it in one place to reskin.
+const th: ui.widgets.Theme = .{};
+
 const State = struct {
     user_buf: [48]u8 = undefined,
     pass_buf: [48]u8 = undefined,
@@ -78,7 +83,7 @@ fn view(a: std.mem.Allocator, state: *State) !ui.Node {
 
     const form = try ui.column(a, .{
         .border = .rounded,
-        .border_style = .{ .foreground = .bright_cyan },
+        .border_style = th.surface.border.resolve(th.palette),
         .padding = .symmetric(2, 1),
         .gap = 1,
         .width = .{ .len = 46 },

--- a/packages/ui/examples/fullscreen.zig
+++ b/packages/ui/examples/fullscreen.zig
@@ -29,6 +29,10 @@ pub const panic = ui.panic;
 
 const tick_ms: u32 = 250;
 
+// The help modal's border + fill come from one theme's surface tokens — change
+// them in a single place and every panel reskins.
+const th: ui.widgets.Theme = .{};
+
 /// Visible rows in the scrolling process pane — a fixed window so `update` can
 /// keep the selection in view without knowing the laid-out height.
 const visible_rows: usize = 8;
@@ -154,9 +158,9 @@ fn view(a: std.mem.Allocator, state: *State) !ui.Node {
 fn helpModal(a: std.mem.Allocator) !ui.Node {
     return ui.column(a, .{
         .border = .rounded,
-        .border_style = .{ .foreground = .bright_cyan },
+        .border_style = th.surface.border.resolve(th.palette),
         .padding = .symmetric(2, 1),
-        .style = .{ .background = .{ .indexed = 236 } }, // opaque panel
+        .style = th.surface.panel.resolve(th.palette), // opaque panel
         .gap = 0,
     }, &.{
         ui.text(.{ .bold = true }, "Keys"),

--- a/packages/ui/examples/popup.zig
+++ b/packages/ui/examples/popup.zig
@@ -32,11 +32,15 @@ const State = struct {
     button: ui.Rect = .{ .x = 0, .y = 0, .w = 0, .h = 0 },
 };
 
+// The panel border + fill come from one theme's surface tokens — change them in
+// a single place and every panel reskins.
+const th: ui.widgets.Theme = .{};
+
 fn panel(a: std.mem.Allocator, child: ui.Node) !ui.Node {
     return ui.column(a, .{
         .border = .rounded,
-        .border_style = .{ .foreground = .bright_cyan },
-        .style = .{ .background = .{ .indexed = 236 } },
+        .border_style = th.surface.border.resolve(th.palette),
+        .style = th.surface.panel.resolve(th.palette),
     }, &.{child});
 }
 


### PR DESCRIPTION
## What

Full-screen apps had no single place to set panel background or border color — the examples repeated `bright_cyan` / `indexed 236` literals. Widget *content* already themes through `PromptTheme`; the gap was the **surface chrome**.

This adds `SurfaceTheme { panel, border }` as the full-screen counterpart to `PromptTheme` (the ADR-0013→0019 panels/overlays), wires it onto `Theme`, and re-themes the examples off the literals.

## Design (approved before implementation)

- **New `SurfaceTheme` group**, not an extension of `PromptTheme` — prompts is the line-oriented layer, surface is the chrome layer.
- **Two tokens only:** `border` (defaults to `.role = .accent`, so one palette edit recolors it) and `panel` (a literal `indexed 236` fill — no foreground palette role owns a surface background). No `overlay`/`focus`/`caret`/`arrow` tokens: none has a consumer yet.
- **Call-site resolution; `ui` core untouched.** Callers resolve a token and assign it to `border_style`/`.style`, the same pattern the focusable widgets already use for prompt tokens. The border *glyph shape* (`.rounded`/`.single`) stays a per-node `BorderStyle` — structure, not palette. This keeps the ADR-0013→0019 "renderer untouched / pure composition" line intact.

## Changes (6 files, +70 / −9)

- `packages/theme/src/definition.zig` — `SurfaceTheme`, `Theme.surface`, `ThemeContext.surfaceTokens()`, unit test.
- `packages/theme/src/theme.zig` — re-export `SurfaceTheme`.
- `packages/ui/examples/{form,popup,fullscreen}.zig` — chrome literals routed through `th.surface.*.resolve(th.palette)`. Faithful to each example's prior look (`form` had only a border, so it stays fill-less).
- `docs/adr/0012-theme-system.md` — amended to record the addition and the call-site decision.

## Testing

- `zig build test` clean in `theme`, `ui`, and the full workspace; `zig fmt --check` clean.
- New theme unit test confirmed wired (breaking the assertion fails exactly 1 of 44 tests, restoring passes).
- **PTY-validated** all three examples (temporary `installArtifact`, reverted): the rounded border corner is now preceded by `ESC[38;5;51m` (accent cyan), and the panel fill emits `48;5;236`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)