### PR TITLE
feat(ui): Select multi-line / wrapped options (ADR-0018 increment 5)

### DIFF
--- a/docs/adr/0018-focusable-widgets.md
+++ b/docs/adr/0018-focusable-widgets.md
@@ -36,6 +36,28 @@ Status: accepted
 > rather than a `fill` label, so the row still measures to its intrinsic width.
 > Deferred: full multi-line/wrapped options (a physical-row windowing rewrite,
 > like `prompts`' `list_render` — no full-screen consumer needs it yet).
+>
+> **Increment 5 (landed): `Select` multi-line / wrapped options.** Opt in with
+> `wrap = true`: options that overflow the field wrap to several physical rows
+> (a hang indent under the label — the continuation lines' marker cells stay
+> blank), and `height` becomes a *physical-row budget*. The visible window is
+> chosen by growing *whole options* out from the cursor until the budget is used
+> (`growWindow`, the ui-side mirror of `prompts`' `list_render.viewport`), so the
+> wrap path is cursor-anchored like a `prompts` list rather than persistent-scroll
+> like the single-line path. That difference is forced, not chosen: persistent
+> scroll needs each option's wrapped height, which needs the granted width, which
+> `handle` never sees — so `handle` is unchanged and the wrap window derives from
+> `highlighted` alone each frame. Rendered by a custom leaf (`WrapSelectView`),
+> because only a leaf's `renderFn` learns the width `view` can't; this reverses
+> increment 4's "render own window, skip the scratch surface" rationale, which
+> was explicitly premised on single-line (row index == option index). Overflow
+> arrows carry over in physical-row terms (↑ on the first painted row, ↓ on the
+> last, `↕` when the whole window is one row). The single-line path — truncation,
+> persistent scroll, arrows — is untouched; `wrap` defaults to `false`. The one
+> genuinely reusable primitive (paint-to-scratch → copy a visible row slice) was
+> already factored out as `Region.copyRows` (ADR-0017); `viewport` and this leaf
+> are two thin peers over it, so `viewport` is left alone rather than overloaded
+> with cursor-following list logic for an audience of one.
 
 ADR-0013/0015 named a focusable widget library as a clean deferral. This is the
 first increment, and it settles the one hard question: how do interactive,
@@ -117,9 +139,7 @@ identity — exactly what this avoids.
   share the vocabulary — `prompts` is neither merged nor replaced.
 - **Next:** the widget catalog now covers the common form controls
   (`TextInput`/`Checkbox`/`Select`/`Button`), with `Select` truncation + overflow
-  arrows landed (increment 4). The one remaining `Select` capability is full
-  multi-line/wrapped options — a physical-row windowing rewrite (like `prompts`'
-  `list_render`), deferred until a full-screen consumer needs it. Still deferred
-  across the library: mouse click-to-focus and a hardware cursor, both of which
-  need layout to expose measured widget positions (the same feedback the
-  anchored-popup deferral waits on).
+  arrows (increment 4) and multi-line/wrapped options (increment 5) both landed —
+  the `Select` capability set is complete. Mouse click-to-focus and the hardware
+  cursor also landed (ADR-0019). The library-wide deferrals that remained are
+  closed; further work is new widgets, not gaps in the existing ones.

--- a/packages/ui/examples/form.zig
+++ b/packages/ui/examples/form.zig
@@ -25,9 +25,19 @@ pub const panic = ui.panic;
 const Field = enum { user, pass, role, remember, submit };
 const field_count = @typeInfo(Field).@"enum".fields.len;
 
-const roles = [_][]const u8{ "admin", "developer", "viewer", "auditor", "billing", "support" };
-// Fewer visible rows than roles, so the select scrolls and shows its ↑/↓ gutter.
-const role_rows: u16 = 3;
+// Descriptive roles: the longer ones wrap to two lines in the field, so the
+// select runs in `wrap` mode (physical-row windowing) rather than one row each.
+const roles = [_][]const u8{
+    "admin (all permissions)",
+    "developer (read/write code and deploy to staging environments)",
+    "viewer (read-only across the workspace)",
+    "auditor (read-only plus access to the full audit log)",
+    "billing (manage plans, invoices, and payment methods)",
+    "support (impersonate users to reproduce reported issues)",
+};
+// A physical-row budget (wrapped mode): enough for a few options, so the select
+// scrolls and shows its ↑/↓ gutter.
+const role_rows: u16 = 6;
 
 const State = struct {
     user_buf: [48]u8 = undefined,
@@ -100,6 +110,7 @@ fn view(a: std.mem.Allocator, state: *State) !ui.Node {
             .focused = state.focus == .role,
             .options = &roles,
             .height = role_rows,
+            .wrap = true,
         }))),
         try ui.probe(a, state.rect(.remember), try state.remember.view(a, .{
             .focused = state.focus == .remember,

--- a/packages/ui/src/input.zig
+++ b/packages/ui/src/input.zig
@@ -273,13 +273,22 @@ pub const Checkbox = struct {
 /// A single-select scrollable list. The options are caller-owned and passed in
 /// each frame (immediate mode); the widget holds only the cursor. ↑/↓/Home/End
 /// move the highlight and are consumed; Enter/Tab/Escape bubble to the form,
-/// which reads the choice as `options[select.highlighted]`. Options are
-/// single-line. The list scrolls to keep the highlight within `height` rows —
-/// `scroll` is persistent, so the window stays put and slides only when the
-/// highlight crosses an edge (a stable viewport, not a highlight glued to the
-/// fold). It renders its own window directly rather than wrapping a `viewport`:
-/// it already knows which slice is visible, so re-rendering every option into a
-/// scratch surface would be wasted work.
+/// which reads the choice as `options[select.highlighted]`.
+///
+/// By default options are single-line: the list scrolls to keep the highlight
+/// within `height` rows — `scroll` is persistent, so the window stays put and
+/// slides only when the highlight crosses an edge (a stable viewport, not a
+/// highlight glued to the fold). It renders its own window directly rather than
+/// wrapping a `viewport`: it already knows which slice is visible, so
+/// re-rendering every option into a scratch surface would be wasted work.
+///
+/// With `wrap = true`, options that overflow the field wrap to several physical
+/// rows and `height` becomes a physical-row budget. The window is chosen by
+/// growing whole options out from the cursor (`WrapSelectView` / `growWindow`),
+/// cursor-anchored like the `prompts` list — persistent scroll can't apply here
+/// because the per-option wrapped height isn't known until layout grants a
+/// width, which `handle` never sees. `handle` is therefore unchanged; the wrap
+/// path derives its window from `highlighted` alone each frame.
 pub const Select = struct {
     highlighted: usize = 0,
     /// First visible option — persistent, maintained by `handle`.
@@ -288,9 +297,14 @@ pub const Select = struct {
     pub const ViewOpts = struct {
         focused: bool = false,
         options: []const []const u8,
-        /// Visible rows; the list scrolls within this window.
+        /// Visible rows. Single-line (`wrap = false`): a count of options. Wrapped
+        /// (`wrap = true`): a budget of *physical* rows the window grows to fill.
         height: u16 = 6,
         theme: *const Theme = &default_theme,
+        /// Opt in to multi-line options: each option wraps to the field width and
+        /// the visible window is chosen by physical-row budget (grow-from-cursor)
+        /// instead of option index. The single-line default is left untouched.
+        wrap: bool = false,
     };
 
     /// Handle a key; returns whether it was consumed. `count` (the option count)
@@ -319,6 +333,27 @@ pub const Select = struct {
         if (count == 0) return .{ .kind = .{ .text = .{ .content = "", .wrap = .clip } } };
 
         const hi = @min(self.highlighted, count - 1);
+
+        // Wrapped options are a different windowing model (physical-row budget,
+        // grow-from-cursor), rendered by a custom leaf that knows its granted
+        // width. The single-line path below is unchanged.
+        if (opts.wrap) {
+            const ctx = try a.create(WrapSelectView);
+            ctx.* = .{
+                .options = opts.options,
+                .highlighted = hi,
+                .budget = @max(opts.height, 1),
+                .focused = opts.focused,
+                .selected = th.prompts.selected.resolve(th.palette),
+                .hint = th.prompts.hint.resolve(th.palette),
+            };
+            return .{ .kind = .{ .custom = .{
+                .context = ctx,
+                .measureFn = WrapSelectView.measureFn,
+                .renderFn = WrapSelectView.renderFn,
+            } } };
+        }
+
         const visible = @min(@max(@as(usize, opts.height), 1), count);
         // Persistent scroll, re-derived so the highlight is always in view even
         // if the caller set `highlighted` directly, bypassing `handle`.
@@ -370,6 +405,149 @@ fn scrollFor(scroll: usize, hi: usize, visible: u16, count: usize) usize {
     if (hi < s) s = hi;
     if (hi >= s + v) s = hi - v + 1;
     return s;
+}
+
+// ---- Wrapped-options rendering (Select `wrap = true`) ----------------------
+
+/// The custom leaf behind a wrapped `Select`. It renders in its granted region,
+/// so it wraps every option at the real field width — the width `Select.view`
+/// can't know when it builds the node. Layout runs `column` [marker(1) space(1)
+/// label(width-3)] and reserves the rightmost column as the overflow gutter, the
+/// same shape as the single-line row.
+const WrapSelectView = struct {
+    options: []const []const u8,
+    highlighted: usize,
+    /// Physical-row budget the visible window grows to fill.
+    budget: u16,
+    focused: bool,
+    /// The highlighted option's style (whole block); neighbours are plain.
+    selected: Style,
+    /// The dim overflow-arrow style.
+    hint: Style,
+
+    /// Columns available to the wrapped label: total minus the 2-cell marker
+    /// prefix and the 1-cell overflow gutter. At least 1 (`wrapForEach` clamps).
+    fn labelWidth(w: u16) usize {
+        return @max(@as(usize, w) -| 3, 1);
+    }
+
+    fn measureFn(context: *anyopaque, _: *const RenderCtx, limits: Limits) Size {
+        const self: *const WrapSelectView = @ptrCast(@alignCast(context));
+        if (limits.max_w == 0 or limits.max_h == 0) return .{ .w = 0, .h = 0 };
+        const lw = labelWidth(limits.max_w);
+        var total: usize = 0;
+        for (self.options) |o| total += terminal.wrapCount(o, lw);
+        const h = @min(@min(total, @as(usize, self.budget)), @as(usize, limits.max_h));
+        return .{ .w = limits.max_w, .h = @intCast(@max(h, 1)) };
+    }
+
+    fn renderFn(context: *anyopaque, _: *const RenderCtx, region: Region) anyerror!void {
+        const self: *const WrapSelectView = @ptrCast(@alignCast(context));
+        const w = region.width();
+        if (w == 0) return;
+        const budget = @min(self.budget, region.height());
+        if (budget == 0) return;
+        const lw = labelWidth(w);
+
+        const wc = WrapCounts{ .options = self.options, .lw = lw };
+        const win = growWindow(self.options.len, self.highlighted, budget, &wc, WrapCounts.at);
+
+        var y: u16 = 0;
+        for (win.start..win.end) |idx| {
+            if (y >= budget) break;
+            const is_hi = idx == self.highlighted;
+            var painter = LinePainter{
+                .region = region,
+                .y = &y,
+                .budget = budget,
+                .width = w,
+                .style = if (is_hi) self.selected else .{},
+                .marker = if (is_hi and self.focused) "›" else " ",
+                .first = true,
+            };
+            try terminal.wrapForEach(self.options[idx], lw, &painter, LinePainter.add);
+        }
+
+        // Overflow arrows in the gutter (rightmost column), in physical-row
+        // terms: ↑ on the first painted row, ↓ on the last. They coincide (↕)
+        // only when the whole window is a single row.
+        const gx = w - 1;
+        const more_above = win.start > 0;
+        const more_below = win.end < self.options.len;
+        const last = y -| 1;
+        if (more_above and more_below and last == 0) {
+            _ = try region.writeText(gx, 0, "↕", self.hint);
+        } else {
+            if (more_above) _ = try region.writeText(gx, 0, "↑", self.hint);
+            if (more_below) _ = try region.writeText(gx, last, "↓", self.hint);
+        }
+    }
+};
+
+/// Paints one option's wrapped lines top-down: a full-width background over the
+/// label area (so the highlight reads as a block), the marker on the first line,
+/// and the label hung at column 2 (continuation lines keep the indent — their
+/// marker cells stay blank). Rows past `budget` are dropped (a single option
+/// taller than the whole window clips).
+const LinePainter = struct {
+    region: Region,
+    y: *u16,
+    budget: u16,
+    width: u16,
+    style: Style,
+    marker: []const u8,
+    first: bool,
+
+    fn add(self: *LinePainter, line: []const u8) anyerror!void {
+        if (self.y.* >= self.budget) return;
+        // Background spans the label area but not the gutter (which carries the
+        // dim arrows, never the highlight) — matching the single-line row.
+        self.region.sub(.{ .x = 0, .y = self.y.*, .w = self.width -| 1, .h = 1 }).fill(self.style);
+        if (self.first) _ = try self.region.writeText(0, self.y.*, self.marker, self.style);
+        _ = try self.region.writeText(2, self.y.*, line, self.style);
+        self.first = false;
+        self.y.* += 1;
+    }
+};
+
+const Window = struct { start: usize, end: usize };
+
+const WrapCounts = struct {
+    options: []const []const u8,
+    lw: usize,
+    fn at(self: *const WrapCounts, i: usize) usize {
+        return terminal.wrapCount(self.options[i], self.lw);
+    }
+};
+
+/// Grow a visible window of whole options out from `cursor` (upward first, to
+/// match the prompts' scroll feel) until `budget` physical rows are used. The
+/// ui-side mirror of `prompts`' `list_render.viewport` — kept private because
+/// `Select` is its only consumer today; promote it if a second one appears.
+fn growWindow(
+    n: usize,
+    cursor: usize,
+    budget: usize,
+    ctx: anytype,
+    comptime rowCount: fn (@TypeOf(ctx), usize) usize,
+) Window {
+    if (n == 0) return .{ .start = 0, .end = 0 };
+    var used = rowCount(ctx, cursor);
+    var start = cursor;
+    while (start > 0) {
+        const c = rowCount(ctx, start - 1);
+        if (used + c > budget) break;
+        used += c;
+        start -= 1;
+    }
+    var end = cursor + 1;
+    while (end < n) {
+        const c = rowCount(ctx, end);
+        if (used + c > budget) break;
+        used += c;
+        end += 1;
+    }
+    return .{ .start = start, .end = end };
 }
 
 // ============================================================================

--- a/packages/ui/src/input_test.zig
+++ b/packages/ui/src/input_test.zig
@@ -347,6 +347,87 @@ test "Select truncates an option too wide for the granted width" {
     try testing.expect(std.mem.indexOf(u8, row, "…") != null);
 }
 
+// A long option wraps to two physical rows at label width 7 (surface 10 wide:
+// 2 marker cols + 7 label + 1 gutter): "hello" then "world".
+const wrap_options = [_][]const u8{ "hello world", "beta", "gamma", "delta" };
+
+test "wrapped Select hangs a multi-row option under its label" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var sel = Select{};
+    const one = [_][]const u8{"hello world"};
+    var s = try ui.Surface.init(testing.allocator, 10, 4);
+    defer s.deinit();
+    try renderNode(a, try sel.view(a, .{ .focused = true, .options = &one, .height = 4, .wrap = true }), &s);
+
+    // The label wraps; the continuation line keeps the hang indent (its marker
+    // cell stays blank), and the whole block wears the selected style.
+    try testing.expectEqualStrings("› hello   ", try rowString(a, &s, 0));
+    try testing.expectEqualStrings("  world   ", try rowString(a, &s, 1));
+    const t = theme_mod.default_theme;
+    const selected = t.prompts.selected.resolve(t.palette);
+    try testing.expect(ui.styleEql(s.cell(2, 0).style, selected));
+    try testing.expect(ui.styleEql(s.cell(2, 1).style, selected)); // continuation too
+}
+
+test "wrapped Select budgets physical rows and shows a down arrow" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // Budget 3: the 2-row highlighted option plus one more fills it; the rest are
+    // hidden below, so the last row carries a ↓.
+    var sel = Select{};
+    var s = try ui.Surface.init(testing.allocator, 10, 4);
+    defer s.deinit();
+    try renderNode(a, try sel.view(a, .{ .focused = true, .options = &wrap_options, .height = 3, .wrap = true }), &s);
+
+    try testing.expectEqualStrings("› hello   ", try rowString(a, &s, 0));
+    try testing.expectEqualStrings("  world   ", try rowString(a, &s, 1));
+    try testing.expectEqualStrings("  beta   ↓", try rowString(a, &s, 2));
+    try testing.expectEqualStrings("          ", try rowString(a, &s, 3)); // past the budget
+    // The highlighted block is styled; a neighbour below it is plain.
+    const t = theme_mod.default_theme;
+    const selected = t.prompts.selected.resolve(t.palette);
+    try testing.expect(ui.styleEql(s.cell(2, 1).style, selected));
+    try testing.expect(ui.styleEql(s.cell(2, 2).style, .{}));
+}
+
+test "wrapped Select grows the window upward with an up arrow" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // Highlight the last option: the window grows up from it (single-row options
+    // above), the highlight sits on the bottom row, and hidden options above put
+    // a ↑ on the top row.
+    var sel = Select{ .highlighted = 3 };
+    var s = try ui.Surface.init(testing.allocator, 10, 3);
+    defer s.deinit();
+    try renderNode(a, try sel.view(a, .{ .focused = true, .options = &wrap_options, .height = 3, .wrap = true }), &s);
+
+    try testing.expectEqualStrings("  beta   ↑", try rowString(a, &s, 0));
+    try testing.expectEqualStrings("  gamma   ", try rowString(a, &s, 1));
+    try testing.expectEqualStrings("› delta   ", try rowString(a, &s, 2));
+}
+
+test "wrapped Select shows both arrows on a single-row window" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const abc = [_][]const u8{ "a", "b", "c" };
+    var sel = Select{ .highlighted = 1 };
+    var s = try ui.Surface.init(testing.allocator, 10, 1);
+    defer s.deinit();
+    try renderNode(a, try sel.view(a, .{ .focused = true, .options = &abc, .height = 1, .wrap = true }), &s);
+
+    // One physical row with options hidden both above and below → a merged ↕.
+    try testing.expectEqualStrings("› b      ↕", try rowString(a, &s, 0));
+}
+
 test "Button renders its label and styles the focused state" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();


### PR DESCRIPTION
Opt in with `wrap = true`: options that overflow the field wrap to several physical rows (a hang indent under the label — continuation lines' marker cells stay blank), and `height` becomes a **physical-row budget**. The visible window is chosen by growing *whole options* out from the cursor until the budget is used (`growWindow`, the ui-side mirror of `prompts`' `list_render.viewport`).

Extends ADR-0018 (increment 5) — no new ADR. Completes the `Select` capability set.

## Design decisions
- **Cursor-anchored, not persistent-scroll (forced, not chosen).** Persistent scroll needs each option's wrapped height → needs the granted width → which `handle` never sees. So `handle` is **unchanged**, and the wrap window derives from `highlighted` alone each frame (matching the `prompts` list feel). The single-line path keeps its persistent scroll.
- **Custom leaf (`WrapSelectView`), not `ui.viewport`.** Only a leaf's `renderFn` learns the width `view` can't, so it wraps at the real field width. This reverses increment 4's "render own window, skip the scratch surface" rationale — which was explicitly premised on single-line (row index == option index). `ui.viewport` is left untouched: the one reusable primitive (scratch → copy a visible row slice) is already `Region.copyRows` (ADR-0017); viewport and this leaf are thin peers over it, and `growWindow` stays private since `Select` is its only consumer.
- **Overflow arrows carry over in physical-row terms** — ↑ on the first painted row, ↓ on the last, ↕ when the whole window is one row.
- **Options stay `[]const []const u8`**; `wrap` defaults to `false` — the single-line path (truncation, persistent scroll, arrows) is byte-for-byte unchanged.

## Tests
New render tests: hang indent, physical-row budgeting + ↓, upward grow + ↑, merged ↕. Existing single-line assertions untouched. `zig build test` clean in `packages/ui` and root; `zig fmt --check` clean.

## Validation
The form example's role select now uses descriptive (wrapping) options and runs in wrap mode. **PTY-validated** (`pyte` + `pty.fork` with `TIOCSWINSZ`): unfocused frame shows the hang indent and whole-option budgeting with a ↓; after focusing the role + Down×4 the window grew upward with ↑/↓ and the `›` marker on the highlighted first line only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)