### PR TITLE
feat(ui): smart anchored-popup placement — flip + clamp (ADR-0019 increment 4)

### DIFF
--- a/docs/adr/0019-position-feedback.md
+++ b/docs/adr/0019-position-feedback.md
@@ -33,6 +33,21 @@ Status: accepted
 > measured size — and the dumb `positioned` clips gracefully off-screen. Demo: a
 > new `popup.zig` dropdown (button → menu anchored below), integrating probe +
 > stack + positioned + `Select`.
+>
+> **Increment 4 (landed): smart placement.** The deferred nicety from increment 3:
+> `ui.anchored(a, anchor, opts, popup)` pins a popup to a probed rect and keeps it
+> on screen — it **flips above** the anchor when the popup would run off the bottom
+> (and above fits), and **clamps** horizontally when it would run off the right
+> edge (never past x=0). `positioned` stays the dumb primitive; `anchored` is the
+> smart layer over it. The trick that makes flip/clamp possible without threading
+> the terminal size through `view`: `anchored` is a **custom leaf** (like `probe`/
+> `viewport`), so at *render* time it's granted the whole viewport as its region
+> (a `stack` layer gets the full inner region, ADR-0016) — enough to `measure` the
+> popup and place it against the real viewport, the two facts `view` lacks. The
+> `AnchorOpts { prefer: .below|.above, halign: .left|.right }` policy: flip only
+> when the preferred side doesn't fit and the other does (else keep-and-clip);
+> horizontal aligns an edge then clamps. `popup.zig` grew a second, corner
+> dropdown whose menu flips above and clamps left, demonstrating both live.
 
 The layout engine (ADR-0013) is immediate-mode: `view(state)` builds a fresh,
 anonymous node tree every frame; `measure`+`render` lay it out and paint it; the

--- a/packages/ui/examples/popup.zig
+++ b/packages/ui/examples/popup.zig
@@ -1,18 +1,24 @@
-//! An anchored dropdown (ADR-0019): a button that opens a menu floating directly
-//! below it. It's pure composition of the pieces built across the TUI thread —
+//! Anchored dropdowns (ADR-0019): buttons that open a menu floating directly by
+//! them, kept on screen with smart placement. It's composition of the pieces
+//! built across the TUI thread —
 //!
-//!   - `ui.probe` reports the button's on-screen rect (the anchor),
+//!   - `ui.probe` reports each button's on-screen rect (the anchor),
 //!   - `ui.stack` composites the menu over the base (ADR-0016),
-//!   - `ui.positioned` places the menu at the anchor's rect,
+//!   - `ui.anchored` places the menu at the anchor — flipping above / clamping
+//!     left so it stays on screen (the smart counterpart to `ui.positioned`),
 //!   - `ui.widgets.Select` is the menu list itself.
 //!
-//! Space/Enter/click opens the menu; ↑/↓ move the highlight; Enter chooses and
-//! closes; Esc closes (or quits when already closed). No core engine change —
-//! the popup is just cells painted over the base surface at an offset.
+//! Two buttons show the two behaviours: the top-left one opens its menu *below*
+//! (plenty of room); the bottom-right one has no room below and would spill off
+//! the right, so its menu **flips above** and **clamps left**. No core engine
+//! change — the popup is just cells painted over the base at a computed offset.
 //!
-//! The menu is positioned from the button's rect as probed on the PREVIOUS
-//! frame; the button doesn't move, so that's exact (one frame of lag only on a
-//! resize) — the immediate-mode trade `probe` already documents.
+//! Click a button (or Space/Enter for the top one) to open; ↑/↓ move the
+//! highlight; Enter chooses and closes; Esc closes (or quits when closed).
+//!
+//! The menu is anchored from the button's rect as probed on the PREVIOUS frame;
+//! the button doesn't move, so that's exact (one frame of lag only on a resize) —
+//! the immediate-mode trade `probe` already documents.
 //!
 //! Run with: zig build run-popup   (from packages/ui, needs a real TTY)
 
@@ -26,10 +32,13 @@ const options = [_][]const u8{ "Name", "Date modified", "Size", "Kind" };
 const menu_rows: u16 = options.len; // short menu — show every option, no scroll
 
 const State = struct {
-    open: bool = false,
-    menu: ui.widgets.Select = .{},
-    // The button's rect, filled by `ui.probe` in `view` — the popup's anchor.
-    button: ui.Rect = .{ .x = 0, .y = 0, .w = 0, .h = 0 },
+    /// Which dropdown is open (at most one at a time).
+    open: enum { none, top, corner } = .none,
+    top: ui.widgets.Select = .{},
+    corner: ui.widgets.Select = .{},
+    // Each button's rect, filled by `ui.probe` in `view` — its menu's anchor.
+    top_rect: ui.Rect = .{ .x = 0, .y = 0, .w = 0, .h = 0 },
+    corner_rect: ui.Rect = .{ .x = 0, .y = 0, .w = 0, .h = 0 },
 };
 
 // The panel border + fill come from one theme's surface tokens — change them in
@@ -44,73 +53,99 @@ fn panel(a: std.mem.Allocator, child: ui.Node) !ui.Node {
     }, &.{child});
 }
 
-fn view(a: std.mem.Allocator, state: *State) !ui.Node {
-    const caret: []const u8 = if (state.open) "▴" else "▾";
-    const label = try std.fmt.allocPrint(a, "Sort: {s}  {s}", .{ options[state.menu.highlighted], caret });
-
-    // The button is the anchor — probe its rect so the menu can pin under it.
-    const button_label = try ui.row(a, .{ .padding = .symmetric(1, 0) }, &.{
+/// A dropdown button: a bordered label whose rect is probed into `out`.
+fn button(a: std.mem.Allocator, out: *ui.Rect, label: []const u8) !ui.Node {
+    const inner = try ui.row(a, .{ .padding = .symmetric(1, 0) }, &.{
         ui.textOpts(.{ .wrap = .clip }, label),
     });
-    const button = try ui.probe(a, &state.button, try panel(a, button_label));
+    return ui.probe(a, out, try panel(a, inner));
+}
 
+fn view(a: std.mem.Allocator, state: *State) !ui.Node {
+    // The top button is wide ("Sort: <value>"), but it fills its row, so its
+    // left edge is pinned regardless of the value — its menu never moves.
+    const top_caret: []const u8 = if (state.open == .top) "▴" else "▾";
+    const top_label = try std.fmt.allocPrint(a, "Sort: {s}  {s}", .{ options[state.top.highlighted], top_caret });
+    const top_button = try button(a, &state.top_rect, top_label);
+
+    // The corner button is compact (narrower than its menu, so the menu visibly
+    // clamps left) and RIGHT-anchored. Its label is FIXED — it doesn't reflow
+    // with the selection — on purpose: a value-reflowing right-anchored button
+    // would move its own left edge frame-to-frame, and the menu, faithfully
+    // anchored to it, would appear to jitter (worsened by probe's one-frame lag).
+    // A fixed-width trigger keeps the anchor still. The choice shows in the menu.
+    const corner_label: []const u8 = if (state.open == .corner) "Sort ▴" else "Sort ▾";
+    const corner_button = try button(a, &state.corner_rect, corner_label);
+
+    // Base: top button in the top-left, corner button pinned bottom-right.
     const base = try ui.column(a, .{
         .padding = .all(1),
         .gap = 1,
         .width = .{ .fill = 1 },
         .height = .{ .fill = 1 },
     }, &.{
-        ui.text(.{ .bold = true }, "Anchored dropdown"),
-        button,
+        ui.text(.{ .bold = true }, "Anchored dropdowns — flip + clamp"),
+        top_button,
         ui.spacer(),
-        ui.text(.{ .dim = true }, "Space/Enter/click opens · ↑/↓ pick · Enter choose · Esc close · q quit"),
+        ui.text(.{ .dim = true }, "Click a button (or Space for the top one) · ↑/↓ pick · Enter choose · Esc close · q quit"),
+        try ui.row(a, .{}, &.{ ui.spacer(), corner_button }),
     });
 
-    if (!state.open) return base;
+    if (state.open == .none) return base;
 
-    // Open: the menu floats in a stack layer, positioned just below the button.
-    const menu = try panel(a, try state.menu.view(a, .{
+    // Open: the menu floats in a stack layer, anchored to its button. `anchored`
+    // opens it below when there's room (top) and flips above + clamps left when
+    // there isn't (corner) — the same helper, the placement adapts to the rect.
+    const sel = if (state.open == .top) &state.top else &state.corner;
+    const rect = if (state.open == .top) state.top_rect else state.corner_rect;
+    const menu = try panel(a, try sel.view(a, .{
         .focused = true,
         .options = &options,
         .height = menu_rows,
     }));
     return ui.stack(a, .{}, &.{
         base,
-        try ui.positioned(a, state.button.x, state.button.y + state.button.h, menu),
+        try ui.anchored(a, rect, .{}, menu),
     });
+}
+
+fn hit(r: ui.Rect, x: u16, y: u16) bool {
+    return x >= r.x and x < r.x + r.w and y >= r.y and y < r.y + r.h;
 }
 
 fn update(state: *State, ev: ?ui.Event) !ui.Flow {
     const e = ev orelse return .keep;
     switch (e) {
         .key => |k| {
-            if (state.open) {
-                // Menu open: navigation goes to the Select; Enter/Esc close it.
-                if (state.menu.handle(k, options.len, menu_rows)) return .keep;
+            if (state.open != .none) {
+                // Menu open: navigation goes to the active Select; Enter/Esc close.
+                const sel = if (state.open == .top) &state.top else &state.corner;
+                if (sel.handle(k, options.len, menu_rows)) return .keep;
                 switch (k) {
-                    .enter, .escape => state.open = false, // Enter keeps the highlight
+                    .enter, .escape => state.open = .none, // Enter keeps the highlight
                     else => {},
                 }
             } else switch (k) {
                 .char => |c| switch (c) {
-                    ' ' => state.open = true,
+                    ' ' => state.open = .top,
                     'q' => return .quit,
                     else => {},
                 },
-                .enter => state.open = true,
+                .enter => state.open = .top,
                 .escape => return .quit,
                 .ctrl => |c| if (c == 'c') return .quit,
                 else => {},
             }
         },
         .mouse => |m| {
-            // Click the button to toggle the menu (hit-test its probed rect).
+            // Click a button to toggle its menu (hit-test the probed rects).
             if (m.button == .left and m.action == .press) {
                 const px = m.x -| 1;
                 const py = m.y -| 1;
-                const r = state.button;
-                if (px >= r.x and px < r.x + r.w and py >= r.y and py < r.y + r.h) {
-                    state.open = !state.open;
+                if (hit(state.top_rect, px, py)) {
+                    state.open = if (state.open == .top) .none else .top;
+                } else if (hit(state.corner_rect, px, py)) {
+                    state.open = if (state.open == .corner) .none else .corner;
                 }
             }
         },
@@ -139,7 +174,7 @@ pub fn main(init: std.process.Init) !void {
     var app = try ui.App.initFullScreen(gpa, &stdout.interface, .{
         .capability = .ansi_256,
         .stdin = &stdin.interface,
-        .mouse = true, // click the button to open
+        .mouse = true, // click a button to open
     });
     defer app.deinit();
 

--- a/packages/ui/src/layout_test.zig
+++ b/packages/ui/src/layout_test.zig
@@ -521,3 +521,99 @@ test "positioned places its child at an absolute offset over a transparent base"
     try testing.expectEqualStrings("...POP..", try rowString(&h, &s, 1));
     try testing.expectEqualStrings("........", try rowString(&h, &s, 2));
 }
+
+// A base of dots the size of the surface; the anchored popup composites over it.
+fn dotBase(h: *Harness, w: u16, rows: u16) !ui.Node {
+    const line = try h.a().alloc(u8, w);
+    @memset(line, '.');
+    const children = try h.a().alloc(ui.Node, rows);
+    for (children) |*c| c.* = ui.textOpts(.{ .wrap = .clip }, line);
+    return ui.column(h.a(), .{}, children);
+}
+
+test "anchored opens below the anchor when there is room" {
+    var h = Harness.init();
+    defer h.deinit();
+    var s = try ui.Surface.init(testing.allocator, 8, 5);
+    defer s.deinit();
+
+    // Anchor is a 2-wide, 1-tall widget at (1, 1); the 3x1 popup opens below it.
+    const anchor: ui.Rect = .{ .x = 1, .y = 1, .w = 2, .h = 1 };
+    const node = try ui.stack(h.a(), .{}, &.{
+        try dotBase(&h, 8, 5),
+        try ui.anchored(h.a(), anchor, .{}, ui.textOpts(.{ .wrap = .clip }, "POP")),
+    });
+    try renderInto(&h, node, &s);
+
+    // Left edge pins to the anchor's x (1); row is anchor.y + anchor.h = 2.
+    try testing.expectEqualStrings("........", try rowString(&h, &s, 1));
+    try testing.expectEqualStrings(".POP....", try rowString(&h, &s, 2));
+    try testing.expectEqualStrings("........", try rowString(&h, &s, 3));
+}
+
+test "anchored flips above when the popup would run off the bottom" {
+    var h = Harness.init();
+    defer h.deinit();
+    var s = try ui.Surface.init(testing.allocator, 8, 5);
+    defer s.deinit();
+
+    // Anchor sits on the last row (y=4); a 2-tall popup can't open below, but
+    // fits above, so it flips to end just above the anchor (rows 2..3).
+    const anchor: ui.Rect = .{ .x = 1, .y = 4, .w = 2, .h = 1 };
+    const popup = try ui.column(h.a(), .{}, &.{
+        ui.textOpts(.{ .wrap = .clip }, "AA"),
+        ui.textOpts(.{ .wrap = .clip }, "BB"),
+    });
+    const node = try ui.stack(h.a(), .{}, &.{
+        try dotBase(&h, 8, 5),
+        try ui.anchored(h.a(), anchor, .{}, popup),
+    });
+    try renderInto(&h, node, &s);
+
+    try testing.expectEqualStrings(".AA.....", try rowString(&h, &s, 2));
+    try testing.expectEqualStrings(".BB.....", try rowString(&h, &s, 3));
+    // The anchor's own row is untouched (base shows through).
+    try testing.expectEqualStrings("........", try rowString(&h, &s, 4));
+}
+
+test "anchored clamps left when the popup would run off the right edge" {
+    var h = Harness.init();
+    defer h.deinit();
+    var s = try ui.Surface.init(testing.allocator, 8, 4);
+    defer s.deinit();
+
+    // Anchor near the right edge (x=6); a 4-wide popup pinned there would end at
+    // x=10, off an 8-wide screen, so it shifts left to sit flush at x=4.
+    const anchor: ui.Rect = .{ .x = 6, .y = 0, .w = 2, .h = 1 };
+    const node = try ui.stack(h.a(), .{}, &.{
+        try dotBase(&h, 8, 4),
+        try ui.anchored(h.a(), anchor, .{}, ui.textOpts(.{ .wrap = .clip }, "WIDE")),
+    });
+    try renderInto(&h, node, &s);
+
+    try testing.expectEqualStrings("....WIDE", try rowString(&h, &s, 1));
+}
+
+test "anchored keeps the preferred side and clips when neither side fits" {
+    var h = Harness.init();
+    defer h.deinit();
+    var s = try ui.Surface.init(testing.allocator, 8, 3);
+    defer s.deinit();
+
+    // A 3-tall popup fits neither below (anchor at y=1, only row 2 left) nor
+    // fully above; it keeps `below` and clips to the one visible row.
+    const anchor: ui.Rect = .{ .x = 0, .y = 1, .w = 2, .h = 1 };
+    const popup = try ui.column(h.a(), .{}, &.{
+        ui.textOpts(.{ .wrap = .clip }, "11"),
+        ui.textOpts(.{ .wrap = .clip }, "22"),
+        ui.textOpts(.{ .wrap = .clip }, "33"),
+    });
+    const node = try ui.stack(h.a(), .{}, &.{
+        try dotBase(&h, 8, 3),
+        try ui.anchored(h.a(), anchor, .{}, popup),
+    });
+    try renderInto(&h, node, &s);
+
+    // Below the anchor: only the popup's first row lands; the rest clips.
+    try testing.expectEqualStrings("11......", try rowString(&h, &s, 2));
+}

--- a/packages/ui/src/ui.zig
+++ b/packages/ui/src/ui.zig
@@ -231,6 +231,84 @@ pub fn positioned(a: std.mem.Allocator, x: u16, y: u16, child: Node) !Node {
     });
 }
 
+/// Smart-placement options for `anchored`.
+pub const AnchorOpts = struct {
+    /// Which side of the anchor to open on when there's room. `anchored` flips
+    /// to the other side only when the preferred side doesn't fit and the other
+    /// does; otherwise it keeps the preferred side (and clips off-screen).
+    prefer: enum { below, above } = .below,
+    /// Which edges to align horizontally: `.left` pins the popup's left edge to
+    /// the anchor's left, `.right` pins their right edges. Either way the popup
+    /// is then clamped so its right edge stays on screen (never shifted past x=0).
+    halign: enum { left, right } = .left,
+};
+
+/// Pin `popup` to `anchor`, keeping it on screen — the smart counterpart to
+/// `positioned` (ADR-0019). It opens below the anchor, but **flips above** when
+/// it would run off the bottom (and above fits), and **clamps** left when it
+/// would run off the right edge. Returns a `stack` layer, so an anchored popup
+/// is `stack{ base, anchored(probed_rect, .{}, popup) }`.
+///
+/// The geometry runs at RENDER time, where a `stack` layer is granted the whole
+/// viewport as its region (ADR-0016) — so the popup can be `measure`d and placed
+/// against the real viewport, the two facts `view` lacks. `anchor` is a probed
+/// rect (ADR-0019), reflecting the previous frame; exact for a stable anchor.
+pub fn anchored(a: std.mem.Allocator, anchor: Rect, opts: AnchorOpts, popup: Node) !Node {
+    const ctx = try a.create(Anchor);
+    ctx.* = .{ .popup = popup, .anchor = anchor, .opts = opts };
+    return .{
+        .kind = .{ .custom = .{
+            .context = ctx,
+            .measureFn = Anchor.measureFn,
+            .renderFn = Anchor.renderFn,
+        } },
+    };
+}
+
+const Anchor = struct {
+    popup: Node,
+    anchor: Rect,
+    opts: AnchorOpts,
+
+    /// Take the whole offer so the `stack` grants this leaf the full viewport.
+    fn measureFn(_: *anyopaque, _: *const RenderCtx, limits: Limits) Size {
+        return .{ .w = limits.max_w, .h = limits.max_h };
+    }
+
+    fn renderFn(context: *anyopaque, rctx: *const RenderCtx, region: Region) anyerror!void {
+        const self: *const Anchor = @ptrCast(@alignCast(context));
+        const vw = region.width();
+        const vh = region.height();
+        const size = measure(rctx, &self.popup, .{ .max_w = vw, .max_h = vh });
+        if (size.w == 0 or size.h == 0) return;
+
+        // Vertical: keep the preferred side, flipping to the other only when the
+        // preferred one overflows and the other fits; else keep it and clip.
+        const below_y = self.anchor.y +| self.anchor.h;
+        const above_y = self.anchor.y -| size.h;
+        const fits_below = @as(u32, below_y) + size.h <= vh;
+        const fits_above = self.anchor.y >= size.h;
+        const y = switch (self.opts.prefer) {
+            .below => if (!fits_below and fits_above) above_y else below_y,
+            .above => if (!fits_above and fits_below) below_y else above_y,
+        };
+
+        // Horizontal: align an edge to the anchor, then clamp on screen. `want_x`
+        // and `max_x` go through i32 because a right-align or a popup wider than
+        // the viewport can push the ideal x negative.
+        const want_x: i32 = switch (self.opts.halign) {
+            .left => @as(i32, self.anchor.x),
+            .right => @as(i32, self.anchor.x) + self.anchor.w - size.w,
+        };
+        const max_x: i32 = @max(0, @as(i32, vw) - size.w);
+        const x: u16 = @intCast(@max(0, @min(want_x, max_x)));
+
+        // `sub` clips against the region, so a kept-but-overflowing popup (the
+        // "doesn't fit either side" case) trims gracefully instead of erroring.
+        try render(rctx, &self.popup, region.sub(.{ .x = x, .y = y, .w = size.w, .h = size.h }));
+    }
+};
+
 pub const ViewportOpts = struct {
     /// Caller-owned vertical scroll offset, in rows (immediate mode — the app
     /// holds it in state and adjusts it on ↑/↓/PageUp/PageDown). Clamped to the


### PR DESCRIPTION
## Summary

Adds `ui.anchored(a, anchor, opts, popup)`, the smart counterpart to `ui.positioned`: it pins a popup to a probed rect and keeps it on screen —

- **flips above** the anchor when the popup would run off the bottom (and above fits), and
- **clamps** horizontally when it would run off the right edge (never past x=0).

`positioned` stays the dumb primitive; `anchored` is the smart layer over it. This closes the last deferral from ADR-0019 increment 3.

## How it works

Flip/clamp needs two things `view` doesn't have: the viewport size and the popup's *measured* size. So `anchored` is a **custom leaf** (like `probe`/`viewport`) that runs the geometry at **render** time — where a `stack` grants each layer the full inner region, which *is* the viewport. Inside `renderFn` it `measure`s the popup against the viewport, picks the vertical side (flip policy), aligns and clamps x, and renders into `region.sub(rect)` (which clips the keep-and-overflow case gracefully). No core engine change.

`AnchorOpts { prefer: .below|.above = .below, halign: .left|.right = .left }` — `halign`, not `align`, which is a Zig keyword.

## Example

`examples/popup.zig` gains a second, bottom-right dropdown whose menu **flips above** and **clamps left**, demonstrating both behaviours live alongside the top dropdown's plain open-below. Its trigger is fixed-width on purpose — a value-reflowing right-anchored button would move its own left edge frame-to-frame, and the menu (faithfully anchored to it) would appear to jitter.

## Tests

4 headless layout tests in `layout_test.zig` (modeled on the existing `positioned` test): opens-below, flips-above, clamps-left, keep-and-clip-when-neither-fits. PTY-validated with a real terminal emulator: top menu opens below; corner menu flips above + clamps ~7 cols left and stays stable across all highlight positions.

Extends ADR-0019 as increment 4 (no new ADR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)