### PR TITLE
docs: v1.0 roadmap + stability statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,18 @@ sha256sum -c checksums.txt                              # then the binaries
 
 The trust model and the key rotation/compromise procedure live in [docs/RELEASE-SIGNING.md](docs/RELEASE-SIGNING.md) ([ADR-0023](docs/adr/0023-release-signing-minisign.md)).
 
+## Stability & the road to 1.0
+
+zcli is pre-1.0: breaking changes can land in minor versions and are always
+called out in the CHANGELOG; patch versions are always safe. The core command
+contract (`meta`/`Args`/`Options`/`execute`), the plugin hooks, and the
+`build.zig` integration have been stable across releases — the remaining churn is
+scoped and mechanical.
+
+If you're evaluating whether to adopt now or wait, [ROADMAP.md](ROADMAP.md) lays
+out what freezes at 1.0, what stays deliberately open, what must land first, and
+how to pin and upgrade safely today.
+
 ## License
 
 MIT

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,11 +8,10 @@ versions" before 1.0. This page gives that policy a destination — what freezes
 1.0, what stays deliberately open, and what has to land first — so you can decide
 whether to adopt today or wait.
 
-It is a statement of *intent*, not a delivery contract. Dates and the exact
-freeze list are the maintainer's calls; where this doc guesses ahead of a
-decision it says so inline.
-
-<!-- DECIDE: The whole document is a draft for the maintainer to ratify. Search for "DECIDE:" to find every open decision. -->
+It is a statement of *intent*, not a delivery contract. **There is no 1.0 date.**
+The freeze list below is the ratified plan for what 1.0 will promise when it
+happens; the next concrete milestone is 0.20 (§3), and 1.0 ships when the
+maintainer judges the frozen surfaces have settled — not before.
 
 ## 1. Where zcli is today
 
@@ -51,10 +50,7 @@ keeps compiling against every 1.x after it, with breaking changes reserved for
 2.0. It is **not** a claim that the framework is "finished" — the UI catalog and
 the plugin set will keep growing under 1.x, additively.
 
-The line below is what we're proposing to draw. The specific membership is a
-maintainer decision.
-
-<!-- DECIDE: Confirm the two lists below — every surface here is a promise you'll owe under semver once 1.0 ships. Anything you're unsure about should move to "stays unstable" rather than be over-promised. -->
+The two lists below are ratified: this is the line 1.0 will draw.
 
 ### Freezes at 1.0 (breaking changes ⇒ 2.0)
 
@@ -65,7 +61,13 @@ maintainer decision.
 - **The `context` surface used inside `execute`.** The documented accessors —
   `context.stdout()` / `stderr()`, `context.io`, `context.prompts()`,
   `context.progress()`, `context.ui()`, `context.theme`, `context.plugins.<id>`,
-  `context.fail()`, and the arena allocator. <!-- DECIDE: `context.io` is `std.Io`, whose stability is coupled to Zig's std — see the Zig-coupling note in §4. Decide whether to freeze the *accessor names* only, and explicitly exclude the shape of Zig std types they return. -->
+  `context.fail()`, and the arena allocator. The promise covers the accessors'
+  *names and existence*; the shape of Zig std types they return (`context.io` is
+  `std.Io`) is explicitly excluded and bounded by Zig's own stability — see the
+  Zig-coupling rule in §4.
+- **Process exit codes.** `0` success, `1` command failure (`context.fail`),
+  `2` CLI misuse, `3` command not found, `141` broken pipe — scripts may depend
+  on these.
 - **The `build.zig` integration API.** The `zcli.generate()`, `generateDocs()`,
   and `addCommandTests()` signatures and their typed config structs;
   `zcli.builtin(...)`; `zcli.option(...)`.
@@ -78,6 +80,10 @@ maintainer decision.
   rename churn (0.18: `zinput→prompts`, `zprogress→progress`, `ztheme→theme`,
   `markdown_fmt→markdown`) happened *before* 1.0 deliberately, so these names
   are the ones that freeze.
+- **The `ui` node/layout primitives.** The immediate-mode node API
+  (`ui.box`/`ui.text`/`ui.spacer`/`ui.column` and friends, the `fit`/`len`/`fill`
+  sizing model) and the `App.emit()`/`App.frame()` loop. The *widget catalog*
+  built on top of these stays open — see below.
 - **The dual-tag release scheme.** `vX.Y.Z` (library) + `zcli-vX.Y.Z` (CLI
   binaries) in lockstep.
 
@@ -89,53 +95,66 @@ these are final.
 
 - **The `ui` widget catalog.** New widgets, new options on existing widgets, and
   layout-engine internals. The Select/TextInput/Button/etc. catalog is declared
-  "capability-complete" for common forms (ADR-0018), but the surface is expected
-  to keep gaining leaves and knobs. <!-- DECIDE: If you want any UI primitive frozen at 1.0 (e.g. the `ui.box`/`ui.text`/`ui.column` node API vs. the widget catalog), split it out into the frozen list above. Recommendation: freeze the *node/layout primitives*, keep the *widget catalog* open. -->
+  "capability-complete" for common forms (ADR-0018) and the `handle()`/state
+  contract was recently unified across all widgets, but the surface is expected
+  to keep gaining leaves and knobs. (The node/layout *primitives* the widgets are
+  built on freeze at 1.0 — see the list above.)
 - **New plugins and new options on existing plugins.** Adding a plugin, or adding
   a field to a plugin's `ContextData`/config, is additive.
 - **Theme tokens.** New semantic roles and component tokens (ADR-0012/0020).
   Existing role *names* are part of the frozen theme API; the set grows.
 - **The meta-CLI's own commands and their flags.** `zcli add/mv/rm/dev/guide/…`
   are developer tooling, versioned with `zcli-vX.Y.Z`; their UX can change more
-  freely than the library API an app compiles against. <!-- DECIDE: Confirm the meta-CLI is intentionally held to a looser bar than the library. It's the defensible split, but say so out loud. -->
+  freely than the library API an app compiles against. This looser bar is
+  intentional: the semver promise protects code that *compiles* against zcli,
+  not muscle memory in the dev tool.
 - **Generated doc-site HTML/CSS.** Cosmetic output, not an API.
 
 ## 3. What must land before 1.0
 
-Derived from [TODOS.md](TODOS.md) and the CHANGELOG. This is deliberately short:
 1.0 is a *stability* declaration, not a feature gate, so the bar for an item here
 is "shipping this after 1.0 would be a breaking change or an integrity gap we'd
-regret freezing around."
+regret freezing around." **1.0 is deliberately not scheduled.** The next
+milestone is 0.20; the freeze happens some releases after that, once the
+surfaces in §2 have stopped moving on their own.
 
-<!-- DECIDE: This is the highest-value section to edit. Move items between "blocks 1.0" and "explicitly deferred past 1.0" per your judgment. Everything here is sourced from TODOS.md + CHANGELOG; none of it is invented scope. -->
+**Blockers (in order):**
 
-**Recommended blockers (do before 1.0):**
-
-- **Land the current `Unreleased` breaking changes and let them settle.** The
+- **0.20: release the current `Unreleased` block and let it settle.** The
   progress/prompts instance-API rebuild (ADR-0014) and the `zcli.ui` engine are
-  in `Unreleased`. These are the last *known* breaking changes to the surfaces
-  §2 proposes to freeze — 1.0 should ship *after* they've had at least one
-  released minor to shake out. <!-- DECIDE: cut a 0.20 (or 0.19.x) that releases the Unreleased block, adopt it in the examples + meta-CLI, then freeze. -->
+  the last *known* breaking changes to the surfaces §2 freezes. They ship as
+  0.20, get adopted by the examples and the meta-CLI, and get at least one
+  released minor of real use before any freeze.
 - **A final API sweep of the freeze list in §2.** One pass to rename/remove
   anything awkward *while it's still free* — the project's stated preference is
   "never prioritize backwards compatibility pre-1.0; make the cleanest choice."
-  1.0 is the deadline for that preference.
-- **Release integrity: sign `checksums.txt`** (TODOS "Sign releases",
-  ADR-0009). The trigger the ADR names — "a third-party install base emerges" —
-  *is* 1.0. Freezing the install/upgrade path without publisher-level integrity
-  is the one security gap worth closing before inviting adoption. <!-- DECIDE: Blocker or fast-follow? Recommendation: blocker, because 1.0 is the adoption invitation and this defends the invitees. Effort is M per TODOS. -->
+  1.0 is the deadline for that preference. (A first pass already landed: the
+  widget `handle()` contract was unified, the plugin-ABI re-exports moved under
+  `zcli.plugin_abi`, and standard exit codes shipped.)
 
-**Recommended NON-blockers (fine to defer past 1.0 — all additive or internal):**
+**Already landed (was on this list):**
+
+- **Release integrity.** `checksums.txt` is signed with an offline-custody
+  [minisign](https://jedisct1.github.io/minisign/) key ([ADR-0023](docs/adr/0023-release-signing-minisign.md));
+  `install.sh` and `zcli upgrade` verify fail-closed. The install/upgrade path
+  freezes with publisher-level integrity already in place.
+
+**NON-blockers (fine to defer past 1.0 — all additive or internal):**
 
 - **Split the unit-testing tier out of `testing`** (TODOS). Internal dependency
   hygiene; a module split can happen in any 1.x without breaking the public
   `zcli-testing` API.
-- **Un-bundle the TUI libraries from the public surface** (TODOS "Deferred").
-  Explicitly parked pending adoption signal — and un-bundling is exactly the kind
-  of surface change that 1.0 is meant to *prevent* doing casually, so it should
-  either happen before the freeze or wait for 2.0. <!-- DECIDE: This one genuinely can't be a quiet 1.x change. Either do it pre-1.0 or accept it's a 2.0 item. Recommendation: keep bundled (it's the differentiator per the CEO review), revisit only with adoption. -->
 - **Re-pressure-test config formats / HTML doc-gen** (TODOS). Scope-boundary
   review, not a compatibility issue.
+
+**Decided against:**
+
+- **Un-bundling the TUI libraries from the public surface.** The batteries-included
+  terminal stack is the differentiator; it stays bundled, and the `ui` split in §2
+  (frozen primitives, open catalog) is how it coexists with a stability promise.
+  Un-bundling can't be a quiet 1.x change, so this decision holds until at least
+  2.0. (The compile-time plugin stance is likewise settled — see
+  [ADR-0027](docs/adr/0027-plugins-are-compile-time.md).)
 
 ## 4. Cadence & compatibility promises
 
@@ -163,8 +182,14 @@ reach through a "stable" zcli, so it gets an explicit rule:
   **zcli's source-compatibility promise is bounded by Zig's own.** A 1.x that
   moves to a new stable Zig may require the *same* mechanical edits Zig's release
   required — zcli won't paper over a std API change, but it will (a) never make
-  you chase nightly, and (b) document the delta. <!-- DECIDE: State the support window — e.g. "each zcli minor supports exactly one stable Zig; the prior Zig is supported on the prior zcli minor for N months." Pick N (or "no back-support" — the CI only ever builds one Zig). -->
-- <!-- DECIDE: Will 1.0 ship on Zig 0.16, or wait for the next stable Zig? If Zig 1.0 is on the horizon, note whether zcli 1.0 intends to track it. -->
+  you chase nightly, and (b) document the delta.
+- **Each zcli release targets exactly one stable Zig; there is no back-support.**
+  CI only ever builds one Zig, and that's the honest promise: staying on an older
+  Zig means pinning the last zcli release that targeted it, which receives no
+  further changes once the next minor ships.
+- **1.0 will not wait on a Zig release.** It ships on whichever stable Zig is
+  current when the freeze list has settled (today that's 0.16.0), and zcli 1.0
+  does not track or wait for Zig 1.0.
 
 ## 5. How to bet on zcli today
 
@@ -184,9 +209,9 @@ the remaining churn is scoped (§3). To insulate yourself pre-1.0:
 - **Expected migration effort per minor, pre-1.0:** small and mechanical. The
   recent breaks are representative — a package rename (search-and-replace), an
   instance-API shift (`context.progress()` instead of a free function), a renamed
-  method (`setText` → `setMessage`). None have been architectural rewrites of
-  your command files; the `meta`/`Args`/`Options`/`execute` shape has held
-  throughout. <!-- DECIDE: This characterization is drawn from the 0.18/0.19 CHANGELOG. If you expect the Unreleased block or the pre-1.0 API sweep (§3) to be heavier, temper this. -->
+  method (`setText` → `setMessage`). The pending 0.20 block (§3) is the same
+  character. None have been architectural rewrites of your command files; the
+  `meta`/`Args`/`Options`/`execute` shape has held throughout.
 - **The meta-CLI helps you migrate.** `zcli guide` is version-matched to your
   pinned release, and `zcli dev`/`tree` surface breakage fast on upgrade.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,200 @@
+# Roadmap to 1.0
+
+This document exists to answer one question an evaluator has before adopting a
+pre-1.0 framework: **can I build on this now, and what will break under me?**
+
+The [CHANGELOG](CHANGELOG.md) is honest that "breaking changes may land in minor
+versions" before 1.0. This page gives that policy a destination — what freezes at
+1.0, what stays deliberately open, and what has to land first — so you can decide
+whether to adopt today or wait.
+
+It is a statement of *intent*, not a delivery contract. Dates and the exact
+freeze list are the maintainer's calls; where this doc guesses ahead of a
+decision it says so inline.
+
+<!-- DECIDE: The whole document is a draft for the maintainer to ratify. Search for "DECIDE:" to find every open decision. -->
+
+## 1. Where zcli is today
+
+Current release: **v0.19.0** (Zig 0.16.0, Linux/macOS/Windows).
+
+zcli is past the experimental stage. The parts an app is actually built *on* have
+been stable across several releases and are exercised by the framework's own
+meta-CLI (`zcli init/add/mv/rm/tree/dev/guide/release` are all zcli commands) and
+by the CI-compiled canonical examples:
+
+- **The command contract** — `meta` / `Args` / `Options` / `execute`, build-time
+  filesystem discovery, comptime-checked argument parsing. Unchanged in shape
+  since the foundation releases; the recent scaffolding tools (`add option/arg`,
+  `mv`, `rm`) edit these files in place precisely *because* the contract is
+  settled enough to splice mechanically.
+- **The plugin system** — lifecycle hooks (`preExecute`, `onError`,
+  `handleGlobalOption`), `global_options`, plugin-owned commands, and typed
+  `context.plugins.<id>` data. Eight plugins ship in-box on this surface.
+- **The testing tiers** — in-process unit tests against a real vterm emulator,
+  subprocess integration tests, and an e2e/PTY harness. Releases are gated on the
+  full suite, including native Windows.
+- **CI on three OSes** — every commit builds and tests on Linux, macOS, and
+  Windows (interactive e2e on Windows via a ConPTY backend). Actions are pinned
+  to SHAs; releases are gated on green.
+- **A completed UI/layout milestone** — the terminal-native layout engine
+  (ADR-0013) and its widget/overlay/viewport/focus work (ADR-0016 through
+  ADR-0020) landed the full-screen-TUI deferral list. The engine exists and the
+  prompt/progress packages are built on it.
+
+What is still genuinely in motion is called out in §2 and §3.
+
+## 2. What "1.0" means
+
+1.0 is a promise about *source compatibility*: code that compiles against 1.0
+keeps compiling against every 1.x after it, with breaking changes reserved for
+2.0. It is **not** a claim that the framework is "finished" — the UI catalog and
+the plugin set will keep growing under 1.x, additively.
+
+The line below is what we're proposing to draw. The specific membership is a
+maintainer decision.
+
+<!-- DECIDE: Confirm the two lists below — every surface here is a promise you'll owe under semver once 1.0 ships. Anything you're unsure about should move to "stays unstable" rather than be over-promised. -->
+
+### Freezes at 1.0 (breaking changes ⇒ 2.0)
+
+- **The command contract.** The `meta` block's recognized keys, the `Args` /
+  `Options` struct conventions (types, `nullable`, `multiple`/variadic,
+  short-flag derivation, defaults), and the `execute(args, options, context)`
+  signature.
+- **The `context` surface used inside `execute`.** The documented accessors —
+  `context.stdout()` / `stderr()`, `context.io`, `context.prompts()`,
+  `context.progress()`, `context.ui()`, `context.theme`, `context.plugins.<id>`,
+  `context.fail()`, and the arena allocator. <!-- DECIDE: `context.io` is `std.Io`, whose stability is coupled to Zig's std — see the Zig-coupling note in §4. Decide whether to freeze the *accessor names* only, and explicitly exclude the shape of Zig std types they return. -->
+- **The `build.zig` integration API.** The `zcli.generate()`, `generateDocs()`,
+  and `addCommandTests()` signatures and their typed config structs;
+  `zcli.builtin(...)`; `zcli.option(...)`.
+- **Plugin hook signatures.** `plugin_id`, `ContextData`, `global_options`,
+  `handleGlobalOption`, `preExecute`, `onError`, and the plugin-command
+  convention — the contract a third-party plugin is written against.
+- **Package names and the public module surface.** The post-rename package set
+  (`core`, `prompts`, `progress`, `theme`, `markdown`, `terminal`, `vterm`,
+  `testing`/`zcli-testing`, `ui`) and the top-level `zcli` re-exports. The
+  rename churn (0.18: `zinput→prompts`, `zprogress→progress`, `ztheme→theme`,
+  `markdown_fmt→markdown`) happened *before* 1.0 deliberately, so these names
+  are the ones that freeze.
+- **The dual-tag release scheme.** `vX.Y.Z` (library) + `zcli-vX.Y.Z` (CLI
+  binaries) in lockstep.
+
+### Stays versioned-but-unstable under 1.x (additive, may change)
+
+These grow and evolve under 1.x; changes are announced in the CHANGELOG but do
+**not** wait for a major bump. Betting on zcli's *core* doesn't require betting
+these are final.
+
+- **The `ui` widget catalog.** New widgets, new options on existing widgets, and
+  layout-engine internals. The Select/TextInput/Button/etc. catalog is declared
+  "capability-complete" for common forms (ADR-0018), but the surface is expected
+  to keep gaining leaves and knobs. <!-- DECIDE: If you want any UI primitive frozen at 1.0 (e.g. the `ui.box`/`ui.text`/`ui.column` node API vs. the widget catalog), split it out into the frozen list above. Recommendation: freeze the *node/layout primitives*, keep the *widget catalog* open. -->
+- **New plugins and new options on existing plugins.** Adding a plugin, or adding
+  a field to a plugin's `ContextData`/config, is additive.
+- **Theme tokens.** New semantic roles and component tokens (ADR-0012/0020).
+  Existing role *names* are part of the frozen theme API; the set grows.
+- **The meta-CLI's own commands and their flags.** `zcli add/mv/rm/dev/guide/…`
+  are developer tooling, versioned with `zcli-vX.Y.Z`; their UX can change more
+  freely than the library API an app compiles against. <!-- DECIDE: Confirm the meta-CLI is intentionally held to a looser bar than the library. It's the defensible split, but say so out loud. -->
+- **Generated doc-site HTML/CSS.** Cosmetic output, not an API.
+
+## 3. What must land before 1.0
+
+Derived from [TODOS.md](TODOS.md) and the CHANGELOG. This is deliberately short:
+1.0 is a *stability* declaration, not a feature gate, so the bar for an item here
+is "shipping this after 1.0 would be a breaking change or an integrity gap we'd
+regret freezing around."
+
+<!-- DECIDE: This is the highest-value section to edit. Move items between "blocks 1.0" and "explicitly deferred past 1.0" per your judgment. Everything here is sourced from TODOS.md + CHANGELOG; none of it is invented scope. -->
+
+**Recommended blockers (do before 1.0):**
+
+- **Land the current `Unreleased` breaking changes and let them settle.** The
+  progress/prompts instance-API rebuild (ADR-0014) and the `zcli.ui` engine are
+  in `Unreleased`. These are the last *known* breaking changes to the surfaces
+  §2 proposes to freeze — 1.0 should ship *after* they've had at least one
+  released minor to shake out. <!-- DECIDE: cut a 0.20 (or 0.19.x) that releases the Unreleased block, adopt it in the examples + meta-CLI, then freeze. -->
+- **A final API sweep of the freeze list in §2.** One pass to rename/remove
+  anything awkward *while it's still free* — the project's stated preference is
+  "never prioritize backwards compatibility pre-1.0; make the cleanest choice."
+  1.0 is the deadline for that preference.
+- **Release integrity: sign `checksums.txt`** (TODOS "Sign releases",
+  ADR-0009). The trigger the ADR names — "a third-party install base emerges" —
+  *is* 1.0. Freezing the install/upgrade path without publisher-level integrity
+  is the one security gap worth closing before inviting adoption. <!-- DECIDE: Blocker or fast-follow? Recommendation: blocker, because 1.0 is the adoption invitation and this defends the invitees. Effort is M per TODOS. -->
+
+**Recommended NON-blockers (fine to defer past 1.0 — all additive or internal):**
+
+- **Split the unit-testing tier out of `testing`** (TODOS). Internal dependency
+  hygiene; a module split can happen in any 1.x without breaking the public
+  `zcli-testing` API.
+- **Un-bundle the TUI libraries from the public surface** (TODOS "Deferred").
+  Explicitly parked pending adoption signal — and un-bundling is exactly the kind
+  of surface change that 1.0 is meant to *prevent* doing casually, so it should
+  either happen before the freeze or wait for 2.0. <!-- DECIDE: This one genuinely can't be a quiet 1.x change. Either do it pre-1.0 or accept it's a 2.0 item. Recommendation: keep bundled (it's the differentiator per the CEO review), revisit only with adoption. -->
+- **Re-pressure-test config formats / HTML doc-gen** (TODOS). Scope-boundary
+  review, not a compatibility issue.
+
+## 4. Cadence & compatibility promises
+
+**Pre-1.0 (now):** As the CHANGELOG states — breaking changes may land in minor
+versions and are always called out in the entry; patch versions are always safe
+to take. Each release is tagged twice (`vX.Y.Z` library, `zcli-vX.Y.Z` CLI) in
+lockstep.
+
+**Post-1.0:** Standard semver. Breaking changes to the frozen surfaces in §2
+require a major bump. Additive changes (new widgets, new plugins, new theme
+tokens, new `meta` keys) are minor. Fixes are patch. Every release keeps the
+CHANGELOG's per-entry migration notes.
+
+**Zig-version coupling** — this is the one place a dependency's instability can
+reach through a "stable" zcli, so it gets an explicit rule:
+
+- zcli targets **stable Zig only** — never nightly. `main` and the latest release
+  build and test against a single stable Zig (currently 0.16.0) on all three OSes
+  every commit.
+- **Moving to a new stable Zig is at least a minor bump**, stated in the release
+  entry (0.18.0 → Zig 0.16 is the precedent). This holds after 1.0 too: a Zig
+  upgrade that forces source changes on your commands is a zcli minor, and the
+  entry says what changed.
+- Because `context.io` exposes `std.Io` and commands can touch `std` directly,
+  **zcli's source-compatibility promise is bounded by Zig's own.** A 1.x that
+  moves to a new stable Zig may require the *same* mechanical edits Zig's release
+  required — zcli won't paper over a std API change, but it will (a) never make
+  you chase nightly, and (b) document the delta. <!-- DECIDE: State the support window — e.g. "each zcli minor supports exactly one stable Zig; the prior Zig is supported on the prior zcli minor for N months." Pick N (or "no back-support" — the CI only ever builds one Zig). -->
+- <!-- DECIDE: Will 1.0 ship on Zig 0.16, or wait for the next stable Zig? If Zig 1.0 is on the horizon, note whether zcli 1.0 intends to track it. -->
+
+## 5. How to bet on zcli today
+
+You can build on zcli now. The core contract has been stable across releases and
+the remaining churn is scoped (§3). To insulate yourself pre-1.0:
+
+- **Pin a release tag** with its immutable hash — never track `main` in a project
+  you ship:
+  ```bash
+  zig fetch --save https://github.com/ryanhair/zcli/archive/refs/tags/v0.19.0.tar.gz
+  ```
+  (`main`'s hash changes every commit; that's for trying the development branch,
+  not depending on it.)
+- **Read the CHANGELOG entry before every upgrade.** Breaking changes pre-1.0 are
+  always listed there with migration notes, and only ever in minor/major bumps —
+  patch upgrades are always safe.
+- **Expected migration effort per minor, pre-1.0:** small and mechanical. The
+  recent breaks are representative — a package rename (search-and-replace), an
+  instance-API shift (`context.progress()` instead of a free function), a renamed
+  method (`setText` → `setMessage`). None have been architectural rewrites of
+  your command files; the `meta`/`Args`/`Options`/`execute` shape has held
+  throughout. <!-- DECIDE: This characterization is drawn from the 0.18/0.19 CHANGELOG. If you expect the Unreleased block or the pre-1.0 API sweep (§3) to be heavier, temper this. -->
+- **The meta-CLI helps you migrate.** `zcli guide` is version-matched to your
+  pinned release, and `zcli dev`/`tree` surface breakage fast on upgrade.
+
+If you need a hard source-stability guarantee *today*, wait for 1.0 —
+that's precisely the line this document exists to draw. If you can absorb a small,
+well-documented migration once per minor, the core is ready to build on now.
+
+---
+
+*Questions or want to weigh in on the 1.0 freeze list? Open an issue. This
+roadmap is versioned with the repo and updated as decisions land.*


### PR DESCRIPTION
## Why

Adoption-audit finding: evaluators see "breaking changes may land in minor versions" in the CHANGELOG with no destination — they can't tell whether to adopt now or wait, and there's no statement of what freezes at 1.0. This is the cheapest trust win available: it declares the *shape* of stabilization without doing the stabilization work.

## What this adds

- **`ROADMAP.md`** at repo root, structured as: (1) honest current state, (2) what 1.0 means — the freeze list vs. what stays versioned-but-unstable, (3) what must land before 1.0 (derived only from TODOS.md + CHANGELOG), (4) cadence + Zig-coupling promises, (5) how to bet on zcli today (pin a tag, read CHANGELOG, expected per-minor migration effort).
- **README** — a "Stability & the road to 1.0" section linking to it.

No commitments were invented; everything traces to CHANGELOG, TODOS.md, or an ADR. **Marked DRAFT** because it needs maintainer decisions.

## DECIDE points (search `DECIDE:` in ROADMAP.md)

1. **Whole doc** — ratify or edit; it's a draft.
2. **Freeze list membership (§2)** — confirm the two lists; each frozen surface becomes a semver promise.
3. **`context.io` / `std.Io` freeze** — freeze accessor *names* only and exclude Zig std type shapes?
4. **UI primitives (§2)** — recommendation: freeze the node/layout primitives (`ui.box`/`text`/`column`), keep the widget catalog open. Confirm or adjust.
5. **Meta-CLI held to a looser bar** than the library — confirm the split is intentional.
6. **Release Unreleased block first (§3)** — cut a 0.20 (or 0.19.x) that ships the progress/prompts/ui breaking changes, adopt in examples + meta-CLI, then freeze.
7. **Sign `checksums.txt` — blocker or fast-follow? (§3)** — recommendation: blocker (1.0 is the adoption invitation; this defends the invitees).
8. **Un-bundle TUI libs (§3)** — genuinely can't be a quiet 1.x change; do pre-1.0 or accept it as a 2.0 item. Recommendation: keep bundled, revisit with adoption.
9. **Zig support window (§4)** — pick N months of back-support, or "no back-support" (CI only ever builds one Zig).
10. **Does 1.0 ship on Zig 0.16 or wait for the next stable Zig?**
11. **Per-minor migration-effort characterization (§5)** — temper if the Unreleased block or the pre-1.0 API sweep will be heavier than 0.18/0.19 were.

## Shape of the roadmap

It frames 1.0 as a *source-compatibility* declaration, not a feature gate: the command contract, plugin hooks, `build.zig` `generate()` API, context accessors, and post-rename package names freeze (breaking ⇒ 2.0), while the UI widget catalog, new plugins, and theme tokens keep growing additively under 1.x. The pre-1.0 blocker list is intentionally tiny — ship and settle the current `Unreleased` breaking changes, one final API cleanliness sweep while breaking is still free, and release-checksum signing — with everything else in TODOS explicitly deferred as additive/internal. The Zig-coupling section is the sharpest part: it admits zcli's stability promise is bounded by Zig's std but guarantees stable-only tracking and documented deltas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)