### PR TITLE
docs: fix website version drift + standardize install URL, guard both in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,50 @@ jobs:
             exit 1
           fi
 
+      # The website's getting-started page shows a demo `install` transcript with
+      # a hardcoded release version ("Fetching latest release… zcli vX.Y.Z" and a
+      # `zcli --version` line). The site builds from a prebuilt Zine binary — not
+      # zig build — so nothing recompiles these strings against the zon; they drift
+      # silently. Pin them to the released version (root build.zig.zon) here.
+      - name: Website transcript version matches the release
+        shell: bash
+        run: |
+          root=$(grep -m1 -oE '\.version = "[0-9]+\.[0-9]+\.[0-9]+"' build.zig.zon | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          gs=website/layouts/getting-started.shtml
+          # Every version string in the demo transcript's two release lines.
+          strings=$(grep -oE 'zcli v?[0-9]+\.[0-9]+\.[0-9]+' "$gs" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | sort -u)
+          if [ -z "$strings" ]; then
+            echo "::error::could not find any 'zcli <version>' string in $gs — did the transcript change shape?"
+            exit 1
+          fi
+          echo "root build.zig.zon:              $root"
+          echo "$gs transcript versions:"
+          echo "$strings" | sed 's/^/  /'
+          for v in $strings; do
+            if [ "$v" != "$root" ]; then
+              echo "::error::version drift: $gs shows zcli $v but the release is $root — update the demo transcript"
+              exit 1
+            fi
+          done
+
+      # The one-line curl installer standardises on the branded zcli.sh host
+      # (https://zcli.sh/install.sh) across README + every website layout. The
+      # drift this catches is a stray raw.githubusercontent.com install URL —
+      # the old form that slipped in on some pages. (The home page renders the
+      # host without the scheme, and the getting-started demo terminal shows an
+      # elided `…/install.sh` placeholder; both are the branded host, so we
+      # simply forbid the wrong host rather than pin an exact string.)
+      - name: Install URL uses the branded host, not raw.githubusercontent
+        shell: bash
+        run: |
+          bad=$(grep -rnE 'raw\.githubusercontent\.com/[^ ]*install\.sh' README.md website/layouts || true)
+          if [ -n "$bad" ]; then
+            echo "::error::install URL drift — use https://zcli.sh/install.sh, not the raw GitHub URL. Offending lines:"
+            echo "$bad"
+            exit 1
+          fi
+          echo "No raw.githubusercontent.com install URLs — all install commands use the branded zcli.sh host"
+
   test:
     name: unit tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/website/layouts/docs.shtml
+++ b/website/layouts/docs.shtml
@@ -95,7 +95,7 @@
           <p>See the <a href="$site.page('install').link()">install page</a> for every option, including shell completions.</p>
           <div class="code">
             <div class="code-head"><span class="fname">terminal</span><span class="lang">sh</span></div>
-<pre><span class="c-prompt">$</span> <span class="c-cmd">curl</span> -fsSL https://raw.githubusercontent.com/ryanhair/zcli/main/install.sh | sh</pre>
+<pre><span class="c-prompt">$</span> <span class="c-cmd">curl</span> -fsSL https://zcli.sh/install.sh | sh</pre>
           </div>
 
           <div class="step"><span class="n">2</span><h2>Scaffold a project</h2></div>

--- a/website/layouts/getting-started.shtml
+++ b/website/layouts/getting-started.shtml
@@ -121,8 +121,8 @@
         <div>
           <p class="col-label">Run</p>
           <div class="cmdbox">
-            <pre><span class="pr">$</span> curl -fsSL https://raw.githubusercontent.com/ryanhair/zcli/main/install.sh | sh</pre>
-            <button onclick="cp(this,'curl -fsSL https://raw.githubusercontent.com/ryanhair/zcli/main/install.sh | sh')">copy</button>
+            <pre><span class="pr">$</span> curl -fsSL https://zcli.sh/install.sh | sh</pre>
+            <button onclick="cp(this,'curl -fsSL https://zcli.sh/install.sh | sh')">copy</button>
           </div>
           <p class="note">The script detects your platform, pulls the matching binary from the latest GitHub release, verifies the checksum when available, and marks it executable.</p>
         </div>
@@ -148,13 +148,13 @@
           <div class="term-body">
 <pre><span class="c-prompt">$</span> <span class="c-cmd">curl</span> -fsSL <span class="c-mut">…/install.sh</span> | sh
 <span class="c-flag">==></span> Detecting platform… macos / aarch64
-<span class="c-flag">==></span> Fetching latest release… zcli v0.18.0
+<span class="c-flag">==></span> Fetching latest release… zcli v0.19.0
 <span class="c-flag">==></span> Downloading binary…
 <span class="c-flag">==></span> Verifying checksum…
 <span class="c-ok">  ✓</span> Installed zcli to ~/.local/bin/zcli
 
 <span class="c-prompt">$</span> <span class="c-cmd">zcli</span> --version
-zcli 0.18.0
+zcli 0.19.0
 
 <span class="c-prompt">$</span> <span class="c-cmd">zcli</span> --help
 <span class="c-mut">Build beautiful CLIs with zcli — scaffold</span>

--- a/website/layouts/install.shtml
+++ b/website/layouts/install.shtml
@@ -56,8 +56,8 @@
         <h3>Install script</h3>
         <p>Downloads the latest release binary for your platform and drops it in your install dir.</p>
         <div class="cmdbox">
-          <pre><span class="pr">$</span> curl -fsSL https://raw.githubusercontent.com/ryanhair/zcli/main/install.sh | sh</pre>
-          <button onclick="cp(this,'curl -fsSL https://raw.githubusercontent.com/ryanhair/zcli/main/install.sh | sh')">copy</button>
+          <pre><span class="pr">$</span> curl -fsSL https://zcli.sh/install.sh | sh</pre>
+          <button onclick="cp(this,'curl -fsSL https://zcli.sh/install.sh | sh')">copy</button>
         </div>
         <p style="font-size:13.5px;">Requires <code class="mono" style="color:var(--accent)">curl</code>. The script reads the latest release from GitHub, verifies the checksum when available, and makes the binary executable.</p>
       </div>


### PR DESCRIPTION
## Summary

The website builds from a prebuilt Zine binary (not `zig build`), so its hardcoded version strings and install commands never recompile against the zon and drift silently. This syncs them to the **0.19.0** release and adds two CI guards (in the existing `version consistency` job) so the drift can't recur.

## zcli.sh URL verdict

`curl -sI https://zcli.sh/install.sh` → **HTTP/2 200**, `content-type: application/x-sh`. The branded URL serves the install script, so everything is standardized on `https://zcli.sh/install.sh` (README and `home.shtml` already used it; the three website pages that used the raw GitHub URL now match).

## Files changed

- `website/layouts/getting-started.shtml:151` — demo transcript `Fetching latest release… zcli v0.18.0` → `v0.19.0`
- `website/layouts/getting-started.shtml:157` — `zcli 0.18.0` → `zcli 0.19.0` (`--version` output line)
- `website/layouts/getting-started.shtml:124-125` — install command + copy button `raw.githubusercontent.com/ryanhair/zcli/main/install.sh` → `https://zcli.sh/install.sh`
- `website/layouts/install.shtml:59-60` — install command + copy button → `https://zcli.sh/install.sh`
- `website/layouts/docs.shtml:98` — install command → `https://zcli.sh/install.sh`
- `.github/workflows/ci.yml` — extended the `version consistency` job with two steps:
  - **Website transcript version matches the release** — asserts every `zcli <version>` string in the getting-started demo transcript equals root `build.zig.zon`.
  - **Install URL uses the branded host, not raw.githubusercontent** — fails if any install command in README/website uses the `raw.githubusercontent.com/...install.sh` host.

## Intentionally left unchanged

- **Zig-version-support tables** (`README.md:360`, `website/layouts/why.shtml:148`, `website/layouts/changelog.shtml:25`): `v0.18.0 and later → 0.16.0` is **accurate**, not stale. CHANGELOG shows v0.18.0 is where Zig 0.16.0 first became required; 0.19.0 is covered by "and later". Narrowing the label to v0.19.0 would wrongly drop 0.18.0 users from the 0.16.0 row. (This matches the finding's own note to verify table semantics first.)
- `home.shtml` renders the host without the scheme (`zcli.sh/install.sh`) and the getting-started demo terminal shows an elided `…/install.sh` placeholder — both are the branded host, so the URL guard forbids only the wrong host rather than pinning an exact string.
- ADR docs referencing old package names (`zinput`/`zprogress`/`ztheme`) — historical, left alone per scope.

## Local verification

All three checks in the `version consistency` job pass locally against the fixed tree:

```
=== version-sync ===   root=0.19.0 cli=0.19.0 readme=0.19.0  → PASS
=== website transcript === root=0.19.0 strings=[0.19.0]      → PASS
=== install URL ===    no raw.githubusercontent.com install URLs → PASS
```

Sanity-checked that the install-URL guard *would* have failed on the pre-fix `raw.githubusercontent.com/...install.sh` lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)