### PR TITLE
docs(ui): prompts vs widgets decision guide + ui README sync

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -76,13 +76,38 @@ try ui.row(a, .{ .gap = 1 }, &.{
 });
 ```
 
+## Full-screen mode
+
+The hybrid shares the screen; a full-screen TUI takes it over on the same
+engine ([ADR-0015](../../docs/adr/0015-full-screen-tui-mode.md)). `context.uiFullScreen()`
+(or `ui.App.initFullScreen`) enters the alternate screen and raw mode, grants
+the frame the whole viewport, and drives a `view → nextEvent → update` loop
+(`app.run` owns it for you, with an optional tick clock). `emit` is an error —
+there's no scrollback to flow into — and a panic hook is required and
+compile-time-enforced (`pub const panic = zcli.ui.panic;`). On exit the shell
+comes back exactly as it was; the final frame does not persist.
+
+Interactive widgets for full-screen forms and menus live in `ui.widgets`
+alongside the progress ones ([ADR-0018](../../docs/adr/0018-focusable-widgets.md)):
+`TextInput` (optional password `mask`), `Checkbox`, `Select` (scrolling window,
+truncation, optional multi-line `wrap`), and `Button`. Each is a plain struct
+you embed in your state with a `view(a, opts) !Node` + `handle(key) bool`
+contract; focus is caller-owned (an enum), and an unconsumed key is form-level
+navigation. Overlays (`stack` + `center`, [ADR-0016](../../docs/adr/0016-overlays-z-layers.md)),
+scrolling panes (`viewport`, [ADR-0017](../../docs/adr/0017-scrollable-viewports.md)),
+and anchored popups (`probe` + `positioned` / `anchored`, [ADR-0019](../../docs/adr/0019-position-feedback.md))
+are all composition on the same tree.
+
 ## Try it
 
 ```sh
-zig build run-demo     # deploy-style task frame; needs a real terminal
-zig build run-hybrid   # the Claude-Code shape: streaming prose + live multi-bar
-zig build test         # pure layout tests + vterm golden-frame tests
+zig build run-demo        # hybrid: deploy-style task frame; needs a real terminal
+zig build run-hybrid      # hybrid: the Claude-Code shape — streaming prose + live multi-bar
+zig build run-fullscreen  # full-screen: a top-style dashboard — viewport, tick, overlay, mouse
+zig build run-form        # full-screen: focusable form — text fields, select, checkbox, button
+zig build run-popup       # full-screen: anchored dropdowns that flip above / clamp on screen
+zig build test            # pure layout tests + vterm golden-frame tests
 ```
 
-Resize the terminal while either runs: the live frame re-lays-out and the
-visible static tail rewraps with it.
+Resize the terminal while a hybrid example runs: the live frame re-lays-out and
+the visible static tail rewraps with it.

--- a/website/layouts/docs.shtml
+++ b/website/layouts/docs.shtml
@@ -263,6 +263,7 @@ exe.root_module.<span class="fn">addImport</span>(<span class="str">"command_reg
     .message = <span class="str">"Token:"</span>,
 });</pre>
           </div>
+          <p>Prompts are one-shot questions that block, return a value, and fall back to line input off a TTY. For a persistent, laid-out, keyboard-driven surface — a live form or dashboard — build a full-screen App from the interactive widgets instead: see <a href="$site.page('ui').link().suffix('#choose')">prompts vs widgets</a>.</p>
         </section>
 
         <!-- ============ PROGRESS & THEMING ============ -->

--- a/website/layouts/ui.shtml
+++ b/website/layouts/ui.shtml
@@ -57,6 +57,7 @@
         <a href="#fullscreen">Full-screen mode</a>
         <a href="#forms">Focusable widgets</a>
         <a href="#overlays">Overlays &amp; popups</a>
+        <a href="#choose">Prompts vs widgets</a>
         <p class="toc-label">Details</p>
         <a href="#standalone">Standalone use</a>
         <a href="#try">Try it</a>
@@ -251,6 +252,24 @@
           </div>
           <p>Two more helpers build on the same idea. A <code>viewport</code> is a scrolling window onto content taller than the space it's granted — a log pane, a long list — with the scroll offset held in your own state. And <code>probe</code> reports where a node actually rendered, which <code>anchored</code> then uses to pin a popup to it: a dropdown that opens under a button, <b>flips above</b> when it would run off the bottom, and <b>clamps left</b> when it would run off the right — smart placement as pure composition, no new primitive.</p>
           <div class="callout"><b>Chrome comes from the theme</b> <code>ui.panel</code>'s border and fill, and any bordered box's border color, derive from your app's <code>zcli_theme</code> surface tokens — so a modal or dropdown needs no style mentions to look right, and one theme change reskins every overlay at once. See <a href="$site.page('theming').link().suffix('#surface')">theming → surface chrome</a>.</div>
+        </section>
+
+        <section id="choose">
+          <h2>Prompts vs widgets</h2>
+          <p>zcli has two ways to ask the user something, and they solve different problems. The <a href="$site.page('docs').link().suffix('#prompts')">prompts</a> package asks a question; the full-screen widgets above build a screen. Reach for the right one:</p>
+          <div class="table-scroll">
+          <table class="ptable">
+            <thead><tr><th></th><th>prompts</th><th>ui widgets</th></tr></thead>
+            <tbody>
+              <tr><td class="name">shape</td><td class="desc">one-shot Q&amp;A — <code>const name = try p.text(.{ ... })</code> blocks, returns a value, moves on</td><td class="desc">persistent widgets you embed in an <code>App</code> you drive frame by frame</td></tr>
+              <tr><td class="name">loop</td><td class="desc">self-contained — the prompt runs its own read loop internally</td><td class="desc">you own the <code>view → update</code> loop (usually via <code>app.run</code>)</td></tr>
+              <tr><td class="name">focus &amp; layout</td><td class="desc">one field at a time, on its own line</td><td class="desc">many fields on screen at once, caller-owned focus, full layout</td></tr>
+              <tr><td class="name">non-TTY</td><td class="desc">falls back to line-based input automatically (pipes, CI)</td><td class="desc">full-screen only — needs a real terminal</td></tr>
+              <tr><td class="name">reach for it when</td><td class="desc">a wizard, a scaffold, a few sequential questions</td><td class="desc">a live form, a dashboard, a pager — anything that owns the screen</td></tr>
+            </tbody>
+          </table>
+          </div>
+          <p>In one line: <b>prompts are a question; widgets are a screen.</b> If you want to ask a few things and print a result, use <a href="$site.page('docs').link().suffix('#prompts')">prompts</a> — they're shorter and degrade gracefully off a TTY. If you want a persistent, laid-out, keyboard-driven surface, build a <a href="#fullscreen">full-screen App</a> from the <a href="#forms">focusable widgets</a>.</p>
         </section>
 
         <section id="standalone">


### PR DESCRIPTION
Rebuilt on `origin/main` after #204 merged, which independently added most of the interactive-stack docs (full-screen mode, focusable widgets, overlays & popups, `stack` in the node table, all five Try-it examples, plus theming/home updates). This PR is now the minimal delta covering the piece #204 didn't ship.

## What's here

- **ui page — "prompts vs widgets" decision guide (`#choose`).** The #1 gap a new user hits: when to reach for a one-shot prompt (self-driving loop, non-TTY fallback, "ask a question") vs an embedded widget in an `App` you drive ("build a screen"). A comparison table plus a one-line rule, placed after `#overlays` with its own TOC entry, referencing the merged page's real anchors (`#forms`, `#fullscreen`) and the docs prompts section.
- **docs page — cross-link.** The prompts section now links to the guide (`ui/#choose`).
- **`packages/ui/README.md` sync.** #204 did *not* touch the README, which was still stale. Added a Full-screen mode section (widgets + overlays + viewport + anchored popups, linking ADRs 0015–0019) and updated the Try-it list to all five examples.

## Dropped as redundant (now on main via #204)

The `#fullscreen`, `#forms`, `#overlays` sections, the "Interactive"/"Full-screen" TOC group, the frame-model callout rewrite, and the Try-it five-example list on the ui page — all landed independently.

## Validation

Clean `zine release` (v0.11.3, matches CI). Verified in the generated HTML: `#choose` anchor + TOC entry resolve, the guide's `#forms`/`#fullscreen`/docs-prompts links resolve, and the docs→`ui/#choose` cross-link resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)