### PR TITLE
docs: sync ui + theming docs with full-screen TUI and theme-derived defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,14 @@ All notable changes to zcli are documented here.
 
 ## Unreleased
 
-The terminal-native layout engine (ADR-0013) and the migration of the interactive packages onto it.
+The terminal-native layout engine (ADR-0013), the migration of the interactive packages onto it, and its growth into a full-screen TUI toolkit (ADRs 0015–0020).
 
 ### Added
-- **`zcli.ui`** — a terminal-native layout engine for CLI/TUI hybrid apps: a static stream flowing into scrollback plus a diffed live region (`app.emit()` / `app.frame(node)`). Immediate-mode node trees (box/text/spacer/custom, `fit`/`len`/`fill` sizing), viewport clamping, resize re-layout including reflow of the visible static tail, real-cursor placement for line editors, and plain-line degradation when piped. `context.ui()` returns a pre-wired `ui.App`.
+- **`zcli.ui`** — a terminal-native layout engine for CLI/TUI hybrid apps: a static stream flowing into scrollback plus a diffed live region (`app.emit()` / `app.frame(node)`). Immediate-mode node trees (box/text/spacer/custom, `fit`/`len`/`fill` sizing), viewport clamping, resize re-layout including reflow of the visible static tail, real-cursor placement for line editors, and plain-line degradation when piped. `context.ui(.{})` returns a pre-wired `ui.App`.
+- **Full-screen TUI mode** — `context.uiFullScreen(.{})` / `App.initFullScreen` run the same layout engine on the alternate screen with raw input and an `App.run` event loop (`view` builds the tree, `update` handles a key/resize/mouse/focus/paste event or a deadline-scheduled `null` tick, an optional post-frame hook places the hardware cursor). The screen and scrollback are restored on exit; requires a `pub const panic = zcli.ui.panic` hook (checked at compile time). (ADR-0015)
+- **Focusable widgets** — `ui.widgets.TextInput`, `Select`, `Checkbox`, and `Button`: immediate-mode structs with a `view`/`handle` contract where `handle` returns whether it consumed the key (the whole routing model), caller-owned focus via `focusNext`/`focusPrev`, hardware-cursor placement, and click-to-focus. `Select` supports multi-line / wrapped options. (ADRs 0018–0019)
+- **Overlays, viewports, and popups** — a `stack` z-layer direction with `center` for modals, `viewport` for content taller than its window, and `probe`/`positioned`/`anchored` for popups that flip above and clamp on screen; plus opt-in `mouse`/`focus`/`paste` events. (ADRs 0016–0019)
+- **Theme-derived style defaults** — every styling default derives from the root `zcli_theme` at compile time: a new `surface` token group (`border`, `panel`) styles full-screen chrome, `ui.panel` and bordered boxes need no call-site `Style`, and `ui.role(r)` resolves a palette role in one word. (ADR-0020)
 - **`progress.MultiBar`** — stacked labeled bars for parallel work with thread-safe updates.
 - vterm supports DECAWM (private mode 7).
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Nine spinner styles, plus stacked multi-bars for parallel work; animations auto-
 Prompts and progress render on `zcli.ui` — a terminal-native layout engine, and it's yours to use directly. Output splits into a static stream that flows into scrollback and a live region that repaints in place just above it — a full layout, from a single line up to the whole viewport, not a fixed bottom strip. Unlike a full-screen TUI it never takes the terminal over, so your scrollback stays intact. This is the shape of modern agent-style CLIs: a component is just a function returning a node, and frames are diffed, so an animation repaints one cell, not the screen.
 
 ```zig
-var app = try context.ui();
+var app = try context.ui(.{});
 defer app.deinit(); // restores the terminal; the final frame persists
 
 try app.emit("compiled {s}", .{name});            // static → scrollback
@@ -235,7 +235,9 @@ try app.frame(try ui.column(app.arena(), .{ .border = .rounded }, &.{
 }));                                              // live → diffed repaint
 ```
 
-Boxes, wrapped text, spacers, and custom leaves; `fit`/`len`/`fill` sizing; viewport-clamped, resize-aware (the live region re-lays-out and the visible scrollback tail reflows), and piped output degrades to plain lines. Design in [ADR-0013](docs/adr/0013-terminal-native-layout-engine.md), API in [packages/ui](packages/ui/).
+Boxes, wrapped text, spacers, and custom leaves; `fit`/`len`/`fill` sizing; viewport-clamped, resize-aware (the live region re-lays-out and the visible scrollback tail reflows), and piped output degrades to plain lines.
+
+When you want the whole terminal — a `top`-style dashboard, an interactive form — the same node tree, layout, and diff run in **full-screen mode**: `context.uiFullScreen(.{})` switches to the alternate screen and hands the `frame → event → update` loop to `app.run`. It comes with focusable widgets (`TextInput`, `Select`, `Checkbox`, `Button` — each a plain struct in your state, routed by a single `handle`-returns-`bool` contract), overlays via a `stack` of z-layers, scrollable viewports, mouse/focus/paste events, and anchored popups that flip and clamp to stay on screen. On exit the shell comes back exactly as it was. Design in [ADR-0013](docs/adr/0013-terminal-native-layout-engine.md) (full-screen and widgets in [ADRs 0015–0020](docs/adr/)), API in [packages/ui](packages/ui/).
 
 ## Theming
 
@@ -259,7 +261,7 @@ try styled("Synced").success().render(writer, &context.theme);
 try styled("Error").red().bold().render(writer, &context.theme);
 ```
 
-Semantic roles (`success`, `err`, `warning`, `command`, `path`, …) resolve at render time and adapt to the terminal: true color, 256 color, 16 color, or no color (respects `NO_COLOR`). Component tokens (`prompts.cursor`, `progress.spinner`, …) default to palette roles, so one palette change restyles everything. Full API in [packages/theme](packages/theme/).
+Semantic roles (`success`, `err`, `warning`, `command`, `path`, …) resolve at render time and adapt to the terminal: true color, 256 color, 16 color, or no color (respects `NO_COLOR`). Component tokens (`prompts.cursor`, `progress.spinner`, `surface.border`, …) default to palette roles, so one palette change restyles everything — including the chrome behind a full-screen panel. Styling defaults *derive* from the theme at compile time, so `ui.panel` and bordered boxes need no `Style` at the call site and `ui.text(ui.role(.success), …)` styles by meaning in one word. Full API in [packages/theme](packages/theme/).
 
 ## Config files
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -787,9 +787,12 @@ command reaches through its `context`:
 
 - **`theme`** — semantic styling. A comptime `Palette` maps roles
   (`success`, `command`, `path`, …) to styles; component tokens
-  (`prompts.cursor`, `progress.spinner`) default to those roles. Everything
+  (`prompts.cursor`, `progress.spinner`, `surface.border`/`surface.panel`)
+  default to those roles. Every styling default derives from the root
+  `zcli_theme` at comptime (ADR-0020), so `ui.panel` and bordered boxes need no
+  call-site style and `ui.role(r)` styles by meaning in one word. Everything
   resolves against the detected terminal capability, from true color down to
-  `NO_COLOR`. See ADR-0012.
+  `NO_COLOR`. See ADR-0012, ADR-0020.
 - **`prompts`** — eight interactive prompt types (`text`, `select`,
   `multiSelect`, `search`, …) with grapheme-aware line editing, falling back to
   line input when stdin is not a TTY.
@@ -805,22 +808,38 @@ into scrollback (`app.emit`) and a **live region** that repaints in place just
 above it (`app.frame`) — a full layout area, from a single line up to the whole
 viewport, positioned above committed scrollback rather than a fixed bottom strip.
 This is the same static-above / live-below split as Ink's `<Static>` and dynamic
-render: the engine shares the screen instead of taking it over (no alternate
-screen buffer), so scrollback is preserved — the deliberate trade against a
-full-screen TUI (ADR-0013). The live region is immediate-mode: a
+render: in this hybrid mode the engine shares the screen instead of taking it
+over (no alternate screen buffer), so scrollback is preserved (ADR-0013). The
+live region is immediate-mode: a
 component is a function returning a `Node`; each frame the tree is rebuilt into a
 per-frame arena, measured, painted onto a cell `Surface`, and diffed against the
 previous frame, so only changed cells reach the terminal. Four node kinds
 (`box`, `text`, `spacer`, `custom`) and three sizing words (`fit`, `len`,
 `fill`) cover the vocabulary; the region re-measures against the terminal each
-frame, so it re-lays-out on resize and clamps to the viewport. A full-screen app
-is just a root sized `fill`, not a separate mode. This is the CLI/TUI hybrid —
-the shape of modern agent-style CLIs — exposed directly as `zcli.ui` /
-`context.ui()`.
+frame, so it re-lays-out on resize and clamps to the viewport. This is the
+CLI/TUI hybrid — the shape of modern agent-style CLIs — exposed directly as
+`zcli.ui` / `context.ui(.{})`.
+
+**Full-screen mode (ADR-0015).** When an app wants the whole terminal instead of
+sharing it — a `top`-style dashboard, an interactive form — the same node tree,
+layout, and diff run on the alternate screen: `context.uiFullScreen(.{})` (or
+`App.initFullScreen` standalone, which requires a `pub const panic =
+zcli.ui.panic` hook, enforced at compile time). `App.run` owns the
+`frame → nextEvent → update` loop — `view(arena, state)` builds the tree,
+`update(state, event)` mutates state for a key/resize/mouse/focus/paste event or
+a deadline-scheduled `null` tick and returns `keep`/`quit`, and an optional
+post-frame hook places the hardware cursor. On top sit focusable widgets
+(`TextInput`/`Select`/`Checkbox`/`Button`, immediate-mode structs routed by a
+single `handle`-returns-`bool` contract with caller-owned focus), overlays (a
+`stack` of z-layers with `center`), scrollable `viewport`s, and anchored popups
+(`probe`/`positioned`/`anchored`, flipping and clamping to stay on screen). On
+exit the shell's screen and scrollback return exactly as they were — the final
+frame does not persist. `emit` is a compile-time error here; everything is the
+frame.
 
 **Construction idiom (ADR-0014).** `context.X()` is the single front door for
 every output capability: `context.theme`, `context.prompts()`,
-`context.progress()`, `context.markdown()`, `context.ui()` each hand back an
+`context.progress()`, `context.markdown()`, `context.ui(.{})` each hand back an
 instance already wired to the command's streams, allocator, io, and theme. The
 stateless packages (`prompts`, `progress`, `markdown`) are value bundles — the
 import *is* the type — so standalone use fills the same fields by hand;

--- a/website/content/theming/index.smd
+++ b/website/content/theming/index.smd
@@ -1,7 +1,7 @@
 ---
 .title = "zcli — Theming",
-.description = "zcli theming: declare one theme and your whole CLI follows it — help output, styled text, prompts, spinners, and progress bars, with graceful degradation from true color down to NO_COLOR.",
-.date = @date("2026-07-07"),
+.description = "zcli theming: declare one theme and your whole CLI follows it — help output, styled text, prompts, spinners, progress bars, and full-screen panel chrome. Styling defaults derive from that one declaration at compile time, with graceful degradation from true color down to NO_COLOR.",
+.date = @date("2026-07-10"),
 .author = "Ryan Hair",
 .layout = "theming.shtml",
 ---

--- a/website/content/ui/index.smd
+++ b/website/content/ui/index.smd
@@ -1,7 +1,7 @@
 ---
 .title = "zcli — The CLI/TUI hybrid",
-.description = "zcli.ui is a terminal-native layout engine: a static stream that flows into scrollback plus a diffed live region that repaints in place — the shape of modern agent-style CLIs. Immediate-mode node trees, viewport-clamped and resize-aware, degrading to plain lines when piped.",
-.date = @date("2026-07-08"),
+.description = "zcli.ui is a terminal-native layout engine: a static stream that flows into scrollback plus a diffed live region that repaints in place — the shape of modern agent-style CLIs — with a full-screen mode for TUIs: an event loop, focusable form widgets, overlays, and mouse input on the alternate screen. Immediate-mode node trees, viewport-clamped and resize-aware, degrading to plain lines when piped.",
+.date = @date("2026-07-10"),
 .author = "Ryan Hair",
 .layout = "ui.shtml",
 ---

--- a/website/layouts/docs.shtml
+++ b/website/layouts/docs.shtml
@@ -304,7 +304,7 @@ spinner.<span class="fn">succeed</span>(<span class="str">"Synced successfully"<
           <p>Prompts and progress both render on <code>zcli.ui</code> — a terminal-native layout engine — and it's yours to use directly. Output splits into a static stream that flows into scrollback and a live region that repaints in place just above it — a full layout, from a single line up to the whole viewport, not a fixed bottom strip. Unlike a full-screen TUI it never takes the terminal over, so your scrollback stays intact. This is the shape of modern agent-style CLIs: a component is just a function returning a node, and frames are diffed, so an animation repaints one cell, not the screen.</p>
           <div class="code">
             <div class="code-head"><span class="fname">src/commands/deploy.zig</span><span class="lang">zig</span></div>
-<pre><span class="kw">var</span> app = <span class="kw">try</span> context.<span class="fn">ui</span>();
+<pre><span class="kw">var</span> app = <span class="kw">try</span> context.<span class="fn">ui</span>(.{});
 <span class="kw">defer</span> app.<span class="fn">deinit</span>(); <span class="cm">// restores the terminal; the final frame persists</span>
 
 <span class="kw">try</span> app.<span class="fn">emit</span>(<span class="str">"compiled {s}"</span>, .{name});            <span class="cm">// static -> scrollback</span>
@@ -313,7 +313,7 @@ spinner.<span class="fn">succeed</span>(<span class="str">"Synced successfully"<
     ui.<span class="fn">text</span>(.{ .bold = <span class="num">true</span> }, <span class="str">"building..."</span>),
 }));                                          <span class="cm">// live -> diffed repaint</span></pre>
           </div>
-          <p>Boxes, wrapped text, spacers, and custom leaves; <code>fit</code>/<code>len</code>/<code>fill</code> sizing; viewport-clamped and resize-aware, degrading to plain lines when piped. The model, the node vocabulary, and the widgets: see the <a href="$site.page('ui').link()">CLI/TUI hybrid guide</a>.</p>
+          <p>Boxes, wrapped text, spacers, and custom leaves; <code>fit</code>/<code>len</code>/<code>fill</code> sizing; viewport-clamped and resize-aware, degrading to plain lines when piped. The same node tree, layout, and diff also run in <b>full-screen mode</b> — <code>context.uiFullScreen(.{})</code> with an event loop, focusable form widgets, and overlays — when you want to take the terminal over. The model, the node vocabulary, the widgets, and full-screen: see the <a href="$site.page('ui').link()">CLI/TUI hybrid guide</a>.</p>
         </section>
 
         <!-- ============ CONFIG ============ -->

--- a/website/layouts/home.shtml
+++ b/website/layouts/home.shtml
@@ -82,6 +82,7 @@
 		@media (max-width: 900px) {
 			.hero .wrap { grid-template-columns: 1fr; }
 			.features { grid-template-columns: 1fr 1fr; }
+			.filler { display: none; }   /* below 3 columns, 8 cards tile clean on their own */
 		}
 		@media (max-width: 600px) {
 			.features { grid-template-columns: 1fr; }
@@ -306,12 +307,25 @@ Deploying api to staging<span class="cursor"></span></pre>
 					<p>Nine spinner styles plus progress bars with ETA. Semantic colors adapt to your terminal's capabilities.</p>
 					<span class="goto">→ docs</span>
 				</a>
+				<a class="feat" href="$site.page('ui').link()">
+					<svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M7 9l3 3-3 3M13 15h4"/></svg>
+					<h3>CLI/TUI hybrid</h3>
+					<p>A terminal-native layout engine: stream into scrollback with a diffed live region, or go full-screen with forms, overlays, and mouse input.</p>
+					<span class="goto">→ ui</span>
+				</a>
+				<a class="feat" href="$site.page('theming').link()">
+					<svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M12 3s6 5.5 6 10a6 6 0 0 1-12 0c0-4.5 6-10 6-10z"/></svg>
+					<h3>Theming</h3>
+					<p>Declare one theme; help, prompts, progress, and full-screen chrome all follow it — true color down to NO_COLOR, no branches in your code.</p>
+					<span class="goto">→ theming</span>
+				</a>
 				<a class="feat" href="$site.page('docs').link().suffix('#docsgen')">
 					<svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M4 4h11l5 5v11H4z"/><path d="M14 4v5h5M8 13h8M8 17h8"/></svg>
 					<h3>Docs generation</h3>
 					<p>Emit markdown, man pages, and HTML straight from command metadata. Config loads transparently from JSON, TOML, or YAML.</p>
 					<span class="goto">→ docs</span>
 				</a>
+				<span class="feat filler" aria-hidden="true"></span>
 			</div>
 		</div>
 	</section>

--- a/website/layouts/theming.shtml
+++ b/website/layouts/theming.shtml
@@ -51,6 +51,7 @@
         <a href="#declare">Declaring a theme</a>
         <a href="#palette">The palette</a>
         <a href="#tokens">Component tokens</a>
+        <a href="#surface">Surface chrome</a>
         <p class="toc-label">What it styles</p>
         <a href="#help">Help output</a>
         <a href="#output">Command output</a>
@@ -68,7 +69,7 @@
           <p>zcli's theme system is built on three layers:</p>
           <ul>
             <li><b>A palette</b> maps 13 semantic roles — <code>success</code>, <code>err</code>, <code>command</code>, <code>accent</code>, … — to complete styles (color <em>and</em> attributes like bold or dim).</li>
-            <li><b>Component tokens</b> style specific UI elements — the prompt cursor, the spinner, the progress-bar fill. Each token defaults to a palette role, so one palette change restyles everything; any token can also be overridden individually.</li>
+            <li><b>Component tokens</b> style specific UI elements — the prompt cursor, the spinner, the progress-bar fill, the chrome behind a full-screen panel. Each token defaults to a palette role, so one palette change restyles everything; any token can also be overridden individually.</li>
             <li><b>Capability detection</b> renders every style at the terminal's level: true color, 256 color, 16 color, or plain text — and always respects <code>NO_COLOR</code>.</li>
           </ul>
         </section>
@@ -133,6 +134,41 @@
     },
 };</pre>
           </div>
+        </section>
+
+        <section id="surface">
+          <h2>Surface chrome</h2>
+          <p>Prompts and progress are line-oriented. A full-screen <a href="$site.page('ui').link()">UI</a> also draws <em>surfaces</em> — panels, modals, dropdowns, the border around a box. Those get their own token group, <code>surface</code>: the one place you set "the panel look" instead of repeating styles at every call site.</p>
+          <div class="table-scroll">
+          <table class="ptable">
+            <thead><tr><th>Token</th><th>Styles</th><th>Default</th></tr></thead>
+            <tbody>
+              <tr><td class="name">border</td><td class="desc">the color of a box or panel border (the glyph <em>shape</em> — <code>rounded</code>, <code>single</code> — stays a per-node choice)</td><td class="desc">the <code>accent</code> role — recolor your brand and every border follows</td></tr>
+              <tr><td class="name">panel</td><td class="desc">the opaque fill behind a panel or overlay's content</td><td class="desc">a literal dark-gray background (no palette role owns a surface fill)</td></tr>
+            </tbody>
+          </table>
+          </div>
+          <p>The point isn't just two more tokens — it's that <b>styling defaults derive from the theme</b>, resolved at compile time from your root <code>zcli_theme</code>. You rarely pass a <code>Style</code> at a call site at all. A bordered <code>ui.box</code> wears <code>surface.border</code> unless you override it; <code>ui.panel</code> wears both tokens, so a modal or dropdown reskins entirely from the theme with zero style mentions. Set the look once; every surface derives from it.</p>
+          <div class="code">
+            <div class="code-head"><span class="fname">src/main.zig</span><span class="lang">zig</span></div>
+<pre><span class="kw">pub const</span> zcli_theme: zcli.Theme = .{
+    .surface = .{
+        <span class="cm">// defaults: border → accent, panel → a dark-gray fill</span>
+        .border = .{ .role = .info }, <span class="cm">// point borders at a different role…</span>
+        .panel = .{ .style = .{ .background = .{ .indexed = <span class="num">234</span> } } }, <span class="cm">// …or pin a fill</span>
+    },
+};</pre>
+          </div>
+          <p>At the call site, chrome and semantic text both come straight from the theme — no <code>Style</code> literals, no plumbing:</p>
+          <div class="code">
+            <div class="code-head"><span class="fname">a full-screen frame</span><span class="lang">zig</span></div>
+<pre><span class="cm">// A modal whose border and fill derive from the theme's surface tokens.</span>
+<span class="kw">try</span> ui.<span class="fn">panel</span>(a, .{ .padding = .<span class="fn">all</span>(<span class="num">1</span>) }, children);
+
+<span class="cm">// ui.role pulls a palette role into any text node — one word, themed.</span>
+ui.<span class="fn">text</span>(ui.<span class="fn">role</span>(.success), <span class="str">"done"</span>);</pre>
+          </div>
+          <div class="callout"><b>Why compile-time</b> The app theme is a comptime constant reached through the root declaration (the same <code>std_options</code> idiom), so every default resolves where it's declared — the <code>ui</code>, <code>prompts</code>, and <code>progress</code> packages read your theme with no value threaded through their APIs. Custom chrome costs nothing at runtime, and a package compiled into your app picks up <em>your</em> theme automatically.</div>
         </section>
 
         <section id="help">

--- a/website/layouts/ui.shtml
+++ b/website/layouts/ui.shtml
@@ -49,10 +49,14 @@
         <a href="#intro">Overview</a>
         <a href="#model">The frame model</a>
         <a href="#nodes">Nodes &amp; sizing</a>
-        <p class="toc-label">Using it</p>
+        <p class="toc-label">The hybrid</p>
         <a href="#app">The App</a>
-        <a href="#widgets">Widgets</a>
+        <a href="#widgets">Progress widgets</a>
         <a href="#resize">Resize &amp; piping</a>
+        <p class="toc-label">Full-screen</p>
+        <a href="#fullscreen">Full-screen mode</a>
+        <a href="#forms">Focusable widgets</a>
+        <a href="#overlays">Overlays &amp; popups</a>
         <p class="toc-label">Details</p>
         <a href="#standalone">Standalone use</a>
         <a href="#try">Try it</a>
@@ -75,7 +79,7 @@
           <h2>The frame model</h2>
           <p>The live region is rebuilt from scratch every frame: the node tree is allocated into a per-frame arena, measured (constraints down, sizes up), painted onto a cell surface, and diffed against the previous surface. An unchanged frame writes <em>zero</em> bytes; a ticking spinner repaints one cell, not the screen.</p>
           <p>Two verbs drive it. <code>emit</code> writes a static line that scrolls up and away; <code>frame</code> replaces the live region with a new node tree. <code>emit</code> is the only way to write while a region is up — it erases the region, prints the line into scrollback, and repaints the region below it.</p>
-          <div class="callout"><b>Not a full-screen TUI</b> "Above the scrollback" describes where the live region sits, not how big it is — it's a full layout tree, one line to the whole viewport (a full-screen app is just a root sized <code>fill</code>). This is the same static-above / live-below split as Ink's <code>&lt;Static&gt;</code> and dynamic render: the engine shares the terminal and never switches to the alternate screen, so scrollback is preserved. The trade is that there's one live region and it's always the bottom-most live content — top-anchored or multiple independent live regions would need the alt-screen model this deliberately avoids.</div>
+          <div class="callout"><b>Two modes, one engine</b> "Above the scrollback" describes where the live region sits in <em>hybrid</em> mode — the shape above. The region is a full layout tree, one line to the whole viewport, sharing the terminal with your scrollback and never switching to the alternate screen (the same static-above / live-below split as Ink's <code>&lt;Static&gt;</code> and dynamic render). When you <em>do</em> want to take the terminal over — a <code>top</code>-style dashboard, an interactive form — the same node tree, layout, and diff run in <a href="#fullscreen"><b>full-screen mode</b></a>: alt-screen, raw input, an event loop, and nothing left behind on exit. Same vocabulary, different frame.</div>
           <div class="code">
             <div class="code-head"><span class="fname">a component is just a function</span><span class="lang">zig</span></div>
 <pre><span class="cm">// State lives in your structs; the frame is a pure function of it.</span>
@@ -97,7 +101,7 @@
           <table class="ptable">
             <thead><tr><th>Node</th><th>What it is</th></tr></thead>
             <tbody>
-              <tr><td class="name">box</td><td class="desc">the only container — <code>row</code> and <code>column</code> are boxes with a direction; carries <code>gap</code>, <code>padding</code>, and an optional <code>border</code></td></tr>
+              <tr><td class="name">box</td><td class="desc">the only container — <code>row</code>, <code>column</code>, and <code>stack</code> are boxes with a direction (<code>stack</code> overlaps its children into <a href="#overlays">z-layers</a>); carries <code>gap</code>, <code>padding</code>, and an optional <code>border</code></td></tr>
               <tr><td class="name">text</td><td class="desc">a styled string; <code>ui.textOpts</code> chooses <code>wrap</code> / <code>truncate</code> / <code>clip</code> and a fixed width</td></tr>
               <tr><td class="name">spacer</td><td class="desc">flexible empty space; put one before a node to right-align it, one on each side to center</td></tr>
               <tr><td class="name">custom</td><td class="desc">the escape hatch — a leaf that draws its own cells (this is how the progress bar is built)</td></tr>
@@ -106,14 +110,15 @@
           </div>
           <p>Every dimension is one of three words. <code>fit</code> shrinks to content, <code>len(n)</code> pins an exact column count, and <code>fill(weight)</code> shares leftover space by weight — so percentages are fill weights and right-alignment is a spacer, not special-cased geometry.</p>
           <div class="callout"><b>Whitespace</b> The default <code>.wrap</code> mode word-wraps and drops break spaces. Labels with significant whitespace — padded numbers, aligned columns — want <code>.clip</code> or <code>.truncate</code> via <code>ui.textOpts</code>.</div>
+          <p>Everything else is composition. <code>center</code> and <code>positioned</code> place a child with spacer scaffolding; <code>panel</code> is a box whose border and fill come from the <a href="$site.page('theming').link()">theme</a>; <code>viewport</code> scrolls content taller than its window; <code>probe</code> and <code>anchored</code> float a popup at a widget's rendered position. None of them is a new node kind — they're helpers built from the four above, so the engine core stays four kinds and three words.</p>
         </section>
 
         <section id="app">
           <h2>The App</h2>
-          <p>In a command, <code>context.ui()</code> returns a <code>zcli.ui.App</code> pre-wired to the command's stdout, allocator, theme capability, and TTY detection. The <code>App</code> owns everything stateful — the frame arena (<code>app.arena()</code>, reset when <code>frame()</code> returns), the live region's rows, the double-buffered surfaces, and the cursor (hidden while a region is up, parked at its top-left between calls, restored on <code>deinit</code>).</p>
+          <p>In a command, <code>context.ui(.{})</code> returns a <code>zcli.ui.App</code> pre-wired to the command's stdout, allocator, theme capability, and TTY detection. The <code>App</code> owns everything stateful — the frame arena (<code>app.arena()</code>, reset when <code>frame()</code> returns), the live region's rows, the double-buffered surfaces, and the cursor (hidden while a region is up, parked at its top-left between calls, restored on <code>deinit</code>).</p>
           <div class="code">
             <div class="code-head"><span class="fname">src/commands/deploy.zig</span><span class="lang">zig</span></div>
-<pre><span class="kw">var</span> app = <span class="kw">try</span> context.<span class="fn">ui</span>();
+<pre><span class="kw">var</span> app = <span class="kw">try</span> context.<span class="fn">ui</span>(.{});
 <span class="kw">defer</span> app.<span class="fn">deinit</span>(); <span class="cm">// restores the terminal; the final frame persists in scrollback</span>
 
 <span class="kw">try</span> app.<span class="fn">emit</span>(<span class="str">"compiled {s}"</span>, .{name});               <span class="cm">// static -> scrollback</span>
@@ -123,8 +128,8 @@
         </section>
 
         <section id="widgets">
-          <h2>Widgets</h2>
-          <p><code>ui.widgets</code> is the progress vocabulary as component functions: a spinner is a <code>text</code> node, a bar is one <code>custom</code> leaf, a multi-bar is a column of rows. No widget owns a repaint loop or hidden state — animation is your tick, progress is your fraction, the frame diff does the rest. Styling flows through the theme's <code>progress</code> tokens, the same ones the progress package reads.</p>
+          <h2>Progress widgets</h2>
+          <p><code>ui.widgets</code> is the progress vocabulary as component functions: a spinner is a <code>text</code> node, a bar is one <code>custom</code> leaf, a multi-bar is a column of rows. No widget owns a repaint loop or hidden state — animation is your tick, progress is your fraction, the frame diff does the rest. Styling flows through the theme's <code>progress</code> tokens, the same ones the progress package reads. (The interactive widgets — text fields, selects, checkboxes, buttons — live in the same namespace and are covered under <a href="#forms">full-screen</a>.)</p>
           <div class="code">
             <div class="code-head"><span class="fname">a bordered status frame</span><span class="lang">zig</span></div>
 <pre><span class="kw">const</span> a = app.<span class="fn">arena</span>();
@@ -154,6 +159,100 @@
           <p>When stdout is not a TTY — a pipe, a file, a CI log — there is no live region to repaint: <code>emit</code> lines print as normal, and a frame degrades to the plain lines it would draw. The same code path produces an interactive frame and a clean log.</p>
         </section>
 
+        <section id="fullscreen">
+          <h2>Full-screen mode</h2>
+          <p>The hybrid shares the terminal. Sometimes you want the whole thing — a <code>top</code>-style dashboard, a wizard, a full-screen form. That's the engine's second mode: <code>context.uiFullScreen(.{})</code> (or <code>App.initFullScreen</code> standalone) switches to the alternate screen and raw input, and the same node trees, layout, and diff run against the full viewport. On exit the shell's screen and scrollback come back exactly as they were — the final frame does <em>not</em> persist. That's the difference from hybrid, where the last frame stays in scrollback.</p>
+          <p>Instead of you calling <code>emit</code>/<code>frame</code> by hand, full-screen apps hand the loop to <code>app.run</code>. You supply two pure-ish functions and it owns the rest:</p>
+          <ul>
+            <li><b><code>view(arena, state)</code></b> — builds the whole screen as a node tree, exactly like a hybrid frame. Treat <code>state</code> as read-only here.</li>
+            <li><b><code>update(state, event)</code></b> — mutates <code>state</code> for a key, resize, mouse, focus, or paste, and returns <code>.keep</code> or <code>.quit</code>. A <code>null</code> event is the periodic tick.</li>
+          </ul>
+          <div class="code">
+            <div class="code-head"><span class="fname">a top-style dashboard</span><span class="lang">zig</span></div>
+<pre><span class="cm">// Required for full-screen: restore the terminal on a panic before the</span>
+<span class="cm">// trace prints. initFullScreen won't compile without it.</span>
+<span class="kw">pub const</span> panic = zcli.ui.panic;
+
+<span class="kw">fn</span> <span class="fn">view</span>(a: std.mem.Allocator, s: *State) !ui.Node {
+    <span class="cm">// ...build the whole screen from state (read-only here), like any frame</span>
+}
+
+<span class="kw">fn</span> <span class="fn">update</span>(s: *State, ev: ?ui.Event) !ui.Flow {
+    <span class="kw">const</span> e = ev <span class="kw">orelse</span> { s.<span class="fn">advance</span>(); <span class="kw">return</span> .keep; }; <span class="cm">// null = the tick</span>
+    <span class="kw">switch</span> (e) {
+        .key => |k| <span class="kw">switch</span> (k) {
+            .char => |c| <span class="kw">if</span> (c == <span class="str">'q'</span>) <span class="kw">return</span> .quit,
+            .up => s.<span class="fn">move</span>(-<span class="num">1</span>),
+            .down => s.<span class="fn">move</span>(<span class="num">1</span>),
+            <span class="kw">else</span> => {},
+        },
+        <span class="kw">else</span> => {}, <span class="cm">// .resize/.mouse/.focus/.paste — enable what you need</span>
+    }
+    <span class="kw">return</span> .keep;
+}
+
+<span class="kw">var</span> app = <span class="kw">try</span> context.<span class="fn">uiFullScreen</span>(.{ .mouse = <span class="num">true</span> });
+<span class="kw">defer</span> app.<span class="fn">deinit</span>();                          <span class="cm">// leaves the alt-screen — nothing persists</span>
+<span class="kw">try</span> app.<span class="fn">run</span>(context.io, &state, <span class="num">250</span>, view, update, <span class="num">null</span>); <span class="cm">// 250ms tick</span></pre>
+          </div>
+          <div class="callout"><b>The tick is a deadline</b> Pass <code>tick_ms</code> and <code>run</code> delivers a <code>null</code> event on a schedule — a clock for animating data. It's scheduled against a <em>deadline</em>, so a burst of keystrokes shrinks the next wait instead of resetting it: input can't starve the refresh. Pass <code>null</code> for a form or menu that should only wake on input. The final argument, <code>after_frame</code>, is an optional post-paint hook — its home use is placing the hardware cursor, below.</div>
+          <p>Events are opt-in past keys and resize: set <code>.mouse</code>, <code>.focus</code>, or <code>.paste</code> in the options to receive those. <code>emit</code> is a compile-time error in full-screen — there's no scrollback stream to write to; everything is the frame.</p>
+        </section>
+
+        <section id="forms">
+          <h2>Focusable widgets</h2>
+          <p>On top of the layout engine sits a small kit of interactive widgets — <code>TextInput</code>, <code>Select</code>, <code>Checkbox</code>, <code>Button</code> — in the same <code>ui.widgets</code> namespace. Each is a plain struct you keep in your own state: immediate mode all the way down, no retained widget tree, no framework-owned event bus. A widget gives you two methods:</p>
+          <ul>
+            <li><b><code>view(arena, opts)</code></b> — returns the widget's node for this frame; pass <code>.focused</code> so it draws its caret or highlight.</li>
+            <li><b><code>handle(key)</code></b> — returns whether it consumed the key. <em>That one bool is the entire routing model.</em></li>
+          </ul>
+          <p>Give the focused widget first crack at each key; an unconsumed key (Tab, Enter, Esc) is form-level navigation. Focus is yours to hold — an enum — and <code>focusNext</code>/<code>focusPrev</code> cycle it with wrap-around. That's the whole contract; there's no form object.</p>
+          <div class="code">
+            <div class="code-head"><span class="fname">routing a key through a form</span><span class="lang">zig</span></div>
+<pre><span class="kw">const</span> Field = <span class="kw">enum</span> { user, role, submit };
+
+<span class="kw">fn</span> <span class="fn">update</span>(s: *State, ev: ?ui.Event) !ui.Flow {
+    <span class="kw">const</span> key = <span class="kw">switch</span> (ev <span class="kw">orelse</span> <span class="kw">return</span> .keep) { .key => |k| k, <span class="kw">else</span> => <span class="kw">return</span> .keep };
+
+    <span class="cm">// The focused widget gets first crack; handle() reports if it consumed the key.</span>
+    <span class="kw">switch</span> (s.focus) {
+        .user   => <span class="kw">if</span> (s.user.<span class="fn">handle</span>(key)) <span class="kw">return</span> .keep,
+        .role   => <span class="kw">if</span> (s.role.<span class="fn">handle</span>(key, roles.len, <span class="num">6</span>)) <span class="kw">return</span> .keep,
+        .submit => <span class="kw">if</span> (s.submit.<span class="fn">handle</span>(key)) <span class="kw">return</span> .quit, <span class="cm">// Enter/Space fires it</span>
+    }
+
+    <span class="cm">// Unconsumed → navigation.</span>
+    <span class="kw">switch</span> (key) {
+        .tab      => s.focus = ui.widgets.<span class="fn">focusNext</span>(Field, s.focus),
+        .back_tab => s.focus = ui.widgets.<span class="fn">focusPrev</span>(Field, s.focus),
+        .escape   => <span class="kw">return</span> .quit,
+        <span class="kw">else</span> => {},
+    }
+    <span class="kw">return</span> .keep;
+}</pre>
+          </div>
+          <p><code>Select</code> takes its options each frame (immediate mode) and a visible-row budget, and can run in <code>.wrap</code> mode for options that span multiple lines. <code>TextInput</code> carries a caller-owned buffer and can <code>.mask</code> its content for passwords.</p>
+          <div class="callout"><b>Hardware cursor</b> A focused text field reports its caret cell through <code>cursor_out</code> during render; the <code>after_frame</code> hook then places the real terminal cursor there with <code>app.cursorAt(...)</code>. The blinking block lands exactly where typing goes — the layout tree tells you the position, so you never track it by hand.</div>
+        </section>
+
+        <section id="overlays">
+          <h2>Overlays &amp; popups</h2>
+          <p>A <code>stack</code> box overlaps its children into layers, painted back to front. A layer with no background is transparent — the layers beneath show through its gaps — and a layer with a background is opaque. That single rule is the whole overlay system: a modal is an opaque <code>panel</code> composited over the base screen, with no absolute cursor addressing anywhere. It's just cells painted on top before the frame diff runs.</p>
+          <div class="code">
+            <div class="code-head"><span class="fname">a help modal over the screen</span><span class="lang">zig</span></div>
+<pre><span class="kw">return</span> ui.<span class="fn">stack</span>(a, .{}, &.{
+    base,                                    <span class="cm">// layer 0: the whole screen</span>
+    <span class="kw">try</span> ui.<span class="fn">center</span>(a, <span class="kw">try</span> ui.<span class="fn">panel</span>(a, .{ .padding = .<span class="fn">symmetric</span>(<span class="num">2</span>, <span class="num">1</span>) }, &.{
+        ui.<span class="fn">text</span>(.{ .bold = <span class="num">true</span> }, <span class="str">"Keys"</span>),
+        ui.<span class="fn">text</span>(.{}, <span class="str">"↑ / ↓   select"</span>),
+        ui.<span class="fn">text</span>(.{}, <span class="str">"?       close"</span>),
+    })),                                     <span class="cm">// layer 1: an opaque, themed modal, centered</span>
+});</pre>
+          </div>
+          <p>Two more helpers build on the same idea. A <code>viewport</code> is a scrolling window onto content taller than the space it's granted — a log pane, a long list — with the scroll offset held in your own state. And <code>probe</code> reports where a node actually rendered, which <code>anchored</code> then uses to pin a popup to it: a dropdown that opens under a button, <b>flips above</b> when it would run off the bottom, and <b>clamps left</b> when it would run off the right — smart placement as pure composition, no new primitive.</p>
+          <div class="callout"><b>Chrome comes from the theme</b> <code>ui.panel</code>'s border and fill, and any bordered box's border color, derive from your app's <code>zcli_theme</code> surface tokens — so a modal or dropdown needs no style mentions to look right, and one theme change reskins every overlay at once. See <a href="$site.page('theming').link().suffix('#surface')">theming → surface chrome</a>.</div>
+        </section>
+
         <section id="standalone">
           <h2>Standalone use</h2>
           <p>Like every zcli package, <code>ui</code> works without the framework. Outside a command there's no <code>context</code>, so construct the <code>App</code> yourself — it owns heap state (surfaces, retained scrollback), so it takes an explicit <code>init</code>/<code>deinit</code> rather than the value-bundle shape of the stateless packages:</p>
@@ -171,11 +270,14 @@
 
         <section id="try">
           <h2>Try it</h2>
-          <p>Two runnable examples live in the <code>ui</code> package — both want a real terminal. Resize the window while either runs and watch the live frame re-lay-out as the visible static tail rewraps with it.</p>
+          <p>Five runnable examples live in the <code>ui</code> package — all want a real terminal. Resize the window while the hybrid ones run and watch the live frame re-lay-out as the visible static tail rewraps with it; press <code>?</code> in the full-screen demo, Tab through the form.</p>
           <div class="code">
             <div class="code-head"><span class="fname">packages/ui</span><span class="lang">sh</span></div>
-<pre>zig build run-demo     <span class="cm"># deploy-style task frame: spinner, task list, live gauges</span>
-zig build run-hybrid   <span class="cm"># the Claude-Code shape: streaming prose + a live multi-bar</span></pre>
+<pre>zig build run-demo        <span class="cm"># hybrid: deploy-style task frame — spinner, task list, gauges</span>
+zig build run-hybrid      <span class="cm"># hybrid: the Claude-Code shape — streaming prose + a live multi-bar</span>
+zig build run-fullscreen  <span class="cm"># full-screen: a top-style table, scrolling viewport, help overlay</span>
+zig build run-form        <span class="cm"># full-screen: a focusable form — text fields, select, checkbox, button</span>
+zig build run-popup       <span class="cm"># full-screen: anchored dropdowns that flip and clamp on screen</span></pre>
           </div>
           <div class="nextlinks">
             <a href="https://github.com/ryanhair/zcli/blob/main/docs/adr/0013-terminal-native-layout-engine.md" target="_blank" rel="noopener"><span class="k">→ design</span><span class="t">ADR-0013: the layout engine</span></a>

--- a/website/layouts/why.shtml
+++ b/website/layouts/why.shtml
@@ -48,7 +48,7 @@
         <tr><td class="hl">Scope</td><td>argument parser</td><td>CLI framework</td><td class="zcli-col hl">CLI framework</td></tr>
         <tr><td class="hl">Commands defined by</td><td>manual dispatch</td><td>runtime builder</td><td class="zcli-col hl">files on disk, discovered at build time</td></tr>
         <tr><td class="hl">Flags are</td><td>comptime DSL → typed result</td><td>registered at runtime, read by name</td><td class="zcli-col hl">struct fields, checked at compile time</td></tr>
-        <tr><td class="hl">Beyond parsing</td><td>help text</td><td>help, version, spinners</td><td class="zcli-col hl">help, completions, prompts, progress, theming, config files, plugins, testing tools</td></tr>
+        <tr><td class="hl">Beyond parsing</td><td>help text</td><td>help, version, spinners</td><td class="zcli-col hl">help, completions, prompts, progress, theming, full-screen TUI, config files, plugins, testing tools</td></tr>
       </tbody>
     </table>
     </div>


### PR DESCRIPTION
The `ui` package and theming grew substantially (ADRs 0015–0020) — full-screen TUI mode, focusable widgets, overlays/viewports/popups, and theme-derived style defaults — but the docs still described only the hybrid engine and the palette/component-token model. This brings them up to date, with the **website** as the focus.

## Website (the focus)

- **`ui.shtml`** — new sections for **Full-screen mode** (`App.run` loop, required panic hook, opt-in mouse/focus/paste), **Focusable widgets** (`TextInput`/`Select`/`Checkbox`/`Button` + the `view`/`handle`-returns-`bool` contract), and **Overlays & popups** (`stack` z-layers, `center`, `viewport`, `probe`/`anchored`). Reframed the "not a full-screen TUI" callout into *two modes, one engine*; fixed the stale `context.ui()` → `context.ui(.{})`; added the new example commands.
- **`theming.shtml`** — new **Surface chrome** section: `surface.border`/`surface.panel` tokens and the ADR-0020 *"styling defaults derive from the theme at compile time"* model (`ui.panel`, `ui.role`, no call-site `Style`).
- **`home.shtml`** — added a **CLI/TUI hybrid** feature card and promoted **Theming** to its own card. Also fixed the grey empty-cell void in the feature grid: trailing cells now render as surface-colored blank cards (one inert filler, shown only at 3 columns), so the grid tiles cleanly at every breakpoint.
- **`docs.shtml` / `why.shtml`** — full-screen-mode mentions + `context.ui(.{})` fix; "full-screen TUI" added to the comparison table.
- Refreshed the `ui` and `theming` page meta descriptions.

## Repo docs

- **`README.md`** — full-screen/widgets paragraph in the hybrid section; surface tokens + derived-defaults in the theming section.
- **`CHANGELOG.md`** — Unreleased "Added" now lists full-screen mode, focusable widgets, overlays/viewports/popups, and theme-derived defaults.
- **`docs/DESIGN.md`** — corrected the now-false "full-screen app is just a root sized `fill`, not a separate mode"; added a full-screen-mode paragraph and surface tokens.

ADR files were left untouched (historical records).

## Verification

- All API details checked against source (`packages/ui/src/{ui,app,widgets,input}.zig`, `packages/theme/src/definition.zig`, `context.zig`) and the real `examples/{form,fullscreen}.zig` — not summaries.
- SHTML validated structurally: balanced `<section>`/`<div>`, no stray `<` in `<pre>` blocks, all TOC anchors resolve.
- Feature-grid fix rendered with the site's real design tokens and screenshotted at desktop width to confirm.
- ⚠️ Could **not** run a full site build — `website/./zine` is gitignored (download-once, Zine v0.11.3), so please preview locally to catch any SuperHTML nits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)