### PR TITLE
fix(stdio): use streaming writes for inherited stdio (P0 output corruption)

### DIFF
--- a/packages/core/src/zcli.zig
+++ b/packages/core/src/zcli.zig
@@ -215,9 +215,19 @@ pub const Stdio = struct {
     /// possible at all.
     pub fn init(self: *@This(), io: std.Io) void {
         self.* = .{ .io = io };
-        self.stdout_writer = std.Io.File.stdout().writer(io, &self.stdout_buf);
-        self.stderr_writer = std.Io.File.stderr().writer(io, &self.stderr_buf);
-        self.stdin_reader = std.Io.File.stdin().reader(io, &self.stdin_buf);
+        // Streaming (plain write(2)), never positional. Inherited stdout/stderr
+        // may be a shared regular-file fd (e.g. `cmd >log`, CI logs, a coding
+        // agent capturing output). Positional mode pwrites from its own offset
+        // starting at 0, ignoring the fd's shared offset — so a second process
+        // writing to the same file overwrites the first from byte 0. Streaming
+        // uses the kernel's shared offset, so appends serialize correctly.
+        self.stdout_writer = std.Io.File.stdout().writerStreaming(io, &self.stdout_buf);
+        self.stderr_writer = std.Io.File.stderr().writerStreaming(io, &self.stderr_buf);
+        // Streaming (plain read(2)) for the same reason: an inherited stdin fd
+        // that is a shared regular file (`cmd <file`) has a live shared offset.
+        // Positional mode would read from byte 0, re-reading data the parent
+        // already consumed instead of continuing from the shared offset.
+        self.stdin_reader = std.Io.File.stdin().readerStreaming(io, &self.stdin_buf);
     }
 
     pub fn stdout(self: *@This()) *std.Io.Writer {

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -80,6 +80,25 @@ fn run(cwd: std.Io.Dir, argv: []const []const u8) !RunResult {
     };
 }
 
+/// Run `argv` with stdout AND stderr both redirected to `out_file` — an
+/// already-open regular file — reproducing an inherited-regular-file fd
+/// (`cmd >log 2>&1`, CI logs, a coding agent capturing output). Unlike `run`,
+/// which pipes (streaming on both sides), this is the exact shape that a
+/// positional-mode stdio writer corrupts: it pwrites from its own offset
+/// starting at 0, overwriting whatever a prior invocation wrote to the same
+/// shared fd. The caller reuses one `out_file` across invocations so the second
+/// run must append at the shared offset, not clobber from byte 0.
+fn runToSharedFile(cwd: std.Io.Dir, out_file: std.Io.File, argv: []const []const u8) !void {
+    var child = try std.process.spawn(io, .{
+        .argv = argv,
+        .cwd = .{ .dir = cwd },
+        .stdin = .ignore,
+        .stdout = .{ .file = out_file },
+        .stderr = .{ .file = out_file },
+    });
+    _ = try child.wait(io);
+}
+
 fn fileExists(dir: std.Io.Dir, path: []const u8) bool {
     // Windows rejects these characters in a path at the syscall layer with
     // OBJECT_NAME_INVALID, which Zig surfaces as an unrecoverable panic rather
@@ -691,6 +710,32 @@ test "scaffolded project builds, runs, and round-trips add command" {
         defer r.deinit();
         try expectOk(r);
         try expectContains(r.stdout, "Hello, World!");
+    }
+
+    // Regression (P0 output corruption): two invocations sharing one inherited
+    // regular-file stdout must both survive, in order. A positional-mode stdio
+    // writer pwrites from offset 0 every time, so the second run clobbered the
+    // first from byte 0 — losing output to CI logs, cron, and agents capturing
+    // command output (pipes/TTYs were unaffected, masking it). Streaming mode
+    // respects the fd's shared offset, so appends serialize.
+    {
+        const log = try proj.createFile(io, "shared.log", .{ .read = true });
+        defer log.close(io);
+
+        try runToSharedFile(proj, log, &.{ demo_bin, "hello", "First" });
+        try runToSharedFile(proj, log, &.{ demo_bin, "hello", "Second" });
+
+        const contents = try readFile(proj, arena.allocator(), "shared.log");
+        const first = std.mem.indexOf(u8, contents, "Hello, First!") orelse {
+            std.debug.print("shared.log lost the first invocation:\n{s}\n", .{contents});
+            return error.FirstOutputClobbered;
+        };
+        const second = std.mem.indexOf(u8, contents, "Hello, Second!") orelse {
+            std.debug.print("shared.log lost the second invocation:\n{s}\n", .{contents});
+            return error.SecondOutputMissing;
+        };
+        // Order preserved: the second append lands after the first, not over it.
+        try testing.expect(second > first);
     }
 
     // Help lists the discovered command (the help plugin writes to stderr).

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -80,21 +80,41 @@ fn run(cwd: std.Io.Dir, argv: []const []const u8) !RunResult {
     };
 }
 
-/// Run `argv` with stdout AND stderr both redirected to `out_file` — an
-/// already-open regular file — reproducing an inherited-regular-file fd
-/// (`cmd >log 2>&1`, CI logs, a coding agent capturing output). Unlike `run`,
-/// which pipes (streaming on both sides), this is the exact shape that a
-/// positional-mode stdio writer corrupts: it pwrites from its own offset
-/// starting at 0, overwriting whatever a prior invocation wrote to the same
-/// shared fd. The caller reuses one `out_file` across invocations so the second
-/// run must append at the shared offset, not clobber from byte 0.
-fn runToSharedFile(cwd: std.Io.Dir, out_file: std.Io.File, argv: []const []const u8) !void {
+/// Run two invocations of the demo binary through a single *shell* redirect
+/// `( a; b ) >log 2>&1`, reproducing an inherited shared regular-file stdout
+/// (`cmd >log`, CI logs, cron, a coding agent capturing output). This is the
+/// exact shape a positional-mode stdio writer corrupts: it pwrites from its own
+/// offset starting at 0, so the second invocation overwrites the first from byte
+/// 0. Streaming mode instead writes at the fd's shared kernel offset, so the two
+/// appends serialize.
+///
+/// The redirect is driven by the *shell*, not by Zig's `std.process.spawn(.file
+/// = ...)`, on purpose. On POSIX, `.file` uses `dup2`, sharing one open file
+/// description (shared offset) — but on Windows, `.file` *reopens* the handle
+/// (`NtCreateFile` with an empty name relative to the handle, Threaded.zig
+/// `processSpawnWindows`), yielding a fresh FILE_OBJECT whose position starts at
+/// 0. Two `.file` spawns would therefore each write from 0 on Windows regardless
+/// of the writer's mode, so that path can't model the shared-offset scenario.
+/// A shell (`cmd.exe` / `sh`) opens the log once and inherits the *same* handle
+/// to both child processes, giving a genuinely shared file position on both
+/// platforms — which is precisely what the reported real-world redirect does.
+fn runTwiceIntoSharedFileViaShell(a: std.mem.Allocator, cwd: std.Io.Dir, log_name: []const u8, bin: []const u8) !void {
+    const argv: []const []const u8 = if (builtin.os.tag == .windows) blk: {
+        // cmd.exe wants backslashes and no leading `./`; normalize `bin`.
+        const trimmed = if (std.mem.startsWith(u8, bin, "./")) bin[2..] else bin;
+        const win_bin = try a.dupe(u8, trimmed);
+        std.mem.replaceScalar(u8, win_bin, '/', '\\');
+        // `( bin hello First & bin hello Second ) > log 2>&1`. `&` sequences
+        // unconditionally (unlike `&&`); `2>&1` folds stderr in.
+        break :blk &.{ "cmd", "/c", try std.fmt.allocPrint(a, "( {s} hello First & {s} hello Second ) > {s} 2>&1", .{ win_bin, win_bin, log_name }) };
+    } else &.{ "sh", "-c", try std.fmt.allocPrint(a, "( '{s}' hello First; '{s}' hello Second ) > {s} 2>&1", .{ bin, bin, log_name }) };
+
     var child = try std.process.spawn(io, .{
         .argv = argv,
         .cwd = .{ .dir = cwd },
         .stdin = .ignore,
-        .stdout = .{ .file = out_file },
-        .stderr = .{ .file = out_file },
+        .stdout = .inherit,
+        .stderr = .inherit,
     });
     _ = try child.wait(io);
 }
@@ -717,13 +737,11 @@ test "scaffolded project builds, runs, and round-trips add command" {
     // writer pwrites from offset 0 every time, so the second run clobbered the
     // first from byte 0 — losing output to CI logs, cron, and agents capturing
     // command output (pipes/TTYs were unaffected, masking it). Streaming mode
-    // respects the fd's shared offset, so appends serialize.
+    // respects the fd's shared offset, so appends serialize. Driven through a
+    // shell redirect (see runTwiceIntoSharedFileViaShell) so the shared handle
+    // is modeled the same way on POSIX and Windows.
     {
-        const log = try proj.createFile(io, "shared.log", .{ .read = true });
-        defer log.close(io);
-
-        try runToSharedFile(proj, log, &.{ demo_bin, "hello", "First" });
-        try runToSharedFile(proj, log, &.{ demo_bin, "hello", "Second" });
+        try runTwiceIntoSharedFileViaShell(arena.allocator(), proj, "shared.log", demo_bin);
 
         const contents = try readFile(proj, arena.allocator(), "shared.log");
         const first = std.mem.indexOf(u8, contents, "Hello, First!") orelse {


### PR DESCRIPTION
## The bug (P0)

Every zcli-generated CLI corrupts its output when stdout/stderr is an inherited **regular file** shared by more than one invocation:

```
zcli init testapp && cd testapp && zig build
( ./zig-out/bin/testapp hello World; ./zig-out/bin/testapp helo ) > /tmp/z.log 2>&1
cat /tmp/z.log   # "Hello, World!" is GONE — the second invocation overwrote it from offset 0
```

A harness capturing many invocations to one file sees interleaved fragments with beginnings destroyed (e.g. `ilable commands:` — the front of `Available commands:` clobbered). Through a **pipe or TTY, output is clean**, which masked the bug outside the exact contexts that matter most: CI logs, cron, and coding agents capturing command output.

## Root cause

`packages/core/src/zcli.zig` — `Stdio.init` built its writers/reader with `std.Io.File.stdout().writer(io, buf)` / `.reader(io, buf)`.

In Zig 0.16, `File.writer()`/`File.reader()` default to **positional** mode (`std/Io/File/Writer.zig:41` → `.mode = .positional`, `pos = 0`). Positional mode uses `pwrite`/`pread` at a self-tracked offset that starts at 0 and **ignores the fd's shared kernel offset**. For a seekable regular file `fileWritePositional` succeeds, so every process pwrites from byte 0 — the second invocation overwrites the first. The streaming fallback in `drainPositional` only triggers on `error.Unseekable` (pipes/TTYs), which is precisely why pipes/TTYs were unaffected.

## Fix

Use `writerStreaming`/`readerStreaming` for all three streams, so they use plain `write(2)`/`read(2)` and honor the fd's shared offset:
- stdout/stderr: appends now serialize at the shared offset instead of clobbering from byte 0.
- stdin: an inherited shared-file stdin (`cmd <file`) continues from the parent's position instead of re-reading from 0.

Streaming is the correct semantic for inherited stdio — the whole point of a shared log fd is that writes advance one shared offset. This is true on **all** platforms after the fix:

- **POSIX:** streaming = `write(2)` on the fd → kernel advances the shared file description's offset.
- **Windows:** streaming = `fileWriteStreamingWindows` (`std/Io/Threaded.zig:10765`), which issues `NtWriteFile` with `ByteOffset = null`. Because stdio handles are opened `.IO = .SYNCHRONOUS_NONALERT` (Threaded.zig `dirCreateFileWindows`, ~L4436), a null byte-offset means "write at the FILE_OBJECT's current file position" and advances it. Positional mode instead calls `NtWriteFile` with an explicit offset (self-tracked, starting at 0), which the kernel honors verbatim and clobbers — the same failure as POSIX.

## Windows test-model note

The first cut of the regression drove the two invocations into one open file by handing the same `File` to `std.process.spawn(.stdout = .{ .file = out_file })`. That faithfully reproduces the bug on POSIX (spawn implements `.file` with `dup2` — one shared open file description), but **not on Windows**: `processSpawnWindows` (`std/Io/Threaded.zig:15525`) implements `.file` by *reopening* the handle — `NtCreateFile` with an empty object name relative to `file.handle` — which yields a fresh `FILE_OBJECT` whose current position starts at 0. Two `.file` spawns therefore each wrote from offset 0 on Windows *regardless of the writer's mode*, so the test tripped `error.FirstOutputClobbered` on `windows-latest` even though the streaming write itself is correct there.

There is no way for zcli's `Stdio` to make two `.file`-spawned children share a file position on Windows — that limitation lives in `std.process.spawn`, not in zcli. But it does not affect the real bug: a shell redirect (`cmd > log`) or a harness that opens the file once and inherits the *raw* handle gives both children the same `FILE_OBJECT` and thus a shared position, which the streaming fix handles correctly.

So the regression now drives the redirect **through the shell** — `sh -c '( a; b ) > log 2>&1'` / `cmd /c "( a & b ) > log 2>&1"` — matching what the reported bug actually is. The shell opens the log once and inherits the same handle to both children, exercising zcli's streaming writer against a genuinely shared file position uniformly on POSIX and Windows.

## Test evidence

New e2e regression in `projects/zcli/test/e2e.zig` (`runTwiceIntoSharedFileViaShell`): runs the built `demo` binary twice, both stdout+stderr redirected by the shell to the **same open regular file**, then asserts both outputs are present **and in order**.

- With the fix: `zig build e2e` on **macOS, Linux, and Windows** → **29/29 tests passed** (CI green on all three OS e2e jobs).
- Reverting just the writer change (positional): the test fails with `error.FirstOutputClobbered` — "Hello, Second!" landed over "Hello, First!".
- `zig build test` (all packages): green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
