### PR TITLE
feat(plugins): enforce plugin_id contract at compile time

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -724,7 +724,10 @@ Plugins attach their own state to the context with full compile-time type
 safety — there is no `StringHashMap` or runtime key lookup. A plugin declares a
 `plugin_id` and a `ContextData` struct; the generated `Context` contains one
 field per plugin, named by `plugin_id`, and accessed as
-`context.plugins.<plugin_id>`:
+`context.plugins.<plugin_id>`. Because `plugin_id` becomes that field name
+verbatim it must be a valid Zig identifier — declaring `ContextData` without a
+`plugin_id`, or giving one that isn't (`"my-plugin"`), is a compile-time error
+naming the plugin and the fix; there is no silent rewriting:
 
 ```zig
 // In the plugin:

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -86,7 +86,11 @@ A plugin is a Zig module with a `plugin_id` and any of the lifecycle exports:
 ```zig
 pub const plugin_id = "my_plugin";
 pub const ContextData = struct { enabled: bool = false };
+```
 
+`plugin_id` becomes the `context.plugins.<id>` field name **verbatim**, so it must be a valid Zig identifier (`[a-zA-Z_][a-zA-Z0-9_]*` — in practice lowercase `snake_case`). A plugin that declares `ContextData` without a `plugin_id`, or gives one that isn't a valid identifier (e.g. `"my-plugin"`), fails at compile time with a message naming the plugin and the fix. zcli does **not** silently rewrite an invalid id — you choose the field name you'll type.
+
+```zig
 pub const global_options = [_]zcli.GlobalOption{
     zcli.option("verbose", bool, .{ .short = 'v', .default = false }),
 };

--- a/packages/core/src/context.zig
+++ b/packages/core/src/context.zig
@@ -11,30 +11,24 @@
 
 const std = @import("std");
 const zcli = @import("zcli.zig");
-const identifier = @import("identifier.zig");
 
-/// Field name in `context.plugins` for a plugin's ContextData: its
-/// `plugin_id` with every non-identifier character replaced by '_'.
-/// Plugins with ContextData MUST declare `pub const plugin_id = "unique_name";`
+/// Field name in `context.plugins` for a plugin's ContextData: its `plugin_id`
+/// verbatim. `plugin_id` is required to be a valid Zig identifier — enforced at
+/// registration by plugin_types.validatePlugin — so there is nothing to rewrite
+/// here. Plugins with ContextData MUST declare `pub const plugin_id = "unique_name";`
 pub fn pluginFieldName(comptime Plugin: type) [:0]const u8 {
     comptime {
         if (!@hasDecl(Plugin, "plugin_id")) {
-            @compileError("Plugins with ContextData must declare 'pub const plugin_id'. " ++
-                "Add: pub const plugin_id = \"my_plugin\";");
+            @compileError("plugin '" ++ @typeName(Plugin) ++ "' declares ContextData but no plugin_id. " ++
+                "ContextData is exposed as a typed field on context.plugins named by plugin_id. Add:\n" ++
+                "    pub const plugin_id = \"my_plugin\";");
         }
 
         const id: []const u8 = Plugin.plugin_id;
-        var result: [256]u8 = undefined;
-        var result_idx: usize = 0;
-        for (id) |c| {
-            if (result_idx >= result.len - 1) break;
-            // Shared rule (identifier.zig) — build-time codegen sanitizes
-            // plugin/module names with the same function.
-            result[result_idx] = identifier.sanitizeChar(c);
-            result_idx += 1;
-        }
-        result[result_idx] = 0;
-        return result[0..result_idx :0];
+        var result: [id.len + 1]u8 = undefined;
+        for (id, 0..) |c, i| result[i] = c;
+        result[id.len] = 0;
+        return result[0..id.len :0];
     }
 }
 

--- a/packages/core/src/plugin_types.zig
+++ b/packages/core/src/plugin_types.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const zcli = @import("zcli.zig");
+const identifier = @import("identifier.zig");
 const testing = std.testing;
 
 // ============================================================================
@@ -266,6 +267,69 @@ pub fn validatePlugin(comptime Plugin: type) void {
                 }
             }
         }
+
+        // The ContextData contract: a plugin's ContextData is exposed as a
+        // typed field on `context.plugins`, named by `plugin_id`. Enforce the
+        // whole contract here at the declaration — a helpful comptime error —
+        // instead of letting it fail obscurely at the `context.plugins.<id>`
+        // use-site (or silently getting no slot).
+        if (@hasDecl(Plugin, "ContextData") and !@hasDecl(Plugin, "plugin_id")) {
+            @compileError("plugin '" ++ @typeName(Plugin) ++ "' declares ContextData but no plugin_id. " ++
+                "ContextData is exposed as a typed field on context.plugins named by plugin_id. Add:\n" ++
+                "    pub const plugin_id = \"my_plugin\";");
+        }
+        // deinitContextData is the cleanup hook for ContextData and only runs
+        // when ContextData exists — without it the function is silently dead,
+        // the same failure shape as a misspelled lifecycle hook above.
+        if (@hasDecl(Plugin, "deinitContextData") and !@hasDecl(Plugin, "ContextData")) {
+            @compileError("plugin '" ++ @typeName(Plugin) ++ "' declares deinitContextData but no ContextData. " ++
+                "deinitContextData is the cleanup hook for a plugin's ContextData and would never be called as written. " ++
+                "Add a ContextData, or remove deinitContextData.");
+        }
+        // plugin_id becomes the `context.plugins.<id>` field name verbatim, so
+        // it must already be a valid Zig identifier (checked whenever declared).
+        if (@hasDecl(Plugin, "plugin_id")) {
+            validatePluginId(@typeName(Plugin), Plugin.plugin_id);
+        }
+    }
+}
+
+/// `plugin_id` becomes the `context.plugins.<id>` field name verbatim, so it
+/// must be a valid Zig identifier (`[a-zA-Z_][a-zA-Z0-9_]*`). An invalid id is
+/// a compile error — the framework does not silently rewrite it, because the
+/// author is choosing the field name they will type in code.
+fn validatePluginId(comptime type_name: []const u8, comptime id: []const u8) void {
+    comptime {
+        if (!isValidIdentifier(id)) {
+            @compileError("plugin '" ++ type_name ++ "': plugin_id \"" ++ id ++ "\" is not a valid Zig identifier. " ++
+                "It becomes the context.plugins.<id> field name you access in code, so it must match " ++
+                "[a-zA-Z_][a-zA-Z0-9_]*. Use \"" ++ identifierSuggestion(id) ++ "\".");
+        }
+    }
+}
+
+/// Whether `id` is a valid Zig identifier: non-empty, first byte a letter or
+/// '_', the rest letters, digits, or '_'.
+fn isValidIdentifier(comptime id: []const u8) bool {
+    comptime {
+        if (id.len == 0) return false;
+        for (id, 0..) |c, i| {
+            const ok = std.ascii.isAlphabetic(c) or c == '_' or (i > 0 and std.ascii.isDigit(c));
+            if (!ok) return false;
+        }
+        return true;
+    }
+}
+
+/// A valid-identifier form of `id` to show in the error message: every
+/// non-identifier byte becomes '_' (the shared identifier rule), with a
+/// leading '_' prepended if the result would otherwise start with a digit.
+fn identifierSuggestion(comptime id: []const u8) []const u8 {
+    comptime {
+        var out: []const u8 = "";
+        for (id) |c| out = out ++ &[_]u8{identifier.sanitizeChar(c)};
+        if (out.len == 0 or std.ascii.isDigit(out[0])) out = "_" ++ out;
+        return out;
     }
 }
 
@@ -318,6 +382,36 @@ test "validatePlugin accepts a well-formed plugin with helpers" {
         }
     };
     comptime validatePlugin(Plugin);
+}
+
+test "validatePlugin accepts ContextData paired with a valid plugin_id" {
+    const Plugin = struct {
+        pub const plugin_id = "my_plugin";
+        pub const ContextData = struct { count: u32 = 0 };
+        pub fn deinitContextData(data: *ContextData, allocator: std.mem.Allocator) void {
+            _ = data;
+            _ = allocator;
+        }
+    };
+    comptime validatePlugin(Plugin);
+}
+
+test "isValidIdentifier accepts identifiers and rejects everything else" {
+    comptime {
+        std.debug.assert(isValidIdentifier("zcli_help"));
+        std.debug.assert(isValidIdentifier("_x9"));
+        std.debug.assert(!isValidIdentifier("my-plugin"));
+        std.debug.assert(!isValidIdentifier("9lives"));
+        std.debug.assert(!isValidIdentifier("has space"));
+        std.debug.assert(!isValidIdentifier(""));
+    }
+}
+
+test "identifierSuggestion rewrites to a valid identifier" {
+    comptime {
+        std.debug.assert(std.mem.eql(u8, identifierSuggestion("my-plugin"), "my_plugin"));
+        std.debug.assert(std.mem.eql(u8, identifierSuggestion("9lives"), "_9lives"));
+    }
 }
 
 // ============================================================================

--- a/packages/core/src/zcli.zig
+++ b/packages/core/src/zcli.zig
@@ -1046,7 +1046,7 @@ test "Stdio.init wires streams to the struct's own buffers, in place" {
 
 test "TestContext.deinit runs plugin deinitContextData hooks" {
     const HookPlugin = struct {
-        pub const plugin_id = "hook-plugin"; // dash exercises field-name sanitization
+        pub const plugin_id = "hook_plugin";
         var hook_ran: bool = false;
         pub const ContextData = struct { payload: ?[]u8 = null };
         pub fn deinitContextData(data: *ContextData, allocator: std.mem.Allocator) void {

--- a/website/layouts/plugins.shtml
+++ b/website/layouts/plugins.shtml
@@ -244,7 +244,7 @@
 
         <section id="data">
           <h2>Reading plugin data from a command</h2>
-          <p>Anything a plugin stores in its <code>ContextData</code> is namespaced under <code>context.plugins.{plugin_id}</code> and fully typed — a command can read it directly:</p>
+          <p>Anything a plugin stores in its <code>ContextData</code> is namespaced under <code>context.plugins.{plugin_id}</code> and fully typed — a command can read it directly. Because <code>plugin_id</code> becomes that field name verbatim, it must be a valid Zig identifier (lowercase <code>snake_case</code>); declaring <code>ContextData</code> without a <code>plugin_id</code>, or using an invalid one like <code>"my-plugin"</code>, is a compile-time error that names the fix.</p>
           <div class="code">
             <div class="code-head"><span class="fname">src/commands/build.zig</span><span class="lang">zig</span></div>
 <pre><span class="kw">const</span> Context = <span class="at">@import</span>(<span class="str">"command_registry"</span>).Context;


### PR DESCRIPTION
## Why

zcli's brand is comptime errors that name the problem and show the fix — but the plugin contract had a gap. A plugin that declared `ContextData` without `plugin_id` failed obscurely at the `context.plugins.<id>` use-site (or silently got no slot), and an id like `"my-plugin"` was silently rewritten into the `context.plugins.my_plugin` field name.

## What

`validatePlugin` (called at plugin registration) now enforces the whole ContextData contract at the declaration, matching the command-contract error style:

- `ContextData` without `plugin_id` → error naming the plugin and showing the fix.
- `deinitContextData` without `ContextData` → error (a silently-dead cleanup hook, same failure shape as a misspelled lifecycle hook).
- `plugin_id` must be a valid Zig identifier (`[a-zA-Z_][a-zA-Z0-9_]*`) — it becomes the `context.plugins.<id>` field name **verbatim**, so the silent dash→underscore sanitization in `context.pluginFieldName` is deleted. The error suggests a valid form.

**Audit:** `ContextData` is the only decl that requires `plugin_id` (commands/global_options don't use it; `deinitContextData` is gated behind `ContextData`), so this is the complete contract.

Only breaking for a hypothetical plugin that relied on the rewrite (e.g. `plugin_id = "my-plugin"`); every built-in plugin already uses a `snake_case` id.

## Rendered errors (evidence)

```
error: plugin '…' declares ContextData but no plugin_id. ContextData is exposed as a typed field on context.plugins named by plugin_id. Add:
    pub const plugin_id = "my_plugin";
```
```
error: plugin '…': plugin_id "my-plugin" is not a valid Zig identifier. It becomes the context.plugins.<id> field name you access in code, so it must match [a-zA-Z_][a-zA-Z0-9_]*. Use "my_plugin".
```
```
error: plugin '…' declares deinitContextData but no ContextData. deinitContextData is the cleanup hook for a plugin's ContextData and would never be called as written. Add a ContextData, or remove deinitContextData.
```

## Testing

- root `zig build test` → 1668/1668 pass (3 new unit tests for the valid shape + identifier helpers)
- `projects/zcli` e2e → 29/29 pass (exercises the registry codegen path with plugins enabled)

Docs updated: `docs/PLUGINS.md`, `docs/DESIGN.md`, `website/layouts/plugins.shtml`. CHANGELOG intentionally left out (batched separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)