### PR TITLE
fix(ux): alphabetical command order, richer init meta, quiet default builds

### DIFF
--- a/packages/core/src/build_utils/code_generation.zig
+++ b/packages/core/src/build_utils/code_generation.zig
@@ -47,10 +47,12 @@ pub fn generateComptimeRegistrySource(
 
 /// Generate command module imports
 fn generateCommandImports(writer: anytype, commands: DiscoveredCommands) !void {
-    var it = commands.root.iterator();
-    while (it.next()) |entry| {
-        const cmd_name = entry.key_ptr.*;
-        const cmd_info = entry.value_ptr.*;
+    // Emit in alphabetical order (see types.sortedByName) so the generated
+    // registry is deterministic rather than filesystem-iteration ordered.
+    const sorted = try types.sortedByName(commands.allocator, &commands.root);
+    defer commands.allocator.free(sorted);
+    for (sorted) |cmd_info| {
+        const cmd_name = cmd_info.name;
 
         if (cmd_info.command_type != .leaf) {
             // Generate import for optional group with index file
@@ -75,10 +77,10 @@ fn generateCommandImports(writer: anytype, commands: DiscoveredCommands) !void {
 /// Generate group command imports recursively
 fn generateGroupImports(writer: anytype, _: []const u8, group_info: *const CommandInfo) !void {
     if (group_info.subcommands) |subcommands| {
-        var it = subcommands.iterator();
-        while (it.next()) |entry| {
-            const subcmd_name = entry.key_ptr.*;
-            const subcmd_info = entry.value_ptr.*;
+        const sorted = try types.sortedByName(subcommands.allocator, &subcommands);
+        defer subcommands.allocator.free(sorted);
+        for (sorted) |subcmd_info| {
+            const subcmd_name = subcmd_info.name;
 
             if (subcmd_info.command_type == .optional_group) {
                 // Generate import for optional group with index file
@@ -191,10 +193,9 @@ fn generatePureCommandGroups(writer: anytype, commands: DiscoveredCommands, allo
 
 /// Recursively generate pure command group entries
 fn generatePureGroupsFromMap(writer: anytype, command_map: *const std.StringHashMap(CommandInfo), allocator: std.mem.Allocator) !void {
-    var it = command_map.iterator();
-    while (it.next()) |entry| {
-        const cmd_info = entry.value_ptr.*;
-
+    const sorted = try types.sortedByName(allocator, command_map);
+    defer allocator.free(sorted);
+    for (sorted) |cmd_info| {
         if (cmd_info.command_type == .pure_group) {
             // Generate entry for this pure group
             try writer.writeAll("    &.{");
@@ -216,10 +217,12 @@ fn generatePureGroupsFromMap(writer: anytype, command_map: *const std.StringHash
 
 /// Generate command registrations
 fn generateCommandRegistrations(writer: anytype, commands: DiscoveredCommands, allocator: std.mem.Allocator) !void {
-    var it = commands.root.iterator();
-    while (it.next()) |entry| {
-        const cmd_name = entry.key_ptr.*;
-        const cmd_info = entry.value_ptr.*;
+    // Registration order becomes the registry's command order (and thus the
+    // order help/completions read back), so emit alphabetically.
+    const sorted = try types.sortedByName(allocator, &commands.root);
+    defer allocator.free(sorted);
+    for (sorted) |cmd_info| {
+        const cmd_name = cmd_info.name;
 
         if (cmd_info.command_type != .leaf) {
             // Register optional group with index file as a command
@@ -254,10 +257,10 @@ fn generateCommandRegistrations(writer: anytype, commands: DiscoveredCommands, a
 /// Generate group command registrations recursively
 fn generateGroupRegistrations(writer: anytype, _: []const u8, group_info: *const CommandInfo, allocator: std.mem.Allocator) !void {
     if (group_info.subcommands) |subcommands| {
-        var it = subcommands.iterator();
-        while (it.next()) |entry| {
-            const subcmd_name = entry.key_ptr.*;
-            const subcmd_info = entry.value_ptr.*;
+        const sorted = try types.sortedByName(allocator, &subcommands);
+        defer allocator.free(sorted);
+        for (sorted) |subcmd_info| {
+            const subcmd_name = subcmd_info.name;
 
             if (subcmd_info.command_type == .optional_group) {
                 // Register the optional group itself

--- a/packages/core/src/build_utils/command_discovery.zig
+++ b/packages/core/src/build_utils/command_discovery.zig
@@ -271,6 +271,33 @@ test "discovery skips underscore-prefixed helper files and directories" {
     try testing.expect(commands.root.get("_helpers") == null);
 }
 
+test "sortedByName yields alphabetical order regardless of discovery order" {
+    const testing = std.testing;
+    const io = testing.io;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // Names chosen so filesystem/hash order is unlikely to be alphabetical.
+    try tmp.dir.writeFile(io, .{ .sub_path = "zebra.zig", .data = "pub fn execute() void {}" });
+    try tmp.dir.writeFile(io, .{ .sub_path = "apple.zig", .data = "pub fn execute() void {}" });
+    try tmp.dir.writeFile(io, .{ .sub_path = "mango.zig", .data = "pub fn execute() void {}" });
+
+    var dir = try tmp.dir.openDir(io, ".", .{ .iterate = true });
+    defer dir.close(io);
+
+    var commands = try discoverInDir(testing.allocator, io, dir);
+    defer commands.deinit();
+
+    const sorted = try types.sortedByName(testing.allocator, &commands.root);
+    defer testing.allocator.free(sorted);
+
+    try testing.expectEqual(@as(usize, 3), sorted.len);
+    try testing.expectEqualStrings("apple", sorted[0].name);
+    try testing.expectEqualStrings("mango", sorted[1].name);
+    try testing.expectEqualStrings("zebra", sorted[2].name);
+}
+
 test "isValidCommandName security checks" {
     const testing = std.testing;
 

--- a/packages/core/src/build_utils/discovery_types.zig
+++ b/packages/core/src/build_utils/discovery_types.zig
@@ -52,6 +52,33 @@ pub const CommandInfo = struct {
     }
 };
 
+/// A command map's entries as a slice sorted alphabetically by name.
+///
+/// Discovery stores each directory level in an (unordered) `StringHashMap`.
+/// Routing the code that *emits* commands through this one helper is what makes
+/// command order deterministic and alphabetical: the generated registry — and
+/// therefore everything downstream that reads it in registration order, like
+/// completions — lists commands by name rather than by filesystem-iteration
+/// order. `zcli tree` sorts its own display nodes; help re-buckets command info
+/// through its own map and sorts there. Caller owns the returned slice.
+pub fn sortedByName(allocator: std.mem.Allocator, map: *const std.StringHashMap(CommandInfo)) ![]CommandInfo {
+    const entries = try allocator.alloc(CommandInfo, map.count());
+    errdefer allocator.free(entries);
+
+    var it = map.iterator();
+    var i: usize = 0;
+    while (it.next()) |entry| : (i += 1) {
+        entries[i] = entry.value_ptr.*;
+    }
+
+    std.mem.sort(CommandInfo, entries, {}, lessByName);
+    return entries;
+}
+
+fn lessByName(_: void, a: CommandInfo, b: CommandInfo) bool {
+    return std.mem.lessThan(u8, a.name, b.name);
+}
+
 /// Container for all discovered commands
 pub const DiscoveredCommands = struct {
     allocator: std.mem.Allocator,

--- a/packages/core/src/build_utils/main.zig
+++ b/packages/core/src/build_utils/main.zig
@@ -233,8 +233,8 @@ pub fn generate(b: *std.Build, exe: *std.Build.Step.Compile, zcli_dep: *std.Buil
 
 /// Generate documentation from command metadata during the build.
 ///
-/// Docs are generated automatically on every `zig build` and also
-/// available via `zig build docs`. Output goes to `output_dir`.
+/// Docs are generated on demand via `zig build docs` (kept off the default
+/// build so ordinary builds stay quiet). Output goes to `output_dir`.
 ///
 /// ```zig
 /// // Single format (default: markdown)
@@ -264,10 +264,9 @@ pub fn generateDocs(b: *std.Build, registry_module: *std.Build.Module, zcli_dep:
         run.addArg(fmt);
     }
 
-    // Run on every `zig build`
-    b.getInstallStep().dependOn(&run.step);
-
-    // Also available as explicit `zig build docs`
+    // Only run when explicitly requested via `zig build docs`. Keeping it off
+    // the default install step means an ordinary `zig build` stays quiet and
+    // fast — no doc-gen output on every build of every consuming project.
     const docs_step = b.step("docs", "Generate documentation");
     docs_step.dependOn(&run.step);
 }

--- a/packages/core/src/build_utils/types.zig
+++ b/packages/core/src/build_utils/types.zig
@@ -12,6 +12,7 @@ const std = @import("std");
 pub const CommandType = @import("discovery_types.zig").CommandType;
 pub const CommandInfo = @import("discovery_types.zig").CommandInfo;
 pub const DiscoveredCommands = @import("discovery_types.zig").DiscoveredCommands;
+pub const sortedByName = @import("discovery_types.zig").sortedByName;
 
 /// Information about a plugin (local or external)
 pub const PluginInfo = struct {

--- a/packages/core/src/plugins/zcli_help/plugin.zig
+++ b/packages/core/src/plugins/zcli_help/plugin.zig
@@ -330,6 +330,11 @@ const CommandListType = union(enum) {
     subcommands_of: []const u8, // Show subcommands of a specific command
 };
 
+/// Sort comparator: order command names alphabetically for display.
+fn lessByNameStr(_: void, a: []const u8, b: []const u8) bool {
+    return std.mem.lessThan(u8, a, b);
+}
+
 /// Check if a name is in the aliases list
 fn isAlias(name: []const u8, aliases: []const []const u8) bool {
     for (aliases) |alias| {
@@ -442,16 +447,20 @@ fn showCommandList(context: anytype, fmt: anytype, list_type: CommandListType) !
         }
     }
 
-    // Second pass: display commands in order
+    // Second pass: display commands in alphabetical order. The dedup map above
+    // is a StringHashMap (unordered), so collect its names and sort them before
+    // printing — otherwise the list comes out in hash order.
     var it = command_map.iterator();
     while (it.next()) |entry| {
         const display_name = entry.key_ptr.*;
-        const info = entry.value_ptr.*;
-
         // Skip help command for top-level (we'll add it manually)
         if (list_type == .top_level and std.mem.eql(u8, display_name, "help")) continue;
-
         try displayed_names.append(context.allocator, display_name);
+    }
+    std.mem.sort([]const u8, displayed_names.items, {}, lessByNameStr);
+
+    for (displayed_names.items) |display_name| {
+        const info = command_map.get(display_name).?;
 
         if (info.description) |desc| {
             if (info.aliases.len > 0) {

--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -338,6 +338,16 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         \\        "hello World",
         \\        "hello Alice --loud",
         \\    },
+        \\    // Arg descriptions are plain strings; option descriptions are structs
+        \\    // that can also declare a short flag (and .name/.env). These show up in
+        \\    // `--help` and the generated docs, so the first command a user reads
+        \\    // models the full grammar.
+        \\    .args = .{
+        \\        .name = "Who to greet",
+        \\    },
+        \\    .options = .{
+        \\        .loud = .{ .description = "Shout the greeting", .short = 'l' },
+        \\    },
         \\};
         \\
         \\pub const Args = struct {


### PR DESCRIPTION
First-impression polish — three small items from the 2026-07-10 UX audit, all landing on the surfaces a new user touches first. One tidy PR.

## 1. Deterministic (alphabetical) command ordering
Command discovery stores each directory level in an unordered `StringHashMap`, so `--help` command lists, completions, and the generated registry came out in filesystem/hash order — arbitrary, and it buried `init`/`add` mid-list in the meta-CLI's own help.

- Added a shared `sortedByName` choke point in `discovery_types.zig`.
- Applied it at all five codegen emission sites (`code_generation.zig`), so the generated registry — and everything downstream that reads it in registration order (completions, `not_found`) — is alphabetical and deterministic.
- Help re-buckets command info through its **own** `StringHashMap`, so it now sorts at the display point as well.
- `zcli tree` already sorted its own display nodes — unchanged.

**Curated/weighted ordering was considered and rejected** — alphabetical everywhere is the honest, simple answer; a priority/weights feature would be scope creep for no real gain.

`zcli --help` now: `add, completions, dev, gh, guide, init, mv, release, rm, tree, upgrade` (with `help` shown last by design).

## 2. Scaffolded `hello.zig` models good meta
The `zcli init` template declared no per-arg/option descriptions, so the very first `--help` a new user generated showed placeholder-quality rows (`name  name`, `--loud  loud`). The template now includes:

```zig
.args = .{ .name = "Who to greet" },
.options = .{ .loud = .{ .description = "Shout the greeting", .short = 'l' } },
```

Note: the audit handoff suggested `.args = .{ .name = .{ .description = ... } }`, but `validateMeta` requires **arg meta to be a plain string** — that form would fail at comptime. Used the correct spelling. The `add command` generator already emits proper descriptions, so no change was needed there.

## 3. Silence docs-generation noise in ordinary builds
`generateDocs` wired the docs run into the default install step, so plain `zig build` printed `Generated markdown/man/html docs …` on every build of every consuming project. Docs now generate **only** on the explicit `zig build docs` step — this both silences and speeds up ordinary builds. No CI or release job relied on the default step producing docs (the website deploys via Zine from `website/`).

## Verification
- Root `zig build test` — green
- `packages/core` tests, including a new `sortedByName` ordering regression test — green
- `projects/zcli` `zig build e2e` — green
- `zcli --help` lists alphabetically; plain `zig build` is quiet; `zig build docs` still produces markdown/man/html

🤖 Generated with [Claude Code](https://claude.com/claude-code)