### PR TITLE
fix(ui): Table click-to-select off-by-one (header row + 1-based mouse)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ The terminal-native layout engine (ADR-0013), the migration of the interactive p
 - **progress**: rebuilt as an instance API (ADR-0014, mirroring Prompts): `@import("progress")` is the `Progress` type bundling writer/`io`/allocator/theme, with `.spinner()`/`.progressBar()`/`.multiBar()` constructors — in commands, `context.progress()`. Indicator types are no longer writer-generic and gained idempotent `deinit()`; `setText` → `setMessage`, `stopAndPersist` → `persist`; `SpinnerConfig.hide_cursor` removed (the engine owns the cursor); piped bars print one finish summary line instead of a line per update.
 - **prompts**: the `text` Preview callback returns one line of plain text from the prompt's frame arena (was: writes raw styled bytes) and is styled with the theme's hint token; `number`'s range errors render inside the prompt frame instead of scrolling past it. Rendering is engine-based throughout — navigation repaints only changed cells, long input wraps correctly, and answered lines persist as static output.
 
+### Fixed
+- **`ui.widgets.Table` click-to-select off-by-one** — clicking a table row selected the row *below* the cursor in the full-screen demo. Two things stacked: mouse reports are 1-based cells while surfaces are 0-based, and `Table.view` paints its column header as the table's first row inside the same rect `probe` reports — so a hand-rolled `row = click_y - rect.y` was off by one on both counts. Added `Table.rowAt(rect, y) ?usize`, which maps a 0-based click row through the header offset and the scroll window (and rejects clicks on the header or below the table), so click-to-select is one call with no layout magic numbers. `examples/fullscreen.zig` now uses `ui.probe` + `rowAt` (the same click-hit-test idiom `form.zig`/`popup.zig` already use). (ADR-0021)
+
 ## v0.19.0 — 2026-07-05
 
 Hardening and tooling release. Requires Zig 0.16.0.

--- a/packages/ui/examples/fullscreen.zig
+++ b/packages/ui/examples/fullscreen.zig
@@ -72,6 +72,9 @@ const State = struct {
     /// its window top — both maintained by `Table.handle`, so `update` no longer
     /// tracks the selection or slides a scroll offset by hand.
     table: ui.widgets.Table = .{},
+    /// The process table's rendered rect (written by `ui.probe` each frame), so a
+    /// click hit-tests against the very layout it's reacting to — no magic offsets.
+    table_rect: ui.Rect = .{ .x = 0, .y = 0, .w = 0, .h = 0 },
     show_help: bool = false,
     procs: [proc_names.len]Proc = undefined,
     last_mouse: ?ui.Mouse = null,
@@ -147,13 +150,16 @@ fn view(a: std.mem.Allocator, state: *State) !ui.Node {
             row_cells[3] = p.name;
             cells.* = row_cells;
         }
-        try rows.append(a, try state.table.view(a, .{
+        // Wrap the table in `ui.probe` so its rendered rect lands in `table_rect`
+        // for click hit-testing (see `update`'s mouse arm). The probe is layout-
+        // transparent — it reports the rect, it doesn't change the layout.
+        try rows.append(a, try ui.probe(a, &state.table_rect, try state.table.view(a, .{
             .focused = true,
             .columns = &proc_columns,
             .rows = grid,
             .height = @intCast(visible_rows),
             .scrollbar = true,
-        }));
+        })));
     } else {
         try rows.append(a, ui.text(.{ .bold = true }, "About"));
         try rows.append(a, ui.text(.{}, ""));
@@ -241,13 +247,13 @@ fn update(state: *State, ev: ?ui.Event) !ui.Flow {
         },
         .mouse => |m| {
             state.last_mouse = m;
-            // Left-click a process row (process tab only): the table's body starts
-            // at y=5 (padding + title + tab bar + blank + header), so a click maps
-            // through the widget's scroll window.
-            if (state.active_tab == 0 and m.button == .left and m.action == .press and m.y >= 5) {
-                const vis = m.y - 5;
-                if (vis < visible_rows) {
-                    const row = @as(usize, state.table.scroll) + vis;
+            // Left-click a process row (process tab only). `Table.rowAt` maps the
+            // click through the probed rect and the widget's scroll window — it
+            // subtracts the header row itself, so there are no layout magic numbers
+            // here. Mouse reports are 1-based; `probe` rects are 0-based, so pass
+            // `m.y - 1`. `rowAt` rejects the header; we clamp against the row count.
+            if (state.active_tab == 0 and m.button == .left and m.action == .press) {
+                if (state.table.rowAt(state.table_rect, m.y - 1)) |row| {
                     if (row < state.procs.len) state.table.highlighted = row;
                 }
             }

--- a/packages/ui/src/input.zig
+++ b/packages/ui/src/input.zig
@@ -34,6 +34,7 @@ const RenderCtx = node_mod.RenderCtx;
 const Region = surface_mod.Region;
 const Style = surface_mod.Style;
 const Point = surface_mod.Point;
+const Rect = surface_mod.Rect;
 const Key = terminal.Key;
 
 pub const Theme = theme_mod.Theme;
@@ -1162,6 +1163,10 @@ pub const Table = struct {
     /// First visible body row — persistent, maintained by `handle`.
     scroll: usize = 0,
 
+    /// Non-scrolling rows `view` paints above the body (just the column header).
+    /// `rowAt` subtracts these so a click maps to a body row, not the header.
+    pub const header_rows: u16 = 1;
+
     /// A column: a header label and a width in the existing `Dim` vocabulary.
     pub const Column = struct {
         header: []const u8,
@@ -1206,6 +1211,24 @@ pub const Table = struct {
         }
         self.scroll = scrollFor(self.scroll, self.highlighted, visible, row_count);
         return true;
+    }
+
+    /// Map a click onto the body row it landed on, or `null` if it missed the
+    /// body (the header row, or outside the table). `rect` is the table's rendered
+    /// rect (from `ui.probe`) and `y` is the click's row — both in 0-based surface
+    /// coordinates. Mouse reports are 1-based, so pass `mouse.y - 1`.
+    ///
+    /// This exists because `view` paints its column header as the table's first
+    /// row (`header_rows`), inside the same rect `probe` reports: a caller doing
+    /// `row = y - rect.y` would be off by the header and select the row below the
+    /// click. `rowAt` subtracts the header and adds `scroll`, so the returned index
+    /// is into the caller's full row slice. It does not bound against the row
+    /// count — the caller clamps (a click below the last populated row is theirs to
+    /// reject); it only rejects the header and rows past the rendered rect.
+    pub fn rowAt(self: *const Table, rect: Rect, y: u16) ?usize {
+        if (y < rect.y + header_rows) return null; // header or above
+        if (y >= rect.y + rect.h) return null; // below the table
+        return self.scroll + (y - rect.y - header_rows);
     }
 
     pub fn view(self: *const Table, a: std.mem.Allocator, opts: ViewOpts) !Node {

--- a/packages/ui/src/input_test.zig
+++ b/packages/ui/src/input_test.zig
@@ -369,6 +369,30 @@ test "Table scrolls to keep the selection in the window" {
     try testing.expectEqual(@as(usize, 2), t.scroll);
 }
 
+test "Table rowAt maps a click through the header offset and scroll window" {
+    // A table rendered at surface rect y=4, height 9 (1 header + 8 body rows).
+    const rect = ui.Rect{ .x = 1, .y = 4, .w = 20, .h = 9 };
+
+    var t = Table{}; // scroll 0
+    // The header row (rect.y) is not a body row.
+    try testing.expectEqual(@as(?usize, null), t.rowAt(rect, 4));
+    // The first body row (rect.y + header) maps to row 0 — NOT row 1. This is the
+    // off-by-one the fullscreen demo hit: a naive `y - rect.y` would return 1.
+    try testing.expectEqual(@as(?usize, 0), t.rowAt(rect, 5));
+    try testing.expectEqual(@as(?usize, 1), t.rowAt(rect, 6));
+    // Last visible body row (rect.y + h - 1); one past the rect is a miss.
+    try testing.expectEqual(@as(?usize, 7), t.rowAt(rect, 12));
+    try testing.expectEqual(@as(?usize, null), t.rowAt(rect, 13));
+    // Above the table is a miss (no underflow).
+    try testing.expectEqual(@as(?usize, null), t.rowAt(rect, 0));
+
+    // Scrolled: the same click rows map through the window top.
+    t.scroll = 20;
+    try testing.expectEqual(@as(?usize, 20), t.rowAt(rect, 5)); // first body → scroll+0
+    try testing.expectEqual(@as(?usize, 27), t.rowAt(rect, 12)); // last body → scroll+7
+    try testing.expectEqual(@as(?usize, null), t.rowAt(rect, 4)); // still the header
+}
+
 // ---- handle: Button --------------------------------------------------------
 
 test "Button activates on Enter and Space, ignores other keys" {


### PR DESCRIPTION
Fixes two bugs reported in `examples/fullscreen.zig` after the ADR-0021 widget-catalog arc merged.

## Root cause

Both reports trace to the demo's hand-rolled click-to-select math, which had **two stacked off-by-ones**:

1. **1-based mouse vs 0-based surface.** `terminal.Mouse` coordinates are 1-based cells (`packages/terminal/src/key.zig:59-60`: "subtract 1 to index a 0-based surface"). The demo used `m.y` directly.
2. **The header row.** `Table.view` paints its column header as the table's **first** row (`packages/ui/src/input.zig`, `view`), *inside* the rect. The demo's `row = m.y - 5` didn't account for the header living inside the probed area.

Net effect: **Bug 1** — clicking a body row selected the row one *below* the cursor (`fullscreen.zig` old mouse arm, `vis = m.y - 5` with 1-based `m.y`).

**Bug 2** ("↓ walks the selection one past the last row") shares this root cause rather than being a second, separate bug. I verified the `Table` widget is correct on both axes:
- `Table.handle` `.down` clamps at `row_count` (`input.zig` `handle`) — after 40 `.down` presses on a 28-row grid, `highlighted == 27` (proven with a repro).
- `Table.view` paints the highlight band only on the last item — rendering the demo-shaped tree at `highlighted=27` (scroll=20, visible=8) put the band on the last body row, never a phantom row past it.

So the only path that could put the highlight "one too far down" was the click; there is no separate keyboard bug. Fixing the click removes both symptoms.

## Layer choice

Fixed at the **widget layer**, because `Table.view` rendering its header inside the probed rect makes this off-by-one inevitable for *every* caller doing click-to-select — not just this demo. Added:

- `Table.header_rows` — the single source of truth for the non-scrolling rows above the body.
- `Table.rowAt(rect, y) ?usize` — maps a 0-based click row through the header offset and the scroll window, rejecting the header row and clicks past the rendered rect. Caller passes `mouse.y - 1` and clamps against its row count.

`examples/fullscreen.zig` now wraps the table in `ui.probe` and calls `rowAt` — the same click-hit-test idiom `form.zig`/`popup.zig` already use — with zero layout magic numbers.

## Other examples

Checked `form.zig` and `popup.zig`: both already convert 1-based → 0-based (`m.x -| 1`, `m.y -| 1`) and hit-test whole-widget rects (click-to-focus / toggle), with no header offset in play. **Clean — no fix needed.**

## Test evidence

- New `input_test.zig` regression test "Table rowAt maps a click through the header offset and scroll window": header row → `null`, first body row → row 0 (not 1), last body row → last index, one past rect → `null`, and the scrolled window. Verified it **fails before** the fix (reintroducing the missing `- header_rows` yields `expected 0, found 1`) and **passes after**.
- Root `zig build test`: pass.
- `packages/ui` `zig build test` (compiles all examples incl. `fullscreen.zig`): pass.
- `projects/zcli` `zig build e2e`: pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)