### PR TITLE
docs: slim COMMANDS/PLUGINS to summaries, cross-link README to zcli.sh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,5 +54,5 @@ zig build test
 - [docs/BUILD.md](docs/BUILD.md) — the build-time codegen pipeline
 - [docs/ERROR_HANDLING.md](docs/ERROR_HANDLING.md) — the error model and diagnostics
 - [docs/TESTING.md](docs/TESTING.md) — the three testing tiers and when to use each
-- [docs/COMMANDS.md](docs/COMMANDS.md) / [docs/PLUGINS.md](docs/PLUGINS.md) — the user-facing reference the README links to
+- [docs/COMMANDS.md](docs/COMMANDS.md) / [docs/PLUGINS.md](docs/PLUGINS.md) — quick repo summaries; the full user-facing reference lives at [zcli.sh](https://zcli.sh)
 - [docs/adr/](docs/adr/) — why things are the way they are

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 zcli is a batteries-included framework for building polished command-line apps in Zig. Drop a `.zig` file in `commands/` and it becomes a command — help text, shell completions, typo suggestions, and typed argument parsing are generated at compile time. One dependency, one self-contained binary.
 
+**Full documentation lives at [zcli.sh](https://zcli.sh)** — [getting started](https://zcli.sh/getting-started/), the [docs](https://zcli.sh/docs/), [plugins](https://zcli.sh/plugins/), the [CLI/TUI hybrid](https://zcli.sh/ui/), [theming](https://zcli.sh/theming/), and [building CLIs with coding agents](https://zcli.sh/ai/). This README is the tour; the site is the reference.
+
 <img alt="Demo of a zcli app: interactive prompts, a colored task table, live search filtering, and a spinner" src="examples/tasks/demo.gif" width="600" />
 
 ## Your CLI is a directory
@@ -48,7 +50,7 @@ Deploying api to staging
 
 No routing tables, no builder calls, no registration. Commands are discovered at build time and routing is generated as ordinary Zig code — the parser is built for your exact structs, so reading an option that doesn't exist is a compile error, and a mistyped command gets a "did you mean?" at runtime.
 
-Variadic args, option types, typed `context`, aliases, and command groups: [docs/COMMANDS.md](docs/COMMANDS.md).
+Variadic args, option types, typed `context`, aliases, and command groups: [zcli.sh/docs](https://zcli.sh/docs/#commands) (repo summary in [docs/COMMANDS.md](docs/COMMANDS.md)).
 
 ## Quick start
 
@@ -237,7 +239,7 @@ try app.frame(try ui.column(app.arena(), .{ .border = .rounded }, &.{
 
 Boxes, wrapped text, spacers, and custom leaves; `fit`/`len`/`fill` sizing; viewport-clamped, resize-aware (the live region re-lays-out and the visible scrollback tail reflows), and piped output degrades to plain lines.
 
-When you want the whole terminal — a `top`-style dashboard, an interactive form — the same node tree, layout, and diff run in **full-screen mode**: `context.uiFullScreen(.{})` switches to the alternate screen and hands the `frame → event → update` loop to `app.run`. It comes with focusable widgets (`TextInput`, `Select`, `Checkbox`, `Button` — each a plain struct in your state, routed by a single `handle`-returns-`bool` contract), overlays via a `stack` of z-layers, scrollable viewports, mouse/focus/paste events, and anchored popups that flip and clamp to stay on screen. On exit the shell comes back exactly as it was. Design in [ADR-0013](docs/adr/0013-terminal-native-layout-engine.md) (full-screen and widgets in [ADRs 0015–0020](docs/adr/)), API in [packages/ui](packages/ui/).
+When you want the whole terminal — a `top`-style dashboard, an interactive form — the same node tree, layout, and diff run in **full-screen mode**: `context.uiFullScreen(.{})` switches to the alternate screen and hands the `frame → event → update` loop to `app.run`. It comes with focusable widgets (`TextInput`, `Select`, `Checkbox`, `Button` — each a plain struct in your state, routed by a single `handle`-returns-`bool` contract), overlays via a `stack` of z-layers, scrollable viewports, mouse/focus/paste events, and anchored popups that flip and clamp to stay on screen. On exit the shell comes back exactly as it was. Walkthrough at [zcli.sh/ui](https://zcli.sh/ui/); design in [ADR-0013](docs/adr/0013-terminal-native-layout-engine.md) (full-screen and widgets in [ADRs 0015–0020](docs/adr/)), API in [packages/ui](packages/ui/).
 
 ## Theming
 
@@ -261,7 +263,7 @@ try styled("Synced").success().render(writer, &context.theme);
 try styled("Error").red().bold().render(writer, &context.theme);
 ```
 
-Semantic roles (`success`, `err`, `warning`, `command`, `path`, …) resolve at render time and adapt to the terminal: true color, 256 color, 16 color, or no color (respects `NO_COLOR`). Component tokens (`prompts.cursor`, `progress.spinner`, `surface.border`, …) default to palette roles, so one palette change restyles everything — including the chrome behind a full-screen panel. Styling defaults *derive* from the theme at compile time, so `ui.panel` and bordered boxes need no `Style` at the call site and `ui.text(ui.role(.success), …)` styles by meaning in one word. Full API in [packages/theme](packages/theme/).
+Semantic roles (`success`, `err`, `warning`, `command`, `path`, …) resolve at render time and adapt to the terminal: true color, 256 color, 16 color, or no color (respects `NO_COLOR`). Component tokens (`prompts.cursor`, `progress.spinner`, `surface.border`, …) default to palette roles, so one palette change restyles everything — including the chrome behind a full-screen panel. Styling defaults *derive* from the theme at compile time, so `ui.panel` and bordered boxes need no `Style` at the call site and `ui.text(ui.role(.success), …)` styles by meaning in one word. Guide at [zcli.sh/theming](https://zcli.sh/theming/); full API in [packages/theme](packages/theme/).
 
 ## Config files
 
@@ -275,13 +277,13 @@ The `zcli_config` plugin transparently loads option defaults from JSON, TOML, or
 }
 ```
 
-Discovery order and formats in [docs/PLUGINS.md](docs/PLUGINS.md#config-file-plugin).
+Discovery order and formats: [zcli.sh/plugins](https://zcli.sh/plugins/#config).
 
 ## Plugins
 
 Cross-cutting features are plugins, added in one line of `build.zig`: help, version, "did you mean?", shell completions (bash/zsh/fish), config files, `--output` formatting (json/table/plain), OS-keychain secrets, and self-upgrade via GitHub releases all ship in the box. Plugins hook the command lifecycle, register global options, expose typed data as `context.plugins.<id>`, and can ship commands of their own.
 
-The full list and a guide to writing your own: [docs/PLUGINS.md](docs/PLUGINS.md).
+The full list and a guide to writing your own: [zcli.sh/plugins](https://zcli.sh/plugins/) (repo summary in [docs/PLUGINS.md](docs/PLUGINS.md)).
 
 ## Testing
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1,5 +1,8 @@
 # Commands
 
+> **Full reference: [zcli.sh/docs](https://zcli.sh/docs/#commands).** This is a quick
+> orientation; the website is the single source of truth for the command contract.
+
 Commands are `.zig` files in your commands directory. The file path becomes the command path:
 
 ```
@@ -13,74 +16,25 @@ src/commands/
 
 Discovery happens at build time — see [BUILD.md](BUILD.md) for how the registry is generated.
 
-## Command structure
-
-Every command has up to four exports:
+Every command is one file with up to four exports:
 
 ```zig
 const zcli = @import("zcli");
-// Name your app's generated context type for full editor autocomplete on `context`.
-const Context = @import("command_registry").Context;
 
-pub const meta = .{
-    .description = "Add files to the index",
-    .examples = &.{ "add file.txt", "add --all" },
-    .args = .{ .files = "Files to add" },
-    .options = .{
-        .all = .{ .short = 'a', .description = "Add all files" },
-    },
-    .aliases = &.{ "a" },
-};
+pub const meta = .{ .description = "Add files to the index" };
+pub const Args = struct { files: []const []const u8 };   // positional; variadic tail
+pub const Options = struct { all: bool = false };        // flags & valued options
 
-pub const Args = struct {
-    files: []const []const u8,          // variadic: captures remaining args
-};
-
-pub const Options = struct {
-    all: bool = false,                  // --all / -a (flag), or --no-all to force false
-    output: []const u8 = "text",        // --output <value>
-    count: u32 = 1,                     // --count <number>
-    verbose: ?bool = null,              // three-state flag: absent=null, --verbose, --no-verbose
-};
-
-pub fn execute(args: Args, options: Options, context: *Context) !void {
-    // context.stdout(), context.stderr(), context.allocator, context.theme,
-    // context.plugins.<plugin_id>, etc. — all typed and autocompletable.
+pub fn execute(args: Args, options: Options, context: anytype) !void {
+    // context.stdout(), context.allocator, context.theme, context.plugins.<id>, …
 }
 ```
 
-- **`meta`** — help text and parsing metadata: `description`, `examples`, per-argument descriptions (`args`), per-option metadata (`options`, including `short` flags), and `aliases`.
-- **`Args`** — positional arguments as a struct. A `[]const []const u8` field is variadic and captures all remaining arguments.
-- **`Options`** — flags and options as a struct. `bool` and `?bool` fields are **flags** (they never take a value); other types take values, and defaults come from the struct initializers.
-  - **Boolean negation.** Every boolean flag `--flag` gets an auto-generated `--no-flag` that sets it to `false`. This is what lets a `bool = true` default be turned off, and it makes `?bool` a genuine three-state flag: absent → `null`, `--flag` → `true`, `--no-flag` → `false`. A boolean may be passed at most once — repeating it, or combining `--flag` with `--no-flag`, is an error. In `--help`, a flag is shown by whichever spelling is useful: a default-`false` flag lists `--flag`, and a default-`true` flag lists `--no-flag` (turning off is the only meaningful action); the other spelling is accepted but hidden.
-  - **Write the description for the spelling that shows.** A description says what *passing the shown flag does*. For a default-`false` bool that's the positive form, so describe turning it on (`--verbose` → "Enable verbose output"). For a default-`true` bool only `--no-flag` shows, so describe turning it **off** (`push: bool = true` → "Create the tag but don't push to remote", displayed against `--no-push`). Since the shown spelling is fixed by the default, you always know which direction to write for. Keep the field's own `///` doc comment describing the field for source readers; the meta `description` is the user-facing help text.
-  - **Two rules the compiler enforces.** A boolean field's name may not start with `no_` (it would collide with another flag's `--no-` negation). And an optional field (`?T`) must default to `null` — that `null` is the "not passed" state; use a non-optional field with a default when you want a guaranteed value.
-- **`execute`** — the command body. Receives the parsed, typed `Args` and `Options` plus the app context.
+- **`meta`** — help text and parsing metadata (`description`, `examples`, per-arg/option descriptions, `short` flags, `aliases`).
+- **`Args`** — positional arguments as a struct; a `[]const []const u8` field is variadic.
+- **`Options`** — `bool`/`?bool` fields are flags; other types take values, with defaults from the initializers.
+- **`execute`** — the command body, receiving the parsed, typed `Args` and `Options` plus the app context.
 
-The parser is generated from these structs at compile time, so an option's type is checked when parsing its value, and code that reads a nonexistent field fails to compile.
+The parser is generated from these structs at compile time, so option types are checked when parsing and reading a nonexistent field fails to compile.
 
-## Typing `context`
-
-`Context` is generated per-app from your config and plugin set, so it carries a
-typed field for every plugin's data (`context.plugins.<plugin_id>`). You can type
-the parameter two ways:
-
-- **`context: *Context`** (above) — import `@import("command_registry").Context`.
-  Best for app-local commands: full autocomplete, go-to-definition, and errors at
-  the definition site. There's no import cycle — `Context` depends only on your
-  config and plugins, not on the command files.
-- **`context: anytype`** — portable across apps with no editor hints. Use this for
-  reusable/library commands and inside plugin hooks (a plugin is compiled
-  independently of the app that hosts it).
-
-## Command groups
-
-Add an `index.zig` to give a directory a description:
-
-```zig
-// src/commands/users/index.zig
-pub const meta = .{ .description = "Manage users" };
-// No execute — running "myapp users" shows subcommands
-```
-
-Give `index.zig` an `execute` and the group itself becomes runnable — `myapp users` runs it, while `myapp users create` still routes to the subcommand. A runnable group must declare an empty `Args` struct (positional arguments would be ambiguous with subcommand names, so the compiler rejects them); `Options` work as usual.
+For the full contract — variadic rules, boolean negation (`--no-flag`) and how it shapes help, typing `context` for editor autocomplete, and runnable command groups — see **[zcli.sh/docs](https://zcli.sh/docs/#commands)**.

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -1,19 +1,10 @@
 # Plugins
 
-Plugins extend every command in an app with lifecycle hooks, global options, and their own commands. zcli ships with eight; the help/version/not-found trio is what most apps start with.
+> **Full reference: [zcli.sh/plugins](https://zcli.sh/plugins/).** This is a quick
+> orientation; the website is the single source of truth for the built-in list,
+> config-file behavior, and the plugin-authoring contract.
 
-| Plugin | Provides | Default? |
-|--------|----------|----------|
-| **zcli_help** | `--help` / `-h`, auto-generated help text | Yes |
-| **zcli_version** | `--version` / `-V` | Yes |
-| **zcli_not_found** | "Did you mean?" suggestions for typos | Yes |
-| **zcli_completions** | `completions generate/install/uninstall` for bash, zsh, fish | Optional |
-| **zcli_config** | Transparent config file loading (JSON, TOML, YAML) | Optional |
-| **zcli_output** | `--output` flag (json, table, plain) | Optional |
-| **zcli_secrets** | Opt-in credential storage in the OS keychain (get/set/delete) | Optional |
-| **zcli_github_upgrade** | `upgrade` command via GitHub releases | Optional |
-
-Add them in `build.zig`:
+Plugins extend every command in an app with lifecycle hooks, global options, and their own commands. zcli ships with a set of built-ins — the help/version/not-found trio is what most apps start with, and completions, config files, `--output` formatting, OS-keychain secrets, and GitHub self-upgrade are opt-in. Enable them in `build.zig`:
 
 ```zig
 const cmd_registry = try zcli.generate(b, exe, zcli_dep, .{
@@ -29,87 +20,12 @@ const cmd_registry = try zcli.generate(b, exe, zcli_dep, .{
 });
 ```
 
-## Plugin context data
-
-Plugins store data in `context.plugins.{plugin_id}` — a typed field on your app's generated `Context`:
+Plugins store typed data in `context.plugins.<plugin_id>` on your app's generated `Context`:
 
 ```zig
-// In a command, check if help was requested
 if (context.plugins.zcli_help.help_requested) { ... }
 ```
 
-## Config file plugin
+A plugin is a Zig module with a `plugin_id` and any of the lifecycle exports (`global_options`, `handleGlobalOption`, `preExecute`, `onError`); it can also ship its own commands. Hook parameters are typed `anytype` — a plugin is compiled independently of the app that hosts it.
 
-The `zcli_config` plugin transparently loads option defaults from a config file. Supports JSON, TOML, and YAML — no changes to command code required.
-
-```zig
-// In build.zig plugins:
-zcli.builtin(.config, .{}),
-```
-
-Config file discovery (by extension priority):
-1. `--config <path>` flag
-2. `.{app_name}.config.json` / `.toml` / `.yaml` / `.yml` (in the current directory)
-3. `$XDG_CONFIG_HOME/{app_name}/config.json` / `.toml` / `.yaml` / `.yml`
-
-Values cascade: **CLI flags > command config > global config > struct defaults**.
-
-```json
-// .myapp.config.json
-{
-  "output": "json",         // global — applies to all commands
-  "list": {                 // scoped — applies only to "list" command
-    "all": true
-  }
-}
-```
-
-```toml
-# .myapp.config.toml
-output = "json"
-
-[list]
-all = true
-```
-
-```yaml
-# .myapp.config.yaml
-output: json
-list:
-  all: true
-```
-
-## Writing plugins
-
-A plugin is a Zig module with a `plugin_id` and any of the lifecycle exports:
-
-```zig
-pub const plugin_id = "my_plugin";
-pub const ContextData = struct { enabled: bool = false };
-```
-
-`plugin_id` becomes the `context.plugins.<id>` field name **verbatim**, so it must be a valid Zig identifier (`[a-zA-Z_][a-zA-Z0-9_]*` — in practice lowercase `snake_case`). A plugin that declares `ContextData` without a `plugin_id`, or gives one that isn't a valid identifier (e.g. `"my-plugin"`), fails at compile time with a message naming the plugin and the fix. zcli does **not** silently rewrite an invalid id — you choose the field name you'll type.
-
-```zig
-pub const global_options = [_]zcli.GlobalOption{
-    zcli.option("verbose", bool, .{ .short = 'v', .default = false }),
-};
-
-pub fn handleGlobalOption(context: anytype, name: []const u8, value: anytype) !void {
-    // Store option values in context.plugins.my_plugin
-}
-
-pub fn preExecute(context: anytype, args: zcli.ParsedArgs) !?zcli.ParsedArgs {
-    // Run before every command. Return null to stop execution.
-    return args;
-}
-
-pub fn onError(context: anytype, err: anyerror) !bool {
-    // Handle errors. Return true if handled.
-    return false;
-}
-```
-
-Plugins can also ship their own commands (the completions plugin's `completions` subcommands work this way). Type hook parameters `anytype` — a plugin is compiled independently of the app that hosts it, so it can't import the app's `Context`.
-
-For how plugins are discovered, merged with native commands, and wired into the generated registry, see [BUILD.md](BUILD.md). Local (in-repo) plugins can be picked up automatically via `plugins_dir`.
+For the full built-in list, config-file discovery and cascade, `plugins_dir` auto-discovery, and the complete plugin-authoring guide, see **[zcli.sh/plugins](https://zcli.sh/plugins/)**. For how plugins are discovered and merged into the generated registry, see [BUILD.md](BUILD.md).


### PR DESCRIPTION
## Why

`docs/COMMANDS.md` and `docs/PLUGINS.md` were thin relative to the website docs pages, so a GitHub-first evaluator (the most common first touch) got the weaker version of the story and often never found the good one — the README linked to zcli.sh **nowhere** except the install curl.

Per the editorial decision, make the website the single source of truth (option (a) — the #201 version-drift guards argue for fewer duplicated surfaces to keep in sync), keep the README as a full tour, and point everything at zcli.sh.

## Changes

- **`docs/COMMANDS.md`** (86 → 40 lines) — slimmed to an orientation (file→command model, the four exports, one line each) with prominent links to `zcli.sh/docs/#commands`. Dropped the drift-prone deep detail (variadic/negation mechanics, `context` typing modes, runnable groups) that the site owns.
- **`docs/PLUGINS.md`** (115 → 30 lines) — same treatment, linking to `zcli.sh/plugins/`. Removed the full built-in plugin **table** and the config-cascade JSON/TOML/YAML triplicate — exactly the surfaces prone to drift.
- **`README.md`** — stays the full tour, now with a top-level **"Full documentation lives at zcli.sh"** pointer and feature-section links redirected to their matching website pages (commands → `/docs/#commands`, config → `/plugins/#config`, plugins → `/plugins/`, UI → `/ui/`, theming → `/theming/`), each keeping the repo-summary link as a secondary pointer.
- **`CONTRIBUTING.md`** — noted these files are now summaries, not the reference.

## Left alone deliberately

- `packages/*` links (real source, not thin docs) and the deep reference docs (TESTING.md, BUILD.md, DESIGN.md, ERROR_HANDLING.md, ADRs) — not thin, no full website parity.
- ADRs 0011 / 0022 mention "Documented in docs/COMMANDS.md" — point-in-time decision records, untouched.
- No CI drift-guard or link-checker references these files, and no remaining links point at removed anchors (`#config-file-plugin`, `#writing-plugins`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)