### PR TITLE
feat(options): cross-field constraints — meta.exclusive + .requires (ADR-0022)

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -75,11 +75,11 @@ pub const Options = struct {
 pub const meta = .{
     // At most one member of each set may be supplied.
     .exclusive = .{
-        .{ "json", "yaml", "xml" },
+        .{ .json, .yaml, .xml },
     },
     .options = .{
         // --output-format is meaningless without --output.
-        .output_format = .{ .requires = .{"output"} },
+        .output_format = .{ .requires = .{.output} },
     },
 };
 ```
@@ -87,7 +87,7 @@ pub const meta = .{
 - **`meta.exclusive`** — a list of *sets*; supplying two members of one set is an error (`Options '--json' and '--yaml' cannot be used together.`). Write a two-element set for a one-off "A conflicts with B".
 - **`meta.options.<field>.requires`** — the options that must accompany this one. Directional: `output_format` needs `output`, but `output` alone is fine (`Option '--output-format' requires '--output'.`).
 
-Names are Options field names, verified at compile time (`@hasField`) — a typo is a build error. The compiler also rejects the nonsensical: a field that requires itself, an `exclusive` set with fewer than two (or duplicated) members, and a *required* option in an `exclusive` set (it's always supplied, so it could never be the "at most one"). You don't need a constraint for exactly-one-of-a-mode — an enum with no default (`format: enum { json, yaml, xml }`) already is exactly-one, and `?enum … = null` is at-most-one.
+Options are named as enum literals (`.output`), the same way an option is keyed elsewhere in `meta` — verified at compile time (`@hasField`), so a typo is a build error. The compiler also rejects the nonsensical: a field that requires itself, an `exclusive` set with fewer than two (or duplicated) members, and a *required* option in an `exclusive` set (it's always supplied, so it could never be the "at most one"). You don't need a constraint for exactly-one-of-a-mode — an enum with no default (`format: enum { json, yaml, xml }`) already is exactly-one, and `?enum … = null` is at-most-one.
 
 ## Typing `context`
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -59,6 +59,36 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
 
 The parser is generated from these structs at compile time, so an option's type is checked when parsing its value, and code that reads a nonexistent field fails to compile.
 
+## Option constraints
+
+Rules that span more than one option live in `meta`, keyed off whether an option was *supplied* (by CLI flag, `.env` variable, or config) — not its value:
+
+```zig
+pub const Options = struct {
+    json: bool = false,
+    yaml: bool = false,
+    xml: bool = false,
+    output: ?[]const u8 = null,
+    output_format: ?enum { pretty, compact } = null,
+};
+
+pub const meta = .{
+    // At most one member of each set may be supplied.
+    .exclusive = .{
+        .{ "json", "yaml", "xml" },
+    },
+    .options = .{
+        // --output-format is meaningless without --output.
+        .output_format = .{ .requires = .{"output"} },
+    },
+};
+```
+
+- **`meta.exclusive`** — a list of *sets*; supplying two members of one set is an error (`Options '--json' and '--yaml' cannot be used together.`). Write a two-element set for a one-off "A conflicts with B".
+- **`meta.options.<field>.requires`** — the options that must accompany this one. Directional: `output_format` needs `output`, but `output` alone is fine (`Option '--output-format' requires '--output'.`).
+
+Names are Options field names, verified at compile time (`@hasField`) — a typo is a build error. The compiler also rejects the nonsensical: a field that requires itself, an `exclusive` set with fewer than two (or duplicated) members, and a *required* option in an `exclusive` set (it's always supplied, so it could never be the "at most one"). You don't need a constraint for exactly-one-of-a-mode — an enum with no default (`format: enum { json, yaml, xml }`) already is exactly-one, and `?enum … = null` is at-most-one.
+
 ## Typing `context`
 
 `Context` is generated per-app from your config and plugin set, so it carries a

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -239,17 +239,18 @@ pub const Options = struct {
 
 pub const meta = .{
     .exclusive = .{
-        .{ "json", "yaml", "xml" },                     // at most one of these
+        .{ .json, .yaml, .xml },                        // at most one of these
     },
     .options = .{
-        .output_format = .{ .requires = .{"output"} },  // needs --output
+        .output_format = .{ .requires = .{.output} },   // needs --output
     },
 };
 ```
 
 Both key off the same notion of "supplied" that required options use — CLI flag,
-`.env` variable, or config file — not the option's *value*. Names are Options
-field names, checked at compile time with `@hasField` (a typo is a build error).
+`.env` variable, or config file — not the option's *value*. Options are named as
+enum literals (`.output`) — the same way an option is keyed elsewhere in `meta` —
+checked at compile time with `@hasField` (a typo is a build error).
 Further comptime guards reject the nonsensical: a field that lists itself in
 `requires`, a set with fewer than two members or a duplicated member, and a
 *required* option placed in an `exclusive` set (it is always supplied, so it

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -218,6 +218,54 @@ lowest: CLI argument > environment variable > default value.
 Values come from the environ threaded down from `process.Init` — the
 framework performs no ambient `getenv`.
 
+**Option Constraints (cross-field):**
+
+Some rules span more than one option. zcli expresses them with two constraints,
+each in its natural home (ADR-0022):
+
+- `meta.exclusive` (command level) — a list of *sets*; at most one member of
+  each set may be supplied.
+- `meta.options.<field>.requires` (field level) — a list of option field names
+  that must also be supplied whenever this field is (a directional dependency).
+
+```zig
+pub const Options = struct {
+    json: bool = false,
+    yaml: bool = false,
+    xml: bool = false,
+    output: ?[]const u8 = null,
+    output_format: ?enum { pretty, compact } = null,
+};
+
+pub const meta = .{
+    .exclusive = .{
+        .{ "json", "yaml", "xml" },                     // at most one of these
+    },
+    .options = .{
+        .output_format = .{ .requires = .{"output"} },  // needs --output
+    },
+};
+```
+
+Both key off the same notion of "supplied" that required options use — CLI flag,
+`.env` variable, or config file — not the option's *value*. Names are Options
+field names, checked at compile time with `@hasField` (a typo is a build error).
+Further comptime guards reject the nonsensical: a field that lists itself in
+`requires`, a set with fewer than two members or a duplicated member, and a
+*required* option placed in an `exclusive` set (it is always supplied, so it
+could never be one of several mutually-exclusive choices).
+
+At runtime the checks run after every source is applied, in order:
+missing-required → `requires` → `exclusive`. A violation is reported like any
+other parse error and is interceptable by `onError` hooks:
+
+- `Options '--json' and '--yaml' cannot be used together.`
+- `Option '--output-format' requires '--output'.`
+
+Exactly-one-of-a-mode needs no constraint: an enum with no default
+(`format: enum { json, yaml, xml }`) is already exactly-one, and `?enum … = null`
+is at-most-one.
+
 **Context Structure:**
 
 The context provides access to system resources and framework features:

--- a/docs/adr/0022-option-constraints.md
+++ b/docs/adr/0022-option-constraints.md
@@ -38,13 +38,18 @@ pub const Options = struct {
 
 pub const meta = .{
     .exclusive = .{
-        .{ "json", "yaml", "xml" },   // at most one
+        .{ .json, .yaml, .xml },   // at most one
     },
     .options = .{
-        .output_format = .{ .requires = .{"output"} },  // directional
+        .output_format = .{ .requires = .{.output} },  // directional
     },
 };
 ```
+
+Options are named as enum literals (`.json`, `.output`) — the same `.name`
+spelling an option is keyed by elsewhere in `meta` — so one uniform rule ("an
+option is `.its_name`") holds across the block. `@tagName` recovers the field
+name at comptime for the `@hasField` check.
 
 Both constraints operate on the same notion of "provided" that `required`
 already uses — the `options_provided` set, filled by CLI / env / config. A

--- a/packages/core/src/command_parser.zig
+++ b/packages/core/src/command_parser.zig
@@ -994,7 +994,7 @@ test "firstMissingDependency: enforced only when the dependent option is supplie
         output: ?[]const u8 = null,
         output_format: ?enum { pretty, compact } = null,
     };
-    const meta = .{ .options = .{ .output_format = .{ .requires = .{"output"} } } };
+    const meta = .{ .options = .{ .output_format = .{ .requires = .{.output} } } };
     const before = Options{};
 
     // output_format supplied, output not → violation.
@@ -1030,7 +1030,7 @@ test "firstMissingDependency: reports effective (custom/dashed) flag names" {
     };
     const meta = .{ .options = .{
         .out = .{ .name = "output" },
-        .fmt = .{ .requires = .{"out"} },
+        .fmt = .{ .requires = .{.out} },
     } };
     const before = Options{};
     const provided = [_]bool{ false, true };
@@ -1047,7 +1047,7 @@ test "firstExclusiveViolation: at most one member of a set may be supplied" {
         yaml: bool = false,
         xml: bool = false,
     };
-    const meta = .{ .exclusive = .{.{ "json", "yaml", "xml" }} };
+    const meta = .{ .exclusive = .{.{ .json, .yaml, .xml }} };
     const opts = Options{};
 
     // Two members supplied → violation, reporting them in declaration order.
@@ -1077,7 +1077,7 @@ test "firstExclusiveViolation: overlapping sets are checked independently" {
         b: bool = false,
         c: bool = false,
     };
-    const meta = .{ .exclusive = .{ .{ "a", "b" }, .{ "b", "c" } } };
+    const meta = .{ .exclusive = .{ .{ .a, .b }, .{ .b, .c } } };
     const opts = Options{};
 
     // a + c: neither set has two supplied members → legal.

--- a/packages/core/src/command_parser.zig
+++ b/packages/core/src/command_parser.zig
@@ -221,6 +221,104 @@ pub fn firstMissingRequiredOption(
     return null;
 }
 
+/// Was this option supplied by *some* source — CLI/env (`provided[index]`) or
+/// config (its value changed between the before/after snapshot)? The same
+/// "provided" notion `firstMissingRequiredOption` uses, shared by the exclusive
+/// and requires constraint walks so all three agree on what "supplied" means.
+fn optionSupplied(
+    comptime OptionsType: type,
+    comptime field_name: []const u8,
+    comptime index: usize,
+    before_config: OptionsType,
+    after_config: OptionsType,
+    provided: [options_parser.optionFieldCount(OptionsType)]bool,
+) bool {
+    if (provided[index]) return true;
+    return !std.meta.eql(@field(before_config, field_name), @field(after_config, field_name));
+}
+
+/// The field index of `name` in `OptionsType` (comptime). Constraint names are
+/// validated with `@hasField` at build time, so this always resolves here.
+fn fieldIndex(comptime OptionsType: type, comptime name: []const u8) usize {
+    inline for (@typeInfo(OptionsType).@"struct".fields, 0..) |field, i| {
+        if (comptime std.mem.eql(u8, field.name, name)) return i;
+    }
+    @compileError("no Options field named '" ++ name ++ "'");
+}
+
+/// A supplied option whose `meta.options.<field>.requires` dependency was not
+/// supplied. Names are effective long flag names (custom `.name` or dashed
+/// field name), static lifetime.
+pub const MissingDependency = struct {
+    option_name: []const u8,
+    required_name: []const u8,
+};
+
+/// The first unmet `requires` dependency (in field order, then dependency
+/// order), or null. A field's dependencies are enforced only when the field
+/// itself was supplied; each dependency must then be supplied by some source.
+/// Runs beside `firstMissingRequiredOption`, over the same `options_provided`
+/// bitset and config snapshot.
+pub fn firstMissingDependency(
+    comptime OptionsType: type,
+    comptime meta: anytype,
+    before_config: OptionsType,
+    after_config: OptionsType,
+    provided: [options_parser.optionFieldCount(OptionsType)]bool,
+) ?MissingDependency {
+    const info = @typeInfo(OptionsType);
+    if (info != .@"struct") return null;
+    inline for (info.@"struct".fields, 0..) |field, i| {
+        if (comptime option_utils.requiresFor(meta, field.name)) |req_list| {
+            if (optionSupplied(OptionsType, field.name, i, before_config, after_config, provided)) {
+                inline for (req_list) |dep| {
+                    const dep_i = comptime fieldIndex(OptionsType, dep);
+                    if (!optionSupplied(OptionsType, dep, dep_i, before_config, after_config, provided)) {
+                        return .{
+                            .option_name = comptime option_utils.effectiveLongName(meta, field.name),
+                            .required_name = comptime option_utils.effectiveLongName(meta, dep),
+                        };
+                    }
+                }
+            }
+        }
+    }
+    return null;
+}
+
+/// Two members of a `meta.exclusive` set that were both supplied. Names are
+/// effective long flag names, static lifetime.
+pub const MutuallyExclusive = struct {
+    first: []const u8,
+    second: []const u8,
+};
+
+/// The first `meta.exclusive` set with two or more supplied members (reporting
+/// the first two in declaration order), or null. Runs beside
+/// `firstMissingRequiredOption`, after `requires`, over the same
+/// `options_provided` bitset and config snapshot.
+pub fn firstExclusiveViolation(
+    comptime OptionsType: type,
+    comptime meta: anytype,
+    before_config: OptionsType,
+    after_config: OptionsType,
+    provided: [options_parser.optionFieldCount(OptionsType)]bool,
+) ?MutuallyExclusive {
+    const sets = comptime option_utils.exclusiveSets(meta);
+    inline for (sets) |set| {
+        var first_name: ?[]const u8 = null;
+        inline for (set) |member| {
+            const idx = comptime fieldIndex(OptionsType, member);
+            if (optionSupplied(OptionsType, member, idx, before_config, after_config, provided)) {
+                const eff = comptime option_utils.effectiveLongName(meta, member);
+                if (first_name) |f| return .{ .first = f, .second = eff };
+                first_name = eff;
+            }
+        }
+    }
+    return null;
+}
+
 /// Check if an options type has any array fields that need cleanup
 fn hasArrayFields(comptime OptionsType: type) bool {
     const type_info = @typeInfo(OptionsType);
@@ -889,6 +987,112 @@ test "firstMissingRequiredOption: no required fields is never missing" {
     const before = Options{};
     const provided = [_]bool{ false, false };
     try std.testing.expect(firstMissingRequiredOption(Options, null, before, before, provided) == null);
+}
+
+test "firstMissingDependency: enforced only when the dependent option is supplied" {
+    const Options = struct {
+        output: ?[]const u8 = null,
+        output_format: ?enum { pretty, compact } = null,
+    };
+    const meta = .{ .options = .{ .output_format = .{ .requires = .{"output"} } } };
+    const before = Options{};
+
+    // output_format supplied, output not → violation.
+    {
+        const provided = [_]bool{ false, true };
+        const miss = firstMissingDependency(Options, meta, before, before, provided);
+        try std.testing.expect(miss != null);
+        try std.testing.expectEqualStrings("output-format", miss.?.option_name);
+        try std.testing.expectEqualStrings("output", miss.?.required_name);
+    }
+    // Both supplied → satisfied.
+    {
+        const provided = [_]bool{ true, true };
+        try std.testing.expect(firstMissingDependency(Options, meta, before, before, provided) == null);
+    }
+    // Dependent option absent → dependency not enforced.
+    {
+        const provided = [_]bool{ true, false };
+        try std.testing.expect(firstMissingDependency(Options, meta, before, before, provided) == null);
+    }
+    // Dependency satisfied by config (value changed between snapshots).
+    {
+        const after = Options{ .output = "out.txt" };
+        const provided = [_]bool{ false, true };
+        try std.testing.expect(firstMissingDependency(Options, meta, before, after, provided) == null);
+    }
+}
+
+test "firstMissingDependency: reports effective (custom/dashed) flag names" {
+    const Options = struct {
+        out: ?[]const u8 = null,
+        fmt: ?[]const u8 = null,
+    };
+    const meta = .{ .options = .{
+        .out = .{ .name = "output" },
+        .fmt = .{ .requires = .{"out"} },
+    } };
+    const before = Options{};
+    const provided = [_]bool{ false, true };
+    const miss = firstMissingDependency(Options, meta, before, before, provided);
+    try std.testing.expect(miss != null);
+    try std.testing.expectEqualStrings("fmt", miss.?.option_name);
+    // The dependency reports its custom flag name, not the field name.
+    try std.testing.expectEqualStrings("output", miss.?.required_name);
+}
+
+test "firstExclusiveViolation: at most one member of a set may be supplied" {
+    const Options = struct {
+        json: bool = false,
+        yaml: bool = false,
+        xml: bool = false,
+    };
+    const meta = .{ .exclusive = .{.{ "json", "yaml", "xml" }} };
+    const opts = Options{};
+
+    // Two members supplied → violation, reporting them in declaration order.
+    {
+        const provided = [_]bool{ true, false, true }; // json + xml
+        const ex = firstExclusiveViolation(Options, meta, opts, opts, provided);
+        try std.testing.expect(ex != null);
+        try std.testing.expectEqualStrings("json", ex.?.first);
+        try std.testing.expectEqualStrings("xml", ex.?.second);
+    }
+    // Exactly one supplied → fine.
+    {
+        const provided = [_]bool{ false, true, false };
+        try std.testing.expect(firstExclusiveViolation(Options, meta, opts, opts, provided) == null);
+    }
+    // None supplied → fine.
+    {
+        const provided = [_]bool{ false, false, false };
+        try std.testing.expect(firstExclusiveViolation(Options, meta, opts, opts, provided) == null);
+    }
+}
+
+test "firstExclusiveViolation: overlapping sets are checked independently" {
+    // a⊥b and b⊥c, but a+c is legal (non-clique graph, ADR example).
+    const Options = struct {
+        a: bool = false,
+        b: bool = false,
+        c: bool = false,
+    };
+    const meta = .{ .exclusive = .{ .{ "a", "b" }, .{ "b", "c" } } };
+    const opts = Options{};
+
+    // a + c: neither set has two supplied members → legal.
+    {
+        const provided = [_]bool{ true, false, true };
+        try std.testing.expect(firstExclusiveViolation(Options, meta, opts, opts, provided) == null);
+    }
+    // b + c: violates the second set.
+    {
+        const provided = [_]bool{ false, true, true };
+        const ex = firstExclusiveViolation(Options, meta, opts, opts, provided);
+        try std.testing.expect(ex != null);
+        try std.testing.expectEqualStrings("b", ex.?.first);
+        try std.testing.expectEqualStrings("c", ex.?.second);
+    }
 }
 
 test "parseArgs failure after array options were parsed does not leak them" {

--- a/packages/core/src/diagnostic_errors.zig
+++ b/packages/core/src/diagnostic_errors.zig
@@ -14,6 +14,8 @@ pub const ZcliError = error{
     OptionBooleanWithValue,
     OptionDuplicate,
     OptionMissingRequired,
+    OptionMutuallyExclusive,
+    OptionMissingDependency,
 
     // Command routing errors
     CommandNotFound,
@@ -91,6 +93,19 @@ pub const ZcliDiagnostic = union(enum) {
         option_name: []const u8,
         expected_type: []const u8,
     },
+    /// Two members of a `meta.exclusive` set were both supplied. Names are the
+    /// effective long flag names (without the leading `--`), static lifetime.
+    OptionMutuallyExclusive: struct {
+        first: []const u8,
+        second: []const u8,
+    },
+    /// A field declaring `meta.options.<field>.requires` was supplied without one
+    /// of its dependencies. Names are the effective long flag names (without the
+    /// leading `--`), static lifetime.
+    OptionMissingDependency: struct {
+        option_name: []const u8,
+        required_name: []const u8,
+    },
 
     // Command routing errors
     CommandNotFound: struct {
@@ -144,6 +159,7 @@ pub const ZcliDiagnostic = union(enum) {
 // Compile-time validation to ensure every error has a corresponding diagnostic
 // This prevents errors and diagnostics from getting out of sync
 comptime {
+    @setEvalBranchQuota(5000);
     const error_fields = std.meta.fields(ZcliError);
     const diagnostic_fields = std.meta.fields(std.meta.FieldEnum(ZcliDiagnostic));
 
@@ -302,6 +318,8 @@ pub fn formatDiagnostic(diagnostic: ZcliDiagnostic, allocator: std.mem.Allocator
         .OptionBooleanWithValue => |ctx| std.fmt.allocPrint(allocator, "Boolean option '{s}{s}' does not accept a value (got '{s}')", .{ if (ctx.is_short) "-" else "--", ctx.option_name, ctx.provided_value }),
         .OptionDuplicate => |ctx| std.fmt.allocPrint(allocator, "Duplicate option '{s}{s}'", .{ if (ctx.is_short) "-" else "--", ctx.option_name }),
         .OptionMissingRequired => |ctx| std.fmt.allocPrint(allocator, "Missing required option '--{s}'. Expected {s}.", .{ ctx.option_name, humanType(ctx.expected_type) }),
+        .OptionMutuallyExclusive => |ctx| std.fmt.allocPrint(allocator, "Options '--{s}' and '--{s}' cannot be used together.", .{ ctx.first, ctx.second }),
+        .OptionMissingDependency => |ctx| std.fmt.allocPrint(allocator, "Option '--{s}' requires '--{s}'.", .{ ctx.option_name, ctx.required_name }),
         .CommandNotFound => |ctx| blk: {
             const base_msg = try std.fmt.allocPrint(allocator, "Unknown command '{s}'", .{ctx.attempted_command});
 
@@ -447,6 +465,24 @@ test "OptionMissingRequired renders a humane message" {
     // The type is humanized, not leaked raw.
     try std.testing.expect(std.mem.indexOf(u8, msg, "text") != null);
     try std.testing.expect(std.mem.indexOf(u8, msg, "[]const u8") == null);
+}
+
+test "OptionMutuallyExclusive names both offending flags" {
+    const allocator = std.testing.allocator;
+    const diag = ZcliDiagnostic{ .OptionMutuallyExclusive = .{ .first = "json", .second = "yaml" } };
+    const msg = try formatDiagnostic(diag, allocator);
+    defer allocator.free(msg);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "--json") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "--yaml") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "cannot be used together") != null);
+}
+
+test "OptionMissingDependency names the supplied option and its missing requirement" {
+    const allocator = std.testing.allocator;
+    const diag = ZcliDiagnostic{ .OptionMissingDependency = .{ .option_name = "output-format", .required_name = "output" } };
+    const msg = try formatDiagnostic(diag, allocator);
+    defer allocator.free(msg);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "'--output-format' requires '--output'") != null);
 }
 
 test "invalid enum value messages carry a did-you-mean" {

--- a/packages/core/src/options/utils.zig
+++ b/packages/core/src/options/utils.zig
@@ -649,6 +649,57 @@ pub fn shortCharForField(comptime meta: anytype, comptime field_name: []const u8
     return if (field_name.len > 0) field_name[0] else 0;
 }
 
+// ============================================================================
+// Cross-field option constraints — `meta.exclusive` and `.<field>.requires`
+// ============================================================================
+//
+// Both constraints (ADR-0022) name Options *field* names as string literals in
+// comptime tuples. These accessors flatten those tuples into plain
+// `[]const []const u8` slices with static lifetime, so the comptime validator,
+// the runtime constraint walks, and help rendering all read one uniform shape.
+
+/// Flatten a comptime tuple of string literals (`.{ "a", "b" }`) into a
+/// `[]const []const u8`. The result has static lifetime.
+pub fn tupleToStrings(comptime tuple: anytype) []const []const u8 {
+    return comptime blk: {
+        var list: []const []const u8 = &.{};
+        for (@typeInfo(@TypeOf(tuple)).@"struct".fields) |f| {
+            const s: []const u8 = @field(tuple, f.name);
+            list = list ++ &[_][]const u8{s};
+        }
+        break :blk list;
+    };
+}
+
+/// The `meta.options.<field>.requires` dependency list — the Options *field*
+/// names that must also be supplied whenever this field is — or null when the
+/// field declares no `requires`.
+pub fn requiresFor(comptime meta: anytype, comptime field_name: []const u8) ?[]const []const u8 {
+    if (@TypeOf(meta) == @TypeOf(null)) return null;
+    if (!@hasField(@TypeOf(meta), "options")) return null;
+    if (!@hasField(@TypeOf(meta.options), field_name)) return null;
+    const field_meta = @field(meta.options, field_name);
+    if (@TypeOf(field_meta) == []const u8) return null;
+    if (!@hasField(@TypeOf(field_meta), "requires")) return null;
+    return tupleToStrings(field_meta.requires);
+}
+
+/// The `meta.exclusive` mutually-exclusive sets — each a list of Options field
+/// names, at most one of which may be supplied — or an empty slice when none are
+/// declared.
+pub fn exclusiveSets(comptime meta: anytype) []const []const []const u8 {
+    if (@TypeOf(meta) == @TypeOf(null)) return &.{};
+    if (!@hasField(@TypeOf(meta), "exclusive")) return &.{};
+    return comptime blk: {
+        var sets: []const []const []const u8 = &.{};
+        for (@typeInfo(@TypeOf(meta.exclusive)).@"struct".fields) |set_field| {
+            const set = @field(meta.exclusive, set_field.name);
+            sets = sets ++ &[_][]const []const u8{tupleToStrings(set)};
+        }
+        break :blk sets;
+    };
+}
+
 /// Whether the long option `option_name` takes a value. Null means no field
 /// matches (an unknown option — the parser reports it with a diagnostic).
 pub fn longOptionTakesValue(
@@ -729,4 +780,34 @@ test "takes-value resolution matches parser semantics" {
     try std.testing.expectEqual(@as(?bool, true), shortOptionTakesValue(Options, meta, 'c'));
     try std.testing.expectEqual(@as(?bool, true), shortOptionTakesValue(Options, meta, 'o'));
     try std.testing.expectEqual(@as(?bool, null), shortOptionTakesValue(Options, meta, 'x'));
+}
+
+test "requiresFor flattens the dependency tuple, or null" {
+    const meta = .{ .options = .{
+        .output_format = .{ .requires = .{"output"} },
+        .verbose = .{ .description = "loud" },
+    } };
+    const reqs = requiresFor(meta, "output_format").?;
+    try std.testing.expectEqual(@as(usize, 1), reqs.len);
+    try std.testing.expectEqualStrings("output", reqs[0]);
+    // A field with no requires, and an unmentioned field, both yield null.
+    try std.testing.expect(requiresFor(meta, "verbose") == null);
+    try std.testing.expect(requiresFor(meta, "output") == null);
+    try std.testing.expect(requiresFor(null, "anything") == null);
+}
+
+test "exclusiveSets flattens the set-of-sets, or empty" {
+    const meta = .{ .exclusive = .{
+        .{ "json", "yaml", "xml" },
+        .{ "a", "b" },
+    } };
+    const sets = exclusiveSets(meta);
+    try std.testing.expectEqual(@as(usize, 2), sets.len);
+    try std.testing.expectEqual(@as(usize, 3), sets[0].len);
+    try std.testing.expectEqualStrings("json", sets[0][0]);
+    try std.testing.expectEqualStrings("xml", sets[0][2]);
+    try std.testing.expectEqualStrings("b", sets[1][1]);
+    // No exclusive declared → empty.
+    try std.testing.expectEqual(@as(usize, 0), exclusiveSets(.{}).len);
+    try std.testing.expectEqual(@as(usize, 0), exclusiveSets(null).len);
 }

--- a/packages/core/src/options/utils.zig
+++ b/packages/core/src/options/utils.zig
@@ -653,19 +653,21 @@ pub fn shortCharForField(comptime meta: anytype, comptime field_name: []const u8
 // Cross-field option constraints — `meta.exclusive` and `.<field>.requires`
 // ============================================================================
 //
-// Both constraints (ADR-0022) name Options *field* names as string literals in
-// comptime tuples. These accessors flatten those tuples into plain
-// `[]const []const u8` slices with static lifetime, so the comptime validator,
-// the runtime constraint walks, and help rendering all read one uniform shape.
+// Both constraints (ADR-0022) name Options *fields* as enum literals in comptime
+// tuples — `.{ .json, .yaml }`, mirroring how an option is keyed elsewhere in
+// meta (`.output_format = .{...}`). These accessors flatten those tuples into
+// plain `[]const []const u8` (field-name) slices with static lifetime, so the
+// comptime validator, the runtime constraint walks, and help rendering all read
+// one uniform shape.
 
-/// Flatten a comptime tuple of string literals (`.{ "a", "b" }`) into a
-/// `[]const []const u8`. The result has static lifetime.
+/// Flatten a comptime tuple of enum literals (`.{ .a, .b }`) into the
+/// `[]const []const u8` of their names. The result has static lifetime.
 pub fn tupleToStrings(comptime tuple: anytype) []const []const u8 {
     return comptime blk: {
         var list: []const []const u8 = &.{};
         for (@typeInfo(@TypeOf(tuple)).@"struct".fields) |f| {
-            const s: []const u8 = @field(tuple, f.name);
-            list = list ++ &[_][]const u8{s};
+            const name: []const u8 = @tagName(@field(tuple, f.name));
+            list = list ++ &[_][]const u8{name};
         }
         break :blk list;
     };
@@ -784,7 +786,7 @@ test "takes-value resolution matches parser semantics" {
 
 test "requiresFor flattens the dependency tuple, or null" {
     const meta = .{ .options = .{
-        .output_format = .{ .requires = .{"output"} },
+        .output_format = .{ .requires = .{.output} },
         .verbose = .{ .description = "loud" },
     } };
     const reqs = requiresFor(meta, "output_format").?;
@@ -798,8 +800,8 @@ test "requiresFor flattens the dependency tuple, or null" {
 
 test "exclusiveSets flattens the set-of-sets, or empty" {
     const meta = .{ .exclusive = .{
-        .{ "json", "yaml", "xml" },
-        .{ "a", "b" },
+        .{ .json, .yaml, .xml },
+        .{ .a, .b },
     } };
     const sets = exclusiveSets(meta);
     try std.testing.expectEqual(@as(usize, 2), sets.len);

--- a/packages/core/src/plugins/zcli_help/plugin.zig
+++ b/packages/core/src/plugins/zcli_help/plugin.zig
@@ -855,11 +855,41 @@ fn generateOptionsHelp(module_info: zcli.CommandModuleInfo, context: anytype) !?
         if (field_info.is_required) {
             try buf_fmt.write(" (required)", .{});
         }
+        if (field_info.requires) |deps| {
+            try buf_fmt.write(" (requires ", .{});
+            for (deps, 0..) |dep, di| {
+                if (di > 0) try buf_fmt.write(", ", .{});
+                try writeDashedFlag(&buf_fmt, dep);
+            }
+            try buf_fmt.write(")", .{});
+        }
+        try buf_fmt.write("\n", .{});
+    }
+
+    // Mutually-exclusive sets, listed once each under the option lines.
+    for (module_info.exclusive) |set| {
+        try buf_fmt.write("    Mutually exclusive: ", .{});
+        for (set, 0..) |member, mi| {
+            if (mi > 0) try buf_fmt.write(", ", .{});
+            try writeDashedFlag(&buf_fmt, member);
+        }
         try buf_fmt.write("\n", .{});
     }
 
     var al = aw.toArrayList();
     return try al.toOwnedSlice(context.allocator);
+}
+
+/// Write an option field name as its `--dashed-flag`, converting underscores to
+/// dashes (matching how option names render above).
+fn writeDashedFlag(buf_fmt: anytype, field_name: []const u8) !void {
+    var name_buf: [64]u8 = undefined;
+    if (field_name.len > name_buf.len) {
+        try buf_fmt.write("--{s}", .{field_name});
+        return;
+    }
+    for (field_name, 0..) |c, i| name_buf[i] = if (c == '_') '-' else c;
+    try buf_fmt.write("<flag>--{s}</flag>", .{name_buf[0..field_name.len]});
 }
 
 test {
@@ -907,6 +937,39 @@ test "help never renders auto-generated --no- negation flags" {
     // default-true bool: negation shown, positive hidden.
     try std.testing.expect(std.mem.indexOf(u8, help, "--no-color") != null);
     try std.testing.expect(std.mem.indexOf(u8, help, "--color") == null);
+}
+
+test "help renders requires markers and mutually-exclusive sets" {
+    const allocator = std.testing.allocator;
+
+    const Ctx = zcli.TestContext(&.{});
+    var stdio: zcli.Stdio = undefined;
+    stdio.init(std.testing.io);
+    const environ = std.process.Environ.Map.init(allocator);
+    var ctx = Ctx.init(allocator, std.testing.io, &stdio, &environ);
+    defer ctx.deinit();
+
+    const module_info = zcli.CommandModuleInfo{
+        .has_options = true,
+        .options_fields = &.{
+            .{ .name = "json", .is_optional = false, .is_array = false, .type_name = "bool", .default_value = "false" },
+            .{ .name = "yaml", .is_optional = false, .is_array = false, .type_name = "bool", .default_value = "false" },
+            .{ .name = "output", .is_optional = true, .is_array = false, .type_name = "?[]const u8" },
+            .{ .name = "output_format", .is_optional = true, .is_array = false, .type_name = "?[]const u8", .requires = &.{"output"} },
+        },
+        .exclusive = &.{&.{ "json", "yaml" }},
+    };
+
+    const help = (try generateOptionsHelp(module_info, &ctx)).?;
+    defer allocator.free(help);
+
+    // The dependent option shows its requirement (dash-converted).
+    try std.testing.expect(std.mem.indexOf(u8, help, "requires ") != null);
+    try std.testing.expect(std.mem.indexOf(u8, help, "--output") != null);
+    // The exclusive set is listed once.
+    try std.testing.expect(std.mem.indexOf(u8, help, "Mutually exclusive:") != null);
+    try std.testing.expect(std.mem.indexOf(u8, help, "--json") != null);
+    try std.testing.expect(std.mem.indexOf(u8, help, "--yaml") != null);
 }
 
 // Note: Integration tests for handleGlobalOption and help command execution

--- a/packages/core/src/registry/compiled.zig
+++ b/packages/core/src/registry/compiled.zig
@@ -833,6 +833,13 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
                         }
                     }
                 }
+                const requires: ?[]const []const u8 = comptime blk: {
+                    if (@TypeOf(field_meta_map) == @TypeOf(null)) break :blk null;
+                    if (!@hasField(@TypeOf(field_meta_map), field.name)) break :blk null;
+                    const fm = @field(field_meta_map, field.name);
+                    if (isStringLike(@TypeOf(fm)) or !@hasField(@TypeOf(fm), "requires")) break :blk null;
+                    break :blk option_utils.tupleToStrings(fm.requires);
+                };
                 const default_value: ?[]const u8 = comptime blk: {
                     const dp = field.default_value_ptr orelse break :blk null;
                     const dv = @as(*const field.type, @ptrCast(@alignCast(dp))).*;
@@ -869,6 +876,7 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
                     .default_value = default_value,
                     .is_required = is_option and comptime option_utils.isRequiredOption(field),
                     .enum_values = enum_values,
+                    .requires = requires,
                 });
             }
             return field_list.toOwnedSlice(allocator);
@@ -913,6 +921,7 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
                 .raw_meta_ptr = if (@hasDecl(Module, "meta")) &Module.meta else null,
                 .args_fields = if (@hasDecl(Module, "Args")) try buildFieldInfoList(Module.Args, args_meta, false, context.allocator) else &.{},
                 .options_fields = if (@hasDecl(Module, "Options")) try buildFieldInfoList(Module.Options, options_meta, true, context.allocator) else &.{},
+                .exclusive = comptime option_utils.exclusiveSets(if (@hasDecl(Module, "meta")) Module.meta else null),
             };
         }
 
@@ -993,6 +1002,31 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
                 if (try runOnErrorHooks(context, error.OptionMissingRequired)) return;
                 try reportParseError(context, diag);
                 return error.OptionMissingRequired;
+            }
+
+            // Cross-field constraints (ADR-0022), checked over the same
+            // provided-set + config snapshot. Order per ADR: requires, then
+            // exclusive (missing-required above ran first).
+            if (command_parser.firstMissingDependency(OptionsType, cmd_meta, before_config, options_instance, parse_result.options_provided)) |dep| {
+                const diag: zcli.ZcliDiagnostic = .{ .OptionMissingDependency = .{
+                    .option_name = dep.option_name,
+                    .required_name = dep.required_name,
+                } };
+                context.diagnostic = diag;
+                if (try runOnErrorHooks(context, error.OptionMissingDependency)) return;
+                try reportParseError(context, diag);
+                return error.OptionMissingDependency;
+            }
+
+            if (command_parser.firstExclusiveViolation(OptionsType, cmd_meta, before_config, options_instance, parse_result.options_provided)) |ex| {
+                const diag: zcli.ZcliDiagnostic = .{ .OptionMutuallyExclusive = .{
+                    .first = ex.first,
+                    .second = ex.second,
+                } };
+                context.diagnostic = diag;
+                if (try runOnErrorHooks(context, error.OptionMutuallyExclusive)) return;
+                try reportParseError(context, diag);
+                return error.OptionMutuallyExclusive;
             }
 
             // Execute. A handled error (onError returns true) is suppressed

--- a/packages/core/src/registry/tests.zig
+++ b/packages/core/src/registry/tests.zig
@@ -1272,9 +1272,9 @@ const ConstraintCapturePlugin = struct {
 const ConstrainedCommand = struct {
     pub const meta = .{
         .description = "constrained",
-        .exclusive = .{.{ "json", "yaml", "xml" }},
+        .exclusive = .{.{ .json, .yaml, .xml }},
         .options = .{
-            .output_format = .{ .requires = .{"output"} },
+            .output_format = .{ .requires = .{.output} },
         },
     };
     pub const Args = struct {};

--- a/packages/core/src/registry/tests.zig
+++ b/packages/core/src/registry/tests.zig
@@ -1243,3 +1243,104 @@ test "global options: missing and invalid values produce diagnostics" {
     try testing.expectEqualStrings("abc", TypedGlobalsPlugin.captured_diag.?.OptionInvalidValue.provided_value);
     try testing.expectEqualStrings("i64", TypedGlobalsPlugin.captured_diag.?.OptionInvalidValue.expected_type);
 }
+
+// ============================================================================
+// Option constraints (ADR-0022) — end-to-end through the wired registry
+// ============================================================================
+
+// Captures the constraint diagnostics so the assertions can read the offending
+// names, and swallows the error so runQuiet returns cleanly.
+const ConstraintCapturePlugin = struct {
+    var captured_err: ?anyerror = null;
+    var captured_diag: ?zcli.ZcliDiagnostic = null;
+    var command_ran: bool = false;
+
+    pub fn reset() void {
+        captured_err = null;
+        captured_diag = null;
+        command_ran = false;
+    }
+
+    pub fn onError(context: anytype, err: anyerror) !bool {
+        captured_err = err;
+        captured_diag = context.diagnostic;
+        return true;
+    }
+};
+
+// --json/--yaml/--xml are mutually exclusive; --output-format requires --output.
+const ConstrainedCommand = struct {
+    pub const meta = .{
+        .description = "constrained",
+        .exclusive = .{.{ "json", "yaml", "xml" }},
+        .options = .{
+            .output_format = .{ .requires = .{"output"} },
+        },
+    };
+    pub const Args = struct {};
+    pub const Options = struct {
+        json: bool = false,
+        yaml: bool = false,
+        xml: bool = false,
+        output: ?[]const u8 = null,
+        output_format: ?enum { pretty, compact } = null,
+    };
+    pub fn execute(_: Args, _: Options, _: anytype) !void {
+        ConstraintCapturePlugin.command_ran = true;
+    }
+};
+
+fn constrainedApp() type {
+    return Registry.init(.{
+        .app_name = "constraints-test",
+        .app_version = "1.0.0",
+        .app_description = "option constraints",
+    })
+        .register("run", ConstrainedCommand)
+        .registerPlugin(ConstraintCapturePlugin)
+        .build();
+}
+
+test "constraints e2e: exclusive members together are rejected" {
+    var app = constrainedApp().init();
+    const env = std.process.Environ.Map.init(testing.allocator);
+
+    ConstraintCapturePlugin.reset();
+    try runQuiet(&app, &env, &.{ "run", "--json", "--yaml" });
+    try testing.expectEqual(@as(?anyerror, error.OptionMutuallyExclusive), ConstraintCapturePlugin.captured_err);
+    try testing.expectEqualStrings("json", ConstraintCapturePlugin.captured_diag.?.OptionMutuallyExclusive.first);
+    try testing.expectEqualStrings("yaml", ConstraintCapturePlugin.captured_diag.?.OptionMutuallyExclusive.second);
+    try testing.expect(!ConstraintCapturePlugin.command_ran);
+}
+
+test "constraints e2e: one exclusive member is fine" {
+    var app = constrainedApp().init();
+    const env = std.process.Environ.Map.init(testing.allocator);
+
+    ConstraintCapturePlugin.reset();
+    try runQuiet(&app, &env, &.{ "run", "--yaml" });
+    try testing.expectEqual(@as(?anyerror, null), ConstraintCapturePlugin.captured_err);
+    try testing.expect(ConstraintCapturePlugin.command_ran);
+}
+
+test "constraints e2e: requires without its dependency is rejected" {
+    var app = constrainedApp().init();
+    const env = std.process.Environ.Map.init(testing.allocator);
+
+    ConstraintCapturePlugin.reset();
+    try runQuiet(&app, &env, &.{ "run", "--output-format", "pretty" });
+    try testing.expectEqual(@as(?anyerror, error.OptionMissingDependency), ConstraintCapturePlugin.captured_err);
+    try testing.expectEqualStrings("output-format", ConstraintCapturePlugin.captured_diag.?.OptionMissingDependency.option_name);
+    try testing.expectEqualStrings("output", ConstraintCapturePlugin.captured_diag.?.OptionMissingDependency.required_name);
+    try testing.expect(!ConstraintCapturePlugin.command_ran);
+}
+
+test "constraints e2e: requires satisfied by its dependency runs" {
+    var app = constrainedApp().init();
+    const env = std.process.Environ.Map.init(testing.allocator);
+
+    ConstraintCapturePlugin.reset();
+    try runQuiet(&app, &env, &.{ "run", "--output-format", "pretty", "--output", "out.txt" });
+    try testing.expectEqual(@as(?anyerror, null), ConstraintCapturePlugin.captured_err);
+    try testing.expect(ConstraintCapturePlugin.command_ran);
+}

--- a/packages/core/src/zcli.zig
+++ b/packages/core/src/zcli.zig
@@ -156,6 +156,11 @@ pub const FieldInfo = struct {
     /// choices — else `null`. Help renders these as `one of: a, b, c`. Names are
     /// comptime string literals with static lifetime.
     enum_values: ?[]const []const u8 = null,
+    /// The option-field names this field depends on via
+    /// `meta.options.<field>.requires`, or `null`. Help renders these as
+    /// `(requires --dep)`. Raw field names (dash-converted at render), static
+    /// lifetime. Always null for positional args.
+    requires: ?[]const []const u8 = null,
 };
 
 /// Information about command module structure for plugin introspection
@@ -165,6 +170,9 @@ pub const CommandModuleInfo = struct {
     raw_meta_ptr: ?*const anyopaque = null, // Points to cmd.module.meta
     args_fields: []const FieldInfo = &.{}, // Runtime-safe field info
     options_fields: []const FieldInfo = &.{}, // Runtime-safe field info
+    /// The command's `meta.exclusive` mutually-exclusive sets — each a list of
+    /// Options field names. Help lists them under OPTIONS. Empty when none.
+    exclusive: []const []const []const u8 = &.{},
 };
 
 /// Execution context provided to commands and plugins — see context.zig,
@@ -434,7 +442,7 @@ pub fn validateMeta(
     }
 
     // Valid top-level meta fields
-    const valid_top_level = .{ "description", "examples", "args", "options", "hidden", "aliases" };
+    const valid_top_level = .{ "description", "examples", "args", "options", "hidden", "aliases", "exclusive" };
 
     // Validate top-level fields
     inline for (meta_info.@"struct".fields) |field| {
@@ -482,7 +490,7 @@ pub fn validateMeta(
             const option_meta_info = @typeInfo(@TypeOf(option_meta));
 
             if (option_meta_info == .@"struct") {
-                const valid_option_fields = .{ "description", "short", "name", "env" };
+                const valid_option_fields = .{ "description", "short", "name", "env", "requires" };
 
                 inline for (option_meta_info.@"struct".fields) |opt_field| {
                     const opt_is_valid = comptime blk: {
@@ -494,7 +502,55 @@ pub fn validateMeta(
                         break :blk false;
                     };
                     if (!opt_is_valid) {
-                        @compileError(loc ++ "unknown option metadata field '" ++ opt_field.name ++ "' in option '" ++ field.name ++ "'. Valid fields are: description, short, name, env");
+                        @compileError(loc ++ "unknown option metadata field '" ++ opt_field.name ++ "' in option '" ++ field.name ++ "'. Valid fields are: description, short, name, env, requires");
+                    }
+                }
+
+                // `requires`: every named dependency must be an Options field,
+                // and a field may not require itself (a no-op that reads as a bug).
+                if (@hasField(@TypeOf(option_meta), "requires")) {
+                    for (option_utils.tupleToStrings(option_meta.requires)) |dep| {
+                        if (!@hasField(OptionsType, dep)) {
+                            @compileError(loc ++ "option '" ++ field.name ++ "' requires '" ++ dep ++
+                                "', which is not a field in the Options struct");
+                        }
+                        if (std.mem.eql(u8, dep, field.name)) {
+                            @compileError(loc ++ "option '" ++ field.name ++ "' lists itself in `requires`");
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Validate 'exclusive' sets if present: each set names two or more distinct
+    // Options fields, at most one of which may be supplied. A *required* field
+    // (always present) can never satisfy "at most one", so it may not appear in
+    // a set at all.
+    if (@hasField(MetaType, "exclusive")) {
+        for (option_utils.exclusiveSets(meta), 0..) |set, set_i| {
+            if (set.len < 2) {
+                @compileError(loc ++ std.fmt.comptimePrint("`meta.exclusive` set #{d} lists {d} option(s); " ++
+                    "a mutually-exclusive set needs at least two members", .{ set_i + 1, set.len }));
+            }
+            for (set, 0..) |member, member_i| {
+                if (!@hasField(OptionsType, member)) {
+                    @compileError(loc ++ "`meta.exclusive` names '" ++ member ++
+                        "', which is not a field in the Options struct");
+                }
+                // No duplicate members within a set.
+                for (set[0..member_i]) |earlier| {
+                    if (std.mem.eql(u8, earlier, member)) {
+                        @compileError(loc ++ "`meta.exclusive` lists '" ++ member ++ "' twice in the same set");
+                    }
+                }
+                // A required option can't participate: it is always supplied, so
+                // no other member of its set could ever be.
+                inline for (@typeInfo(OptionsType).@"struct".fields) |opt_field| {
+                    if (comptime std.mem.eql(u8, opt_field.name, member) and option_utils.isRequiredOption(opt_field)) {
+                        @compileError(loc ++ "`meta.exclusive` includes required option '" ++ member ++
+                            "'. A required option is always supplied, so it can't be one of several mutually-" ++
+                            "exclusive choices — give it a default, make it optional, or drop it from the set.");
                     }
                 }
             }
@@ -594,6 +650,21 @@ test "validateCommand accepts a well-formed command" {
 //   command 'broken': meta.options describes 'nope', which is not a field in the Options struct
 //     pub const meta = .{ .options = .{ .nope = .{ .short = 'x' } } };
 //     pub const Options = struct { real: bool = false };
+//
+//   Option constraints (ADR-0022). Each guard below is verified by hand:
+//
+//   command 'broken': `meta.exclusive` names 'yamlx', which is not a field ...
+//     pub const meta = .{ .exclusive = .{.{ "json", "yamlx" }} };
+//
+//   command 'broken': `meta.exclusive` includes required option 'region' ...
+//     pub const meta = .{ .exclusive = .{.{ "region", "json" }} };
+//     pub const Options = struct { region: []const u8, json: bool = false };
+//
+//   command 'broken': `meta.exclusive` set #1 lists 1 option(s); a ... needs at least two
+//     pub const meta = .{ .exclusive = .{.{"json"}} };
+//
+//   command 'broken': option 'a' lists itself in `requires`
+//     pub const meta = .{ .options = .{ .a = .{ .requires = .{"a"} } } };
 
 test "Context creation" {
     const allocator = testing.allocator;

--- a/packages/core/src/zcli.zig
+++ b/packages/core/src/zcli.zig
@@ -654,17 +654,17 @@ test "validateCommand accepts a well-formed command" {
 //   Option constraints (ADR-0022). Each guard below is verified by hand:
 //
 //   command 'broken': `meta.exclusive` names 'yamlx', which is not a field ...
-//     pub const meta = .{ .exclusive = .{.{ "json", "yamlx" }} };
+//     pub const meta = .{ .exclusive = .{.{ .json, .yamlx }} };
 //
 //   command 'broken': `meta.exclusive` includes required option 'region' ...
-//     pub const meta = .{ .exclusive = .{.{ "region", "json" }} };
+//     pub const meta = .{ .exclusive = .{.{ .region, .json }} };
 //     pub const Options = struct { region: []const u8, json: bool = false };
 //
 //   command 'broken': `meta.exclusive` set #1 lists 1 option(s); a ... needs at least two
-//     pub const meta = .{ .exclusive = .{.{"json"}} };
+//     pub const meta = .{ .exclusive = .{.{.json}} };
 //
 //   command 'broken': option 'a' lists itself in `requires`
-//     pub const meta = .{ .options = .{ .a = .{ .requires = .{"a"} } } };
+//     pub const meta = .{ .options = .{ .a = .{ .requires = .{.a} } } };
 
 test "Context creation" {
     const allocator = testing.allocator;


### PR DESCRIPTION
Implements ADR-0022 (merged ADR-only in #218). Two cross-field option constraints, each in its natural home, both keyed off the same "supplied by any source" (CLI/env/config) notion required options already use — a constraint is about whether an option was *supplied*, not its value.

## What's added
- **`meta.exclusive`** (command level) — a list of *sets*; at most one member of each set may be supplied. A two-element set covers a one-off "A conflicts with B"; overlapping sets cover non-clique graphs.
- **`meta.options.<field>.requires`** (field level) — a directional dependency: the options that must also be supplied whenever this field is.

Options are named as **enum literals** (`.json`, `.output`), matching how an option is keyed everywhere else in `meta` (`.output_format = .{...}`) — one uniform "an option is `.its_name`" rule. `@tagName` recovers the field name at comptime for the `@hasField` check.

```zig
pub const meta = .{
    .exclusive = .{ .{ .json, .yaml, .xml } },       // at most one
    .options = .{
        .output_format = .{ .requires = .{.output} }, // needs --output
    },
};
```

## Where it lives
| Concern | Location |
|---|---|
| Comptime meta accessors | `options/utils.zig` — `tupleToStrings` (via `@tagName`), `requiresFor`, `exclusiveSets` |
| Comptime validation + guards | `zcli.zig` `validateMeta` — `@hasField` checks; reject self-require, a required option in an exclusive set, and sets with <2 / duplicate members |
| Runtime checks | `command_parser.zig` — `firstMissingDependency` + `firstExclusiveViolation`, sharing `optionSupplied` (provided bitset ∪ config-snapshot change) |
| Wiring | `registry/compiled.zig` — after config apply, order: missing-required → requires → exclusive |
| Diagnostics | `diagnostic_errors.zig` — `OptionMutuallyExclusive` / `OptionMissingDependency` + rendering |
| Help | `FieldInfo.requires` + `CommandModuleInfo.exclusive` → `(requires --x)` markers and `Mutually exclusive:` line |
| Docs | `docs/COMMANDS.md`, `docs/DESIGN.md`, ADR example |

Runtime messages:
- `Options '--json' and '--yaml' cannot be used together.`
- `Option '--output-format' requires '--output'.`

## Deliberately not built
Per the ADR's deferrals: field-level `conflicts`, a root `together`/`inclusive`, and any exactly-one/at-least-one flavor (exactly-one is already an enum with no default).

## Tests
Unit tests (utils, command_parser, diagnostics, help) plus end-to-end integration tests through the wired registry (`registry/tests.zig`). The four comptime guards were hand-verified to fire with correct messages and are documented in the compile-error comment block. `zig build test` and `zig build e2e` both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)