### PR TITLE
refactor(testing): split unit tier into its own module (zcli_testing_unit)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -119,21 +119,16 @@ then the context tail `examples → guide → AGENTS.md`. **Parallelizable early
   starts pulling zcli toward static-site-generator concerns.
 - **Effort:** S–M (per item).
 
-### Split the unit-testing tier out of the `testing` package
-- **What:** The `testing` package was zero-dependency until the 2026-06-01 unit-tier move
-  (commit `703fd69`). It now depends on `core` + `vterm` (and transitively on serde and core's
-  whole sibling tree) solely because the **unit tier** (`testing.unit` / `runCommand`) needs
-  `zcli.Stdio`/`TestContext` + vterm. The **integration** and **E2E** tiers need none of that.
-  Consider splitting the unit tier into its own sub-module/package so consumers who only write
-  subprocess/PTY tests don't pull the entire framework + a remote serde dep into their test build.
-- **Why deferred:** Acceptable trade-off for putting the unit tier in its natural home; not worth
-  the extra package/module split pre-adoption. Flagged in the 2026-06-01 five-axis code review as
-  the one "Important" architectural item.
-- **Trigger to revisit:** A user complains about the testing package's dependency footprint, or
-  integration/E2E-only consumers report unwanted transitive deps (esp. the remote serde fetch).
-- **Effort:** S–M (module split within `packages/testing`, or a new `zcli-testing-unit` package).
-- **Context:** `packages/testing/build.zig.zon` (the new `zcli_core` + `vterm` deps);
-  `packages/testing/src/unit.zig` is the only tier needing core.
+### Split the unit-testing tier out of the `testing` package — DONE
+- **What:** The `testing` package depended on `core` + `vterm` (transitively serde + core's
+  whole sibling tree) solely because the **unit tier** (`runCommand`) needs
+  `zcli.Stdio`/`TestContext` + vterm — dragging those into every subprocess/PTY-only consumer's
+  test build.
+- **Done:** `unit.zig` is now its own module (`zcli_testing_unit`, root `build.zig`), and the
+  `testing` module (`zcli_testing`) is std-only again — subprocess/snapshot + a re-export of the
+  std-only e2e tier. `addCommandTests` wires the unit module into scaffolded command tests under
+  the import name `zcli-testing` (unchanged for authors). Integration/E2E-only consumers no longer
+  pull zcli/vterm/serde. See `packages/testing/README.md` for the per-tier wiring.
 
 ### Sign releases (checksums.txt) with a pinned client key — DONE
 

--- a/build.zig
+++ b/build.zig
@@ -34,10 +34,15 @@ pub fn build(b: *std.Build) void {
     // The terminal-native layout engine (ADR-0013) — the substrate progress
     // and prompts render on, exposed for hybrid CLI/TUI apps.
     expose(b, "ui", ui_dep.module("ui"));
-    // The unit-testing tier for scaffolded projects (see `zcli.addCommandTests`):
-    // in-process command execution plus vterm-rendered assertions. Lazy — costs
-    // nothing unless a consumer imports it.
+    // The subprocess/snapshot testing tier (std-only): compile the CLI, run it,
+    // assert on stdout/stderr/exit code, and snapshot golden output. Lazy — costs
+    // nothing unless a consumer imports it, and pulls in no zcli/vterm.
     expose(b, "zcli_testing", testing_dep.module("testing"));
+    // The in-process unit-testing tier for scaffolded projects (see
+    // `zcli.addCommandTests`): `runCommand` executes a command's execute() with no
+    // subprocess, plus vterm-rendered assertions. Split from `zcli_testing` so the
+    // subprocess/PTY-only tiers stay free of zcli/vterm.
+    expose(b, "zcli_testing_unit", testing_dep.module("unit"));
     // The PTY-based interactive test harness alone (std-only), for CLI projects
     // that drive a real TTY in their e2e tests.
     expose(b, "testing_e2e", testing_dep.module("e2e"));

--- a/packages/core/src/build_utils/command_tests.zig
+++ b/packages/core/src/build_utils/command_tests.zig
@@ -25,8 +25,9 @@ const PluginInfo = types.PluginInfo;
 ///     builds the same TestContext) can invoke it. The real generated registry
 ///     is deliberately not used: a command's tests must not require the whole
 ///     app to compile.
-///   - `zcli-testing`     — the unit-testing tier, exposed by the zcli
-///     dependency, so no extra dependency is needed.
+///   - `zcli-testing`     — the in-process unit-testing tier (`zcli_testing_unit`),
+///     exposed by the zcli dependency, so no extra dependency is needed. (Command
+///     tests are in-process; the subprocess/PTY tiers live in separate modules.)
 ///   - any `shared_modules` the commands were generated with.
 ///
 /// Returns the created `test` step so the caller can attach more to it.
@@ -103,7 +104,7 @@ pub fn addCommandTests(
         .optimize = config.optimize,
         .zcli_module = zcli_module,
         .registry_stub = registry_stub,
-        .testing_module = zcli_dep.module("zcli_testing"),
+        .testing_module = zcli_dep.module("zcli_testing_unit"),
         .shared_modules = shared_modules,
     };
 

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -10,16 +10,26 @@ The complete guide with worked examples per tier is [zcli.sh/testing](https://zc
 
 ## Getting it
 
-The testing tiers ship with the zcli dependency — no separate dependency entry:
+The testing tiers ship with the zcli dependency — no separate dependency entry. Each
+tier is its own module, so you only pull the dependencies the tier actually needs: the
+**unit** tier (`zcli_testing_unit`) needs zcli + vterm; the **integration/snapshot**
+(`zcli_testing`) and **e2e** (`testing_e2e`) tiers are std-only.
 
-- **Scaffolded projects are already wired**: `zcli.addCommandTests(...)` (emitted by `zcli init`) compiles each command file as its own test root with `zcli-testing` importable, so `zig build test` just works.
-- **Manual wiring** for any other test module:
+- **Scaffolded projects are already wired**: `zcli.addCommandTests(...)` (emitted by `zcli init`) compiles each command file as its own test root with the unit tier importable as `zcli-testing`, so `zig build test` just works.
+- **Manual wiring** — pick the tier your test module uses (the import name is just a local alias):
 
   ```zig
+  // In-process unit tests (runCommand): pulls in zcli + vterm.
+  test_module.addImport("zcli-testing", zcli_dep.module("zcli_testing_unit"));
+
+  // Subprocess + snapshot tests (runSubprocess, expectSnapshot): std-only.
   test_module.addImport("zcli-testing", zcli_dep.module("zcli_testing"));
+
+  // PTY harness alone (e2e.runInteractive): std-only.
+  test_module.addImport("testing_e2e", zcli_dep.module("testing_e2e"));
   ```
 
-- **PTY harness alone**: `zcli_dep.module("testing_e2e")` exposes just the e2e tier (std-only — no zcli/vterm) for driving a TTY from a project's own e2e suite.
+  A test module that uses more than one tier just adds more than one import.
 
 ## API surface
 
@@ -32,6 +42,7 @@ The testing tiers ship with the zcli dependency — no separate dependency entry
 ## Quick taste
 
 ```zig
+// Unit tier — module `zcli_testing_unit`, wired as `zcli-testing`.
 const testing = @import("zcli-testing");
 
 test "add command prints confirmation" {
@@ -43,15 +54,18 @@ test "add command prints confirmation" {
     try std.testing.expectEqualStrings("Added widget\n", result.stdout);
 }
 
+// E2E tier — module `testing_e2e` (std-only), a separate import.
+const e2e = @import("testing_e2e");
+
 test "login prompts for credentials" {
-    var script = testing.e2e.InteractiveScript.init(allocator);
+    var script = e2e.InteractiveScript.init(allocator);
     _ = script
         .expect("Username:")
         .send("alice")
         .expect("Password:")
         .sendHidden("secret123")
         .expect("Login successful");
-    var result = try testing.e2e.runInteractive(
+    var result = try e2e.runInteractive(
         allocator,
         std.testing.io,
         &.{ "./zig-out/bin/myapp", "login" },
@@ -69,6 +83,9 @@ test "login prompts for credentials" {
 - Snapshot files are masked and ANSI-stripped by default (`SnapshotOptions`), so dynamic content doesn't churn goldens.
 
 ## Dependencies
+
+Only the **unit** tier (`zcli_testing_unit`) depends on these; the subprocess/snapshot
+and e2e tiers are std-only.
 
 - [`core`](../core/) — `Stdio`, `TestContext` for in-process execution
 - [`vterm`](../vterm/) — terminal emulation for rendered-output assertions

--- a/packages/testing/build.zig
+++ b/packages/testing/build.zig
@@ -5,19 +5,34 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    // Dependencies — the unit-testing tier (in-process command execution) needs the
-    // zcli core module (Stdio, TestContext) and vterm (rendered-output assertions).
+    // Dependencies — only the unit-testing tier (in-process command execution)
+    // needs the zcli core module (Stdio, TestContext) and vterm (rendered-output
+    // assertions). The subprocess/snapshot and PTY tiers are std-only.
     const zcli_dep = b.dependency("zcli_core", .{ .target = target, .optimize = optimize });
     const vterm_dep = b.dependency("vterm", .{ .target = target, .optimize = optimize });
 
-    // Create the testing module
-    const testing_mod = b.addModule("testing", .{
+    // The subprocess/snapshot testing tier (main.zig): std-only, so importing it
+    // does NOT drag zcli/vterm/serde into a consumer's test build. The root
+    // package re-exports this as `zcli_testing`.
+    _ = b.addModule("testing", .{
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
     });
-    testing_mod.addImport("zcli", zcli_dep.module("zcli"));
-    testing_mod.addImport("vterm", vterm_dep.module("vterm"));
+
+    // The in-process unit-testing tier (unit.zig): `runCommand` executes a
+    // command's execute() without a subprocess, so it needs zcli (Stdio,
+    // TestContext) and vterm (rendered-output assertions). Split into its own
+    // module so subprocess/PTY-only consumers don't pay for those deps. The root
+    // package re-exports this as `zcli_testing_unit`, and `addCommandTests` wires
+    // it into scaffolded command tests under the import name `zcli-testing`.
+    const unit_mod = b.addModule("unit", .{
+        .root_source_file = b.path("src/unit.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    unit_mod.addImport("zcli", zcli_dep.module("zcli"));
+    unit_mod.addImport("vterm", vterm_dep.module("vterm"));
 
     // Expose the PTY-based interactive harness (e2e.zig) as its own module.
     // It is std-only — no zcli/vterm — so CLI projects can drive a real TTY in
@@ -29,22 +44,27 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
-    // Create tests
-    const test_mod = b.addModule("test-testing", .{
+    const test_step = b.step("test", "Run all tests");
+
+    // Tests for the std-only tier (main.zig re-exports subprocess/snapshot/e2e).
+    const testing_test_mod = b.addModule("test-testing", .{
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
     });
-    test_mod.addImport("zcli", zcli_dep.module("zcli"));
-    test_mod.addImport("vterm", vterm_dep.module("vterm"));
-    const main_tests = b.addTest(.{
-        .root_module = test_mod,
+    const testing_tests = b.addTest(.{ .root_module = testing_test_mod });
+    test_step.dependOn(&b.addRunArtifact(testing_tests).step);
+
+    // Tests for the unit tier (needs zcli/vterm).
+    const unit_test_mod = b.addModule("test-unit", .{
+        .root_source_file = b.path("src/unit.zig"),
+        .target = target,
+        .optimize = optimize,
     });
-
-    const run_main_tests = b.addRunArtifact(main_tests);
-
-    const test_step = b.step("test", "Run all tests");
-    test_step.dependOn(&run_main_tests.step);
+    unit_test_mod.addImport("zcli", zcli_dep.module("zcli"));
+    unit_test_mod.addImport("vterm", vterm_dep.module("vterm"));
+    const unit_tests = b.addTest(.{ .root_module = unit_test_mod });
+    test_step.dependOn(&b.addRunArtifact(unit_tests).step);
 }
 
 // Re-export build utilities for use in other build.zig files

--- a/packages/testing/src/main.zig
+++ b/packages/testing/src/main.zig
@@ -1,9 +1,9 @@
-//! zcli Testing Framework
+//! zcli Testing Framework — subprocess & PTY tiers
 //!
-//! Provides three tiers of CLI testing:
-//!
-//! - **Unit testing** (`testing.unit` / `testing.runCommand`): In-process command execution —
-//!   test a single command's logic without compiling a binary.
+//! This module (`zcli_testing`) is std-only. The in-process **unit tier**
+//! (`runCommand`) lives in its own module (`zcli_testing_unit`) because it needs
+//! zcli/vterm; importing it here would drag those into every subprocess/PTY-only
+//! consumer's test build. See `unit.zig`.
 //!
 //! - **Integration testing** (`runner`, `assertions`, `snapshot`): Subprocess execution —
 //!   compile your CLI, run it with args, assert on stdout/stderr/exit code. Snapshot
@@ -34,14 +34,6 @@
 //! ```
 
 const std = @import("std");
-
-// ============================================================================
-// Unit Testing — in-process command execution (no subprocess, no binary)
-// ============================================================================
-
-pub const unit = @import("unit.zig");
-pub const runCommand = unit.runCommand;
-pub const CommandResult = unit.CommandResult;
 
 // ============================================================================
 // Integration Testing — subprocess-based CLI testing

--- a/packages/testing/src/unit.zig
+++ b/packages/testing/src/unit.zig
@@ -4,8 +4,12 @@
 //! capturing stdout and stderr output for assertions. Includes a virtual
 //! terminal (VTerm) for testing colors, formatting, and cursor positioning.
 //!
+//! Exposed as its own module (`zcli_testing_unit`, imported as `zcli-testing` in
+//! scaffolded command tests) rather than folded into `zcli_testing`, so the
+//! subprocess/PTY tiers stay free of the zcli/vterm dependencies below.
+//!
 //! ```zig
-//! const testing = @import("testing");
+//! const testing = @import("zcli-testing");
 //!
 //! test "add command" {
 //!     var result = try testing.runCommand(AddCommand, .{

--- a/website/content/testing/index.smd
+++ b/website/content/testing/index.smd
@@ -26,8 +26,10 @@ The unit-testing tier ships with the `zcli` dependency itself — no separate de
 
 ```zig
 // build.zig
-test_module.addImport("zcli-testing", zcli_dep.module("zcli_testing"));
+test_module.addImport("zcli-testing", zcli_dep.module("zcli_testing_unit"));
 ```
+
+The unit tier lives in its own module (`zcli_testing_unit`) because `runCommand` runs in-process and so needs zcli + vterm; the subprocess and PTY tiers below are std-only and live in separate modules, so importing them doesn't drag those dependencies into your test build.
 
 ### Writing tests
 
@@ -163,7 +165,7 @@ Test your compiled CLI binary as a subprocess. This validates the full stack —
 
 ### Setup
 
-The integration tier lives in the same `zcli-testing` module the unit tier uses — it ships with the `zcli` dependency, so the wiring is one line:
+The integration tier lives in the std-only `zcli_testing` module (separate from the unit tier's `zcli_testing_unit`) — it ships with the `zcli` dependency, so the wiring is one line:
 
 ```zig
 // build.zig


### PR DESCRIPTION
## What

The in-process **unit tier** (`unit.zig` / `runCommand`) was the only part of `packages/testing` importing `zcli` + `vterm`, yet it lived inside the aggregate `testing` module. Any consumer using only the **subprocess** or **PTY** tiers therefore dragged zcli/vterm (and transitively serde + core's sibling tree) into its test build — slower builds, fatter dependency graph, no benefit.

This splits `unit.zig` into its own module, exposed at the root as **`zcli_testing_unit`**. The `testing` module (`zcli_testing`) is std-only again.

Tracked in `TODOS.md`; decision on this workspace was "separate unit testing support into its own module."

## Changes

- **`packages/testing/build.zig`** — new `unit` module (imports zcli + vterm); the `testing` module (`main.zig`) no longer imports zcli/vterm; two test artifacts so both the std-only tier and the unit tier still run under `zig build test`.
- **`packages/testing/src/main.zig`** — drop the `unit`/`runCommand`/`CommandResult` re-exports. `zcli_testing` = subprocess/snapshot + a re-export of the std-only e2e tier.
- **`build.zig`** (root) — expose `zcli_testing_unit`; `zcli_testing` stays as the std-only subprocess/snapshot tier.
- **`addCommandTests`** — bind scaffolded command tests to `zcli_testing_unit`. The author-facing import alias (`zcli-testing`) and `runCommand` API are **unchanged**, so no generated-code or command-test source churn.
- **Docs** — `packages/testing/README.md` and the website testing guide get per-tier wiring (each tier is its own module now); `TODOS.md` item marked done.

## Result

A consumer of `zcli_testing` / `testing_e2e` gets a module graph that references **no** zcli/vterm/serde — guaranteed by construction (those modules don't import them; Zig only compiles what's imported).

## Migration note (no backwards-compat shim, per repo preference)

The import *alias* `zcli-testing` is a local build-wiring choice; point it at the tier you use:

| Tier | Module | Deps |
|---|---|---|
| Unit (`runCommand`) | `zcli_testing_unit` | zcli + vterm |
| Integration + snapshot (`runSubprocess`, `expectSnapshot`) | `zcli_testing` | std-only |
| E2E / PTY (`runInteractive`) | `testing_e2e` | std-only |

The only breaking change: an out-of-repo consumer that wired `zcli_testing` and called `runCommand` off it must switch that module to `zcli_testing_unit`. No in-repo consumer did this — every committed consumer uses exactly one tier and needed no source change.

## Verification

- `zig build test` — all packages + examples + `projects/zcli` (which exercise `addCommandTests`): **pass**
- `projects/zcli` `zig build e2e` — scaffolds projects via `zcli init` and builds them, the real end-to-end check of the generated wiring: **pass**
- `zig build build-examples build-cli`: **pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)