### PR TITLE
feat(options): comma-separated multi-value array options (ADR-0024)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -199,6 +199,14 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
   at most once; repeating it (including `--flag` together with `--no-flag`) is an
   error. `--help` lists the useful spelling: `--flag` for a default-`false` flag,
   `--no-flag` for a default-`true` flag; the other is accepted but hidden.
+- An **accumulating array** option (`[][]const u8`, `[]u32`, …) collects multiple
+  values two ways, which compose: by **repeating** the flag (`--tag a --tag b`) or
+  by a **comma-separated** value (`--tag a,b`, `--tag=a,b`, `-t a,b`). Every value
+  token is split on `,`; an empty segment (`a,,b`, `,a`, `a,`) is a value error. A
+  literal comma is therefore always a separator here — it cannot appear inside an
+  element. `--help` marks these options `(repeatable)`. zcli deliberately does *not*
+  support the greedy space-separated form (`--tag a b`): it is ambiguous with zcli's
+  interleaved positionals (see ADR-0024).
 - Two compile-time guards keep the above coherent: a boolean field's name may not
   start with `no_` (it would collide with a `--no-` negation), and an optional
   field must default to `null` (that `null` is the "not passed" state; use a

--- a/docs/adr/0024-multi-value-options.md
+++ b/docs/adr/0024-multi-value-options.md
@@ -1,0 +1,63 @@
+# Multi-value options: comma-separated, not greedy space-separated
+
+Status: proposed
+
+An array-typed option (`tags: [][]const u8`, `nums: []u32`, …) collects several
+values. Until now the only spelling was **repetition** — `--tag a --tag b`. Users
+coming from other CLIs asked for a way to pass several values without repeating the
+flag. Two spellings were on the table:
+
+- **Comma-separated** — `--tag a,b`
+- **Greedy space-separated** — `--tag a b` (one flag consuming consecutive tokens)
+
+## Decision
+
+Add **comma-separated** values and keep repetition. The two compose. Deliberately
+**reject** greedy space-separated.
+
+Every value token of an array-typed option is split on `,`:
+
+```
+--tag a,b          →  [a, b]
+--tag=a,b   -t a,b →  [a, b]        (equals and short forms too)
+--tag a,b --tag c  →  [a, b, c]     (composes with repetition)
+--tag a,,b         →  value error   (empty segment rejected: also ,a and a,)
+```
+
+A literal comma is therefore always a separator for array options — it cannot
+appear inside an element. Scalar (non-array) options are untouched: a comma stays a
+literal character in their single value. `--help` marks array options `(repeatable)`.
+
+## Why not greedy space-separated
+
+Greedy consumption is fundamentally **ambiguous with zcli's interleaved
+positionals.** zcli is GNU-style: options and positionals may appear in any order
+(`packages/core/src/options/parser.zig`). A greedy array option would swallow any
+following non-flag token — including intended positionals. For a command with both
+`tags: [][]const u8` and a positional `file`, `--tags a file.txt` means
+`tags=[a], file="file.txt"` today; greedy would silently change it to
+`tags=[a, "file.txt"]`. So greedy is **not additive** — it changes the meaning of
+existing command lines — whereas comma is additive (only a literal comma in a value
+changes meaning).
+
+This is not a zcli-specific worry. Every framework that offers greedy multi-value
+documents the hazard: Rust `clap`'s `num_args(1..)` is opt-in with an explicit
+"does not get along with trailing positionals/subcommands" warning (clap #1721), and
+Python `argparse`'s `nargs='+'` is the canonical source of "my positional
+disappeared" bugs. The dominant server/cloud ecosystem (Go `pflag` →
+kubectl/docker/helm/Hashicorp) settled on exactly **comma + repetition** and does not
+do greedy space. We follow that convention.
+
+## Consequences
+
+- **Purely additive parse change.** Splitting happens inside the array value-append
+  path (`options/array_utils.zig`); the two-layer parse (the `command_parser.zig`
+  pre-split, then `options/parser.zig`) still routes exactly one value token per
+  option occurrence, so the layers stay in agreement with no change to either's
+  boundary logic, `--` handling, negative-number handling, or positional parsing.
+- **The comma-in-value tradeoff.** A value that must contain a literal comma cannot
+  use this syntax. This mirrors pflag `StringSlice` and is acceptable: comma-bearing
+  values are rare, and repetition remains available for any single value (though its
+  tokens are split too — the rule is uniform).
+- **No scaffold change.** `zcli add option --multiple` already emits array fields;
+  comma parsing is a parse-time capability of any array option.

--- a/packages/core/src/command_parser.zig
+++ b/packages/core/src/command_parser.zig
@@ -565,6 +565,27 @@ test "e2e: multiple array values" {
     try testing.expectEqualStrings("c.txt", result.options.files[2]);
 }
 
+test "e2e: comma-separated array values through the pre-split" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    const ArrayOptions = struct {
+        files: [][]const u8 = &.{},
+        numbers: []i32 = &.{},
+    };
+
+    // The pre-split must feed the comma token through intact so the options
+    // parser can split it; repetition composes with the comma form.
+    const result = try parseCommandLine(struct {}, ArrayOptions, null, allocator, null, &.{ "--files", "a.txt,b.txt", "--files", "c.txt", "--numbers", "1,2,3" }, null);
+    defer result.deinit();
+
+    try testing.expectEqual(@as(usize, 3), result.options.files.len);
+    try testing.expectEqualStrings("a.txt", result.options.files[0]);
+    try testing.expectEqualStrings("b.txt", result.options.files[1]);
+    try testing.expectEqualStrings("c.txt", result.options.files[2]);
+    try testing.expectEqualSlices(i32, &.{ 1, 2, 3 }, result.options.numbers);
+}
+
 test "e2e: array options mixed with other options" {
     const testing = std.testing;
     const allocator = testing.allocator;

--- a/packages/core/src/options/array_utils.zig
+++ b/packages/core/src/options/array_utils.zig
@@ -96,6 +96,34 @@ pub fn appendToArrayListUnionShort(comptime ElementType: type, allocator: std.me
     }
 }
 
+/// Split a single option token on `,` and append each element, so an
+/// array-typed option accepts `--opt a,b` as shorthand for `--opt a --opt b`.
+/// An empty segment (`a,,b`, `,a`, `a,`) is rejected as an invalid value.
+/// Delegates to `appendToArrayListUnion` per segment, reusing its per-element
+/// parsing and diagnostics unchanged.
+pub fn appendCsvToArrayListUnion(comptime ElementType: type, allocator: std.mem.Allocator, list_union: *ArrayListUnion, value: []const u8, option_name: []const u8) !void {
+    var it = std.mem.splitScalar(u8, value, ',');
+    while (it.next()) |segment| {
+        if (segment.len == 0) {
+            logging.invalidOptionValue(option_name, value, "value");
+            return error.InvalidOptionValue;
+        }
+        try appendToArrayListUnion(ElementType, allocator, list_union, segment, option_name);
+    }
+}
+
+/// Comma-splitting append for short options (see `appendCsvToArrayListUnion`).
+pub fn appendCsvToArrayListUnionShort(comptime ElementType: type, allocator: std.mem.Allocator, list_union: *ArrayListUnion, value: []const u8, char: u8) !void {
+    var it = std.mem.splitScalar(u8, value, ',');
+    while (it.next()) |segment| {
+        if (segment.len == 0) {
+            logging.invalidShortOptionValue(char, value, "value");
+            return error.InvalidOptionValue;
+        }
+        try appendToArrayListUnionShort(ElementType, allocator, list_union, segment, char);
+    }
+}
+
 /// Generic helper to convert ArrayListUnion to owned slice
 /// Replaces ~15 lines of repetitive switch cases with clean generic code
 pub fn arrayListUnionToOwnedSlice(comptime ElementType: type, allocator: std.mem.Allocator, list_union: *ArrayListUnion) !ElementType {
@@ -186,6 +214,60 @@ test "appendToArrayListUnionShort" {
     try std.testing.expectEqual(@as(usize, 2), result.len);
     try std.testing.expectEqualStrings("value1", result[0]);
     try std.testing.expectEqualStrings("value2", result[1]);
+}
+
+test "appendCsvToArrayListUnion splits on comma and rejects empty segments" {
+    const allocator = std.testing.allocator;
+
+    // Strings split into elements.
+    {
+        var list = createArrayListUnion([]const u8);
+        defer list.deinit(allocator);
+
+        try appendCsvToArrayListUnion([]const u8, allocator, &list, "a,b,c", "tags");
+        const result = try arrayListUnionToOwnedSlice([][]const u8, allocator, &list);
+        defer allocator.free(result);
+
+        try std.testing.expectEqual(@as(usize, 3), result.len);
+        try std.testing.expectEqualStrings("a", result[0]);
+        try std.testing.expectEqualStrings("b", result[1]);
+        try std.testing.expectEqualStrings("c", result[2]);
+    }
+
+    // A single value (no comma) yields one element.
+    {
+        var list = createArrayListUnion([]const u8);
+        defer list.deinit(allocator);
+
+        try appendCsvToArrayListUnion([]const u8, allocator, &list, "solo", "tags");
+        const result = try arrayListUnionToOwnedSlice([][]const u8, allocator, &list);
+        defer allocator.free(result);
+
+        try std.testing.expectEqual(@as(usize, 1), result.len);
+        try std.testing.expectEqualStrings("solo", result[0]);
+    }
+
+    // Numeric elements are parsed per-segment.
+    {
+        var list = createArrayListUnion(i32);
+        defer list.deinit(allocator);
+
+        try appendCsvToArrayListUnion(i32, allocator, &list, "1,-2,3", "nums");
+        const result = try arrayListUnionToOwnedSlice([]i32, allocator, &list);
+        defer allocator.free(result);
+
+        try std.testing.expectEqualSlices(i32, &.{ 1, -2, 3 }, result);
+    }
+
+    // Empty segments (interior, leading, trailing) are rejected.
+    {
+        var list = createArrayListUnion([]const u8);
+        defer list.deinit(allocator);
+
+        try std.testing.expectError(error.InvalidOptionValue, appendCsvToArrayListUnion([]const u8, allocator, &list, "a,,b", "tags"));
+        try std.testing.expectError(error.InvalidOptionValue, appendCsvToArrayListUnionShort([]const u8, allocator, &list, ",a", 't'));
+        try std.testing.expectError(error.InvalidOptionValue, appendCsvToArrayListUnion([]const u8, allocator, &list, "a,", "tags"));
+    }
 }
 
 // Tests migrated from array_options_test.zig

--- a/packages/core/src/options/parser.zig
+++ b/packages/core/src/options/parser.zig
@@ -551,7 +551,7 @@ fn parseLongOptions(
                 // Handle array accumulation
                 const element_type = @typeInfo(field.type).pointer.child;
                 if (array_lists[i]) |*list_union| {
-                    try array_utils.appendToArrayListUnion(element_type, allocator, list_union, value, option_name);
+                    try array_utils.appendCsvToArrayListUnion(element_type, allocator, list_union, value, option_name);
                 }
             } else {
                 // Handle single values
@@ -738,7 +738,7 @@ fn parseShortOptionsWithMeta(
                         // For array types, accumulate values
                         if (array_lists.*[i]) |*list_union| {
                             const element_type = @typeInfo(field.type).pointer.child;
-                            try array_utils.appendToArrayListUnionShort(element_type, allocator, list_union, value, char);
+                            try array_utils.appendCsvToArrayListUnionShort(element_type, allocator, list_union, value, char);
                         }
                     } else {
                         const parsed_value = utils.parseOptionValue(field.type, value) catch |err| {
@@ -1202,6 +1202,53 @@ test "parseOptions array accumulation with short flags" {
     try std.testing.expectEqual(@as(usize, 2), parsed.options.numbers.len);
     try std.testing.expectEqual(@as(i32, 10), parsed.options.numbers[0]);
     try std.testing.expectEqual(@as(i32, 20), parsed.options.numbers[1]);
+}
+
+test "parseOptions comma-separated array values" {
+    const TestOptions = struct {
+        files: [][]const u8 = &.{},
+        numbers: []i32 = &.{},
+        label: ?[]const u8 = null,
+    };
+
+    const allocator = std.testing.allocator;
+
+    // Long, short, attached-short, and equals forms all split on comma; a comma
+    // repetition composes; and a comma in a *scalar* option stays literal.
+    const args = [_][]const u8{
+        "--files",  "a.txt,b.txt", // long space form
+        "-f",       "c.txt", // repetition composes with the comma form
+        "--numbers=1,2,3", // equals form
+        "-n3,4", // attached short form
+        "--label",  "x,y", // scalar option — NOT split
+    };
+    const parsed = try parseOptions(TestOptions, allocator, &args, null);
+    defer cleanupOptions(TestOptions, parsed.options, allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), parsed.options.files.len);
+    try std.testing.expectEqualStrings("a.txt", parsed.options.files[0]);
+    try std.testing.expectEqualStrings("b.txt", parsed.options.files[1]);
+    try std.testing.expectEqualStrings("c.txt", parsed.options.files[2]);
+
+    try std.testing.expectEqual(@as(usize, 5), parsed.options.numbers.len);
+    try std.testing.expectEqualSlices(i32, &.{ 1, 2, 3, 3, 4 }, parsed.options.numbers);
+
+    // Scalar option keeps the comma as a literal character.
+    try std.testing.expectEqualStrings("x,y", parsed.options.label.?);
+}
+
+test "parseOptions comma-separated rejects empty segments" {
+    const TestOptions = struct {
+        files: [][]const u8 = &.{},
+    };
+
+    const allocator = std.testing.allocator;
+
+    // Interior, leading, and trailing empty segments are all invalid.
+    inline for (.{ "a,,b", ",a", "a," }) |bad| {
+        const args = [_][]const u8{ "--files", bad };
+        try std.testing.expectError(ZcliError.OptionInvalidValue, parseOptions(TestOptions, allocator, &args, null));
+    }
 }
 
 test "parseOptionsWithMeta custom name mapping" {

--- a/packages/core/src/options/parser.zig
+++ b/packages/core/src/options/parser.zig
@@ -1216,11 +1216,11 @@ test "parseOptions comma-separated array values" {
     // Long, short, attached-short, and equals forms all split on comma; a comma
     // repetition composes; and a comma in a *scalar* option stays literal.
     const args = [_][]const u8{
-        "--files",  "a.txt,b.txt", // long space form
-        "-f",       "c.txt", // repetition composes with the comma form
+        "--files", "a.txt,b.txt", // long space form
+        "-f", "c.txt", // repetition composes with the comma form
         "--numbers=1,2,3", // equals form
         "-n3,4", // attached short form
-        "--label",  "x,y", // scalar option — NOT split
+        "--label", "x,y", // scalar option — NOT split
     };
     const parsed = try parseOptions(TestOptions, allocator, &args, null);
     defer cleanupOptions(TestOptions, parsed.options, allocator);

--- a/packages/core/src/plugins/zcli_help/plugin.zig
+++ b/packages/core/src/plugins/zcli_help/plugin.zig
@@ -855,6 +855,11 @@ fn generateOptionsHelp(module_info: zcli.CommandModuleInfo, context: anytype) !?
         if (field_info.is_required) {
             try buf_fmt.write(" (required)", .{});
         }
+        // Array-typed options accept several values — via `--opt a,b` or by
+        // repeating the flag — so mark them as such at a glance.
+        if (field_info.is_array) {
+            try buf_fmt.write(" (repeatable)", .{});
+        }
         if (field_info.requires) |deps| {
             try buf_fmt.write(" (requires ", .{});
             for (deps, 0..) |dep, di| {
@@ -970,6 +975,34 @@ test "help renders requires markers and mutually-exclusive sets" {
     try std.testing.expect(std.mem.indexOf(u8, help, "Mutually exclusive:") != null);
     try std.testing.expect(std.mem.indexOf(u8, help, "--json") != null);
     try std.testing.expect(std.mem.indexOf(u8, help, "--yaml") != null);
+}
+
+test "help marks array options as repeatable but not scalars" {
+    const allocator = std.testing.allocator;
+
+    const Ctx = zcli.TestContext(&.{});
+    var stdio: zcli.Stdio = undefined;
+    stdio.init(std.testing.io);
+    const environ = std.process.Environ.Map.init(allocator);
+    var ctx = Ctx.init(allocator, std.testing.io, &stdio, &environ);
+    defer ctx.deinit();
+
+    const module_info = zcli.CommandModuleInfo{
+        .has_options = true,
+        .options_fields = &.{
+            .{ .name = "tags", .is_optional = false, .is_array = true, .type_name = "[][]const u8", .description = "Tags to apply" },
+            .{ .name = "output", .is_optional = true, .is_array = false, .type_name = "?[]const u8", .description = "Output path" },
+        },
+    };
+
+    const help = (try generateOptionsHelp(module_info, &ctx)).?;
+    defer allocator.free(help);
+
+    // The array option carries the marker; the scalar option does not (there is
+    // exactly one occurrence of "(repeatable)" in the whole block).
+    try std.testing.expect(std.mem.indexOf(u8, help, "--tags") != null);
+    try std.testing.expect(std.mem.indexOf(u8, help, "(repeatable)") != null);
+    try std.testing.expect(std.mem.lastIndexOf(u8, help, "(repeatable)").? == std.mem.indexOf(u8, help, "(repeatable)").?);
 }
 
 // Note: Integration tests for handleGlobalOption and help command execution

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -819,6 +819,19 @@ test "scaffolded project builds, runs, and round-trips add command" {
         try expectOk(r);
         try expectContains(r.stdout, "TODO: Implement ping");
     }
+    // The comma-separated multi-value form is accepted by the real binary
+    // (equivalent to repeating --tags), while an empty segment is rejected.
+    {
+        var r = try run(proj, &.{ demo_bin, "ping", "--tags", "a,b", "--tags", "c" });
+        defer r.deinit();
+        try expectOk(r);
+        try expectContains(r.stdout, "TODO: Implement ping");
+    }
+    {
+        var r = try run(proj, &.{ demo_bin, "ping", "--tags", "a,,b" });
+        defer r.deinit();
+        try testing.expect(r.exit_code != 0);
+    }
 
     // A second command assembled entirely from atomic `add arg`/`add option`
     // edits — the flag interface that replaced the JSON blob (ADR-0005). This


### PR DESCRIPTION
## What

Array-typed options (`tags: [][]const u8`, `nums: []u32`, …) now accept **comma-separated** values in addition to the existing repetition form. The two compose:

```
--tag a,b            →  [a, b]
--tag=a,b   -t a,b   →  [a, b]        (equals and short forms too)
--tag a,b --tag c    →  [a, b, c]     (composes with repetition)
--tag a,,b           →  value error   (empty segment; also ,a and a,)
```

Scalar (non-array) options are untouched — a comma stays literal in their single value. `--help` now marks array options `(repeatable)`.

## Why comma, not greedy space (`--tag a b`)

Greedy space-separated consumption is **ambiguous with zcli's interleaved positionals** (GNU-style: options and positionals may appear in any order). A greedy array option would swallow following positionals — e.g. for a command with both `tags` and a positional `file`, `--tags a file.txt` means `tags=[a], file="file.txt"` today; greedy would silently change it to `tags=[a,"file.txt"]`. So greedy is **not additive**, whereas comma is.

This matches the mainstream: Go `pflag` (kubectl/docker/helm/Hashicorp) uses comma + repetition; `clap`'s greedy `num_args(1..)` and `argparse`'s `nargs='+'` both ship with explicit positional-ambiguity warnings. Full rationale in **ADR-0024**.

## How

Splitting happens inside the array value-append path (`options/array_utils.zig`: new `appendCsvToArrayListUnion` / `…Short`, reusing the existing per-element parse + diagnostics). The two-layer parse (the `command_parser.zig` pre-split, then `options/parser.zig`) still routes exactly one value token per option occurrence, so **neither layer's boundary logic, `--`/negative-number handling, nor positional parsing changes**. No scaffold change — `zcli add option --multiple` already emits array fields.

## Tests

- `array_utils.zig` — direct CSV helper unit test (split, single value, numeric per-segment parse, empty-segment rejection)
- `options/parser.zig` — long/short/attached/equals comma forms, repetition composition, numeric arrays, empty-segment errors, and a scalar-option control (comma **not** split)
- `command_parser.zig` — comma token flows through the pre-split intact
- `zcli_help/plugin.zig` — `(repeatable)` on array options only
- `projects/zcli/test/e2e.zig` — real compiled binary accepts `--tags a,b`, rejects `--tags a,,b`

Verified: `zig build test` and `zig build e2e` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)