### PR TITLE
feat(validate): per-field validate hooks on options and args (ADR-0024)

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -30,7 +30,7 @@ pub fn execute(args: Args, options: Options, context: anytype) !void {
 }
 ```
 
-- **`meta`** — help text and parsing metadata (`description`, `examples`, per-arg/option descriptions, `short` flags, `aliases`).
+- **`meta`** — help text and parsing metadata (`description`, `examples`, per-arg/option descriptions, `short` flags, `aliases`, `.env` fallbacks, cross-field constraints, and per-field `validate` hooks).
 - **`Args`** — positional arguments as a struct; a `[]const []const u8` field is variadic.
 - **`Options`** — `bool`/`?bool` fields are flags; other types take values, with defaults from the initializers.
 - **`execute`** — the command body, receiving the parsed, typed `Args` and `Options` plus the app context.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -267,6 +267,43 @@ Exactly-one-of-a-mode needs no constraint: an enum with no default
 (`format: enum { json, yaml, xml }`) is already exactly-one, and `?enum … = null`
 is at-most-one.
 
+**Per-field validation:**
+
+A field whose *type* is right but whose *value* needs a further rule declares a
+`validate` hook — on `meta.options.<field>` or `meta.args.<field>` (ADR-0024):
+
+```zig
+pub const Args = struct { name: []const u8 };
+pub const Options = struct { port: u16 = 8080 };
+
+pub const meta = .{
+    .args = .{ .name = .{ .validate = validateName } },
+    .options = .{ .port = .{ .validate = validatePort } },
+};
+
+fn validateName(name: []const u8) ?[]const u8 {
+    return if (name.len == 0) "must not be empty" else null;
+}
+fn validatePort(port: u16) ?[]const u8 {
+    return if (port == 0) "must be between 1 and 65535" else null;
+}
+```
+
+The hook is `fn(Base) ?[]const u8`, where `Base` is the field type with one
+optional level removed (a `?T` field's hook sees a present value, never null, and
+is skipped when absent). Returning `null` means valid; a returned string is the
+reason shown to the user. Unlike the constraints above, validation keys off the
+*value*: it runs on the finally-resolved value from any source — CLI, env, config,
+or default — so no source can slip an invalid value through. A failure is reported
+like any other bad-value parse error, with the offending value and a usage hint:
+
+- `Invalid value '0' for option '--port': must be between 1 and 65535.`
+
+Reach for `validate` when the field's native type already parses the input and you
+only need an extra rule. When turning the string into your value needs custom
+logic (`"5m30s"` → a duration), that is *parsing*, and belongs in a custom type —
+see ADR-0024.
+
 **Context Structure:**
 
 The context provides access to system resources and framework features:

--- a/docs/adr/0024-field-validation-and-custom-parse-types.md
+++ b/docs/adr/0024-field-validation-and-custom-parse-types.md
@@ -1,0 +1,110 @@
+# Field validation and custom parse types
+
+Status: accepted (validation shipped; custom parse types are a planned follow-up)
+
+zcli derives a command's inputs from its `Args`/`Options` structs: a field's type
+drives parsing, its enum variants are the valid choices, `?T`/default decide
+required-ness. `meta` is the escape hatch for what a single field's type *can't*
+express — descriptions, custom flag names, `.env` fallback, and the cross-field
+constraints of ADR-0022 (`exclusive`, `requires`).
+
+What was missing is *per-field value* checking beyond "does it parse as the
+type": a `u16` port that must be 1–65535, a non-empty name, a string that is only
+meaningful once turned into a `Duration`. Today an author hand-writes those checks
+at the top of `execute`, with an ad-hoc message and exit path.
+
+The question was whether to add one mechanism or two — and specifically whether a
+validation *function* and a custom *type* are "two ways to do one thing".
+
+## Decision
+
+Two complementary features, because they are two different jobs:
+
+- **Validation** — *the field's type is already right; the value needs checking.*
+  A `validate` hook in `meta` refines an existing type. No new type, no ceremony.
+  This is the common case (ranges, non-empty, length). **Shipped here.**
+
+- **Custom parse types** — *producing the value from text needs your code.* A
+  user-defined type declares `pub fn parse`, so a string that doesn't map to a
+  native scalar (`"5m30s"` → `Duration`, `"4GiB"` → `ByteSize`, `Email`) becomes a
+  typed, valid-by-construction value. Parsing validates as it builds. **Planned as
+  the second increment.**
+
+They are not redundant: a `validate` fn *cannot* do a custom parse (declare the
+field `u64` and `"5m30s"` fails at parse before validate runs; declare it
+`[]const u8` and you've thrown away the value), and no one mints a type to
+range-check a `u16`. The only overlap is refining a plain scalar, where `validate`
+is the recommended lighter tool — the same soft overlap `enum` already has with
+"string + validate" for a fixed choice set. They compose: a custom-typed field may
+also carry a `validate` hook.
+
+**Teachable boundary:**
+> Does the string map straight to a type zcli already parses (int/float/enum/
+> string)? Declare that type; add `validate` for extra rules.
+> Does turning the string into your value need your own logic (or you want a
+> distinct domain type)? Make a custom type with `parse`.
+
+### The `validate` contract
+
+```zig
+pub const Options = struct { port: u16 = 8080 };
+
+pub const meta = .{
+    .options = .{ .port = .{ .validate = validatePort } },
+};
+
+fn validatePort(port: u16) ?[]const u8 {
+    return if (port == 0) "must be between 1 and 65535" else null;
+}
+```
+
+- Signature `fn(Base) ?[]const u8`, where `Base` is the field type with one
+  optional level removed. `null` means valid; a returned string is the reason
+  shown to the user. Verified at comptime, like every other `meta` contract.
+- Works identically on `meta.args.<field>` (struct form, ADR after #225) and
+  `meta.options.<field>`.
+- Runs on the **final resolved value from any source** — CLI, env, config, or
+  default — after required/requires/exclusive, so no source can inject an invalid
+  value. A `?T` field is validated only when a value is present.
+- Reported through the ADR-#206 diagnostic path, so a validation failure reads
+  like any other bad-input error and carries the same usage hint:
+  `Error: Invalid value '0' for option '--port': must be between 1 and 65535.`
+
+### Why a reason string, not an error or `context.fail`
+
+A validation failure is a bad-*input* error — a sibling of "invalid enum value",
+not a business-logic failure. #206 gives that whole family one uniform treatment
+(`Invalid value 'X' for option '--Y'`, humanized type, usage hint, `onError`
+introspection), and validation is its natural extension.
+
+- Returning a bare `error` would surface `@errorName` (camelCase — the un-humane
+  output #206 removed) unless we add a mapping layer.
+- `context.fail(...)` is the *business-failure* idiom from `execute`: freeform,
+  no usage hint, and it bypasses the structured diagnostic. Using it here would
+  make `--port 0` behave inconsistently with `--level xyz`.
+- A reason *string* keeps the hook pure and context-free — trivially testable,
+  reusable across commands, side-effect-free — and `?[]const u8` (null = ok) *is*
+  "error-or-not, with the reason attached". Environment-dependent checks (a file
+  must exist) deliberately don't belong in a value hook; they are execute-time
+  logic (TOCTOU).
+
+By contrast, `parse` *constructs* and composes with `try` over sub-parsers, so it
+returns an error union — the asymmetry mirrors what each function actually does.
+
+## Consequences
+
+- One way to constrain an existing type (`validate`) and one way to parse a new
+  one (`parse`); no DSL, nothing added to a field's type for the former.
+- Validation is a single post-resolution sweep beside the ADR-0022 constraint
+  walks, reusing the provided-set/config-snapshot machinery — no new state through
+  parsing, and no changes to the parse sites or config (the field type is
+  unchanged). Two diagnostics join the structured set: `OptionValidationFailed`
+  and `ArgumentValidationFailed`.
+- Fixed a latent gap found alongside this work: the ADR-0022 constraint errors
+  (`OptionMutuallyExclusive`, `OptionMissingDependency`) were absent from the
+  clean-exit set, so a violation printed its message *and then* a raw error trace.
+  They now exit cleanly like every other reported parse error.
+- Deferred: the custom `parse` protocol (`pub fn parse(s) E!@This()` + optional
+  `hint`/`describe`), which will touch the parse sites and the config
+  deserializer, and gives valid-by-construction domain types. Documented here so
+  the two features stay coherent when it lands.

--- a/packages/core/src/command_parser.zig
+++ b/packages/core/src/command_parser.zig
@@ -319,6 +319,104 @@ pub fn firstExclusiveViolation(
     return null;
 }
 
+/// A field whose `validate` hook rejected the resolved value. `name` is the
+/// effective long flag name (options) or field name (args); `provided_value` is
+/// the rejected value rendered to a string (for the "Invalid value 'X'" clause);
+/// `reason` is the author's message; `position` is the 0-based positional index
+/// for args.
+pub const ValidationFailure = struct {
+    name: []const u8,
+    reason: []const u8,
+    provided_value: []const u8 = "",
+    position: usize = 0,
+};
+
+/// Render a validated value to a string for the diagnostic. Strings pass through
+/// as-is; enums via `@tagName`; scalars are formatted. The result lives on
+/// `allocator` (an arena in practice, like the rendered diagnostic message) or is
+/// static — never individually freed.
+fn renderValidatedValue(allocator: std.mem.Allocator, comptime T: type, value: T) []const u8 {
+    return switch (@typeInfo(T)) {
+        .pointer => |p| if (p.child == u8) value else (std.fmt.allocPrint(allocator, "{any}", .{value}) catch "?"),
+        .@"enum" => @tagName(value),
+        .int, .float => std.fmt.allocPrint(allocator, "{d}", .{value}) catch "?",
+        .bool => if (value) "true" else "false",
+        else => std.fmt.allocPrint(allocator, "{any}", .{value}) catch "?",
+    };
+}
+
+/// The first Options field whose `meta.options.<field>.validate` rejected the
+/// resolved value (in field order), or null. Runs after required/requires/
+/// exclusive, on the final value from any source; a `?T` field is validated
+/// only when a value is present (null is skipped, since absence is governed by
+/// required/optional, not by the value hook).
+pub fn firstOptionValidationError(
+    allocator: std.mem.Allocator,
+    comptime OptionsType: type,
+    comptime meta: anytype,
+    options: OptionsType,
+) ?ValidationFailure {
+    const info = @typeInfo(OptionsType);
+    if (info != .@"struct") return null;
+    inline for (info.@"struct".fields) |field| {
+        if (comptime option_utils.hasValidate(meta, field.name)) {
+            const validate_fn = @field(meta.options, field.name).validate;
+            const value = @field(options, field.name);
+            switch (@typeInfo(field.type)) {
+                .optional => if (value) |v| {
+                    if (validate_fn(v)) |r| return .{
+                        .name = comptime option_utils.effectiveLongName(meta, field.name),
+                        .reason = r,
+                        .provided_value = renderValidatedValue(allocator, @TypeOf(v), v),
+                    };
+                },
+                else => if (validate_fn(value)) |r| return .{
+                    .name = comptime option_utils.effectiveLongName(meta, field.name),
+                    .reason = r,
+                    .provided_value = renderValidatedValue(allocator, field.type, value),
+                },
+            }
+        }
+    }
+    return null;
+}
+
+/// The first positional Args field whose `meta.args.<field>.validate` rejected
+/// the parsed value (in positional order), or null. Same value-hook semantics as
+/// options; `position` is the 0-based field index for the diagnostic.
+pub fn firstArgValidationError(
+    allocator: std.mem.Allocator,
+    comptime ArgsType: type,
+    comptime meta: anytype,
+    args: ArgsType,
+) ?ValidationFailure {
+    const info = @typeInfo(ArgsType);
+    if (info != .@"struct") return null;
+    inline for (info.@"struct".fields, 0..) |field, i| {
+        if (comptime option_utils.hasValidateArg(meta, field.name)) {
+            const validate_fn = @field(meta.args, field.name).validate;
+            const value = @field(args, field.name);
+            switch (@typeInfo(field.type)) {
+                .optional => if (value) |v| {
+                    if (validate_fn(v)) |r| return .{
+                        .name = field.name,
+                        .reason = r,
+                        .provided_value = renderValidatedValue(allocator, @TypeOf(v), v),
+                        .position = i,
+                    };
+                },
+                else => if (validate_fn(value)) |r| return .{
+                    .name = field.name,
+                    .reason = r,
+                    .provided_value = renderValidatedValue(allocator, field.type, value),
+                    .position = i,
+                },
+            }
+        }
+    }
+    return null;
+}
+
 /// Check if an options type has any array fields that need cleanup
 fn hasArrayFields(comptime OptionsType: type) bool {
     const type_info = @typeInfo(OptionsType);
@@ -1093,6 +1191,98 @@ test "firstExclusiveViolation: overlapping sets are checked independently" {
         try std.testing.expectEqualStrings("b", ex.?.first);
         try std.testing.expectEqualStrings("c", ex.?.second);
     }
+}
+
+test "firstOptionValidationError: reports the first field the hook rejects" {
+    const V = struct {
+        fn port(p: u16) ?[]const u8 {
+            return if (p == 0) "must be between 1 and 65535" else null;
+        }
+    };
+    const Options = struct { port: u16 = 8080 };
+    const meta = .{ .options = .{ .port = .{ .validate = V.port } } };
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // A valid value (from any source — the sweep sees only the final value).
+    try std.testing.expect(firstOptionValidationError(a, Options, meta, .{ .port = 8080 }) == null);
+
+    // An invalid value → failure carrying the reason, flag name, and rendered value.
+    const f = firstOptionValidationError(a, Options, meta, .{ .port = 0 });
+    try std.testing.expect(f != null);
+    try std.testing.expectEqualStrings("port", f.?.name);
+    try std.testing.expectEqualStrings("must be between 1 and 65535", f.?.reason);
+    try std.testing.expectEqualStrings("0", f.?.provided_value);
+}
+
+test "firstOptionValidationError: optional field is validated only when present" {
+    const V = struct {
+        fn nonzero(n: u32) ?[]const u8 {
+            return if (n == 0) "must not be zero" else null;
+        }
+    };
+    const Options = struct { limit: ?u32 = null };
+    const meta = .{ .options = .{ .limit = .{ .validate = V.nonzero } } };
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    try std.testing.expect(firstOptionValidationError(a, Options, meta, .{ .limit = null }) == null);
+    try std.testing.expect(firstOptionValidationError(a, Options, meta, .{ .limit = 5 }) == null);
+    try std.testing.expect(firstOptionValidationError(a, Options, meta, .{ .limit = 0 }) != null);
+}
+
+test "firstOptionValidationError: reports the effective (custom) flag name" {
+    const V = struct {
+        fn nonempty(s: []const u8) ?[]const u8 {
+            return if (s.len == 0) "must not be empty" else null;
+        }
+    };
+    const Options = struct { output_dir: []const u8 = "" };
+    const meta = .{ .options = .{ .output_dir = .{ .name = "out", .validate = V.nonempty } } };
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const f = firstOptionValidationError(arena.allocator(), Options, meta, .{ .output_dir = "" });
+    try std.testing.expect(f != null);
+    try std.testing.expectEqualStrings("out", f.?.name);
+}
+
+test "firstArgValidationError: reports the field, reason, and position" {
+    const V = struct {
+        fn nonempty(s: []const u8) ?[]const u8 {
+            return if (s.len == 0) "must not be empty" else null;
+        }
+        fn small(n: u8) ?[]const u8 {
+            return if (n > 10) "must be 10 or less" else null;
+        }
+    };
+    const Args = struct { name: []const u8, count: u8 };
+    const meta = .{ .args = .{
+        .name = .{ .validate = V.nonempty },
+        .count = .{ .description = "how many", .validate = V.small },
+    } };
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // All valid.
+    try std.testing.expect(firstArgValidationError(a, Args, meta, .{ .name = "x", .count = 3 }) == null);
+
+    // Second positional rejected → position 1 (0-based), reported after name passes.
+    const f = firstArgValidationError(a, Args, meta, .{ .name = "x", .count = 99 });
+    try std.testing.expect(f != null);
+    try std.testing.expectEqualStrings("count", f.?.name);
+    try std.testing.expectEqualStrings("must be 10 or less", f.?.reason);
+    try std.testing.expectEqualStrings("99", f.?.provided_value);
+    try std.testing.expectEqual(@as(usize, 1), f.?.position);
+
+    // Bare-string arg meta (no validate) is simply skipped.
+    const meta2 = .{ .args = .{ .name = "just a description" } };
+    try std.testing.expect(firstArgValidationError(a, Args, meta2, .{ .name = "", .count = 0 }) == null);
 }
 
 test "parseArgs failure after array options were parsed does not leak them" {

--- a/packages/core/src/diagnostic_errors.zig
+++ b/packages/core/src/diagnostic_errors.zig
@@ -6,6 +6,7 @@ pub const ZcliError = error{
     ArgumentMissingRequired,
     ArgumentInvalidValue,
     ArgumentTooMany,
+    ArgumentValidationFailed,
 
     // Option parsing errors
     OptionUnknown,
@@ -16,6 +17,7 @@ pub const ZcliError = error{
     OptionMissingRequired,
     OptionMutuallyExclusive,
     OptionMissingDependency,
+    OptionValidationFailed,
 
     // Command routing errors
     CommandNotFound,
@@ -58,6 +60,16 @@ pub const ZcliDiagnostic = union(enum) {
     ArgumentTooMany: struct {
         expected_count: usize,
         actual_count: usize,
+    },
+    /// A positional arg's `meta.args.<field>.validate` rejected the parsed value.
+    /// `field_name` is the Args field name; `position` is 0-based;
+    /// `provided_value` is the rejected value rendered to a string; `reason` is
+    /// the author-provided message, rendered verbatim.
+    ArgumentValidationFailed: struct {
+        field_name: []const u8,
+        position: usize,
+        provided_value: []const u8,
+        reason: []const u8,
     },
 
     // Option parsing errors
@@ -105,6 +117,15 @@ pub const ZcliDiagnostic = union(enum) {
     OptionMissingDependency: struct {
         option_name: []const u8,
         required_name: []const u8,
+    },
+    /// A field's `meta.options.<field>.validate` rejected the resolved value.
+    /// `option_name` is the effective long flag name (without `--`);
+    /// `provided_value` is the rejected value rendered to a string; `reason` is
+    /// the author-provided message, rendered verbatim.
+    OptionValidationFailed: struct {
+        option_name: []const u8,
+        provided_value: []const u8,
+        reason: []const u8,
     },
 
     // Command routing errors
@@ -291,6 +312,7 @@ pub fn formatDiagnostic(diagnostic: ZcliDiagnostic, allocator: std.mem.Allocator
         else
             std.fmt.allocPrint(allocator, "Invalid value '{s}' for argument '{s}' at position {d}. Expected {s}.", .{ ctx.provided_value, ctx.field_name, ctx.position + 1, humanType(ctx.expected_type) }),
         .ArgumentTooMany => |ctx| std.fmt.allocPrint(allocator, "Too many arguments provided. Expected {d} arguments, got {d}", .{ ctx.expected_count, ctx.actual_count }),
+        .ArgumentValidationFailed => |ctx| std.fmt.allocPrint(allocator, "Invalid value '{s}' for argument '{s}' at position {d}: {s}.", .{ ctx.provided_value, ctx.field_name, ctx.position + 1, ctx.reason }),
         .OptionUnknown => |ctx| blk: {
             const base_msg = try std.fmt.allocPrint(allocator, "Unknown option '{s}{s}'", .{ if (ctx.is_short) "-" else "--", ctx.option_name });
 
@@ -320,6 +342,7 @@ pub fn formatDiagnostic(diagnostic: ZcliDiagnostic, allocator: std.mem.Allocator
         .OptionMissingRequired => |ctx| std.fmt.allocPrint(allocator, "Missing required option '--{s}'. Expected {s}.", .{ ctx.option_name, humanType(ctx.expected_type) }),
         .OptionMutuallyExclusive => |ctx| std.fmt.allocPrint(allocator, "Options '--{s}' and '--{s}' cannot be used together.", .{ ctx.first, ctx.second }),
         .OptionMissingDependency => |ctx| std.fmt.allocPrint(allocator, "Option '--{s}' requires '--{s}'.", .{ ctx.option_name, ctx.required_name }),
+        .OptionValidationFailed => |ctx| std.fmt.allocPrint(allocator, "Invalid value '{s}' for option '--{s}': {s}.", .{ ctx.provided_value, ctx.option_name, ctx.reason }),
         .CommandNotFound => |ctx| blk: {
             const base_msg = try std.fmt.allocPrint(allocator, "Unknown command '{s}'", .{ctx.attempted_command});
 
@@ -483,6 +506,22 @@ test "OptionMissingDependency names the supplied option and its missing requirem
     const msg = try formatDiagnostic(diag, allocator);
     defer allocator.free(msg);
     try std.testing.expect(std.mem.indexOf(u8, msg, "'--output-format' requires '--output'") != null);
+}
+
+test "ArgumentValidationFailed renders the field, 1-based position, and reason" {
+    const allocator = std.testing.allocator;
+    const diag = ZcliDiagnostic{ .ArgumentValidationFailed = .{ .field_name = "count", .position = 1, .provided_value = "99", .reason = "must be 10 or less" } };
+    const msg = try formatDiagnostic(diag, allocator);
+    defer allocator.free(msg);
+    try std.testing.expectEqualStrings("Invalid value '99' for argument 'count' at position 2: must be 10 or less.", msg);
+}
+
+test "OptionValidationFailed renders the flag and the author's reason" {
+    const allocator = std.testing.allocator;
+    const diag = ZcliDiagnostic{ .OptionValidationFailed = .{ .option_name = "replicas", .provided_value = "0", .reason = "must be between 1 and 100" } };
+    const msg = try formatDiagnostic(diag, allocator);
+    defer allocator.free(msg);
+    try std.testing.expectEqualStrings("Invalid value '0' for option '--replicas': must be between 1 and 100.", msg);
 }
 
 test "invalid enum value messages carry a did-you-mean" {

--- a/packages/core/src/options/utils.zig
+++ b/packages/core/src/options/utils.zig
@@ -686,6 +686,31 @@ pub fn requiresFor(comptime meta: anytype, comptime field_name: []const u8) ?[]c
     return tupleToStrings(field_meta.requires);
 }
 
+/// Whether `meta.options.<field>` declares a `validate` hook. The hook's type is
+/// verified by `validateCommand` to be `fn(Base) ?[]const u8` (Base = the field
+/// type with one optional level removed); the validation sweep reads the decl
+/// directly once this gate passes.
+pub fn hasValidate(comptime meta: anytype, comptime field_name: []const u8) bool {
+    if (@TypeOf(meta) == @TypeOf(null)) return false;
+    if (!@hasField(@TypeOf(meta), "options")) return false;
+    if (!@hasField(@TypeOf(meta.options), field_name)) return false;
+    const field_meta = @field(meta.options, field_name);
+    if (@typeInfo(@TypeOf(field_meta)) != .@"struct") return false;
+    return @hasField(@TypeOf(field_meta), "validate");
+}
+
+/// Whether `meta.args.<field>` declares a `validate` hook. The struct form of
+/// args metadata (a bare string carries none) may carry the same `fn(Base)
+/// ?[]const u8` hook as options; `validateCommand` verifies its signature.
+pub fn hasValidateArg(comptime meta: anytype, comptime field_name: []const u8) bool {
+    if (@TypeOf(meta) == @TypeOf(null)) return false;
+    if (!@hasField(@TypeOf(meta), "args")) return false;
+    if (!@hasField(@TypeOf(meta.args), field_name)) return false;
+    const field_meta = @field(meta.args, field_name);
+    if (@typeInfo(@TypeOf(field_meta)) != .@"struct") return false;
+    return @hasField(@TypeOf(field_meta), "validate");
+}
+
 /// The `meta.exclusive` mutually-exclusive sets — each a list of Options field
 /// names, at most one of which may be supplied — or an empty slice when none are
 /// declared.

--- a/packages/core/src/registry/compiled.zig
+++ b/packages/core/src/registry/compiled.zig
@@ -65,9 +65,16 @@ fn isReportedCliError(err: anyerror) bool {
         error.OptionBooleanWithValue,
         error.OptionDuplicate,
         error.OptionMissingRequired,
+        // Cross-field constraint violations (ADR-0022) and per-field validation
+        // failures also print their own diagnostic via reportParseError, so they
+        // exit cleanly like every other reported parse error.
+        error.OptionMutuallyExclusive,
+        error.OptionMissingDependency,
+        error.OptionValidationFailed,
         error.ArgumentMissingRequired,
         error.ArgumentInvalidValue,
         error.ArgumentTooMany,
+        error.ArgumentValidationFailed,
         error.ResourceLimitExceeded,
         // A command that failed via context.fail() already printed its own
         // user-facing message; exit non-zero without the name/trace.
@@ -80,6 +87,11 @@ fn isReportedCliError(err: anyerror) bool {
 test "isReportedCliError: context.fail's error exits cleanly, unexpected errors don't" {
     try std.testing.expect(isReportedCliError(error.CommandFailed));
     try std.testing.expect(isReportedCliError(error.ArgumentMissingRequired));
+    // Constraint + validation violations self-report, so they exit cleanly too.
+    try std.testing.expect(isReportedCliError(error.OptionMutuallyExclusive));
+    try std.testing.expect(isReportedCliError(error.OptionMissingDependency));
+    try std.testing.expect(isReportedCliError(error.OptionValidationFailed));
+    try std.testing.expect(isReportedCliError(error.ArgumentValidationFailed));
     // An unexpected failure keeps its name + trace (propagated, not swallowed).
     try std.testing.expect(!isReportedCliError(error.OutOfMemory));
 }
@@ -1027,6 +1039,34 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
                 if (try runOnErrorHooks(context, error.OptionMutuallyExclusive)) return;
                 try reportParseError(context, diag);
                 return error.OptionMutuallyExclusive;
+            }
+
+            // Per-field validation (meta.args/options.<field>.validate), run last
+            // on the fully-resolved values so the hooks see every source's effect.
+            // Args first (positional), then options — mirroring their parse order.
+            if (command_parser.firstArgValidationError(context.allocator, ArgsType, cmd_meta, args_instance)) |failure| {
+                const diag: zcli.ZcliDiagnostic = .{ .ArgumentValidationFailed = .{
+                    .field_name = failure.name,
+                    .position = failure.position,
+                    .provided_value = failure.provided_value,
+                    .reason = failure.reason,
+                } };
+                context.diagnostic = diag;
+                if (try runOnErrorHooks(context, error.ArgumentValidationFailed)) return;
+                try reportParseError(context, diag);
+                return error.ArgumentValidationFailed;
+            }
+
+            if (command_parser.firstOptionValidationError(context.allocator, OptionsType, cmd_meta, options_instance)) |failure| {
+                const diag: zcli.ZcliDiagnostic = .{ .OptionValidationFailed = .{
+                    .option_name = failure.name,
+                    .provided_value = failure.provided_value,
+                    .reason = failure.reason,
+                } };
+                context.diagnostic = diag;
+                if (try runOnErrorHooks(context, error.OptionValidationFailed)) return;
+                try reportParseError(context, diag);
+                return error.OptionValidationFailed;
             }
 
             // Execute. A handled error (onError returns true) is suppressed

--- a/packages/core/src/zcli.zig
+++ b/packages/core/src/zcli.zig
@@ -490,7 +490,7 @@ pub fn validateMeta(
             const option_meta_info = @typeInfo(@TypeOf(option_meta));
 
             if (option_meta_info == .@"struct") {
-                const valid_option_fields = .{ "description", "short", "name", "env", "requires" };
+                const valid_option_fields = .{ "description", "short", "name", "env", "requires", "validate" };
 
                 inline for (option_meta_info.@"struct".fields) |opt_field| {
                     const opt_is_valid = comptime blk: {
@@ -502,7 +502,37 @@ pub fn validateMeta(
                         break :blk false;
                     };
                     if (!opt_is_valid) {
-                        @compileError(loc ++ "unknown option metadata field '" ++ opt_field.name ++ "' in option '" ++ field.name ++ "'. Valid fields are: description, short, name, env, requires");
+                        @compileError(loc ++ "unknown option metadata field '" ++ opt_field.name ++ "' in option '" ++ field.name ++ "'. Valid fields are: description, short, name, env, requires, validate");
+                    }
+                }
+
+                // `validate`: an optional per-field hook run after the value is
+                // resolved from every source. Its signature must be
+                // `fn(Base) ?[]const u8`, where Base is the Options field type
+                // with one optional level removed (the hook sees a present value,
+                // never null). Null means valid; a returned string is the reason.
+                if (@hasField(@TypeOf(option_meta), "validate")) {
+                    const FieldT = comptime blk: {
+                        for (options_fields) |of| {
+                            if (std.mem.eql(u8, of.name, field.name)) break :blk of.type;
+                        }
+                        unreachable;
+                    };
+                    const Base = switch (@typeInfo(FieldT)) {
+                        .optional => |o| o.child,
+                        else => FieldT,
+                    };
+                    const v_info = @typeInfo(@TypeOf(option_meta.validate));
+                    const sig_ok = comptime blk: {
+                        if (v_info != .@"fn") break :blk false;
+                        const f = v_info.@"fn";
+                        if (f.params.len != 1) break :blk false;
+                        const param_ok = if (f.params[0].type) |pt| pt == Base else false;
+                        const ret_ok = if (f.return_type) |rt| rt == ?[]const u8 else false;
+                        break :blk param_ok and ret_ok;
+                    };
+                    if (!sig_ok) {
+                        @compileError(loc ++ "option '" ++ field.name ++ "' `validate` must have signature `fn(" ++ @typeName(Base) ++ ") ?[]const u8`");
                     }
                 }
 
@@ -592,7 +622,7 @@ pub fn validateMeta(
             const arg_meta_info = @typeInfo(arg_meta_type);
 
             if (arg_meta_info == .@"struct") {
-                const valid_arg_fields = .{"description"};
+                const valid_arg_fields = .{ "description", "validate" };
 
                 inline for (arg_meta_info.@"struct".fields) |arg_field| {
                     const arg_is_valid = comptime blk: {
@@ -604,7 +634,35 @@ pub fn validateMeta(
                         break :blk false;
                     };
                     if (!arg_is_valid) {
-                        @compileError(loc ++ "unknown arg metadata field '" ++ arg_field.name ++ "' in arg '" ++ field.name ++ "'. Valid fields are: description");
+                        @compileError(loc ++ "unknown arg metadata field '" ++ arg_field.name ++ "' in arg '" ++ field.name ++ "'. Valid fields are: description, validate");
+                    }
+                }
+
+                // `validate`: same per-field hook as options, run on the parsed
+                // positional value. Signature `fn(Base) ?[]const u8`, Base = the
+                // Args field type with one optional level removed.
+                if (@hasField(@TypeOf(arg_meta), "validate")) {
+                    const FieldT = comptime blk: {
+                        for (args_fields) |af| {
+                            if (std.mem.eql(u8, af.name, field.name)) break :blk af.type;
+                        }
+                        unreachable;
+                    };
+                    const Base = switch (@typeInfo(FieldT)) {
+                        .optional => |o| o.child,
+                        else => FieldT,
+                    };
+                    const v_info = @typeInfo(@TypeOf(arg_meta.validate));
+                    const sig_ok = comptime blk: {
+                        if (v_info != .@"fn") break :blk false;
+                        const f = v_info.@"fn";
+                        if (f.params.len != 1) break :blk false;
+                        const param_ok = if (f.params[0].type) |pt| pt == Base else false;
+                        const ret_ok = if (f.return_type) |rt| rt == ?[]const u8 else false;
+                        break :blk param_ok and ret_ok;
+                    };
+                    if (!sig_ok) {
+                        @compileError(loc ++ "arg '" ++ field.name ++ "' `validate` must have signature `fn(" ++ @typeName(Base) ++ ") ?[]const u8`");
                     }
                 }
             } else {


### PR DESCRIPTION
## What

Adds a per-field `validate` hook — the first of the two features from ADR-0024 (the second, custom `parse` types, is a planned follow-up).

```zig
pub const Options = struct { port: u16 = 8080 };

pub const meta = .{
    .options = .{ .port = .{ .validate = validatePort } },
};

fn validatePort(port: u16) ?[]const u8 {
    return if (port == 0) "must be between 1 and 65535" else null;
}
```

- **Contract:** `fn(Base) ?[]const u8`, where `Base` is the field type minus one optional level. `null` = valid; a returned string is the reason. Verified at comptime like every other `meta` contract. Works on both `meta.options.<field>` and `meta.args.<field>` (struct form, #225).
- **All sources:** runs on the finally-resolved value from CLI / env / config / default, after required/requires/exclusive, so no source can slip an invalid value through. `?T` validated only when present.
- **#206 family:** reported through the same diagnostic path as other bad-input errors, with the offending value + usage hint:
  ```
  Error: Invalid value '0' for option '--port': must be between 1 and 65535.
  Run 'app cmd --help' for usage.
  ```

Because the field type is unchanged, parsing and config are untouched — this is a single post-resolution sweep beside the ADR-0022 constraint walks, adding two structured diagnostics (`OptionValidationFailed`, `ArgumentValidationFailed`).

## Design notes (why a reason string, not an error / `context.fail`)

A validation failure is a bad-*input* error — a sibling of "invalid enum value", not a business failure. A bare `error` would surface `@errorName` (camelCase — the un-humane output #206 removed); `context.fail` is the freeform business-failure idiom (no usage hint, bypasses the structured diagnostic) and would make `--port 0` behave differently from `--level xyz`. A pure, context-free `?[]const u8` keeps the hook testable/reusable and *is* "error-or-not, with the reason attached". Full rationale in ADR-0024.

## Drive-by fix

Found alongside: `OptionMutuallyExclusive` / `OptionMissingDependency` (ADR-0022) were missing from `isReportedCliError`, so a constraint violation printed its friendly message **and then** a raw error trace. Now they exit cleanly, locked with a test.

## Tests

- Unit: option + arg sweeps (valid / rejected / optional-null-skipped / custom flag name / rendered value / bare-string arg meta), diagnostic formatting, `isReportedCliError` classification.
- E2E (verified locally, reverted): built a real CLI with a validated `--limit`; `--limit 0` → friendly message + usage hint + exit 1, no trace; `--limit abc` → ordinary parse error; `--limit 5` → runs.
- `zig build test` green across all 8 packages + examples + `projects/zcli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)