### PR TITLE
feat(parse): custom parse types — typed, valid-by-construction fields (ADR-0024)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -310,7 +310,44 @@ like any other bad-value parse error, with the offending value and a usage hint:
 Reach for `validate` when the field's native type already parses the input and you
 only need an extra rule. When turning the string into your value needs custom
 logic (`"5m30s"` → a duration), that is *parsing*, and belongs in a custom type —
-see ADR-0024.
+see below.
+
+**Custom parse types:**
+
+When the argument string doesn't map straight to a native scalar, give the field a
+type that constructs itself, by declaring `pub fn parse`:
+
+```zig
+const Duration = struct {
+    secs: u64,
+    pub const hint = "a duration like 5m30s";
+    pub fn parse(s: []const u8) error{ BadFormat, TooLong }!Duration { … }
+    pub fn describe(err: error{ BadFormat, TooLong }) []const u8 {
+        return switch (err) {
+            error.BadFormat => "use a form like 5m30s",
+            error.TooLong => "must be under an hour",
+        };
+    }
+};
+
+pub const Options = struct { timeout: Duration = .{ .secs = 30 } };
+```
+
+A field type is *custom-parsed* when (after unwrapping one optional level) it is a
+struct/union/enum with `pub fn parse(s: []const u8) E!@This()` — an error union, so
+it composes with `try` over sub-parsers. `execute` then receives the domain type
+itself, valid by construction. Optional companions: `pub const hint` (the
+"Expected …" phrase and help placeholder) and `pub fn describe(err)` (a humane
+message per failure variant). Every source builds it the same way — CLI and env
+parse the string through `parse`, and config does too when the value is a string
+(env/config stay lenient: an unparseable value is ignored, never injected). A parse
+failure is reported like any other bad value, showing `describe`'s reason when
+present, else the hint:
+
+- `Invalid value 'nope' for option '--timeout': use a form like 5m30s.`
+
+This is the division: `validate` refines a value of an existing type; a custom
+type *is* the value and owns how it's built. See ADR-0024.
 
 **Context Structure:**
 

--- a/docs/adr/0024-field-validation-and-custom-parse-types.md
+++ b/docs/adr/0024-field-validation-and-custom-parse-types.md
@@ -1,6 +1,6 @@
 # Field validation and custom parse types
 
-Status: accepted (validation shipped; custom parse types are a planned follow-up)
+Status: accepted (both increments shipped)
 
 zcli derives a command's inputs from its `Args`/`Options` structs: a field's type
 drives parsing, its enum variants are the valid choices, `?T`/default decide
@@ -27,7 +27,7 @@ Two complementary features, because they are two different jobs:
 - **Custom parse types** — *producing the value from text needs your code.* A
   user-defined type declares `pub fn parse`, so a string that doesn't map to a
   native scalar (`"5m30s"` → `Duration`, `"4GiB"` → `ByteSize`, `Email`) becomes a
-  typed, valid-by-construction value. Parsing validates as it builds. **Planned as
+  typed, valid-by-construction value. Parsing validates as it builds. **Shipped as
   the second increment.**
 
 They are not redundant: a `validate` fn *cannot* do a custom parse (declare the
@@ -91,6 +91,44 @@ introspection), and validation is its natural extension.
 By contrast, `parse` *constructs* and composes with `try` over sub-parsers, so it
 returns an error union — the asymmetry mirrors what each function actually does.
 
+### The `parse` contract
+
+```zig
+const Duration = struct {
+    secs: u64,
+    pub const hint = "a duration like 5m30s";
+    pub fn parse(s: []const u8) error{ BadFormat, TooLong }!Duration { … }
+    pub fn describe(err: error{ BadFormat, TooLong }) []const u8 {
+        return switch (err) {
+            error.BadFormat => "use a form like 5m30s",
+            error.TooLong => "must be under an hour",
+        };
+    }
+};
+
+pub const Options = struct { timeout: Duration = .{ .secs = 30 } };
+```
+
+- A field type is *custom-parsed* when — after unwrapping one optional level — it
+  is a struct/union/enum declaring `pub fn parse(s: []const u8) E!@This()`. The
+  error union is idiomatic Zig, composes with `try`, and matches zcli's own
+  `parseOptionValue`. The signature is checked at comptime with a friendly message.
+- Optional companions: `pub const hint` (the "Expected …" phrase and help
+  placeholder; defaults to the type name) and `pub fn describe(err)` (a humane
+  message per failure variant).
+- Every source constructs the type the same way — CLI and env parse the string
+  through `parse`; config does too when the value is a string. Because the field
+  *is* the domain type, `execute` receives a value that is valid by construction.
+- A parse failure reuses the existing `OptionInvalidValue`/`ArgumentInvalidValue`
+  diagnostics: the specific error collapses to the canonical reported error (clean
+  exit), while the humane reason is recovered at the diagnostic site — `describe`'s
+  message when present, else the hint:
+  `Invalid value 'nope' for option '--timeout': use a form like 5m30s.`
+  We deliberately never render `@errorName` (camelCase would break the #206 tone).
+- env and config are *lenient*, exactly as they already are for every scalar: an
+  unparseable value is ignored and the default stays, so no source can inject an
+  *invalid* value (there simply is no value), preserving valid-by-construction.
+
 ## Consequences
 
 - One way to constrain an existing type (`validate`) and one way to parse a new
@@ -104,7 +142,11 @@ returns an error union — the asymmetry mirrors what each function actually doe
   (`OptionMutuallyExclusive`, `OptionMissingDependency`) were absent from the
   clean-exit set, so a violation printed its message *and then* a raw error trace.
   They now exit cleanly like every other reported parse error.
-- Deferred: the custom `parse` protocol (`pub fn parse(s) E!@This()` + optional
-  `hint`/`describe`), which will touch the parse sites and the config
-  deserializer, and gives valid-by-construction domain types. Documented here so
-  the two features stay coherent when it lands.
+- Custom `parse` types reuse the invalid-value diagnostics (a `reason` field was
+  added to `OptionInvalidValue`/`ArgumentInvalidValue`) and extend the three
+  string→value sites (`parseOptionValue`, args `parseValue`, `applyEnvValue`) plus
+  the config deserializer to construct a type from its string. `expectedTypeName`
+  returns a custom type's `hint`. No new diagnostic variant.
+- Detection/construction helpers live in `custom_type.zig`, re-exported as
+  `zcli.custom_type` so the config plugin (which imports only "zcli") can build a
+  custom-typed field the same way the parser does.

--- a/packages/core/src/args.zig
+++ b/packages/core/src/args.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const diagnostic_errors = @import("diagnostic_errors.zig");
 const type_utils = @import("type_utils.zig");
+const custom_type = @import("custom_type.zig");
 
 pub const ZcliError = diagnostic_errors.ZcliError;
 pub const ZcliDiagnostic = diagnostic_errors.ZcliDiagnostic;
@@ -135,6 +136,7 @@ fn parseArgsInternal(comptime ArgsType: type, args: []const []const u8, diag: ?*
                             .provided_value = args[pos],
                             .expected_type = diagnostic_errors.expectedTypeName(field_type),
                             .suggestion = diagnostic_errors.nearestEnumValue(field_type, args[pos]),
+                            .reason = custom_type.describeError(field_type, args[pos]),
                         } };
                     }
                     return err;
@@ -156,6 +158,7 @@ fn parseArgsInternal(comptime ArgsType: type, args: []const []const u8, diag: ?*
                             .provided_value = args[pos],
                             .expected_type = diagnostic_errors.expectedTypeName(field_type),
                             .suggestion = diagnostic_errors.nearestEnumValue(field_type, args[pos]),
+                            .reason = custom_type.describeError(field_type, args[pos]),
                         } };
                     }
                     return err;
@@ -184,6 +187,7 @@ fn parseArgsInternal(comptime ArgsType: type, args: []const []const u8, diag: ?*
                         .provided_value = args[pos],
                         .expected_type = diagnostic_errors.expectedTypeName(field_type),
                         .suggestion = diagnostic_errors.nearestEnumValue(field_type, args[pos]),
+                        .reason = custom_type.describeError(field_type, args[pos]),
                     } };
                 }
                 return err;
@@ -244,6 +248,17 @@ fn parseValue(comptime T: type, value: []const u8) ZcliError!T {
         .optional => |opt_info| {
             // Parse the underlying type
             return try parseValue(opt_info.child, value);
+        },
+        .@"struct", .@"union" => {
+            // Custom type: build itself from the string via `pub fn parse`. The
+            // specific error collapses to the canonical ArgumentInvalidValue; the
+            // humane reason is recovered at the diagnostic site via describeError.
+            if (comptime custom_type.isCustomParsed(T)) {
+                custom_type.assertValidParse(T);
+                return T.parse(value) catch return ZcliError.ArgumentInvalidValue;
+            }
+            @compileError("Unsupported argument type: " ++ @typeName(T) ++
+                " — a struct/union field must declare `pub fn parse(s: []const u8) !@This()`");
         },
         else => {
             @compileError("Unsupported argument type: " ++ @typeName(T));

--- a/packages/core/src/custom_type.zig
+++ b/packages/core/src/custom_type.zig
@@ -1,0 +1,117 @@
+//! Custom parse types (ADR-0024, increment 2).
+//!
+//! A field type is *custom-parsed* when — after unwrapping one optional level —
+//! it is a struct declaring `pub fn parse(s: []const u8) E!@This()`. The field
+//! then holds the user's own domain type (a `Duration`, `Port`, `Email`), built
+//! from the argument string by its own `parse`, which validates as it constructs.
+//!
+//! Optional companions on the type:
+//!   - `pub const hint: []const u8` — the "Expected …" phrase / help placeholder.
+//!   - `pub fn describe(err) []const u8` — a humane message per failure variant.
+//!
+//! Every value source (CLI, env, config) constructs the type the same way, so the
+//! parse sites and the config deserializer all route through `parse`. A parse
+//! failure is reported as an ordinary invalid-value error (reusing the #206
+//! `OptionInvalidValue`/`ArgumentInvalidValue` diagnostics), showing `describe`'s
+//! reason when present, else the hint.
+
+const std = @import("std");
+
+/// One optional level removed; identity otherwise. The value a `parse` produces
+/// and a `validate` hook sees.
+pub fn Base(comptime T: type) type {
+    return switch (@typeInfo(T)) {
+        .optional => |o| o.child,
+        else => T,
+    };
+}
+
+/// Whether `T` (or its optional child) is a struct declaring `pub fn parse`.
+/// Kept lenient — the exact signature is checked by `assertValidParse` at the
+/// parse site so a mistake is a clear message, not a cryptic call error.
+pub fn isCustomParsed(comptime T: type) bool {
+    const B = Base(T);
+    return switch (@typeInfo(B)) {
+        .@"struct", .@"union", .@"enum" => @hasDecl(B, "parse"),
+        else => false,
+    };
+}
+
+/// Comptime contract check for a custom-parse type, with friendly errors.
+pub fn assertValidParse(comptime T: type) void {
+    const B = Base(T);
+    const name = @typeName(B);
+    const info = @typeInfo(@TypeOf(B.parse));
+    if (info != .@"fn") @compileError("`" ++ name ++ ".parse` must be a function `fn(s: []const u8) !" ++ name ++ "`");
+    const f = info.@"fn";
+    if (f.params.len != 1 or (f.params[0].type orelse void) != []const u8)
+        @compileError("`" ++ name ++ ".parse` must take a single `[]const u8`, e.g. `fn(s: []const u8) !" ++ name ++ "`");
+    const ret = f.return_type orelse @compileError("`" ++ name ++ ".parse` must return `!" ++ name ++ "`");
+    const ret_info = @typeInfo(ret);
+    if (ret_info != .error_union or ret_info.error_union.payload != B)
+        @compileError("`" ++ name ++ ".parse` must return an error union yielding `" ++ name ++ "` (e.g. `error{ … }!" ++ name ++ "`)");
+}
+
+/// The "Expected …" phrase for a custom type: its `pub const hint` if declared,
+/// else the bare type name.
+pub fn hintFor(comptime T: type) []const u8 {
+    const B = Base(T);
+    if (@hasDecl(B, "hint")) return B.hint;
+    return @typeName(B);
+}
+
+/// On the error path, the humane reason for why `value` failed to parse as the
+/// custom type — from `pub fn describe` if declared, else null (the caller then
+/// falls back to the hint). Re-parses to recover the typed error; `parse` is a
+/// pure string→value function, so this is deterministic and only runs on failure.
+pub fn describeError(comptime T: type, value: []const u8) ?[]const u8 {
+    const B = Base(T);
+    if (comptime isCustomParsed(T) and @hasDecl(B, "describe")) {
+        _ = B.parse(value) catch |e| return B.describe(e);
+    }
+    return null;
+}
+
+test "isCustomParsed detects a struct with parse, through optionals" {
+    const Port = struct {
+        value: u16,
+        pub fn parse(s: []const u8) error{Bad}!@This() {
+            return .{ .value = std.fmt.parseInt(u16, s, 10) catch return error.Bad };
+        }
+    };
+    try std.testing.expect(isCustomParsed(Port));
+    try std.testing.expect(isCustomParsed(?Port));
+    try std.testing.expect(!isCustomParsed(u16));
+    try std.testing.expect(!isCustomParsed([]const u8));
+    try std.testing.expect(!isCustomParsed(struct { x: u8 }));
+}
+
+test "hintFor prefers a declared hint" {
+    const WithHint = struct {
+        v: u8,
+        pub const hint = "a small number";
+        pub fn parse(s: []const u8) error{Bad}!@This() {
+            return .{ .v = std.fmt.parseInt(u8, s, 10) catch return error.Bad };
+        }
+    };
+    try std.testing.expectEqualStrings("a small number", hintFor(WithHint));
+    try std.testing.expectEqualStrings("a small number", hintFor(?WithHint));
+}
+
+test "describeError maps the failure variant when describe is present" {
+    const Dur = struct {
+        secs: u64,
+        pub fn parse(s: []const u8) error{ Empty, Bad }!@This() {
+            if (s.len == 0) return error.Empty;
+            return .{ .secs = std.fmt.parseInt(u64, s, 10) catch return error.Bad };
+        }
+        pub fn describe(err: error{ Empty, Bad }) []const u8 {
+            return switch (err) {
+                error.Empty => "must not be empty",
+                error.Bad => "expected a whole number of seconds",
+            };
+        }
+    };
+    try std.testing.expectEqualStrings("expected a whole number of seconds", describeError(Dur, "xyz").?);
+    try std.testing.expect(describeError(Dur, "10") == null); // parses fine → no reason
+}

--- a/packages/core/src/diagnostic_errors.zig
+++ b/packages/core/src/diagnostic_errors.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const levenshtein = @import("levenshtein.zig");
+const custom_type = @import("custom_type.zig");
 
 pub const ZcliError = error{
     // Argument parsing errors
@@ -56,6 +57,9 @@ pub const ZcliDiagnostic = union(enum) {
         /// Nearest valid choice for a mistyped enum value ("did you mean … ?"),
         /// or null. A comptime variant name with static lifetime — never freed.
         suggestion: ?[]const u8 = null,
+        /// A custom type's `describe(err)` reason for why parsing failed, or null.
+        /// When set it replaces the "Expected …" clause (and any suggestion).
+        reason: ?[]const u8 = null,
     },
     ArgumentTooMany: struct {
         expected_count: usize,
@@ -91,6 +95,9 @@ pub const ZcliDiagnostic = union(enum) {
         /// Nearest valid choice for a mistyped enum value ("did you mean … ?"),
         /// or null. A comptime variant name with static lifetime — never freed.
         suggestion: ?[]const u8 = null,
+        /// A custom type's `describe(err)` reason for why parsing failed, or null.
+        /// When set it replaces the "Expected …" clause (and any suggestion).
+        reason: ?[]const u8 = null,
     },
     OptionBooleanWithValue: struct {
         option_name: []const u8,
@@ -225,6 +232,8 @@ pub fn expectedTypeName(comptime T: type) []const u8 {
         .optional => |o| o.child,
         else => T,
     };
+    // A custom type describes its own expectation via `hint` (else its type name).
+    if (comptime custom_type.isCustomParsed(Bare)) return custom_type.hintFor(Bare);
     return switch (@typeInfo(Bare)) {
         .@"enum" => |e| comptime blk: {
             var list: []const u8 = "one of: ";
@@ -300,6 +309,11 @@ fn humanType(type_name: []const u8) []const u8 {
         'f' => if (bare.len > 1 and allDigits(bare[1..])) return "a number",
         else => {},
     }
+    // A custom-type `hint` is author-written text — a plain phrase (has a space,
+    // no brackets/dots of a raw type name). Pass it through verbatim; anything
+    // else (a qualified or unusual type name) becomes the generic phrase.
+    if (std.mem.indexOfScalar(u8, type_name, ' ') != null and
+        std.mem.indexOfAny(u8, type_name, "[].") == null) return type_name;
     return "a value";
 }
 
@@ -307,7 +321,9 @@ fn humanType(type_name: []const u8) []const u8 {
 pub fn formatDiagnostic(diagnostic: ZcliDiagnostic, allocator: std.mem.Allocator) ![]u8 {
     return switch (diagnostic) {
         .ArgumentMissingRequired => |ctx| std.fmt.allocPrint(allocator, "Missing required argument '{s}' at position {d}. Expected {s}.", .{ ctx.field_name, ctx.position + 1, humanType(ctx.expected_type) }),
-        .ArgumentInvalidValue => |ctx| if (ctx.suggestion) |s|
+        .ArgumentInvalidValue => |ctx| if (ctx.reason) |r|
+            std.fmt.allocPrint(allocator, "Invalid value '{s}' for argument '{s}' at position {d}: {s}.", .{ ctx.provided_value, ctx.field_name, ctx.position + 1, r })
+        else if (ctx.suggestion) |s|
             std.fmt.allocPrint(allocator, "Invalid value '{s}' for argument '{s}' at position {d}. Expected {s}. Did you mean '{s}'?", .{ ctx.provided_value, ctx.field_name, ctx.position + 1, humanType(ctx.expected_type), s })
         else
             std.fmt.allocPrint(allocator, "Invalid value '{s}' for argument '{s}' at position {d}. Expected {s}.", .{ ctx.provided_value, ctx.field_name, ctx.position + 1, humanType(ctx.expected_type) }),
@@ -333,7 +349,9 @@ pub fn formatDiagnostic(diagnostic: ZcliDiagnostic, allocator: std.mem.Allocator
             }
         },
         .OptionMissingValue => |ctx| std.fmt.allocPrint(allocator, "Option '{s}{s}' requires {s}.", .{ if (ctx.is_short) "-" else "--", ctx.option_name, humanType(ctx.expected_type) }),
-        .OptionInvalidValue => |ctx| if (ctx.suggestion) |s|
+        .OptionInvalidValue => |ctx| if (ctx.reason) |r|
+            std.fmt.allocPrint(allocator, "Invalid value '{s}' for option '{s}{s}': {s}.", .{ ctx.provided_value, if (ctx.is_short) "-" else "--", ctx.option_name, r })
+        else if (ctx.suggestion) |s|
             std.fmt.allocPrint(allocator, "Invalid value '{s}' for option '{s}{s}'. Expected {s}. Did you mean '{s}'?", .{ ctx.provided_value, if (ctx.is_short) "-" else "--", ctx.option_name, humanType(ctx.expected_type), s })
         else
             std.fmt.allocPrint(allocator, "Invalid value '{s}' for option '{s}{s}'. Expected {s}.", .{ ctx.provided_value, if (ctx.is_short) "-" else "--", ctx.option_name, humanType(ctx.expected_type) }),
@@ -514,6 +532,47 @@ test "ArgumentValidationFailed renders the field, 1-based position, and reason" 
     const msg = try formatDiagnostic(diag, allocator);
     defer allocator.free(msg);
     try std.testing.expectEqualStrings("Invalid value '99' for argument 'count' at position 2: must be 10 or less.", msg);
+}
+
+test "expectedTypeName uses a custom type's hint" {
+    const Dur = struct {
+        secs: u64,
+        pub const hint = "a duration like 5m30s";
+        pub fn parse(s: []const u8) error{Bad}!@This() {
+            return .{ .secs = std.fmt.parseInt(u64, s, 10) catch return error.Bad };
+        }
+    };
+    try std.testing.expectEqualStrings("a duration like 5m30s", expectedTypeName(Dur));
+    try std.testing.expectEqualStrings("a duration like 5m30s", expectedTypeName(?Dur));
+}
+
+test "OptionInvalidValue renders a custom type's describe reason, else its hint" {
+    const allocator = std.testing.allocator;
+    // With a describe reason: shown after the colon, no "Expected" clause.
+    {
+        const diag = ZcliDiagnostic{ .OptionInvalidValue = .{
+            .option_name = "timeout",
+            .is_short = false,
+            .provided_value = "25h",
+            .expected_type = "a duration",
+            .reason = "hours must be less than 24",
+        } };
+        const msg = try formatDiagnostic(diag, allocator);
+        defer allocator.free(msg);
+        try std.testing.expectEqualStrings("Invalid value '25h' for option '--timeout': hours must be less than 24.", msg);
+    }
+    // Without a reason, the hint (a phrase) passes through humanType verbatim.
+    {
+        const diag = ZcliDiagnostic{ .OptionInvalidValue = .{
+            .option_name = "timeout",
+            .is_short = false,
+            .provided_value = "nope",
+            .expected_type = "a duration like 5m30s",
+        } };
+        const msg = try formatDiagnostic(diag, allocator);
+        defer allocator.free(msg);
+        try std.testing.expectEqualStrings("Invalid value 'nope' for option '--timeout'. Expected a duration like 5m30s.", msg);
+    }
 }
 
 test "OptionValidationFailed renders the flag and the author's reason" {

--- a/packages/core/src/options/parser.zig
+++ b/packages/core/src/options/parser.zig
@@ -5,6 +5,7 @@ const array_utils = @import("array_utils.zig");
 const logging = @import("../logging.zig");
 const args_parser = @import("../args.zig");
 const diagnostic_errors = @import("../diagnostic_errors.zig");
+const custom_type = @import("../custom_type.zig");
 const type_utils = @import("../type_utils.zig");
 const levenshtein = @import("../levenshtein.zig");
 const ZcliError = diagnostic_errors.ZcliError;
@@ -418,6 +419,14 @@ fn applyEnvValue(comptime T: type, target: *T, env_value: []const u8) bool {
         return true;
     }
 
+    // Custom type: construct from the env string via `pub fn parse`, the same
+    // path a CLI value takes. A value that doesn't parse is ignored (default
+    // kept), matching how env handles every other unparseable value.
+    if (comptime custom_type.isCustomParsed(T)) {
+        target.* = T.parse(env_value) catch return false;
+        return true;
+    }
+
     // Unsupported type (accumulating arrays, etc.)
     return false;
 }
@@ -562,6 +571,7 @@ fn parseLongOptions(
                         .provided_value = value,
                         .expected_type = diagnostic_errors.expectedTypeName(field.type),
                         .suggestion = diagnostic_errors.nearestEnumValue(field.type, value),
+                        .reason = custom_type.describeError(field.type, value),
                     } };
                     return err;
                 };
@@ -748,6 +758,7 @@ fn parseShortOptionsWithMeta(
                                 .provided_value = value,
                                 .expected_type = diagnostic_errors.expectedTypeName(field.type),
                                 .suggestion = diagnostic_errors.nearestEnumValue(field.type, value),
+                                .reason = custom_type.describeError(field.type, value),
                             } };
                             return err;
                         };
@@ -1717,6 +1728,25 @@ test "applyEnvValue numeric, optional, and enum types" {
     try std.testing.expect(applyEnvValue(Mode, &mode, "fast"));
     try std.testing.expectEqual(Mode.fast, mode);
     try std.testing.expect(!applyEnvValue(Mode, &mode, "warp"));
+}
+
+test "applyEnvValue builds a custom type, and keeps the default when it won't parse" {
+    const Port = struct {
+        value: u16,
+        pub fn parse(s: []const u8) error{Bad}!@This() {
+            const n = std.fmt.parseInt(u16, s, 10) catch return error.Bad;
+            if (n == 0) return error.Bad;
+            return .{ .value = n };
+        }
+    };
+    var port: ?Port = null;
+    try std.testing.expect(applyEnvValue(?Port, &port, "8080"));
+    try std.testing.expectEqual(@as(u16, 8080), port.?.value);
+    // Unparseable env value is ignored — the default (null) stays, matching how
+    // env treats every other type. No invalid value is ever injected.
+    port = null;
+    try std.testing.expect(!applyEnvValue(?Port, &port, "0"));
+    try std.testing.expect(port == null);
 }
 
 test "diagnostics: option error sites fill precise context" {

--- a/packages/core/src/options/utils.zig
+++ b/packages/core/src/options/utils.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const types = @import("types.zig");
 const logging = @import("../logging.zig");
+const custom_type = @import("../custom_type.zig");
 
 /// Convert dashes to underscores in option names
 pub fn dashesToUnderscores(buf: []u8, input: []const u8) ![]const u8 {
@@ -289,6 +290,18 @@ pub fn parseOptionValue(comptime T: type, value: []const u8) !T {
         .optional => |opt_info| {
             return try parseOptionValue(opt_info.child, value);
         },
+        .@"struct", .@"union" => {
+            // A custom type constructs itself from the string via `pub fn parse`.
+            // Its specific error is collapsed to the canonical InvalidOptionValue
+            // (so it classifies as a reported CLI error); the humane reason is
+            // recovered by `custom_type.describeError` at the diagnostic site.
+            if (comptime custom_type.isCustomParsed(T)) {
+                custom_type.assertValidParse(T);
+                return T.parse(value) catch return error.InvalidOptionValue;
+            }
+            @compileError("Unsupported option type: " ++ @typeName(T) ++
+                " — a struct/union field must declare `pub fn parse(s: []const u8) !@This()`");
+        },
         else => {
             @compileError("Unsupported option type: " ++ @typeName(T));
         },
@@ -542,6 +555,25 @@ test "parseOptionValue optional types" {
 
     const value2 = try parseOptionValue(?[]const u8, "test");
     try std.testing.expectEqualStrings("test", value2.?);
+}
+
+test "parseOptionValue builds a custom type via its parse" {
+    const Port = struct {
+        value: u16,
+        pub const hint = "a port (1-65535)";
+        pub fn parse(s: []const u8) error{ Empty, Range }!@This() {
+            if (s.len == 0) return error.Empty;
+            const n = std.fmt.parseInt(u16, s, 10) catch return error.Range;
+            if (n == 0) return error.Range;
+            return .{ .value = n };
+        }
+    };
+    try std.testing.expectEqual(@as(u16, 8080), (try parseOptionValue(Port, "8080")).value);
+    // Optional wrapper parses through to the base type.
+    try std.testing.expectEqual(@as(u16, 443), (try parseOptionValue(?Port, "443")).?.value);
+    // Any parse failure collapses to the canonical InvalidOptionValue.
+    try std.testing.expectError(error.InvalidOptionValue, parseOptionValue(Port, "0"));
+    try std.testing.expectError(error.InvalidOptionValue, parseOptionValue(Port, "xyz"));
 }
 
 test "isBooleanType function" {

--- a/packages/core/src/plugins/zcli_config/plugin.zig
+++ b/packages/core/src/plugins/zcli_config/plugin.zig
@@ -165,6 +165,15 @@ fn applyJsonObject(comptime OptionsType: type, options: *OptionsType, obj: std.j
                     if (value == .integer) @field(options, field.name) = @intCast(value.integer);
                 } else if (field.type == ?bool) {
                     if (value == .bool) @field(options, field.name) = value.bool;
+                } else if (comptime zcli.custom_type.isCustomParsed(field.type)) {
+                    // A custom type is written as a string in config; build it via
+                    // its own `parse`, the same path CLI/env take. Unparseable →
+                    // leave the default (config is best-effort here).
+                    if (value == .string) {
+                        if (zcli.custom_type.Base(field.type).parse(value.string)) |v| {
+                            @field(options, field.name) = v;
+                        } else |_| {}
+                    }
                 }
             }
         }
@@ -263,6 +272,15 @@ fn applyDynamicMap(comptime OptionsType: type, options: *OptionsType, map: anyty
                     if (value == .integer) @field(options, field.name) = @intCast(value.integer);
                 } else if (field.type == ?bool) {
                     if (value == .boolean) @field(options, field.name) = value.boolean;
+                } else if (comptime zcli.custom_type.isCustomParsed(field.type)) {
+                    // A custom type is written as a string in config; build it via
+                    // its own `parse`, the same path CLI/env take. Unparseable →
+                    // leave the default (config is best-effort here).
+                    if (value == .string) {
+                        if (zcli.custom_type.Base(field.type).parse(value.string)) |v| {
+                            @field(options, field.name) = v;
+                        } else |_| {}
+                    }
                 }
             }
         }

--- a/packages/core/src/zcli.zig
+++ b/packages/core/src/zcli.zig
@@ -70,6 +70,12 @@ pub const http = @import("http.zig");
 /// tree without building it (e.g. the `zcli tree` command).
 pub const command_discovery = @import("build_utils/command_discovery.zig");
 
+/// Custom parse-type helpers (ADR-0024): detection and construction for fields
+/// whose type declares `pub fn parse`. Exposed so the config plugin — which may
+/// import only "zcli" — can build such a field from a config string the same way
+/// the CLI parser does.
+pub const custom_type = @import("custom_type.zig");
+
 const testing = std.testing;
 
 // Re-export error types


### PR DESCRIPTION
## What

Increment 2 of ADR-0024 (the follow-up to per-field `validate`, #227). A field whose type declares `pub fn parse` builds itself from the argument string — for inputs that don't map to a native scalar:

```zig
const Duration = struct {
    secs: u64,
    pub const hint = "a duration like 5m30s";
    pub fn parse(s: []const u8) error{ BadFormat, TooLong }!Duration { … }
    pub fn describe(err: error{ BadFormat, TooLong }) []const u8 {
        return switch (err) {
            error.BadFormat => "use a form like 5m30s",
            error.TooLong => "must be under an hour",
        };
    }
};

pub const Options = struct { timeout: Duration = .{ .secs = 30 } };
```

`validate` refines a value of an existing type; a custom type *is* the value and owns how it's built, so `execute` receives it **valid by construction**.

## How

- **Detection/construction** in a new `custom_type.zig` (`isCustomParsed`, `Base`, `hintFor`, `describeError`), re-exported as `zcli.custom_type` so the config plugin (imports only `"zcli"`) can build a custom-typed field too.
- **Every source constructs the same way:** CLI (`parseOptionValue`, args `parseValue`), env (`applyEnvValue`), and config (when the value is a string). env/config stay lenient — an unparseable value is ignored and the default stays — so no source can inject an *invalid* value.
- **Diagnostics reuse** `OptionInvalidValue`/`ArgumentInvalidValue` (added a `reason` field): the type's specific error collapses to the canonical reported error (clean exit), while the humane reason is `describe(err)` when present, else the type's `hint`. `expectedTypeName` returns the hint. We never render `@errorName`.

Contract: `pub fn parse(s: []const u8) E!@This()` — an error union (idiomatic Zig, composes with `try`), signature-checked at comptime. Optional `pub const hint` and `pub fn describe(err)`.

## Tests

- Unit: `custom_type` helpers; `parseOptionValue`/`applyEnvValue` construction + lenient failure; `expectedTypeName` hint; `OptionInvalidValue` reason-vs-hint rendering.
- E2E (verified locally, reverted): a `Limit` custom type on `notes list` — `--limit 5` → parsed; `--limit 0` → `must be at least 1`; `--limit abc` → `must be a whole number` (both `describe` variants, clean exit 1); `NOTES_LIMIT=7` → built from env; `NOTES_LIMIT=0` → leniently ignored; no Zig type name leaks in help.
- `zig build test` green across all 8 packages + examples + `projects/zcli`.

## Note (not from this PR)

`main` has an ADR-number collision: both `0024-field-validation-and-custom-parse-types.md` (#227) and `0024-multi-value-options.md` (#226) landed as 0024. This PR only updates the existing field-validation ADR, so it doesn't add to it — flagging for a possible renumber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)