### PR TITLE
fix(not_found,version): suggestion guard, --version onError, behavioral tests

### DIFF
--- a/packages/core/src/levenshtein.zig
+++ b/packages/core/src/levenshtein.zig
@@ -60,56 +60,6 @@ pub fn editDistance(a: []const u8, b: []const u8) usize {
     return prev_row[shorter_len];
 }
 
-/// Find commands similar to the input using edit distance
-pub fn findSimilarCommands(input: []const u8, candidates: []const []const u8, allocator: std.mem.Allocator) ![][]const u8 {
-    var suggestions = std.ArrayList([]const u8).empty;
-    defer suggestions.deinit(allocator);
-
-    for (candidates) |candidate| {
-        const distance = editDistance(input, candidate);
-
-        // Only suggest if the edit distance is reasonable
-        if (distance <= 3 and distance < input.len) {
-            try suggestions.append(allocator, candidate);
-        }
-    }
-
-    return suggestions.toOwnedSlice(allocator);
-}
-
-/// Find similar commands with configurable threshold and max suggestions
-pub fn findSimilarCommandsWithConfig(input: []const u8, candidates: []const []const u8, allocator: std.mem.Allocator, max_distance: usize, max_suggestions: usize) ![][]const u8 {
-    var suggestions_with_distance = std.ArrayList(struct { command: []const u8, distance: usize }).empty;
-    defer suggestions_with_distance.deinit(allocator);
-
-    for (candidates) |candidate| {
-        const distance = editDistance(input, candidate);
-
-        // Only suggest if the edit distance is within threshold
-        if (distance <= max_distance and distance < input.len) {
-            try suggestions_with_distance.append(allocator, .{ .command = candidate, .distance = distance });
-        }
-    }
-
-    // Sort by distance (closest matches first)
-    std.mem.sort(@TypeOf(suggestions_with_distance.items[0]), suggestions_with_distance.items, {}, struct {
-        fn lessThan(_: void, a: @TypeOf(suggestions_with_distance.items[0]), b: @TypeOf(suggestions_with_distance.items[0])) bool {
-            return a.distance < b.distance;
-        }
-    }.lessThan);
-
-    // Extract just the command names, limited to max_suggestions
-    var result = std.ArrayList([]const u8).empty;
-    defer result.deinit(allocator);
-
-    const limit = @min(max_suggestions, suggestions_with_distance.items.len);
-    for (suggestions_with_distance.items[0..limit]) |item| {
-        try result.append(allocator, item.command);
-    }
-
-    return result.toOwnedSlice(allocator);
-}
-
 // Tests
 test "editDistance basic" {
     try std.testing.expectEqual(@as(usize, 0), editDistance("hello", "hello"));
@@ -117,32 +67,6 @@ test "editDistance basic" {
     try std.testing.expectEqual(@as(usize, 1), editDistance("hello", "helloo"));
     try std.testing.expectEqual(@as(usize, 2), editDistance("hello", "bell"));
     try std.testing.expectEqual(@as(usize, 4), editDistance("hello", "world"));
-}
-
-test "findSimilarCommands basic" {
-    const commands = [_][]const u8{ "list", "search", "create", "delete", "status" };
-
-    const suggestions = findSimilarCommands("serach", &commands, std.testing.allocator) catch &[_][]const u8{};
-    defer if (suggestions.len > 0) std.testing.allocator.free(suggestions);
-    try std.testing.expect(suggestions.len > 0);
-    try std.testing.expectEqualStrings("search", suggestions[0]);
-}
-
-test "findSimilarCommandsWithConfig" {
-    const commands = [_][]const u8{ "list", "search", "create", "delete", "status", "start" };
-
-    const suggestions = try findSimilarCommandsWithConfig("stat", &commands, std.testing.allocator, 2, 3);
-    defer std.testing.allocator.free(suggestions);
-
-    try std.testing.expect(suggestions.len > 0);
-    // Should find "status" and "start" as similar to "stat"
-    var found_status = false;
-    var found_start = false;
-    for (suggestions) |suggestion| {
-        if (std.mem.eql(u8, suggestion, "status")) found_status = true;
-        if (std.mem.eql(u8, suggestion, "start")) found_start = true;
-    }
-    try std.testing.expect(found_status or found_start);
 }
 
 test "editDistance edge cases" {

--- a/packages/core/src/plugin_pipeline_test.zig
+++ b/packages/core/src/plugin_pipeline_test.zig
@@ -18,6 +18,11 @@ const std = @import("std");
 const zcli = @import("zcli");
 const testing = std.testing;
 
+// The real plugins under test, imported by source so the behavioral tests below
+// exercise the shipped code, not a re-implementation.
+const NotFound = @import("plugins/zcli_not_found/plugin.zig");
+const Version = @import("plugins/zcli_version/plugin.zig");
+
 // ---------------------------------------------------------------------------
 // Test harness
 // ---------------------------------------------------------------------------
@@ -63,6 +68,48 @@ fn run(comptime App: type, argv: []const []const u8) !void {
     stdio.stdout_override = &out_aw.writer;
     stdio.stderr_override = &err_aw.writer;
     try app.executeWithStdio(testing.allocator, std.testing.io, &environ, argv, &stdio);
+}
+
+/// Like `run`, but returns the captured stdout and stderr (arena-freed by the
+/// caller). Also reports whether the invocation errored, so tests can assert
+/// both the output and the propagation behavior in one call.
+const Captured = struct {
+    stdout: []const u8,
+    stderr: []const u8,
+    err: ?anyerror,
+
+    fn deinit(self: Captured, allocator: std.mem.Allocator) void {
+        allocator.free(self.stdout);
+        allocator.free(self.stderr);
+    }
+};
+
+fn runCapture(comptime App: type, argv: []const []const u8) !Captured {
+    var app = App.init();
+    const environ = std.process.Environ.Map.init(testing.allocator);
+    var out_aw = std.Io.Writer.Allocating.init(testing.allocator);
+    defer out_aw.deinit();
+    var err_aw = std.Io.Writer.Allocating.init(testing.allocator);
+    defer err_aw.deinit();
+    var stdio: zcli.Stdio = undefined;
+    stdio.init(std.testing.io);
+    stdio.stdout_override = &out_aw.writer;
+    stdio.stderr_override = &err_aw.writer;
+
+    const maybe_err: ?anyerror = blk: {
+        app.executeWithStdio(testing.allocator, std.testing.io, &environ, argv, &stdio) catch |e| break :blk e;
+        break :blk null;
+    };
+
+    return .{
+        .stdout = try testing.allocator.dupe(u8, out_aw.written()),
+        .stderr = try testing.allocator.dupe(u8, err_aw.written()),
+        .err = maybe_err,
+    };
+}
+
+fn contains(haystack: []const u8, needle: []const u8) bool {
+    return std.mem.indexOf(u8, haystack, needle) != null;
 }
 
 const test_config = zcli.Config{
@@ -738,4 +785,250 @@ test "pipeline security: an oversized argument vector does not crash the pipelin
     // Echo wants a single positional, so this errors — but it must not panic,
     // leak, or corrupt state while scanning thousands of args.
     run(App, args.items) catch {};
+}
+
+// ===========================================================================
+// zcli_version behavioral tests (the real plugin, in a real registry)
+// ===========================================================================
+
+test "version: --version prints '<name> v<version>' and skips the command" {
+    const App = zcli.Registry.init(test_config)
+        .register("greet", Greet)
+        .registerPlugin(Version)
+        .build();
+
+    Greet.executed = false;
+    const cap = try runCapture(App, &.{ "--version", "greet" });
+    defer cap.deinit(testing.allocator);
+
+    try testing.expect(cap.err == null);
+    try testing.expect(!Greet.executed); // preExecute cancels before the command runs
+    try testing.expectEqualStrings("test v1.0.0\n", cap.stdout);
+}
+
+test "version: -V short flag works too" {
+    const App = zcli.Registry.init(test_config)
+        .register("greet", Greet)
+        .registerPlugin(Version)
+        .build();
+
+    Greet.executed = false;
+    const cap = try runCapture(App, &.{"-V"});
+    defer cap.deinit(testing.allocator);
+
+    try testing.expect(cap.err == null);
+    try testing.expect(contains(cap.stdout, "test v1.0.0"));
+}
+
+test "version: --version with a valid command still shows the version" {
+    const App = zcli.Registry.init(test_config)
+        .register("greet", Greet)
+        .registerPlugin(Version)
+        .build();
+
+    Greet.executed = false;
+    const cap = try runCapture(App, &.{ "greet", "--version" });
+    defer cap.deinit(testing.allocator);
+
+    try testing.expect(cap.err == null);
+    try testing.expect(!Greet.executed);
+    try testing.expect(contains(cap.stdout, "test v1.0.0"));
+}
+
+test "version: --version on a bogus command shows the version via onError (regression: was 'command not found')" {
+    const App = zcli.Registry.init(test_config)
+        .register("greet", Greet)
+        .registerPlugin(Version)
+        .build();
+
+    const cap = try runCapture(App, &.{ "--version", "does-not-exist" });
+    defer cap.deinit(testing.allocator);
+
+    // onError caught CommandNotFound, printed the version, and suppressed the
+    // error — the user gets what they asked for, not a not-found message.
+    try testing.expect(cap.err == null);
+    try testing.expect(contains(cap.stdout, "test v1.0.0"));
+    try testing.expect(!contains(cap.stderr, "Unknown command"));
+}
+
+test "version: declares priority 90 so a higher-priority plugin's preExecute wins" {
+    // The priority mechanism orders EVERY dispatched hook highest-first (see the
+    // "descending priority order" test above). Version sits at 90 so that when
+    // help (priority 100, added on help's own branch) also fires for
+    // `--help --version`, help's preExecute cancels first and the version line
+    // never prints. We can't register the real Help here (its priority isn't 100
+    // on this branch), so assert the value directly and prove the ordering with
+    // a stand-in higher-priority cancel plugin.
+    try testing.expectEqual(@as(i32, 90), Version.priority);
+
+    const App = zcli.Registry.init(test_config)
+        .register("greet", Greet)
+        .registerPlugin(Version)
+        .registerPlugin(OrderPlugin("cancel", 100)) // a 100-priority preExecute
+        .build();
+
+    // OrderPlugin records but returns the args unchanged, so version still runs;
+    // the point is the *order*: the 100-priority hook is consulted before
+    // version's 90-priority preExecute.
+    Trace.reset();
+    const cap = try runCapture(App, &.{ "--version", "greet" });
+    defer cap.deinit(testing.allocator);
+    try testing.expect(cap.err == null);
+    // The 100-priority plugin ran (its preExecute fired before version's).
+    try testing.expect(Trace.len >= 1);
+    try testing.expectEqualStrings("cancel", Trace.events[0]);
+}
+
+// ===========================================================================
+// zcli_not_found behavioral tests (the real plugin, WITHOUT help so the plugin
+// must be self-contained across all three CommandNotFound origins)
+// ===========================================================================
+
+const Init = struct {
+    pub const meta = .{ .description = "init" };
+    pub const Args = struct {};
+    pub const Options = struct {};
+    pub fn execute(_: Args, _: Options, _: anytype) !void {}
+};
+
+const Run = struct {
+    pub const meta = .{ .description = "run" };
+    pub const Args = struct {};
+    pub const Options = struct {};
+    pub fn execute(_: Args, _: Options, _: anytype) !void {}
+};
+
+/// A metadata-only group with two subcommands, for the bare-group origin.
+const RemoteProvider = struct {
+    pub const commands = struct {
+        pub const remote = struct {
+            pub const meta = .{ .description = "manage remotes" };
+            pub const add = struct {
+                pub const meta = .{ .description = "add a remote" };
+                pub const Args = struct { name: []const u8 };
+                pub const Options = struct {};
+                pub fn execute(_: Args, _: Options, _: anytype) !void {}
+            };
+            pub const remove = struct {
+                pub const meta = .{ .description = "remove a remote" };
+                pub const Args = struct { name: []const u8 };
+                pub const Options = struct {};
+                pub fn execute(_: Args, _: Options, _: anytype) !void {}
+            };
+        };
+    };
+};
+
+test "not_found: an unknown command reports it and suggests the closest match" {
+    const App = zcli.Registry.init(test_config)
+        .register("search", Greet)
+        .register("status", Checkout)
+        .registerPlugin(NotFound)
+        .build();
+
+    // "serach" is one transposition from "search".
+    const cap = try runCapture(App, &.{"serach"});
+    defer cap.deinit(testing.allocator);
+
+    // The error propagates (not_found returns false on the genuine-unknown path).
+    try testing.expectEqual(@as(?anyerror, error.CommandNotFound), cap.err);
+    try testing.expect(contains(cap.stderr, "Unknown command 'serach'"));
+    try testing.expect(contains(cap.stderr, "Did you mean 'search'?"));
+}
+
+test "not_found: multiple close matches list several suggestions" {
+    const App = zcli.Registry.init(test_config)
+        .register("start", Greet)
+        .register("status", Checkout)
+        .registerPlugin(NotFound)
+        .build();
+
+    // "stat" is within distance 3 of both "start" and "status" (and < input.len).
+    const cap = try runCapture(App, &.{"stat"});
+    defer cap.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(?anyerror, error.CommandNotFound), cap.err);
+    try testing.expect(contains(cap.stderr, "Did you mean one of these?"));
+    try testing.expect(contains(cap.stderr, "start"));
+    try testing.expect(contains(cap.stderr, "status"));
+}
+
+test "not_found: a short input offers no suggestions (guard against noise)" {
+    const App = zcli.Registry.init(test_config)
+        .register("init", Init)
+        .register("run", Run)
+        .registerPlugin(NotFound)
+        .build();
+
+    // "i" is distance 3 from both "init" and "run"; the length guard rejects
+    // both, so there is no "Did you mean" line at all.
+    const cap = try runCapture(App, &.{"i"});
+    defer cap.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(?anyerror, error.CommandNotFound), cap.err);
+    try testing.expect(contains(cap.stderr, "Unknown command 'i'"));
+    try testing.expect(!contains(cap.stderr, "Did you mean"));
+}
+
+test "not_found: nothing close offers no suggestions but still lists commands" {
+    const App = zcli.Registry.init(test_config)
+        .register("search", Greet)
+        .registerPlugin(NotFound)
+        .build();
+
+    const cap = try runCapture(App, &.{"zzzzzzzz"});
+    defer cap.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(?anyerror, error.CommandNotFound), cap.err);
+    try testing.expect(contains(cap.stderr, "Unknown command 'zzzzzzzz'"));
+    try testing.expect(!contains(cap.stderr, "Did you mean"));
+    try testing.expect(contains(cap.stderr, "Available commands:"));
+    try testing.expect(contains(cap.stderr, "search"));
+}
+
+test "not_found (self-contained): a bare command group lists its subcommands, no double output" {
+    const App = zcli.Registry.init(test_config)
+        .registerPlugin(NotFound)
+        .registerPlugin(RemoteProvider)
+        .build();
+
+    // "remote" is a real group — not a typo. Accessing it bare must show its
+    // subcommands and suppress the registry's own "'remote' is a command group"
+    // line (the not_found plugin returns true), so it appears exactly once.
+    const cap = try runCapture(App, &.{"remote"});
+    defer cap.deinit(testing.allocator);
+
+    try testing.expect(cap.err == null); // handled -> suppressed
+    try testing.expect(contains(cap.stderr, "'remote' is a command group"));
+    try testing.expect(contains(cap.stderr, "add"));
+    try testing.expect(contains(cap.stderr, "remove"));
+    // Not a typo, so no suggestions and no "Unknown command" framing.
+    try testing.expect(!contains(cap.stderr, "Unknown command"));
+    try testing.expect(!contains(cap.stderr, "Did you mean"));
+    // The registry's own group line ("Use --help to see available subcommands")
+    // must not appear on top of ours.
+    try testing.expect(!contains(cap.stderr, "Use --help to see available subcommands"));
+}
+
+test "not_found (self-contained): no command at all lists commands, no bare fallback" {
+    const App = zcli.Registry.init(test_config)
+        .register("search", Greet)
+        .register("status", Checkout)
+        .registerPlugin(NotFound)
+        .build();
+
+    // Empty argv -> no command, no root. not_found renders the command list and
+    // suppresses the registry's bare "No command specified. Use --help..." line.
+    const cap = try runCapture(App, &.{});
+    defer cap.deinit(testing.allocator);
+
+    try testing.expect(cap.err == null); // handled -> suppressed
+    try testing.expect(contains(cap.stderr, "No command specified."));
+    try testing.expect(contains(cap.stderr, "Available commands:"));
+    try testing.expect(contains(cap.stderr, "search"));
+    try testing.expect(contains(cap.stderr, "status"));
+    // Never the useless "Unknown command 'unknown'".
+    try testing.expect(!contains(cap.stderr, "Unknown command 'unknown'"));
+    // The registry's own bare fallback must not double-print.
+    try testing.expect(!contains(cap.stderr, "Use --help for usage information"));
 }

--- a/packages/core/src/plugins/zcli_not_found/plugin.zig
+++ b/packages/core/src/plugins/zcli_not_found/plugin.zig
@@ -4,43 +4,126 @@ const levenshtein = zcli.levenshtein;
 
 /// zcli-not-found Plugin
 ///
-/// Handles command-not-found errors with intelligent "did you mean" suggestions
-/// using Levenshtein distance algorithm to find similar commands.
-/// Error hook - handles command not found errors with suggestions
+/// Answers `error.CommandNotFound` — the single origin for three distinct
+/// situations the registry funnels through it (see registry/compiled.zig):
+///
+///   1. A genuinely unknown command (`command_path` is the mistyped argv).
+///      Renders "Unknown command '<x>'" with Levenshtein "did you mean"
+///      suggestions and the available-command list, then returns `false` so
+///      the error propagates and the process exits non-zero. The registry
+///      prints no bare fallback on this path — this block is the sole output.
+///
+///   2. A known command *group* accessed bare (`command_path` is a real
+///      prefix of one or more commands, but names no executable leaf).
+///      Renders the group's subcommands. This is NOT a typo, so no
+///      suggestions — and it returns `true` (handled) so the registry does
+///      not also print its own "'<x>' is a command group" line on top.
+///
+///   3. No command at all (`command_path` is empty). Renders the top-level
+///      command list, returns `true` so the registry's bare "No command
+///      specified" line is suppressed.
+///
+/// The plugin is self-contained: it handles all three sensibly on its own,
+/// with or without zcli_help registered. When help IS registered it runs at
+/// higher priority and answers cases 2 and 3 with richer, themed help,
+/// suppressing the error before this plugin is consulted; this plugin then
+/// only reaches case 1. When help is absent, this plugin covers all three.
 pub fn onError(
     context: anytype,
     err: anyerror,
 ) !bool {
-    if (err == error.CommandNotFound) {
-        // Get available commands and filter out hidden ones
-        const all_command_info = context.getAvailableCommandInfo();
-        var visible_commands = std.ArrayList([]const []const u8).empty;
-        defer visible_commands.deinit(context.allocator);
+    if (err != error.CommandNotFound) return false;
 
-        for (all_command_info) |cmd_info| {
-            if (!cmd_info.hidden) {
-                try visible_commands.append(context.allocator, cmd_info.path);
-            }
+    // Collect visible (non-hidden) command paths once — every branch needs them.
+    const all_command_info = context.getAvailableCommandInfo();
+    var visible_commands = std.ArrayList([]const []const u8).empty;
+    defer visible_commands.deinit(context.allocator);
+    for (all_command_info) |cmd_info| {
+        if (!cmd_info.hidden) {
+            try visible_commands.append(context.allocator, cmd_info.path);
         }
-
-        const attempted_command = if (context.command_path.len > 0)
-            try std.mem.join(context.allocator, " ", context.command_path)
-        else
-            try context.allocator.dupe(u8, "unknown");
-        defer context.allocator.free(attempted_command);
-        try generateCommandNotFoundHelp(context, attempted_command, visible_commands.items);
-
-        // We've rendered the styled block (the single source of truth for
-        // command-not-found). Let the error keep propagating so the entry point
-        // exits non-zero — but the framework must NOT print its own bare
-        // fallback line on top of ours (see the routing site).
-        return false;
     }
 
-    return false; // Error not handled
+    // Case 3: no command named at all.
+    if (context.command_path.len == 0) {
+        try generateNoCommandHelp(context, visible_commands.items);
+        return true; // Handled — suppress the registry's bare fallback line.
+    }
+
+    // Case 2: the named path is a known command group (a strict prefix of at
+    // least one command), not a typo. Show its subcommands.
+    if (isCommandGroup(context.command_path, visible_commands.items)) {
+        const group_name = try std.mem.join(context.allocator, " ", context.command_path);
+        try generateCommandGroupHelp(context, group_name, visible_commands.items);
+        return true; // Handled — suppress the registry's group line.
+    }
+
+    // Case 1: a genuinely unknown command.
+    const attempted_command = try std.mem.join(context.allocator, " ", context.command_path);
+    try generateCommandNotFoundHelp(context, attempted_command, visible_commands.items);
+
+    // We've rendered the styled block (the single source of truth for
+    // command-not-found). Let the error keep propagating so the entry point
+    // exits non-zero — the registry prints no bare fallback on this path.
+    return false;
 }
 
-/// Generate help text for command not found errors
+/// True when `path` names a known command *group* — i.e. it is a strict prefix
+/// of at least one available command, but not an executable command itself.
+fn isCommandGroup(path: []const []const u8, available_commands: []const []const []const u8) bool {
+    for (available_commands) |cmd_parts| {
+        if (cmd_parts.len <= path.len) continue;
+        var is_prefix = true;
+        for (path, 0..) |part, i| {
+            if (!std.mem.eql(u8, part, cmd_parts[i])) {
+                is_prefix = false;
+                break;
+            }
+        }
+        if (is_prefix) return true;
+    }
+    return false;
+}
+
+/// Render help for a bare group access (case 2): its direct subcommands.
+fn generateCommandGroupHelp(
+    context: anytype,
+    group_name: []const u8,
+    available_commands: []const []const []const u8,
+) !void {
+    var writer = context.stderr();
+    try writer.print("'{s}' is a command group.\n\n", .{group_name});
+    try writer.print("Subcommands:\n", .{});
+
+    const depth = std.mem.count(u8, group_name, " ") + 1;
+    for (available_commands) |cmd_parts| {
+        if (cmd_parts.len != depth + 1) continue;
+        var matches = true;
+        var i: usize = 0;
+        var iter = std.mem.splitScalar(u8, group_name, ' ');
+        while (iter.next()) |part| : (i += 1) {
+            if (!std.mem.eql(u8, part, cmd_parts[i])) {
+                matches = false;
+                break;
+            }
+        }
+        if (matches) try writer.print("    {s}\n", .{cmd_parts[depth]});
+    }
+
+    try writer.print("\nRun '{s} {s} <subcommand> --help' for more information.\n", .{ context.app_name, group_name });
+}
+
+/// Render help when no command was named at all (case 3): the command list.
+fn generateNoCommandHelp(
+    context: anytype,
+    available_commands: []const []const []const u8,
+) !void {
+    var writer = context.stderr();
+    try writer.print("No command specified.\n\n", .{});
+    try printAvailableCommands(context, writer, available_commands);
+}
+
+/// Generate help text for a genuinely unknown command (case 1).
 fn generateCommandNotFoundHelp(
     context: anytype,
     attempted_command: []const u8,
@@ -58,55 +141,63 @@ fn generateCommandNotFoundHelp(
         return;
     }
 
-    // Convert hierarchical commands to flat strings for suggestion processing
+    // Convert hierarchical commands to flat strings for suggestion processing.
+    // Both the suggestion list and the returned strings live in the arena-per-
+    // command allocator, so nothing here needs an explicit free.
     var flat_commands = std.ArrayList([]const u8).empty;
-    defer {
-        for (flat_commands.items) |cmd| {
-            context.allocator.free(cmd);
-        }
-        flat_commands.deinit(context.allocator);
-    }
-
+    defer flat_commands.deinit(context.allocator);
     for (available_commands) |cmd_parts| {
         const joined_cmd = try std.mem.join(context.allocator, " ", cmd_parts);
         try flat_commands.append(context.allocator, joined_cmd);
     }
 
-    // Find similar commands
-    const suggestions = findBestSuggestions(
+    // Find similar commands.
+    const suggestions = try findBestSuggestions(
         attempted_command,
         flat_commands.items,
         context.allocator,
         3, // max suggestions
         3, // max edit distance
-    ) catch null;
+    );
 
-    if (suggestions) |suggs| {
-        defer context.allocator.free(suggs);
-
-        if (suggs.len > 0) {
-            if (suggs.len == 1) {
-                try writer.print("Did you mean '{s}'?\n\n", .{suggs[0]});
-            } else {
-                try writer.print("Did you mean one of these?\n", .{});
-                for (suggs) |suggestion| {
-                    try writer.print("    {s}\n", .{suggestion});
-                }
-                try writer.print("\n", .{});
+    if (suggestions.len > 0) {
+        if (suggestions.len == 1) {
+            try writer.print("Did you mean '{s}'?\n\n", .{suggestions[0]});
+        } else {
+            try writer.print("Did you mean one of these?\n", .{});
+            for (suggestions) |suggestion| {
+                try writer.print("    {s}\n", .{suggestion});
             }
+            try writer.print("\n", .{});
         }
     }
 
-    // Show available commands
-    try writer.print("Available commands:\n", .{});
-    for (flat_commands.items) |cmd| {
-        try writer.print("    {s}\n", .{cmd});
-    }
+    try printAvailableCommands(context, writer, available_commands);
+}
 
+/// Print the "Available commands" section shared by cases 1 and 3.
+fn printAvailableCommands(
+    context: anytype,
+    writer: *std.Io.Writer,
+    available_commands: []const []const []const u8,
+) !void {
+    try writer.print("Available commands:\n", .{});
+    for (available_commands) |cmd_parts| {
+        const joined = try std.mem.join(context.allocator, " ", cmd_parts);
+        try writer.print("    {s}\n", .{joined});
+    }
     try writer.print("\nRun '{s} --help' to see all available commands.\n", .{context.app_name});
 }
 
-/// Find best command suggestions using Levenshtein distance
+/// Find best command suggestions using Levenshtein distance. Returned strings
+/// are duped into `allocator` (the arena-per-command allocator), so the caller
+/// never holds a borrow into a shorter-lived buffer.
+///
+/// A candidate is suggested only when its edit distance is within
+/// `max_distance` AND strictly less than the input length. That second guard
+/// stops short inputs from matching everything at a fixed distance — e.g. `i`
+/// against `init` and `run` is distance 3 to both, but suggesting either is
+/// noise, so neither is offered.
 fn findBestSuggestions(
     input: []const u8,
     commands: []const []const u8,
@@ -114,12 +205,10 @@ fn findBestSuggestions(
     max_suggestions: usize,
     max_distance: usize,
 ) ![][]const u8 {
-    // Safety checks
     if (commands.len == 0 or input.len == 0) {
         return allocator.alloc([]const u8, 0);
     }
 
-    // Structure to hold command and its distance
     const ScoredCommand = struct {
         command: []const u8,
         distance: usize,
@@ -133,18 +222,12 @@ fn findBestSuggestions(
     defer allocator.free(scored);
 
     var valid_count: usize = 0;
-
-    // Calculate distances for all commands
     for (commands) |cmd| {
-        // Safety check for each command
         if (cmd.len == 0) continue;
 
         const distance = levenshtein.editDistance(input, cmd);
-        if (distance <= max_distance) {
-            scored[valid_count] = .{
-                .command = cmd,
-                .distance = distance,
-            };
+        if (distance <= max_distance and distance < input.len) {
+            scored[valid_count] = .{ .command = cmd, .distance = distance };
             valid_count += 1;
         }
     }
@@ -153,15 +236,15 @@ fn findBestSuggestions(
         return allocator.alloc([]const u8, 0);
     }
 
-    // Sort by distance
     std.sort.pdq(ScoredCommand, scored[0..valid_count], {}, ScoredCommand.lessThan);
 
-    // Return top suggestions
     const result_count = @min(valid_count, max_suggestions);
     var result = try allocator.alloc([]const u8, result_count);
-
     for (0..result_count) |i| {
-        result[i] = scored[i].command;
+        // Dupe: the source strings live in a caller buffer (`flat_commands`)
+        // that may outlive this call only by statement ordering. Copying into
+        // the arena makes the returned slice self-owning.
+        result[i] = try allocator.dupe(u8, scored[i].command);
     }
 
     return result;
@@ -179,7 +262,7 @@ test "find best suggestions" {
 
     // Test with typo "serach" -> should suggest "search"
     const suggestions = try findBestSuggestions("serach", &commands, allocator, 3, 3);
-    defer allocator.free(suggestions);
+    defer freeSuggestions(allocator, suggestions);
 
     try std.testing.expect(suggestions.len > 0);
     try std.testing.expectEqualStrings("search", suggestions[0]);
@@ -190,9 +273,8 @@ test "find best suggestions with empty input" {
 
     const commands = [_][]const u8{ "list", "search", "create" };
 
-    // Test with empty input
     const suggestions = try findBestSuggestions("", &commands, allocator, 3, 3);
-    defer allocator.free(suggestions);
+    defer freeSuggestions(allocator, suggestions);
 
     try std.testing.expect(suggestions.len == 0);
 }
@@ -202,9 +284,46 @@ test "find best suggestions with no commands" {
 
     const commands = [_][]const u8{};
 
-    // Test with no available commands
     const suggestions = try findBestSuggestions("test", &commands, allocator, 3, 3);
-    defer allocator.free(suggestions);
+    defer freeSuggestions(allocator, suggestions);
 
     try std.testing.expect(suggestions.len == 0);
+}
+
+test "find best suggestions guards short inputs against noise" {
+    const allocator = std.testing.allocator;
+
+    // `i` is edit-distance 3 from both "init" and "run", but the
+    // `distance < input.len` guard rejects both — a single letter should not
+    // suggest anything. Without the guard this returned two false positives.
+    const commands = [_][]const u8{ "init", "run" };
+    const suggestions = try findBestSuggestions("i", &commands, allocator, 3, 3);
+    defer freeSuggestions(allocator, suggestions);
+
+    try std.testing.expect(suggestions.len == 0);
+}
+
+test "isCommandGroup detects prefixes but not leaves or unknowns" {
+    const commands = [_][]const []const u8{
+        &.{ "remote", "add" },
+        &.{ "remote", "remove" },
+        &.{"status"},
+    };
+
+    // "remote" is a strict prefix of two commands -> a group.
+    try std.testing.expect(isCommandGroup(&.{"remote"}, &commands));
+    // "status" is an executable leaf, not a prefix of anything longer.
+    try std.testing.expect(!isCommandGroup(&.{"status"}, &commands));
+    // "bogus" matches nothing.
+    try std.testing.expect(!isCommandGroup(&.{"bogus"}, &commands));
+    // "remote add" is itself a leaf, not a group.
+    try std.testing.expect(!isCommandGroup(&.{ "remote", "add" }, &commands));
+}
+
+/// Free a suggestion slice from `findBestSuggestions` when the caller owns the
+/// allocator (tests use `std.testing.allocator`; the plugin uses the arena and
+/// never frees). Each element is a dupe, so both levels are freed.
+fn freeSuggestions(allocator: std.mem.Allocator, suggestions: [][]const u8) void {
+    for (suggestions) |s| allocator.free(s);
+    allocator.free(suggestions);
 }

--- a/packages/core/src/plugins/zcli_version/plugin.zig
+++ b/packages/core/src/plugins/zcli_version/plugin.zig
@@ -8,6 +8,13 @@ const zcli = @import("zcli");
 /// Unique identifier for this plugin (required for type-safe context data)
 pub const plugin_id = "zcli_version";
 
+/// Run below zcli_help (priority 100): when both `--help` and `--version` are
+/// passed, help wins. Priority orders every hook the registry dispatches
+/// (preExecute, onError, …) highest-first, so this also decides who answers a
+/// `--version` that lands on a non-existent command (see `onError` below) —
+/// help's group/no-command handling is consulted before ours.
+pub const priority = 90;
+
 /// Plugin-specific context data
 pub const ContextData = struct {
     version_requested: bool = false,
@@ -30,8 +37,9 @@ pub fn handleGlobalOption(
     value: anytype,
 ) !void {
     if (std.mem.eql(u8, option_name, "version")) {
-        const bool_val = if (@TypeOf(value) == bool) value else false;
-        if (bool_val) {
+        // The registry always dispatches the declared bool value for this
+        // option, so use it directly — no type guard needed.
+        if (value) {
             context.plugins.zcli_version.version_requested = true;
         }
     }
@@ -52,6 +60,25 @@ pub fn preExecute(
     return args;
 }
 
+/// Error hook: honor `--version` even when routing fails.
+///
+/// The flag is consumed pre-routing (in `handleGlobalOption`) but only acted on
+/// post-routing (in `preExecute`). When it rides on a non-existent command,
+/// routing returns `error.CommandNotFound` before `preExecute` ever runs — so
+/// `myapp --version bogus` would otherwise report "command not found" instead
+/// of the version the user asked for. Catch that here: if a version was
+/// requested, print it (stdout) and mark the error handled.
+pub fn onError(
+    context: anytype,
+    err: anyerror,
+) !bool {
+    if (err == error.CommandNotFound and context.plugins.zcli_version.version_requested) {
+        try showVersion(context);
+        return true; // Handled — the user got their version.
+    }
+    return false;
+}
+
 /// Display version information
 fn showVersion(context: anytype) !void {
     var stdout = context.stdout();
@@ -66,9 +93,11 @@ test "version plugin structure" {
     try std.testing.expect(@hasDecl(@This(), "global_options"));
     try std.testing.expect(@hasDecl(@This(), "handleGlobalOption"));
     try std.testing.expect(@hasDecl(@This(), "preExecute"));
+    try std.testing.expect(@hasDecl(@This(), "onError"));
     try std.testing.expect(@hasDecl(@This(), "ContextData"));
     try std.testing.expect(@hasDecl(@This(), "isVersionRequested"));
 }
 
-// Note: Integration tests for handleGlobalOption and preExecute
-// require a compiled registry with this plugin registered. See integration tests.
+// Note: behavioral coverage (—version prints and skips execution, -V, and the
+// onError path for --version on a bogus command) lives in
+// plugin_pipeline_test.zig, which registers this plugin in a real registry.

--- a/packages/core/src/security_test.zig
+++ b/packages/core/src/security_test.zig
@@ -275,19 +275,19 @@ test "security: resource exhaustion - processing time limits" {
     const io = std.testing.io;
     const start = std.Io.Timestamp.now(io, .awake);
 
-    // Test that suggestion algorithm has reasonable performance
+    // Test that the edit-distance kernel (the core of suggestion matching) has
+    // reasonable performance across many candidates.
     const command_count = 50; // Reasonable test size
     const similar_commands = try generateSimilarStrings(allocator, command_count, "command");
     defer freeSimilarStrings(allocator, similar_commands);
 
-    // Test command suggestion with typo
-    const suggestions = levenshtein.findSimilarCommands("commnd", similar_commands, allocator) catch |err| switch (err) {
-        error.OutOfMemory => {
-            // Acceptable - ran out of memory during suggestion generation
-            return;
-        },
-    };
-    defer allocator.free(suggestions); // Free the suggestions memory
+    // Score every candidate against a typo, mirroring the suggestion hot loop.
+    var closest: usize = std.math.maxInt(usize);
+    for (similar_commands) |candidate| {
+        const distance = levenshtein.editDistance("commnd", candidate);
+        if (distance < closest) closest = distance;
+    }
+    try testing.expect(closest != std.math.maxInt(usize));
 
     const elapsed = start.untilNow(io, .awake).nanoseconds;
 


### PR DESCRIPTION
Fixes verified audit defects in two small plugins: `zcli_not_found` and `zcli_version`.

## zcli_not_found
- **P2 short-input false positives** — `findBestSuggestions` now guards `distance <= max_distance and distance < input.len`, so `i` no longer suggests both `init` and `run`. The dead public `findSimilarCommands`/`findSimilarCommandsWithConfig` (which had the guard but were used only by a test) are **deleted** from `levenshtein.zig`; `editDistance` stays. The plugin's private `findBestSuggestions` is the single implementation. `security_test.zig`'s perf test now drives `editDistance` directly.
- **P3 borrowed suggestion strings (latent UAF)** — returned suggestions are now `dupe`d into the arena-per-command allocator, so they no longer borrow into `flat_commands` (safe before only by statement ordering).
- **P3 swallowed alloc failure** — `catch null` → `try`.
- **P2 undocumented hard dependency on zcli_help** — the plugin is now **self-contained** across all three `CommandNotFound` origins (detected from context, no `compiled.zig` change):
  - **no command** (`command_path` empty) → "No command specified." + command list, returns `true` (suppresses the registry's bare fallback).
  - **bare command group** (`command_path` is a strict prefix of a known command) → the group's subcommands, returns `true` (suppresses the registry's "'x' is a command group" line). No typo framing/suggestions — it's a real command.
  - **genuine unknown** → the Unknown-command block with suggestions, returns `false` so the process exits non-zero (the registry prints nothing here).

  When `zcli_help` is registered it runs at higher priority and answers the group/no-command cases with richer help before this plugin is consulted; the plugin's own handling is the fallback when help is absent.

## zcli_version
- **P2 `--version <bogus>` showed "command not found"** — added `onError`: on `CommandNotFound`, if `version_requested` is set, print the version (stdout) and return `true`. Modeled on help/not_found's `onError`.
- **P3 priority** — added `pub const priority = 90;`. Priority orders every dispatched hook highest-first; help gets 100 on its own branch, so help wins for `--help --version`.
- **P3 dead type-guard** — dropped `if (@TypeOf(value) == bool) value else false`; the registry always passes the typed bool.

## Tests
Real-plugin behavioral coverage added to `plugin_pipeline_test.zig` (registers the actual plugins in a real registry, captures stdout/stderr):
- version: `--version` prints `test v1.0.0` and skips the command; `-V`; `--version <validcmd>`; `--version <bogus>` via `onError` (the defect-5 regression); priority=90 ordering.
- not_found: unknown+closest suggestion; multi-suggestion; short-input guard (no suggestions); no-close-match; bare-group and no-command origins **without help registered** (self-contained, single output, correct suppression).

`zig build test` at root: **pass** (exit 0).

## Note on the priority test
The `--help --version` interaction can't be asserted against the real `Help` plugin here — help's `priority = 100` lands on a separate branch (owned by another agent); on this branch help defaults to 50. The test asserts `Version.priority == 90` and proves the ordering with a stand-in 100-priority plugin instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)