### PR TITLE
fix(config): honor CLI-provided values, full type coercion, loud failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Semantic roles (`success`, `err`, `warning`, `command`, `path`, …) resolve at 
 
 ## Config files
 
-The `zcli_config` plugin transparently loads option defaults from JSON, TOML, or YAML — zero changes to command code. Values cascade: **CLI flags > command config > global config > struct defaults**.
+The `zcli_config` plugin transparently loads option defaults from JSON, TOML, or YAML — zero changes to command code. Values cascade: **CLI flags > env vars > command config > global config > struct defaults**. A CLI flag or env var wins even when its value equals the struct default. Every option type coerces from config the same way it parses on the command line — bools, all int widths, floats, enums, arrays, and custom parse types.
 
 ```json
 // .myapp.config.json

--- a/packages/core/build.zig
+++ b/packages/core/build.zig
@@ -135,6 +135,7 @@ pub fn build(b: *std.Build) void {
         "src/plugin_github_upgrade_test.zig",
         "src/plugin_pipeline_test.zig",
         "src/plugins/zcli_config/plugin.zig",
+        "src/plugin_config_integration_test.zig",
     };
     const plugin_test_imports = [_]TestDep{.{ .name = "zcli", .module = zcli_module }} ++ dep_imports;
     for (feature_plugin_test_files) |test_file| {

--- a/packages/core/src/plugin_config_integration_test.zig
+++ b/packages/core/src/plugin_config_integration_test.zig
@@ -1,0 +1,266 @@
+//! Integration tests for the zcli_config plugin: a real config file on disk,
+//! driven end-to-end through `preExecute` (discovery + read) and
+//! `applyConfigDefaults` (coercion + precedence), via a minimal duck-typed
+//! context — the shape the registry passes. Complements the in-file unit tests
+//! (which drive the apply functions directly).
+
+const std = @import("std");
+const zcli = @import("zcli");
+const config = @import("plugins/zcli_config/plugin.zig");
+const testing = std.testing;
+
+/// The slice of `context` the config plugin reads. `plugins.zcli_config` is the
+/// per-command ContextData the framework threads; the rest are plain accessors.
+const FakeContext = struct {
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    environ: *const std.process.Environ.Map,
+    app_name: []const u8,
+    command_path: []const []const u8,
+    stderr_writer: *std.Io.Writer,
+    plugins: struct { zcli_config: config.ContextData = .{} },
+
+    pub fn stderr(self: *@This()) *std.Io.Writer {
+        return self.stderr_writer;
+    }
+};
+
+fn makeCtx(allocator: std.mem.Allocator, environ: *const std.process.Environ.Map, cmd_path: []const []const u8, stderr: *std.Io.Writer) FakeContext {
+    return .{
+        .allocator = allocator,
+        .io = testing.io,
+        .environ = environ,
+        .app_name = "myapp",
+        .command_path = cmd_path,
+        .stderr_writer = stderr,
+        .plugins = .{},
+    };
+}
+
+// Every test runs the plugin under an arena, exactly as the registry does
+// (docs/adr/0001) — so array coercion and the parse arena are reclaimed
+// wholesale and there's nothing to hand-free.
+fn arena() std.heap.ArenaAllocator {
+    return std.heap.ArenaAllocator.init(testing.allocator);
+}
+
+var discard = std.Io.Writer.Discarding.init(&.{});
+
+test "integration: --config path drives coercion for every type through the real pipeline" {
+    var a = arena();
+    defer a.deinit();
+    const alloc = a.allocator();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const io = testing.io;
+
+    const content =
+        \\{ "flag": true, "name": "hi", "color": "green", "count": 7,
+        \\  "ratio": 2.5, "tags": ["a", "b"] }
+    ;
+    try tmp.dir.writeFile(io, .{ .sub_path = "myapp.json", .data = content });
+    const abs = try tmp.dir.realPathFileAlloc(io, "myapp.json", alloc);
+
+    var environ = std.process.Environ.Map.init(alloc);
+
+    const cmd_path = [_][]const u8{};
+    var ctx = makeCtx(alloc, &environ, &cmd_path, &discard.writer);
+    // The --config global option handler stores this before preExecute runs.
+    ctx.plugins.zcli_config.custom_path = abs;
+
+    const args = zcli.ParsedArgs.init(alloc);
+    _ = try config.preExecute(&ctx, args);
+    try testing.expect(ctx.plugins.zcli_config.format.? == .json);
+
+    const Color = enum { red, green, blue };
+    const Opts = struct {
+        flag: bool = false,
+        name: []const u8 = "def",
+        color: Color = .red,
+        count: u32 = 0,
+        ratio: f64 = 0,
+        tags: []const []const u8 = &.{},
+    };
+    var opts = Opts{};
+    const provided = [_]bool{false} ** 6;
+    config.applyConfigDefaults(&ctx, Opts, &opts, &provided);
+
+    try testing.expect(opts.flag);
+    try testing.expectEqualStrings("hi", opts.name);
+    try testing.expect(opts.color == .green);
+    try testing.expectEqual(@as(u32, 7), opts.count);
+    try testing.expectEqual(@as(f64, 2.5), opts.ratio);
+    try testing.expectEqual(@as(usize, 2), opts.tags.len);
+    try testing.expectEqualStrings("b", opts.tags[1]);
+
+    config.deinitContextData(&ctx.plugins.zcli_config, alloc);
+}
+
+test "integration: cwd discovery finds .{app}.config.toml (via chdir into tmp)" {
+    var a = arena();
+    defer a.deinit();
+    const alloc = a.allocator();
+    const io = testing.io;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(io, .{ .sub_path = ".myapp.config.toml", .data = "count = 42\n" });
+
+    // preExecute discovers relative to the process cwd; point it at tmp for the
+    // duration of this test, then restore. (Serial test file — no other test
+    // depends on cwd concurrently.)
+    var orig_dir = try std.Io.Dir.cwd().openDir(io, ".", .{});
+    defer orig_dir.close(io);
+    try std.process.setCurrentDir(io, tmp.dir);
+    defer std.process.setCurrentDir(io, orig_dir) catch {};
+
+    var environ = std.process.Environ.Map.init(alloc);
+    const cmd_path = [_][]const u8{};
+    var ctx = makeCtx(alloc, &environ, &cmd_path, &discard.writer);
+
+    const args = zcli.ParsedArgs.init(alloc);
+    _ = try config.preExecute(&ctx, args);
+    try testing.expect(ctx.plugins.zcli_config.format != null);
+    try testing.expect(ctx.plugins.zcli_config.format.? == .toml);
+
+    const Opts = struct { count: u32 = 0 };
+    var opts = Opts{};
+    const provided = [_]bool{false};
+    config.applyConfigDefaults(&ctx, Opts, &opts, &provided);
+    try testing.expectEqual(@as(u32, 42), opts.count);
+
+    config.deinitContextData(&ctx.plugins.zcli_config, alloc);
+}
+
+test "integration: required option satisfied by config (through parseCommandLine + apply)" {
+    var a = arena();
+    defer a.deinit();
+    const alloc = a.allocator();
+    const io = testing.io;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(io, .{ .sub_path = "myapp.yaml", .data = "token: secret123\n" });
+    const abs = try tmp.dir.realPathFileAlloc(io, "myapp.yaml", alloc);
+
+    var environ = std.process.Environ.Map.init(alloc);
+    const cmd_path = [_][]const u8{};
+    var ctx = makeCtx(alloc, &environ, &cmd_path, &discard.writer);
+    ctx.plugins.zcli_config.custom_path = abs;
+
+    const args = zcli.ParsedArgs.init(alloc);
+    _ = try config.preExecute(&ctx, args);
+
+    // `token` is a required option (no default, non-optional). Nothing on the
+    // CLI supplies it — parse yields the placeholder + provided[i] == false.
+    const Opts = struct { token: []const u8 };
+    const result = try zcli.parseCommandLine(struct {}, Opts, null, alloc, &environ, &.{}, null);
+    defer result.deinit();
+    try testing.expect(!result.options_provided[0]); // no source yet
+
+    var opts = result.options;
+    const before = opts;
+    config.applyConfigDefaults(&ctx, Opts, &opts, &result.options_provided);
+
+    // Config filled it — the value differs from the pre-config snapshot, which
+    // is exactly what the registry's required-option check treats as "supplied".
+    try testing.expectEqualStrings("secret123", opts.token);
+    try testing.expect(!std.mem.eql(u8, before.token, opts.token));
+
+    config.deinitContextData(&ctx.plugins.zcli_config, alloc);
+}
+
+test "integration: CLI-provided value beats config (equal-to-default regression)" {
+    var a = arena();
+    defer a.deinit();
+    const alloc = a.allocator();
+    const io = testing.io;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(io, .{ .sub_path = "myapp.json", .data = "{\"count\": 10}" });
+    const abs = try tmp.dir.realPathFileAlloc(io, "myapp.json", alloc);
+
+    var environ = std.process.Environ.Map.init(alloc);
+    const cmd_path = [_][]const u8{};
+    var ctx = makeCtx(alloc, &environ, &cmd_path, &discard.writer);
+    ctx.plugins.zcli_config.custom_path = abs;
+    const args = zcli.ParsedArgs.init(alloc);
+    _ = try config.preExecute(&ctx, args);
+
+    // User typed --count 5, which equals the struct default. The provided bitset
+    // (not a value comparison) records that the CLI set it.
+    const Opts = struct { count: u32 = 5 };
+    const result = try zcli.parseCommandLine(struct {}, Opts, null, alloc, &environ, &.{ "--count", "5" }, null);
+    defer result.deinit();
+    try testing.expect(result.options_provided[0]);
+
+    var opts = result.options;
+    config.applyConfigDefaults(&ctx, Opts, &opts, &result.options_provided);
+    try testing.expectEqual(@as(u32, 5), opts.count); // config's 10 did NOT win
+
+    config.deinitContextData(&ctx.plugins.zcli_config, alloc);
+}
+
+test "integration: env-provided value beats config" {
+    var a = arena();
+    defer a.deinit();
+    const alloc = a.allocator();
+    const io = testing.io;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(io, .{ .sub_path = "myapp.json", .data = "{\"count\": 10}" });
+    const abs = try tmp.dir.realPathFileAlloc(io, "myapp.json", alloc);
+
+    var environ = std.process.Environ.Map.init(alloc);
+    try environ.put("MYAPP_COUNT", "99");
+
+    const cmd_path = [_][]const u8{};
+    var ctx = makeCtx(alloc, &environ, &cmd_path, &discard.writer);
+    ctx.plugins.zcli_config.custom_path = abs;
+    const args = zcli.ParsedArgs.init(alloc);
+    _ = try config.preExecute(&ctx, args);
+
+    // The env fallback sets count=99 and marks it provided; config's 10 must lose.
+    const Opts = struct { count: u32 = 0 };
+    const meta = .{ .options = .{ .count = .{ .env = "MYAPP_COUNT" } } };
+    const result = try zcli.parseCommandLine(struct {}, Opts, meta, alloc, &environ, &.{}, null);
+    defer result.deinit();
+    try testing.expect(result.options_provided[0]); // env supplied it
+
+    var opts = result.options;
+    config.applyConfigDefaults(&ctx, Opts, &opts, &result.options_provided);
+    try testing.expectEqual(@as(u32, 99), opts.count); // env wins over config
+
+    config.deinitContextData(&ctx.plugins.zcli_config, alloc);
+}
+
+test "integration: multiple config files warn about ambiguity" {
+    var a = arena();
+    defer a.deinit();
+    const alloc = a.allocator();
+    const io = testing.io;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(io, .{ .sub_path = ".myapp.config.json", .data = "{}" });
+    try tmp.dir.writeFile(io, .{ .sub_path = ".myapp.config.toml", .data = "" });
+
+    var orig_dir = try std.Io.Dir.cwd().openDir(io, ".", .{});
+    defer orig_dir.close(io);
+    try std.process.setCurrentDir(io, tmp.dir);
+    defer std.process.setCurrentDir(io, orig_dir) catch {};
+
+    var aw = std.Io.Writer.Allocating.init(alloc);
+    var environ = std.process.Environ.Map.init(alloc);
+    const cmd_path = [_][]const u8{};
+    var ctx = makeCtx(alloc, &environ, &cmd_path, &aw.writer);
+
+    const args = zcli.ParsedArgs.init(alloc);
+    _ = try config.preExecute(&ctx, args);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "multiple config files") != null);
+
+    config.deinitContextData(&ctx.plugins.zcli_config, alloc);
+}

--- a/packages/core/src/plugins/zcli_config/plugin.zig
+++ b/packages/core/src/plugins/zcli_config/plugin.zig
@@ -4,13 +4,28 @@ const zcli = @import("zcli");
 /// zcli-config Plugin
 ///
 /// Transparent config file loading. Supports JSON, TOML, and YAML.
-/// Add this plugin and option values automatically cascade:
-/// CLI flags > config file > struct defaults.
+/// Add this plugin and option values automatically cascade with the same
+/// precedence every source shares:
+///
+///   CLI flag > env var (option's `.env`) > config file > struct default.
+///
+/// Config only fills an option that no higher source supplied — a value passed
+/// on the CLI, or read from the option's env fallback, always wins, even when it
+/// happens to equal the struct default (`--count 5` beats a config `count = 10`
+/// for `count: u32 = 5`).
 ///
 /// Config file discovery (by extension):
 ///   1. --config <path>
 ///   2. .{app_name}.config.json / .toml / .yaml / .yml (in the current directory — note the leading dot)
-///   3. $XDG_CONFIG_HOME/{app_name}/config.json / .toml / .yaml / .yml
+///   3. {user config dir}/{app_name}/config.json / .toml / .yaml / .yml
+///      ($XDG_CONFIG_HOME or ~/.config on POSIX; %APPDATA% on Windows)
+///
+/// Coercion: a config scalar is stringified and run through the *same* value
+/// parser the CLI and env use, so every option type works from config — bools,
+/// all int widths, floats, enums (incl. optionals), custom `parse` types, and
+/// arrays/multi-value (from a config list). Config stays lenient: a value that
+/// won't parse (bad format, out of range, unknown enum variant) is skipped with
+/// a warning, never injected — see docs/DESIGN.md.
 pub const plugin_id = "zcli_config";
 
 pub const Format = enum { json, toml, yaml };
@@ -55,19 +70,20 @@ pub fn handleGlobalOption(context: anytype, option_name: []const u8, value: anyt
 pub fn preExecute(context: anytype, args: zcli.ParsedArgs) !?zcli.ParsedArgs {
     const allocator = context.allocator;
     const data = &context.plugins.zcli_config;
+    const stderr = context.stderr();
 
     var path_allocated = false;
-    const path = findConfigFile(allocator, context.io, context.environ, context.app_name, data.custom_path, &path_allocated) orelse return args;
+    const path = findConfigFile(allocator, context.io, context.environ, context.app_name, data.custom_path, stderr, &path_allocated) orelse return args;
 
     const format = detectFormat(path) orelse {
         // Unrecognized extension — warn and skip
-        const stderr = context.stderr();
         try stderr.print("Warning: Config file '{s}' has unrecognized extension. Use .json, .toml, .yaml, or .yml\n", .{path});
         if (path_allocated) allocator.free(path);
         return args;
     };
 
-    const content = std.Io.Dir.cwd().readFileAlloc(context.io, path, allocator, .limited(1024 * 1024)) catch {
+    const content = std.Io.Dir.cwd().readFileAlloc(context.io, path, allocator, .limited(1024 * 1024)) catch |err| {
+        try stderr.print("Warning: Could not read config file '{s}': {s}\n", .{ path, @errorName(err) });
         if (path_allocated) allocator.free(path);
         return args;
     };
@@ -80,7 +96,11 @@ pub fn preExecute(context: anytype, args: zcli.ParsedArgs) !?zcli.ParsedArgs {
     return args;
 }
 
-/// Called by the registry after CLI option parsing.
+/// Called by the registry after CLI/env option parsing. `provided` is one flag
+/// per Options field (in field-declaration order), true when the CLI or the
+/// option's env fallback set it; config only fills fields it left false, so
+/// CLI > env > config falls out of a single check.
+///
 /// Applies config values scoped to the current command, plus global values,
 /// identically for JSON, TOML, and YAML. Top-level keys are global (apply to
 /// every command); keys nested under the command path are command-scoped and
@@ -88,36 +108,68 @@ pub fn preExecute(context: anytype, args: zcli.ParsedArgs) !?zcli.ParsedArgs {
 ///   { "output": "json",            // global — applies to all commands
 ///     "list": { "all": true } }    // scoped — applies only to "list" command
 /// and the equivalent TOML `[list]` table / YAML `list:` mapping.
-/// Precedence: CLI flag > command-scoped config > global config > struct default.
-pub fn applyConfigDefaults(context: anytype, comptime OptionsType: type, options: *OptionsType) void {
+/// Precedence: CLI flag > env > command-scoped config > global config > struct default.
+pub fn applyConfigDefaults(context: anytype, comptime OptionsType: type, options: *OptionsType, provided: []const bool) void {
     const data = &context.plugins.zcli_config;
     const content = data.raw_content orelse return;
     const format = data.format orelse return;
+
+    const ctx: ApplyCtx = .{
+        .allocator = context.allocator,
+        .stderr = context.stderr(),
+        .path = data.loaded_path orelse "config",
+    };
 
     // Command path segments, e.g. ["sprint", "create"]; used to locate the
     // command-scoped section within the config tree.
     const cmd_path = context.command_path;
 
+    // Config's own two-tier precedence (command-scoped > global) is tracked here:
+    // the command-scope pass runs first and marks fields it fills; the global
+    // pass then skips them. Without this, the second pass would overwrite a more
+    // specific value. Sized per Options field, in declaration order — same
+    // keying as `provided`.
+    const field_count = @typeInfo(OptionsType).@"struct".fields.len;
+    var applied = [_]bool{false} ** field_count;
+
     switch (format) {
-        .json => applyFromJsonScoped(OptionsType, options, content, context.allocator, data, cmd_path),
-        .toml => applyFromTomlScoped(OptionsType, options, content, context.allocator, data, cmd_path),
-        .yaml => applyFromYamlScoped(OptionsType, options, content, context.allocator, data, cmd_path),
+        .json => applyFromJsonScoped(OptionsType, options, content, ctx, data, cmd_path, provided, &applied),
+        .toml => applyFromTomlScoped(OptionsType, options, content, ctx, data, cmd_path, provided, &applied),
+        .yaml => applyFromYamlScoped(OptionsType, options, content, ctx, data, cmd_path, provided, &applied),
     }
 }
 
-fn applyFromJsonScoped(comptime OptionsType: type, options: *OptionsType, content: []const u8, allocator: std.mem.Allocator, data: *ContextData, cmd_path: []const []const u8) void {
-    const parsed = std.json.parseFromSlice(std.json.Value, allocator, content, .{
+/// Everything the apply pass needs beyond the parsed tree: the (arena) allocator
+/// backing multi-value coercion — always the same arena that holds the parsed
+/// tree, so array slices die with `deinitContextData` — a writer for
+/// lenient-skip warnings, and the file path for those warnings.
+const ApplyCtx = struct {
+    allocator: std.mem.Allocator,
+    stderr: *std.Io.Writer,
+    path: []const u8,
+};
+
+fn applyFromJsonScoped(comptime OptionsType: type, options: *OptionsType, content: []const u8, ctx_in: ApplyCtx, data: *ContextData, cmd_path: []const []const u8, provided: []const bool, applied: []bool) void {
+    const parsed = std.json.parseFromSlice(std.json.Value, ctx_in.allocator, content, .{
         .allocate = .alloc_always,
-    }) catch return;
+    }) catch |err| {
+        warnParse(ctx_in, err);
+        return;
+    };
     data._parse_arena = parsed.arena;
 
     if (parsed.value != .object) return;
     const obj = parsed.value.object;
 
-    // Precedence: command-scoped > global > struct default (CLI already wins,
-    // since a field set on the CLI no longer equals its default). Apply the more
-    // specific command scope FIRST so the global pass can only fill fields it
-    // left untouched.
+    // Coerced arrays are allocated from the parse arena so they outlive `ctx`'s
+    // scalar buffers and are reclaimed by deinitContextData.
+    var ctx = ctx_in;
+    ctx.allocator = parsed.arena.allocator();
+
+    // Precedence: command-scoped > global > struct default (CLI/env already win,
+    // since `provided` gates every field). Apply the more specific command scope
+    // FIRST and mark the fields it fills (`applied`) so the global pass only
+    // touches what it left untouched.
     //
     // Command scope: traverse nested objects matching the command path,
     // e.g. {"sprint": {"create": {"verbose": true}}} for path ["sprint", "create"].
@@ -130,67 +182,29 @@ fn applyFromJsonScoped(comptime OptionsType: type, options: *OptionsType, conten
                 } else break;
             } else break;
         } else {
-            applyJsonObject(OptionsType, options, current);
+            applyMap(OptionsType, options, JsonMap{ .obj = current }, ctx, provided, applied);
         }
     }
 
     // Global values (top-level keys that match option fields).
-    applyJsonObject(OptionsType, options, obj);
+    applyMap(OptionsType, options, JsonMap{ .obj = obj }, ctx, provided, applied);
 }
 
-fn applyJsonObject(comptime OptionsType: type, options: *OptionsType, obj: std.json.ObjectMap) void {
-    const info = @typeInfo(OptionsType);
-    if (info != .@"struct") return;
-
-    inline for (info.@"struct".fields) |field| {
-        if (obj.get(field.name)) |value| {
-            const should_apply = if (field.default_value_ptr) |default_ptr| blk: {
-                const default: *const field.type = @ptrCast(@alignCast(default_ptr));
-                const dest_val = @field(options, field.name);
-                // Only apply if dest still has default (CLI didn't set it)
-                break :blk std.meta.eql(dest_val, default.*);
-            } else true;
-
-            if (should_apply) {
-                // Apply the JSON value to the option field
-                if (field.type == bool) {
-                    if (value == .bool) @field(options, field.name) = value.bool;
-                } else if (field.type == []const u8) {
-                    if (value == .string) @field(options, field.name) = value.string;
-                } else if (field.type == u32 or field.type == i32 or field.type == u64 or field.type == i64) {
-                    if (value == .integer) @field(options, field.name) = @intCast(value.integer);
-                } else if (field.type == ?[]const u8) {
-                    if (value == .string) @field(options, field.name) = value.string;
-                } else if (field.type == ?u32 or field.type == ?i32 or field.type == ?u64 or field.type == ?i64) {
-                    if (value == .integer) @field(options, field.name) = @intCast(value.integer);
-                } else if (field.type == ?bool) {
-                    if (value == .bool) @field(options, field.name) = value.bool;
-                } else if (comptime zcli.custom_type.isCustomParsed(field.type)) {
-                    // A custom type is written as a string in config; build it via
-                    // its own `parse`, the same path CLI/env take. Unparseable →
-                    // leave the default (config is best-effort here).
-                    if (value == .string) {
-                        if (zcli.custom_type.Base(field.type).parse(value.string)) |v| {
-                            @field(options, field.name) = v;
-                        } else |_| {}
-                    }
-                }
-            }
-        }
-    }
-}
-
-fn applyFromTomlScoped(comptime OptionsType: type, options: *OptionsType, content: []const u8, allocator: std.mem.Allocator, data: *ContextData, cmd_path: []const []const u8) void {
+fn applyFromTomlScoped(comptime OptionsType: type, options: *OptionsType, content: []const u8, ctx_in: ApplyCtx, data: *ContextData, cmd_path: []const []const u8, provided: []const bool, applied: []bool) void {
     // Parse into a dynamic table tree and keep it alive via an arena — applied
     // string values point into it, mirroring the JSON path.
-    const arena = allocator.create(std.heap.ArenaAllocator) catch return;
-    arena.* = std.heap.ArenaAllocator.init(allocator);
-    const table = zcli.config_parse.parseToml(arena.allocator(), content) catch {
+    const arena = ctx_in.allocator.create(std.heap.ArenaAllocator) catch return;
+    arena.* = std.heap.ArenaAllocator.init(ctx_in.allocator);
+    const table = zcli.config_parse.parseToml(arena.allocator(), content) catch |err| {
         arena.deinit();
-        allocator.destroy(arena);
+        ctx_in.allocator.destroy(arena);
+        warnParse(ctx_in, err);
         return;
     };
     data._parse_arena = arena;
+
+    var ctx = ctx_in;
+    ctx.allocator = arena.allocator();
 
     // Command scope first, then global — see applyFromJsonScoped for the ordering
     // rationale. e.g. [sprint.create] \n verbose = true  for path ["sprint", "create"].
@@ -203,26 +217,30 @@ fn applyFromTomlScoped(comptime OptionsType: type, options: *OptionsType, conten
                 } else break;
             } else break;
         } else {
-            applyDynamicMap(OptionsType, options, current);
+            applyMap(OptionsType, options, DynMap(@TypeOf(table)){ .map = current }, ctx, provided, applied);
         }
     }
 
     // Global values (top-level keys that match option fields).
-    applyDynamicMap(OptionsType, options, table);
+    applyMap(OptionsType, options, DynMap(@TypeOf(table)){ .map = table }, ctx, provided, applied);
 }
 
-fn applyFromYamlScoped(comptime OptionsType: type, options: *OptionsType, content: []const u8, allocator: std.mem.Allocator, data: *ContextData, cmd_path: []const []const u8) void {
-    const arena = allocator.create(std.heap.ArenaAllocator) catch return;
-    arena.* = std.heap.ArenaAllocator.init(allocator);
-    const root = zcli.config_parse.parseYaml(arena.allocator(), content) catch {
+fn applyFromYamlScoped(comptime OptionsType: type, options: *OptionsType, content: []const u8, ctx_in: ApplyCtx, data: *ContextData, cmd_path: []const []const u8, provided: []const bool, applied: []bool) void {
+    const arena = ctx_in.allocator.create(std.heap.ArenaAllocator) catch return;
+    arena.* = std.heap.ArenaAllocator.init(ctx_in.allocator);
+    const root = zcli.config_parse.parseYaml(arena.allocator(), content) catch |err| {
         arena.deinit();
-        allocator.destroy(arena);
+        ctx_in.allocator.destroy(arena);
+        warnParse(ctx_in, err);
         return;
     };
     data._parse_arena = arena;
 
     if (root != .mapping) return;
     const map = root.mapping;
+
+    var ctx = ctx_in;
+    ctx.allocator = arena.allocator();
 
     // Command scope first, then global — see applyFromJsonScoped for the ordering
     // rationale. e.g. sprint: \n create: \n verbose: true  for path ["sprint", "create"].
@@ -235,56 +253,207 @@ fn applyFromYamlScoped(comptime OptionsType: type, options: *OptionsType, conten
                 } else break;
             } else break;
         } else {
-            applyDynamicMap(OptionsType, options, current);
+            applyMap(OptionsType, options, DynMap(@TypeOf(map)){ .map = current }, ctx, provided, applied);
         }
     }
 
     // Global values (top-level keys that match option fields).
-    applyDynamicMap(OptionsType, options, map);
+    applyMap(OptionsType, options, DynMap(@TypeOf(map)){ .map = map }, ctx, provided, applied);
 }
 
-/// Apply a serde dynamic map (a TOML `Table` or YAML `Mapping`) onto option
-/// fields. Both value unions name their scalar tags identically
-/// (`boolean`/`integer`/`string`), so one function serves both formats. Only
-/// fields still at their struct default are touched, so CLI-provided values win.
-fn applyDynamicMap(comptime OptionsType: type, options: *OptionsType, map: anytype) void {
+fn warnParse(ctx: ApplyCtx, err: anyerror) void {
+    ctx.stderr.print("Warning: Could not parse config file '{s}': {s}\n", .{ ctx.path, @errorName(err) }) catch {};
+}
+
+// ---------------------------------------------------------------------------
+// Format-agnostic apply
+//
+// Each format's value union differs only in tag names (JSON `.bool`/`.object`/
+// `.array` vs serde's `.boolean`/`.table`|`.mapping`/`.array`|`.sequence`). Two
+// thin adapters (`JsonMap`, `DynMap`) expose one shape — `get(name) -> ?FieldVal`
+// where `FieldVal` is a scalar string, a list of scalar strings, or an
+// unsupported container — so a single `applyMap` handles all three formats and
+// routes every scalar through the one CLI/env value parser.
+// ---------------------------------------------------------------------------
+
+/// A config field's value, normalized across formats: a scalar rendered to its
+/// string form (the shape the value parser consumes), a homogeneous list of such
+/// strings (for array/multi-value options), or a container/unsupported value the
+/// apply pass ignores. `buf` backs scalar renderings that aren't already strings
+/// (numbers, bools); `list` slots are arena-allocated.
+const FieldVal = union(enum) {
+    scalar: []const u8,
+    list: []const []const u8,
+    unsupported,
+};
+
+/// Adapter over a `std.json.ObjectMap`.
+const JsonMap = struct {
+    obj: std.json.ObjectMap,
+
+    fn get(self: JsonMap, name: []const u8, allocator: std.mem.Allocator, buf: []u8) ?FieldVal {
+        const v = self.obj.get(name) orelse return null;
+        return jsonValueToField(v, allocator, buf);
+    }
+
+    fn jsonValueToField(v: std.json.Value, allocator: std.mem.Allocator, buf: []u8) FieldVal {
+        return switch (v) {
+            .bool => |b| .{ .scalar = if (b) "true" else "false" },
+            .integer => |i| .{ .scalar = std.fmt.bufPrint(buf, "{d}", .{i}) catch return .unsupported },
+            .float => |f| .{ .scalar = std.fmt.bufPrint(buf, "{d}", .{f}) catch return .unsupported },
+            .number_string => |s| .{ .scalar = s },
+            .string => |s| .{ .scalar = s },
+            .array => |arr| listFromScalars(std.json.Value, arr.items, allocator),
+            .null, .object => .unsupported,
+        };
+    }
+};
+
+/// Adapter over a serde dynamic map (TOML `Table` / YAML `Mapping`). Both value
+/// unions name their scalar tags identically, so one adapter serves both.
+fn DynMap(comptime MapType: type) type {
+    return struct {
+        const Self = @This();
+        map: MapType,
+
+        fn get(self: Self, name: []const u8, allocator: std.mem.Allocator, buf: []u8) ?FieldVal {
+            const v = self.map.get(name) orelse return null;
+            return dynValueToField(@TypeOf(v), v, allocator, buf);
+        }
+    };
+}
+
+fn dynValueToField(comptime ValueType: type, v: ValueType, allocator: std.mem.Allocator, buf: []u8) FieldVal {
+    // TOML names its list tag `.array`, YAML names it `.sequence`; each union
+    // has exactly one, so pick it at comptime (referencing both in one switch
+    // is a compile error against either union).
+    const list_tag = if (@hasField(ValueType, "array")) "array" else "sequence";
+    return switch (v) {
+        .boolean => |b| .{ .scalar = if (b) "true" else "false" },
+        .integer => |i| .{ .scalar = std.fmt.bufPrint(buf, "{d}", .{i}) catch return .unsupported },
+        .float => |f| .{ .scalar = std.fmt.bufPrint(buf, "{d}", .{f}) catch return .unsupported },
+        .string => |s| .{ .scalar = s },
+        inline else => |payload, tag| if (comptime std.mem.eql(u8, @tagName(tag), list_tag))
+            listFromScalars(ValueType, payload, allocator)
+        else
+            .unsupported, // .table / .mapping / .null_val
+    };
+}
+
+/// Render an array/sequence of *scalar* values to a list of strings for
+/// multi-value coercion. A non-scalar element (nested list/table) makes the
+/// whole list unsupported. Each string is arena-allocated so it outlives `buf`.
+fn listFromScalars(comptime ValueType: type, items: anytype, allocator: std.mem.Allocator) FieldVal {
+    const out = allocator.alloc([]const u8, items.len) catch return .unsupported;
+    for (items, 0..) |item, idx| {
+        var elem_buf: [64]u8 = undefined;
+        const fv = if (ValueType == std.json.Value)
+            JsonMap.jsonValueToField(item, allocator, &elem_buf)
+        else
+            dynValueToField(ValueType, item, allocator, &elem_buf);
+        switch (fv) {
+            .scalar => |s| out[idx] = allocator.dupe(u8, s) catch return .unsupported,
+            else => return .unsupported,
+        }
+    }
+    return .{ .list = out };
+}
+
+/// Apply a normalized map onto option fields. A field is touched only if no
+/// higher source set it (`provided`) and no earlier config pass already set it
+/// (`applied` — command scope runs before global). Fields this pass fills are
+/// marked in `applied`. Every value is coerced through the shared CLI/env value
+/// parser; anything that won't parse is skipped with a warning (config is
+/// lenient — never injects a bad value, and a skip does not mark the field).
+fn applyMap(comptime OptionsType: type, options: *OptionsType, map: anytype, ctx: ApplyCtx, provided: []const bool, applied: []bool) void {
     const info = @typeInfo(OptionsType);
     if (info != .@"struct") return;
 
-    inline for (info.@"struct".fields) |field| {
-        if (map.get(field.name)) |value| {
-            const should_apply = if (field.default_value_ptr) |default_ptr| blk: {
-                const default: *const field.type = @ptrCast(@alignCast(default_ptr));
-                const dest_val = @field(options, field.name);
-                break :blk std.meta.eql(dest_val, default.*);
-            } else true;
-
-            if (should_apply) {
-                if (field.type == bool) {
-                    if (value == .boolean) @field(options, field.name) = value.boolean;
-                } else if (field.type == []const u8) {
-                    if (value == .string) @field(options, field.name) = value.string;
-                } else if (field.type == u32 or field.type == i32 or field.type == u64 or field.type == i64) {
-                    if (value == .integer) @field(options, field.name) = @intCast(value.integer);
-                } else if (field.type == ?[]const u8) {
-                    if (value == .string) @field(options, field.name) = value.string;
-                } else if (field.type == ?u32 or field.type == ?i32 or field.type == ?u64 or field.type == ?i64) {
-                    if (value == .integer) @field(options, field.name) = @intCast(value.integer);
-                } else if (field.type == ?bool) {
-                    if (value == .boolean) @field(options, field.name) = value.boolean;
-                } else if (comptime zcli.custom_type.isCustomParsed(field.type)) {
-                    // A custom type is written as a string in config; build it via
-                    // its own `parse`, the same path CLI/env take. Unparseable →
-                    // leave the default (config is best-effort here).
-                    if (value == .string) {
-                        if (zcli.custom_type.Base(field.type).parse(value.string)) |v| {
-                            @field(options, field.name) = v;
-                        } else |_| {}
-                    }
+    inline for (info.@"struct".fields, 0..) |field, field_index| {
+        // `provided`/`applied` are keyed by field-declaration order (same as the
+        // parser's bitset), so index i is this field.
+        if (!provided[field_index] and !applied[field_index]) {
+            var buf: [64]u8 = undefined;
+            if (map.get(field.name, ctx.allocator, &buf)) |fv| {
+                if (applyField(field.type, &@field(options, field.name), field.name, fv, ctx)) {
+                    applied[field_index] = true;
                 }
             }
         }
     }
+}
+
+/// Coerce and store one field. Returns true when a value was actually applied
+/// (so the caller marks it), false on a lenient skip (bad value, wrong shape).
+fn applyField(comptime T: type, dest: *T, field_name: []const u8, fv: FieldVal, ctx: ApplyCtx) bool {
+    if (comptime zcli.config_coerce.isArrayType(T)) {
+        // Multi-value option: coerce each element through the element parser.
+        const Child = @typeInfo(T).pointer.child;
+        switch (fv) {
+            .list => |items| {
+                const out = ctx.allocator.alloc(Child, items.len) catch return false;
+                for (items, 0..) |s, idx| {
+                    out[idx] = zcli.config_coerce.parseOptionValue(Child, s) catch {
+                        warnValue(ctx, field_name, s);
+                        return false; // Lenient: one bad element skips the whole option.
+                    };
+                }
+                dest.* = out;
+                return true;
+            },
+            // A scalar for an array option: treat as a single-element list.
+            .scalar => |s| {
+                const parsed = zcli.config_coerce.parseOptionValue(Child, s) catch {
+                    warnValue(ctx, field_name, s);
+                    return false;
+                };
+                const out = ctx.allocator.alloc(Child, 1) catch return false;
+                out[0] = parsed;
+                dest.* = out;
+                return true;
+            },
+            .unsupported => return false,
+        }
+    }
+
+    // Boolean flags parse by presence on the CLI, so the value parser doesn't
+    // handle them; a config boolean maps directly. `bool`/`?bool` both accept
+    // the "true"/"false" strings the adapters render for a config boolean.
+    if (comptime zcli.config_coerce.isBooleanFlag(T)) {
+        switch (fv) {
+            .scalar => |s| {
+                if (std.mem.eql(u8, s, "true")) {
+                    dest.* = true;
+                    return true;
+                } else if (std.mem.eql(u8, s, "false")) {
+                    dest.* = false;
+                    return true;
+                }
+                warnValue(ctx, field_name, s);
+                return false;
+            },
+            .list, .unsupported => return false,
+        }
+    }
+
+    // Scalar option (ints, floats, enums, strings, optionals, custom parse).
+    switch (fv) {
+        .scalar => |s| {
+            dest.* = zcli.config_coerce.parseOptionValue(T, s) catch {
+                warnValue(ctx, field_name, s);
+                return false;
+            };
+            return true;
+        },
+        .list, .unsupported => return false, // a list for a scalar option is ignored
+    }
+}
+
+fn warnValue(ctx: ApplyCtx, field_name: []const u8, value: []const u8) void {
+    ctx.stderr.print(
+        "Warning: config '{s}' has an invalid value '{s}' for '{s}' — ignoring\n",
+        .{ ctx.path, value, field_name },
+    ) catch {};
 }
 
 fn detectFormat(path: []const u8) ?Format {
@@ -295,7 +464,31 @@ fn detectFormat(path: []const u8) ?Format {
     return null;
 }
 
-fn findConfigFile(allocator: std.mem.Allocator, io: std.Io, environ: *const std.process.Environ.Map, app_name: []const u8, custom_path: ?[]const u8, allocated: *bool) ?[]const u8 {
+/// Resolve the user-level config base directory per platform.
+///   - Windows: %APPDATA% (the roaming XDG-config equivalent), else %USERPROFILE%.
+///   - POSIX:   $XDG_CONFIG_HOME, else $HOME/.config.
+/// The caller owns the returned string only when `allocated` is set (the
+/// $HOME/.config fallback allocates; every other branch borrows from `environ`).
+fn userConfigDir(allocator: std.mem.Allocator, environ: *const std.process.Environ.Map, allocated: *bool) ?[]const u8 {
+    allocated.* = false;
+    if (@import("builtin").os.tag == .windows) {
+        if (environ.get("APPDATA")) |appdata| return appdata;
+        if (environ.get("USERPROFILE")) |up| {
+            const dir = std.fmt.allocPrint(allocator, "{s}\\.config", .{up}) catch return null;
+            allocated.* = true;
+            return dir;
+        }
+        return null;
+    }
+
+    if (environ.get("XDG_CONFIG_HOME")) |xdg| return xdg;
+    const home = environ.get("HOME") orelse return null;
+    const dir = std.fmt.allocPrint(allocator, "{s}/.config", .{home}) catch return null;
+    allocated.* = true;
+    return dir;
+}
+
+fn findConfigFile(allocator: std.mem.Allocator, io: std.Io, environ: *const std.process.Environ.Map, app_name: []const u8, custom_path: ?[]const u8, stderr: *std.Io.Writer, allocated: *bool) ?[]const u8 {
     allocated.* = false;
     const cwd = std.Io.Dir.cwd();
 
@@ -306,38 +499,65 @@ fn findConfigFile(allocator: std.mem.Allocator, io: std.Io, environ: *const std.
         }
     }
 
-    // Project-local: ./{app_name}.config.{ext}
     const extensions = [_][]const u8{ ".json", ".toml", ".yaml", ".yml" };
+
+    // Project-local: ./.{app_name}.config.{ext}
+    if (firstExisting(allocator, io, cwd, stderr, "", app_name, &extensions, allocated)) |p| return p;
+
+    // User-level: {config dir}/{app_name}/config.{ext}
+    var base_allocated = false;
+    const base = userConfigDir(allocator, environ, &base_allocated) orelse return null;
+    defer if (base_allocated) allocator.free(base);
+
+    return firstExisting(allocator, io, cwd, stderr, base, app_name, &extensions, allocated);
+}
+
+/// Return the first existing config file across the extension list, warning if
+/// more than one candidate exists (ambiguous — first-in-list wins silently
+/// otherwise). `base` empty selects the project-local `.{app}.config{ext}`
+/// naming; a non-empty base selects `{base}/{app}/config{ext}`. The returned
+/// path is always heap-allocated (`allocated` set true).
+fn firstExisting(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    cwd: std.Io.Dir,
+    stderr: *std.Io.Writer,
+    base: []const u8,
+    app_name: []const u8,
+    extensions: []const []const u8,
+    allocated: *bool,
+) ?[]const u8 {
+    var chosen: ?[]const u8 = null;
+    var extra_count: usize = 0;
+
     for (extensions) |ext| {
-        const local_name = std.fmt.allocPrint(allocator, ".{s}.config{s}", .{ app_name, ext }) catch continue;
-        if (cwd.access(io, local_name, .{})) |_| {
-            allocated.* = true;
-            return local_name;
+        const candidate = if (base.len == 0)
+            std.fmt.allocPrint(allocator, ".{s}.config{s}", .{ app_name, ext }) catch continue
+        else
+            std.fmt.allocPrint(allocator, "{s}/{s}/config{s}", .{ base, app_name, ext }) catch continue;
+
+        if (cwd.access(io, candidate, .{})) |_| {
+            if (chosen == null) {
+                chosen = candidate;
+            } else {
+                extra_count += 1;
+                allocator.free(candidate);
+            }
         } else |_| {
-            allocator.free(local_name);
+            allocator.free(candidate);
         }
     }
 
-    // User-level: $XDG_CONFIG_HOME/{app_name}/config.{ext}
-    const home = environ.get("HOME") orelse return null;
-    const xdg_env = environ.get("XDG_CONFIG_HOME");
-    const xdg_fallback = if (xdg_env == null)
-        std.fmt.allocPrint(allocator, "{s}/.config", .{home}) catch return null
-    else
-        null;
-    defer if (xdg_fallback) |fb| allocator.free(fb);
-    const xdg_base = xdg_env orelse xdg_fallback.?;
-
-    for (extensions) |ext| {
-        const user_path = std.fmt.allocPrint(allocator, "{s}/{s}/config{s}", .{ xdg_base, app_name, ext }) catch continue;
-        if (cwd.access(io, user_path, .{})) |_| {
-            allocated.* = true;
-            return user_path;
-        } else |_| {
-            allocator.free(user_path);
+    if (chosen) |c| {
+        if (extra_count > 0) {
+            stderr.print(
+                "Warning: multiple config files found; using '{s}' (found {d} more)\n",
+                .{ c, extra_count },
+            ) catch {};
         }
+        allocated.* = true;
+        return c;
     }
-
     return null;
 }
 
@@ -345,372 +565,447 @@ fn findConfigFile(allocator: std.mem.Allocator, io: std.Io, environ: *const std.
 // Tests
 // ============================================================================
 
+const testing = std.testing;
+
+/// A no-op writer for tests that don't assert on warnings.
+fn nullWriter() *std.Io.Writer {
+    return &nullWriterState.writer;
+}
+var nullWriterState = std.Io.Writer.Discarding.init(&.{});
+
+fn testCtx(allocator: std.mem.Allocator) ApplyCtx {
+    return .{ .allocator = allocator, .stderr = &nullWriterState.writer, .path = "test.cfg" };
+}
+
+// Thin test wrappers that supply the config-internal `applied` bitset (the
+// registry never passes it — `applyConfigDefaults` owns it), keeping the tests
+// focused on the format-specific apply behavior.
+fn applyJson(comptime O: type, opts: *O, content: []const u8, ctx: ApplyCtx, data: *ContextData, cmd_path: []const []const u8, provided: []const bool) void {
+    var applied = [_]bool{false} ** @typeInfo(O).@"struct".fields.len;
+    applyFromJsonScoped(O, opts, content, ctx, data, cmd_path, provided, &applied);
+}
+fn applyToml(comptime O: type, opts: *O, content: []const u8, ctx: ApplyCtx, data: *ContextData, cmd_path: []const []const u8, provided: []const bool) void {
+    var applied = [_]bool{false} ** @typeInfo(O).@"struct".fields.len;
+    applyFromTomlScoped(O, opts, content, ctx, data, cmd_path, provided, &applied);
+}
+fn applyYaml(comptime O: type, opts: *O, content: []const u8, ctx: ApplyCtx, data: *ContextData, cmd_path: []const []const u8, provided: []const bool) void {
+    var applied = [_]bool{false} ** @typeInfo(O).@"struct".fields.len;
+    applyFromYamlScoped(O, opts, content, ctx, data, cmd_path, provided, &applied);
+}
+
 test "plugin structure" {
-    try std.testing.expect(@hasDecl(@This(), "global_options"));
-    try std.testing.expect(@hasDecl(@This(), "handleGlobalOption"));
-    try std.testing.expect(@hasDecl(@This(), "preExecute"));
-    try std.testing.expect(@hasDecl(@This(), "applyConfigDefaults"));
-    try std.testing.expect(@hasDecl(@This(), "ContextData"));
-    try std.testing.expect(@hasDecl(@This(), "deinitContextData"));
+    try testing.expect(@hasDecl(@This(), "global_options"));
+    try testing.expect(@hasDecl(@This(), "handleGlobalOption"));
+    try testing.expect(@hasDecl(@This(), "preExecute"));
+    try testing.expect(@hasDecl(@This(), "applyConfigDefaults"));
+    try testing.expect(@hasDecl(@This(), "ContextData"));
+    try testing.expect(@hasDecl(@This(), "deinitContextData"));
 }
 
 test "detectFormat" {
-    try std.testing.expect(detectFormat("config.json").? == .json);
-    try std.testing.expect(detectFormat("config.toml").? == .toml);
-    try std.testing.expect(detectFormat("config.yaml").? == .yaml);
-    try std.testing.expect(detectFormat("config.yml").? == .yaml);
-    try std.testing.expect(detectFormat("config.txt") == null);
-    try std.testing.expect(detectFormat("config") == null);
+    try testing.expect(detectFormat("config.json").? == .json);
+    try testing.expect(detectFormat("config.toml").? == .toml);
+    try testing.expect(detectFormat("config.yaml").? == .yaml);
+    try testing.expect(detectFormat("config.yml").? == .yaml);
+    try testing.expect(detectFormat("config.txt") == null);
+    try testing.expect(detectFormat("config") == null);
 }
 
 test "findConfigFile: returns null when no config exists" {
-    var environ = std.process.Environ.Map.init(std.testing.allocator);
+    var environ = std.process.Environ.Map.init(testing.allocator);
     defer environ.deinit();
     var allocated = false;
-    const result = findConfigFile(std.testing.allocator, std.testing.io, &environ, "nonexistent_xyz", null, &allocated);
-    try std.testing.expect(result == null);
+    const result = findConfigFile(testing.allocator, testing.io, &environ, "nonexistent_xyz", null, nullWriter(), &allocated);
+    try testing.expect(result == null);
 }
 
 test "findConfigFile: custom path returns null for missing file" {
-    var environ = std.process.Environ.Map.init(std.testing.allocator);
+    var environ = std.process.Environ.Map.init(testing.allocator);
     defer environ.deinit();
     var allocated = false;
-    const result = findConfigFile(std.testing.allocator, std.testing.io, &environ, "test", "/nonexistent/path.json", &allocated);
-    try std.testing.expect(result == null);
+    const result = findConfigFile(testing.allocator, testing.io, &environ, "test", "/nonexistent/path.json", nullWriter(), &allocated);
+    try testing.expect(result == null);
+}
+
+test "userConfigDir: POSIX XDG_CONFIG_HOME wins" {
+    if (@import("builtin").os.tag == .windows) return error.SkipZigTest;
+    var environ = std.process.Environ.Map.init(testing.allocator);
+    defer environ.deinit();
+    try environ.put("XDG_CONFIG_HOME", "/custom/xdg");
+    try environ.put("HOME", "/home/u");
+    var allocated = false;
+    const dir = userConfigDir(testing.allocator, &environ, &allocated).?;
+    defer if (allocated) testing.allocator.free(dir);
+    try testing.expectEqualStrings("/custom/xdg", dir);
+    try testing.expect(!allocated);
+}
+
+test "userConfigDir: POSIX HOME fallback allocates ~/.config" {
+    if (@import("builtin").os.tag == .windows) return error.SkipZigTest;
+    var environ = std.process.Environ.Map.init(testing.allocator);
+    defer environ.deinit();
+    try environ.put("HOME", "/home/u");
+    var allocated = false;
+    const dir = userConfigDir(testing.allocator, &environ, &allocated).?;
+    defer if (allocated) testing.allocator.free(dir);
+    try testing.expect(allocated);
+    try testing.expectEqualStrings("/home/u/.config", dir);
+}
+
+test "userConfigDir: Windows APPDATA wins" {
+    if (@import("builtin").os.tag != .windows) return error.SkipZigTest;
+    var environ = std.process.Environ.Map.init(testing.allocator);
+    defer environ.deinit();
+    try environ.put("APPDATA", "C:\\Users\\u\\AppData\\Roaming");
+    var allocated = false;
+    const dir = userConfigDir(testing.allocator, &environ, &allocated).?;
+    defer if (allocated) testing.allocator.free(dir);
+    try testing.expectEqualStrings("C:\\Users\\u\\AppData\\Roaming", dir);
 }
 
 test "ContextData defaults" {
     const data = ContextData{};
-    try std.testing.expect(data.custom_path == null);
-    try std.testing.expect(data.raw_content == null);
-    try std.testing.expect(data.format == null);
+    try testing.expect(data.custom_path == null);
+    try testing.expect(data.raw_content == null);
+    try testing.expect(data.format == null);
 }
 
 test "deinitContextData: safe on empty data" {
     var data = ContextData{};
-    deinitContextData(&data, std.testing.allocator);
+    deinitContextData(&data, testing.allocator);
 }
 
-test "applyJsonObject: parses and applies" {
-    const Opts = struct {
-        all: bool = false,
-        status: []const u8 = "todo",
-    };
+// --- Precedence vs. CLI/env (the defect-1 regression) ---
+//
+// `provided[i] == true` means a higher source (CLI or env) already set the
+// field; config must not touch it, even when the field equals its struct
+// default. Run for all three formats.
 
-    const allocator = std.testing.allocator;
-    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, "{\"all\": true}", .{ .allocate = .alloc_always });
-    defer parsed.deinit();
-
-    var opts = Opts{};
-    applyJsonObject(Opts, &opts, parsed.value.object);
-
-    try std.testing.expect(opts.all == true);
-    try std.testing.expectEqualStrings("todo", opts.status);
-}
-
-test "applyJsonObject: ignores unknown fields" {
-    const Opts = struct {
-        verbose: bool = false,
-    };
-
-    const allocator = std.testing.allocator;
-    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, "{\"verbose\": true, \"unknown\": 42}", .{ .allocate = .alloc_always });
-    defer parsed.deinit();
-
-    var opts = Opts{};
-    applyJsonObject(Opts, &opts, parsed.value.object);
-
-    try std.testing.expect(opts.verbose == true);
-}
-
-test "applyJsonObject: respects CLI-set values (non-default)" {
-    const Opts = struct {
-        verbose: bool = false,
-        count: u32 = 1,
-    };
-
-    const allocator = std.testing.allocator;
-    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, "{\"verbose\": true, \"count\": 99}", .{ .allocate = .alloc_always });
-    defer parsed.deinit();
-
-    // Simulate CLI setting verbose=true (differs from default)
-    var opts = Opts{ .verbose = true, .count = 1 };
-    applyJsonObject(Opts, &opts, parsed.value.object);
-
-    // verbose was already non-default, should NOT be overwritten
-    try std.testing.expect(opts.verbose == true);
-    // count was still at default, should be overwritten by config
-    try std.testing.expectEqual(@as(u32, 99), opts.count);
-}
-
-test "applyFromJsonScoped: applies global values" {
-    const Opts = struct {
-        output: []const u8 = "text",
-        all: bool = false,
-    };
-
-    const allocator = std.testing.allocator;
-    const content = "{\"output\": \"json\", \"all\": true}";
+test "JSON: provided field survives config (equal to default)" {
+    const Opts = struct { count: u32 = 5 };
+    const allocator = testing.allocator;
     var data = ContextData{};
-    var opts = Opts{};
+    defer deinitContextData(&data, allocator);
+    var opts = Opts{ .count = 5 }; // user passed --count 5 (== default)
+    const provided = [_]bool{true}; // CLI set it
     const cmd_path = [_][]const u8{};
 
-    applyFromJsonScoped(Opts, &opts, content, allocator, &data, &cmd_path);
-
-    try std.testing.expectEqualStrings("json", opts.output);
-    try std.testing.expect(opts.all == true);
-
-    // Clean up arena allocated by applyFromJsonScoped
-    if (data._parse_arena) |arena| {
-        arena.deinit();
-        allocator.destroy(arena);
-    }
+    applyJson(Opts, &opts, "{\"count\": 10}", testCtx(allocator), &data, &cmd_path, &provided);
+    try testing.expectEqual(@as(u32, 5), opts.count); // config did NOT override
 }
 
-test "applyFromJsonScoped: applies command-scoped values" {
-    const Opts = struct {
-        all: bool = false,
-        status: []const u8 = "todo",
-    };
-
-    const allocator = std.testing.allocator;
-    // "list" command section overrides "all" for that command
-    const content = "{\"status\": \"done\", \"list\": {\"all\": true}}";
-    var data = ContextData{};
-    var opts = Opts{};
-    const cmd_path = [_][]const u8{"list"};
-
-    applyFromJsonScoped(Opts, &opts, content, allocator, &data, &cmd_path);
-
-    // Global "status" applied
-    try std.testing.expectEqualStrings("done", opts.status);
-    // Command-scoped "all" applied
-    try std.testing.expect(opts.all == true);
-
-    if (data._parse_arena) |arena| {
-        arena.deinit();
-        allocator.destroy(arena);
-    }
-}
-
-test "applyFromJsonScoped: command scope overrides global" {
-    const Opts = struct {
-        output: []const u8 = "text",
-    };
-
-    const allocator = std.testing.allocator;
-    // Global says "json", but "list" command says "table"
-    const content = "{\"output\": \"json\", \"list\": {\"output\": \"table\"}}";
-    var data = ContextData{};
-    var opts = Opts{};
-    const cmd_path = [_][]const u8{"list"};
-
-    applyFromJsonScoped(Opts, &opts, content, allocator, &data, &cmd_path);
-
-    // Command-scoped value wins over global (applied second)
-    try std.testing.expectEqualStrings("table", opts.output);
-
-    if (data._parse_arena) |arena| {
-        arena.deinit();
-        allocator.destroy(arena);
-    }
-}
-
-test "applyFromJsonScoped: nested command path" {
-    const Opts = struct {
-        verbose: bool = false,
-    };
-
-    const allocator = std.testing.allocator;
-    // Nested path: {"sprint": {"create": {"verbose": true}}}
-    const content = "{\"sprint\": {\"create\": {\"verbose\": true}}}";
-    var data = ContextData{};
-    var opts = Opts{};
-    const cmd_path = [_][]const u8{ "sprint", "create" };
-
-    applyFromJsonScoped(Opts, &opts, content, allocator, &data, &cmd_path);
-
-    try std.testing.expect(opts.verbose == true);
-
-    if (data._parse_arena) |arena| {
-        arena.deinit();
-        allocator.destroy(arena);
-    }
-}
-
-test "applyFromJsonScoped: unrelated command section ignored" {
-    const Opts = struct {
-        all: bool = false,
-    };
-
-    const allocator = std.testing.allocator;
-    // "delete" section should not apply to "list" command
-    const content = "{\"delete\": {\"all\": true}}";
-    var data = ContextData{};
-    var opts = Opts{};
-    const cmd_path = [_][]const u8{"list"};
-
-    applyFromJsonScoped(Opts, &opts, content, allocator, &data, &cmd_path);
-
-    try std.testing.expect(opts.all == false);
-
-    if (data._parse_arena) |arena| {
-        arena.deinit();
-        allocator.destroy(arena);
-    }
-}
-
-// --- TOML command scoping (mirrors the JSON cases above) ---
-
-test "applyFromTomlScoped: applies global values" {
-    const Opts = struct {
-        output: []const u8 = "text",
-        all: bool = false,
-    };
-
-    const allocator = std.testing.allocator;
-    const content = "output = \"json\"\nall = true\n";
+test "TOML: provided field survives config (equal to default)" {
+    const Opts = struct { count: u32 = 5 };
+    const allocator = testing.allocator;
     var data = ContextData{};
     defer deinitContextData(&data, allocator);
-    var opts = Opts{};
+    var opts = Opts{ .count = 5 };
+    const provided = [_]bool{true};
     const cmd_path = [_][]const u8{};
 
-    applyFromTomlScoped(Opts, &opts, content, allocator, &data, &cmd_path);
-
-    try std.testing.expectEqualStrings("json", opts.output);
-    try std.testing.expect(opts.all == true);
+    applyToml(Opts, &opts, "count = 10\n", testCtx(allocator), &data, &cmd_path, &provided);
+    try testing.expectEqual(@as(u32, 5), opts.count);
 }
 
-test "applyFromTomlScoped: applies command-scoped values and override" {
-    const Opts = struct {
-        output: []const u8 = "text",
-        all: bool = false,
-    };
-
-    const allocator = std.testing.allocator;
-    // Global output=json; the [list] table overrides it and sets all=true.
-    const content = "output = \"json\"\n[list]\noutput = \"table\"\nall = true\n";
+test "YAML: provided field survives config (equal to default)" {
+    const Opts = struct { count: u32 = 5 };
+    const allocator = testing.allocator;
     var data = ContextData{};
     defer deinitContextData(&data, allocator);
-    var opts = Opts{};
-    const cmd_path = [_][]const u8{"list"};
-
-    applyFromTomlScoped(Opts, &opts, content, allocator, &data, &cmd_path);
-
-    // Command-scoped value wins over global (applied second).
-    try std.testing.expectEqualStrings("table", opts.output);
-    try std.testing.expect(opts.all == true);
-}
-
-test "applyFromTomlScoped: nested command path" {
-    const Opts = struct {
-        verbose: bool = false,
-    };
-
-    const allocator = std.testing.allocator;
-    // Nested table: [sprint.create] verbose = true
-    const content = "[sprint.create]\nverbose = true\n";
-    var data = ContextData{};
-    defer deinitContextData(&data, allocator);
-    var opts = Opts{};
-    const cmd_path = [_][]const u8{ "sprint", "create" };
-
-    applyFromTomlScoped(Opts, &opts, content, allocator, &data, &cmd_path);
-
-    try std.testing.expect(opts.verbose == true);
-}
-
-test "applyFromTomlScoped: unrelated command section ignored" {
-    const Opts = struct {
-        all: bool = false,
-    };
-
-    const allocator = std.testing.allocator;
-    // [delete] should not apply to the "list" command.
-    const content = "[delete]\nall = true\n";
-    var data = ContextData{};
-    defer deinitContextData(&data, allocator);
-    var opts = Opts{};
-    const cmd_path = [_][]const u8{"list"};
-
-    applyFromTomlScoped(Opts, &opts, content, allocator, &data, &cmd_path);
-
-    try std.testing.expect(opts.all == false);
-}
-
-// --- YAML command scoping (mirrors the JSON cases above) ---
-
-test "applyFromYamlScoped: applies global values" {
-    const Opts = struct {
-        output: []const u8 = "text",
-        all: bool = false,
-    };
-
-    const allocator = std.testing.allocator;
-    const content = "output: json\nall: true\n";
-    var data = ContextData{};
-    defer deinitContextData(&data, allocator);
-    var opts = Opts{};
+    var opts = Opts{ .count = 5 };
+    const provided = [_]bool{true};
     const cmd_path = [_][]const u8{};
 
-    applyFromYamlScoped(Opts, &opts, content, allocator, &data, &cmd_path);
-
-    try std.testing.expectEqualStrings("json", opts.output);
-    try std.testing.expect(opts.all == true);
+    applyYaml(Opts, &opts, "count: 10\n", testCtx(allocator), &data, &cmd_path, &provided);
+    try testing.expectEqual(@as(u32, 5), opts.count);
 }
 
-test "applyFromYamlScoped: applies command-scoped values and override" {
+test "JSON: not-provided field IS filled from config" {
+    const Opts = struct { count: u32 = 5 };
+    const allocator = testing.allocator;
+    var data = ContextData{};
+    defer deinitContextData(&data, allocator);
+    var opts = Opts{};
+    const provided = [_]bool{false};
+    const cmd_path = [_][]const u8{};
+
+    applyJson(Opts, &opts, "{\"count\": 10}", testCtx(allocator), &data, &cmd_path, &provided);
+    try testing.expectEqual(@as(u32, 10), opts.count);
+}
+
+// --- Coercion matrix: every option type, from JSON and TOML/YAML ---
+
+const Color = enum { red, green, blue };
+
+const AllTypes = struct {
+    flag: bool = false,
+    name: []const u8 = "default",
+    color: Color = .red,
+    maybe_color: ?Color = null,
+    ratio: f64 = 0.0,
+    small: u16 = 0,
+    tiny: i8 = 0,
+    tags: []const []const u8 = &.{},
+    ports: []const u16 = &.{},
+};
+
+test "JSON: full coercion matrix" {
+    const allocator = testing.allocator;
+    var data = ContextData{};
+    defer deinitContextData(&data, allocator);
+    var opts = AllTypes{};
+    const provided = [_]bool{false} ** @typeInfo(AllTypes).@"struct".fields.len;
+    const cmd_path = [_][]const u8{};
+    const content =
+        \\{ "flag": true, "name": "x", "color": "green", "maybe_color": "blue",
+        \\  "ratio": 1.5, "small": 300, "tiny": -5,
+        \\  "tags": ["a", "b"], "ports": [80, 443] }
+    ;
+    applyJson(AllTypes, &opts, content, testCtx(allocator), &data, &cmd_path, &provided);
+
+    try testing.expect(opts.flag);
+    try testing.expectEqualStrings("x", opts.name);
+    try testing.expect(opts.color == .green);
+    try testing.expect(opts.maybe_color == .blue);
+    try testing.expectEqual(@as(f64, 1.5), opts.ratio);
+    try testing.expectEqual(@as(u16, 300), opts.small);
+    try testing.expectEqual(@as(i8, -5), opts.tiny);
+    try testing.expectEqual(@as(usize, 2), opts.tags.len);
+    try testing.expectEqualStrings("a", opts.tags[0]);
+    try testing.expectEqual(@as(usize, 2), opts.ports.len);
+    try testing.expectEqual(@as(u16, 443), opts.ports[1]);
+}
+
+test "TOML: full coercion matrix" {
+    const allocator = testing.allocator;
+    var data = ContextData{};
+    defer deinitContextData(&data, allocator);
+    var opts = AllTypes{};
+    const provided = [_]bool{false} ** @typeInfo(AllTypes).@"struct".fields.len;
+    const cmd_path = [_][]const u8{};
+    const content =
+        \\flag = true
+        \\name = "x"
+        \\color = "green"
+        \\maybe_color = "blue"
+        \\ratio = 1.5
+        \\small = 300
+        \\tiny = -5
+        \\tags = ["a", "b"]
+        \\ports = [80, 443]
+        \\
+    ;
+    applyToml(AllTypes, &opts, content, testCtx(allocator), &data, &cmd_path, &provided);
+
+    try testing.expect(opts.flag);
+    try testing.expect(opts.color == .green);
+    try testing.expect(opts.maybe_color == .blue);
+    try testing.expectEqual(@as(f64, 1.5), opts.ratio);
+    try testing.expectEqual(@as(u16, 300), opts.small);
+    try testing.expectEqual(@as(i8, -5), opts.tiny);
+    try testing.expectEqual(@as(usize, 2), opts.tags.len);
+    try testing.expectEqual(@as(u16, 443), opts.ports[1]);
+}
+
+test "YAML: full coercion matrix" {
+    const allocator = testing.allocator;
+    var data = ContextData{};
+    defer deinitContextData(&data, allocator);
+    var opts = AllTypes{};
+    const provided = [_]bool{false} ** @typeInfo(AllTypes).@"struct".fields.len;
+    const cmd_path = [_][]const u8{};
+    const content =
+        \\flag: true
+        \\name: x
+        \\color: green
+        \\maybe_color: blue
+        \\ratio: 1.5
+        \\small: 300
+        \\tiny: -5
+        \\tags:
+        \\  - a
+        \\  - b
+        \\ports:
+        \\  - 80
+        \\  - 443
+        \\
+    ;
+    applyYaml(AllTypes, &opts, content, testCtx(allocator), &data, &cmd_path, &provided);
+
+    try testing.expect(opts.flag);
+    try testing.expect(opts.color == .green);
+    try testing.expect(opts.maybe_color == .blue);
+    try testing.expectEqual(@as(f64, 1.5), opts.ratio);
+    try testing.expectEqual(@as(u16, 300), opts.small);
+    try testing.expectEqual(@as(usize, 2), opts.tags.len);
+    try testing.expectEqual(@as(u16, 443), opts.ports[1]);
+}
+
+// --- Custom parse type from config ---
+
+const Doubled = struct {
+    n: u32,
+    pub fn parse(s: []const u8) !Doubled {
+        return .{ .n = (try std.fmt.parseInt(u32, s, 10)) * 2 };
+    }
+};
+
+test "JSON: custom parse type from config string" {
+    const Opts = struct { d: Doubled = .{ .n = 0 } };
+    const allocator = testing.allocator;
+    var data = ContextData{};
+    defer deinitContextData(&data, allocator);
+    var opts = Opts{};
+    const provided = [_]bool{false};
+    const cmd_path = [_][]const u8{};
+    applyJson(Opts, &opts, "{\"d\": \"21\"}", testCtx(allocator), &data, &cmd_path, &provided);
+    try testing.expectEqual(@as(u32, 42), opts.d.n);
+}
+
+// --- Lenient skip: out-of-range and negative-into-unsigned, no panic ---
+
+test "JSON: out-of-range int is skipped (no panic), warns" {
+    const Opts = struct { count: u8 = 7 };
+    const allocator = testing.allocator;
+    var data = ContextData{};
+    defer deinitContextData(&data, allocator);
+    var opts = Opts{};
+    const provided = [_]bool{false};
+    const cmd_path = [_][]const u8{};
+
+    var aw = std.Io.Writer.Allocating.init(allocator);
+    defer aw.deinit();
+    var ctx = testCtx(allocator);
+    ctx.stderr = &aw.writer;
+
+    applyJson(Opts, &opts, "{\"count\": 300}", ctx, &data, &cmd_path, &provided);
+    try testing.expectEqual(@as(u8, 7), opts.count); // unchanged
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "invalid value") != null);
+}
+
+test "JSON: negative into unsigned is skipped (no panic)" {
+    const Opts = struct { count: u32 = 7 };
+    const allocator = testing.allocator;
+    var data = ContextData{};
+    defer deinitContextData(&data, allocator);
+    var opts = Opts{};
+    const provided = [_]bool{false};
+    const cmd_path = [_][]const u8{};
+    applyJson(Opts, &opts, "{\"count\": -1}", testCtx(allocator), &data, &cmd_path, &provided);
+    try testing.expectEqual(@as(u32, 7), opts.count);
+}
+
+test "JSON: unknown enum variant is skipped, warns" {
+    const Opts = struct { color: Color = .red };
+    const allocator = testing.allocator;
+    var data = ContextData{};
+    defer deinitContextData(&data, allocator);
+    var opts = Opts{};
+    const provided = [_]bool{false};
+    const cmd_path = [_][]const u8{};
+
+    var aw = std.Io.Writer.Allocating.init(allocator);
+    defer aw.deinit();
+    var ctx = testCtx(allocator);
+    ctx.stderr = &aw.writer;
+
+    applyJson(Opts, &opts, "{\"color\": \"purple\"}", ctx, &data, &cmd_path, &provided);
+    try testing.expect(opts.color == .red);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "invalid value") != null);
+}
+
+// --- Malformed config warns (but the run continues) ---
+
+test "JSON: malformed content warns" {
+    const Opts = struct { x: u32 = 1 };
+    const allocator = testing.allocator;
+    var data = ContextData{};
+    defer deinitContextData(&data, allocator);
+    var opts = Opts{};
+    const provided = [_]bool{false};
+    const cmd_path = [_][]const u8{};
+
+    var aw = std.Io.Writer.Allocating.init(allocator);
+    defer aw.deinit();
+    var ctx = testCtx(allocator);
+    ctx.stderr = &aw.writer;
+
+    applyJson(Opts, &opts, "{ this is not json", ctx, &data, &cmd_path, &provided);
+    try testing.expectEqual(@as(u32, 1), opts.x);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "Could not parse") != null);
+}
+
+// --- Command scoping still works (mirrors the original suite) ---
+
+test "JSON scoped: command scope overrides global" {
+    const Opts = struct { output: []const u8 = "text" };
+    const allocator = testing.allocator;
+    var data = ContextData{};
+    defer deinitContextData(&data, allocator);
+    var opts = Opts{};
+    const provided = [_]bool{false};
+    const cmd_path = [_][]const u8{"list"};
+
+    applyJson(Opts, &opts, "{\"output\": \"json\", \"list\": {\"output\": \"table\"}}", testCtx(allocator), &data, &cmd_path, &provided);
+    try testing.expectEqualStrings("table", opts.output);
+}
+
+test "JSON scoped: nested command path" {
+    const Opts = struct { verbose: bool = false };
+    const allocator = testing.allocator;
+    var data = ContextData{};
+    defer deinitContextData(&data, allocator);
+    var opts = Opts{};
+    const provided = [_]bool{false};
+    const cmd_path = [_][]const u8{ "sprint", "create" };
+
+    applyJson(Opts, &opts, "{\"sprint\": {\"create\": {\"verbose\": true}}}", testCtx(allocator), &data, &cmd_path, &provided);
+    try testing.expect(opts.verbose);
+}
+
+test "JSON scoped: unrelated command section ignored" {
+    const Opts = struct { all: bool = false };
+    const allocator = testing.allocator;
+    var data = ContextData{};
+    defer deinitContextData(&data, allocator);
+    var opts = Opts{};
+    const provided = [_]bool{false};
+    const cmd_path = [_][]const u8{"list"};
+
+    applyJson(Opts, &opts, "{\"delete\": {\"all\": true}}", testCtx(allocator), &data, &cmd_path, &provided);
+    try testing.expect(!opts.all);
+}
+
+test "TOML scoped: command scope overrides global" {
     const Opts = struct {
         output: []const u8 = "text",
         all: bool = false,
     };
-
-    const allocator = std.testing.allocator;
-    // Global output=json; the "list" mapping overrides it and sets all=true.
-    const content = "output: json\nlist:\n  output: table\n  all: true\n";
+    const allocator = testing.allocator;
     var data = ContextData{};
     defer deinitContextData(&data, allocator);
     var opts = Opts{};
+    const provided = [_]bool{false} ** 2;
     const cmd_path = [_][]const u8{"list"};
 
-    applyFromYamlScoped(Opts, &opts, content, allocator, &data, &cmd_path);
-
-    try std.testing.expectEqualStrings("table", opts.output);
-    try std.testing.expect(opts.all == true);
+    applyToml(Opts, &opts, "output = \"json\"\n[list]\noutput = \"table\"\nall = true\n", testCtx(allocator), &data, &cmd_path, &provided);
+    try testing.expectEqualStrings("table", opts.output);
+    try testing.expect(opts.all);
 }
 
-test "applyFromYamlScoped: nested command path" {
+test "YAML scoped: command scope overrides global" {
     const Opts = struct {
-        verbose: bool = false,
-    };
-
-    const allocator = std.testing.allocator;
-    // Nested mapping: sprint: { create: { verbose: true } }
-    const content = "sprint:\n  create:\n    verbose: true\n";
-    var data = ContextData{};
-    defer deinitContextData(&data, allocator);
-    var opts = Opts{};
-    const cmd_path = [_][]const u8{ "sprint", "create" };
-
-    applyFromYamlScoped(Opts, &opts, content, allocator, &data, &cmd_path);
-
-    try std.testing.expect(opts.verbose == true);
-}
-
-test "applyFromYamlScoped: unrelated command section ignored" {
-    const Opts = struct {
+        output: []const u8 = "text",
         all: bool = false,
     };
-
-    const allocator = std.testing.allocator;
-    // "delete" should not apply to the "list" command.
-    const content = "delete:\n  all: true\n";
+    const allocator = testing.allocator;
     var data = ContextData{};
     defer deinitContextData(&data, allocator);
     var opts = Opts{};
+    const provided = [_]bool{false} ** 2;
     const cmd_path = [_][]const u8{"list"};
 
-    applyFromYamlScoped(Opts, &opts, content, allocator, &data, &cmd_path);
-
-    try std.testing.expect(opts.all == false);
+    applyYaml(Opts, &opts, "output: json\nlist:\n  output: table\n  all: true\n", testCtx(allocator), &data, &cmd_path, &provided);
+    try testing.expectEqualStrings("table", opts.output);
+    try testing.expect(opts.all);
 }

--- a/packages/core/src/registry/compiled.zig
+++ b/packages/core/src/registry/compiled.zig
@@ -993,11 +993,14 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
             // check below can see which fields the config pass filled in.
             const before_config = options_instance;
 
-            // Config defaults override struct defaults; CLI-provided values
-            // (already parsed) still take precedence.
+            // Config defaults fill only options no higher source set. The
+            // provided bitset (CLI + env, keyed by Options field order) is the
+            // single mechanism enforcing CLI > env > config: config skips any
+            // field whose flag is true. Passed by value copy — the plugin reads,
+            // never mutates it.
             inline for (sorted_plugins) |Plugin| {
                 if (@hasDecl(Plugin, "applyConfigDefaults")) {
-                    Plugin.applyConfigDefaults(context, OptionsType, &options_instance);
+                    Plugin.applyConfigDefaults(context, OptionsType, &options_instance, &parse_result.options_provided);
                 }
             }
 

--- a/packages/core/src/zcli.zig
+++ b/packages/core/src/zcli.zig
@@ -76,6 +76,26 @@ pub const command_discovery = @import("build_utils/command_discovery.zig");
 /// the CLI parser does.
 pub const custom_type = @import("custom_type.zig");
 
+/// Option value-coercion surface for the zcli_config plugin. A config file
+/// stores scalars in a format-native shape (JSON/TOML/YAML); the plugin
+/// stringifies them and routes through *the same* parser the CLI and env use,
+/// so every option type coerces identically from every source (single source of
+/// truth — no per-type ladder in the plugin). Plugin modules import only "zcli",
+/// so this is the entire coercion surface they need.
+pub const config_coerce = struct {
+    /// Parse a string into an option field type `T` exactly as a CLI/env value
+    /// would be: ints (all widths, checked), floats, enums, `[]const u8`,
+    /// optionals, and custom `parse` types. Errors (bad format, out of range,
+    /// unknown enum variant) surface as `error.InvalidOptionValue` so config can
+    /// stay lenient (skip + warn) per DESIGN.md.
+    pub const parseOptionValue = option_utils.parseOptionValue;
+    /// True for accumulating array fields (`[]T` where `T != u8`) — a multi-value
+    /// option. `[]const u8` is a string, not an array.
+    pub const isArrayType = option_utils.isArrayType;
+    /// True for `bool`/`?bool` flags, which coerce from a config boolean directly.
+    pub const isBooleanFlag = option_utils.isBooleanFlag;
+};
+
 const testing = std.testing;
 
 // Re-export error types


### PR DESCRIPTION
Fixes five verified defects in the `zcli_config` plugin. The unifying change: config scalars now route through the **same value parser the CLI and env use** (`options/utils.zig:parseOptionValue`), so config coercion and precedence match every other source.

## Defects fixed

**P1 — CLI value equal to a struct default was overridden by config.** The apply pass gated on `std.meta.eql(dest, default)`, which cannot distinguish "provided and happens to equal the default" from "never set". `applyConfigDefaults` now receives the parser's `provided` bitset (already computed at the call site in `compiled.zig`, keyed by Options-field order, covering **both CLI and env**) and fills only fields no higher source set. `--count 5` now beats a config `count = 10` for `count: u32 = 5`.

**How env-vs-config precedence is enforced:** the options parser (`options/parser.zig`) sets `provided[i]` for env fallbacks (`applyEnvValue`, ~:218) *and* CLI-set fields (~:295), in struct-field order. Config's apply loop iterates the same field order and skips any field with `provided[i] == true`. One check gives `CLI > env > config`. Config's own two-tier order (command-scoped > global) is preserved with a separate `applied` bitset shared across the two passes.

**P1 — enums, floats, arrays/multi-value, and most int widths were silently ignored.** The old ladder only handled bool/`[]const u8`/u32/i32/u64/i64. Now a config scalar is stringified and coerced via `parseOptionValue`, exposed through a minimal `zcli.config_coerce` shim. The three format value shapes (JSON `.bool`/`.object`/`.array` vs serde `.boolean`/`.table`|`.mapping`/`.array`|`.sequence`) collapse onto one `FieldVal` adapter, so a single apply routine serves all three formats. Arrays/multi-value coerce element-by-element.

**P1 — out-of-range/negative config ints panicked** via bare `@intCast`. `parseOptionValue`'s checked `parseInt` turns these into a lenient skip + stderr warning (per DESIGN.md: env/config never inject a bad value).

**P2 — malformed/unreadable config was swallowed.** Parse and read failures now warn to stderr, naming the file and error; the run continues (buffered writer flushed on normal completion).

**P2 — Windows user-config discovery was dead** (`HOME` only). New `userConfigDir` helper: %APPDATA% (else %USERPROFILE%\\.config) on Windows, $XDG_CONFIG_HOME (else ~/.config) on POSIX.

**P3 — multi-file ambiguity** across extensions resolved first-wins silently; now warns. Plugin doc comment + README precedence corrected to include env.

## Tests
- Precedence-vs-CLI regression (equal-to-default survives config) for JSON/TOML/YAML.
- Full coercion matrix: enum, optional enum, f64, u16, i8, string arrays, u16 arrays, custom parse type — from JSON, TOML, and YAML.
- Lenient skips (no panic) + warnings: out-of-range int, negative-into-unsigned, unknown enum variant.
- Malformed config warns, run continues.
- `userConfigDir` per-platform (POSIX + Windows-gated).
- Integration suite (`plugin_config_integration_test.zig`): real `tmpDir` config file through `preExecute` + `applyConfigDefaults`, `--config <path>` and cwd discovery, required-option-satisfied-by-config, CLI-beats-config, env-beats-config, and multi-file ambiguity warning — all driving the real `parseCommandLine` provided bitset.

`zig build test` at root passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)