### PR TITLE
docs: sync README + guides with plugin-audit fixes (#233-#238)

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ The `zcli_config` plugin transparently loads option defaults from JSON, TOML, or
 }
 ```
 
-Discovery order and formats: [zcli.sh/plugins](https://zcli.sh/plugins/#config).
+Discovery order and formats: [zcli.sh/docs/config](https://zcli.sh/docs/config/).
 
 ## Plugins
 

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -28,4 +28,4 @@ if (context.plugins.zcli_help.help_requested) { ... }
 
 A plugin is a Zig module with a `plugin_id` and any of the lifecycle exports (`global_options`, `handleGlobalOption`, `preExecute`, `onError`); it can also ship its own commands. Hook parameters are typed `anytype` — a plugin is compiled independently of the app that hosts it.
 
-For the full built-in list, config-file discovery and cascade, `plugins_dir` auto-discovery, and the complete plugin-authoring guide, see **[zcli.sh/plugins](https://zcli.sh/plugins/)**. For how plugins are discovered and merged into the generated registry, see [BUILD.md](BUILD.md).
+For the full built-in list, `plugins_dir` auto-discovery, and the complete plugin-authoring guide, see **[zcli.sh/plugins](https://zcli.sh/plugins/)**; config-file discovery and the value cascade have their own guide at **[zcli.sh/docs/config](https://zcli.sh/docs/config/)**. For how plugins are discovered and merged into the generated registry, see [BUILD.md](BUILD.md).

--- a/website/content/docs/config.smd
+++ b/website/content/docs/config.smd
@@ -25,7 +25,9 @@ The first match wins:
 
 1. `--config <path>` — an explicit file passed on the command line (a global option the plugin contributes)
 2. `./{app}.config.json|toml|yaml` — a project-local file in the working directory
-3. `$XDG_CONFIG_HOME/{app}/config.json|toml|yaml` — the user-level config
+3. `{user config dir}/{app}/config.json|toml|yaml` — the user-level config (`$XDG_CONFIG_HOME` or `~/.config` on POSIX; `%APPDATA%`, else `%USERPROFILE%`, on Windows)
+
+If more than one candidate exists, the first in this order is used and the plugin prints a notice naming the file it chose.
 
 ## Global and per-command values
 
@@ -49,7 +51,13 @@ Config sits between explicit user input and your struct defaults:
 CLI flag  >  env var  >  command-scoped config  >  global config  >  struct default
 ```
 
-Config can satisfy a [required option]($link.page('docs/args-options')) and participates in [validation and constraints]($link.page('docs/validation')) like any other source — a `validate` hook runs on the final value wherever it came from, and a config value counts as "supplied" for `exclusive`/`requires` checks. An unparseable config value for a [custom type]($link.page('docs/validation')) is ignored rather than trusted — the default stays.
+A value set on the command line — or read from an option's `env` fallback — always wins, even when it happens to equal the struct default; the plugin only fills fields the CLI and env left unset.
+
+**Every option type coerces from config.** A config scalar is stringified and run through the *same* value parser the CLI and env use, so bools, all integer widths, floats, enums (including optionals), [custom `parse` types]($link.page('docs/validation')), and arrays / multi-value options (from a config list) all work — no per-type wiring.
+
+**Failures are loud, never silent.** A malformed config file, an unrecognized extension, an out-of-range number, or an unknown enum variant is **skipped with a warning on stderr** — the default stays — rather than crashing the CLI or being trusted. A value that won't parse is never injected.
+
+Config can satisfy a [required option]($link.page('docs/args-options')) and participates in [validation and constraints]($link.page('docs/validation')) like any other source — a `validate` hook runs on the final value wherever it came from, and a config value counts as "supplied" for `exclusive`/`requires` checks.
 
 ## Next
 

--- a/website/content/docs/secrets.smd
+++ b/website/content/docs/secrets.smd
@@ -48,7 +48,18 @@ try context.plugins.zcli_secrets.delete(context, "token");
 | Linux | Secret Service via `secret-tool`, falling back to `pass` — chosen at runtime |
 | Windows | Credential Manager |
 
-The Linux backend deliberately **shells out** instead of linking libsecret — so a static musl build of your CLI stays fully static and still gets real keychain storage on desktops that have it. On Windows, entries are keyed `{app_name}:{name}` and values are capped at the Credential Manager's limit (2560 bytes). Any other target is a compile error — never a plaintext file.
+The Linux backend deliberately **shells out** instead of linking libsecret — so a static musl build of your CLI stays fully static and still gets real keychain storage on desktops that have it. Autodetection prefers a live Secret Service and falls through to `pass`; set `ZCLI_SECRETS_BACKEND=secret-service|pass` to force one. Any other target is a compile error — never a plaintext file.
+
+Secret **names** must be valid UTF-8 with no NUL byte — validated once, up front, so the contract is uniform across every backend.
+
+### Value size limits
+
+Two backends bound a secret's size, and both **reject oversized values cleanly** with a hint — never a silent truncation:
+
+- **Windows Credential Manager** caps a value at **2560 bytes**.
+- **Linux Secret Service** caps a value at roughly **6 KiB** raw — `secret-tool` reads the secret through a fixed 8 KiB stdin buffer, so a larger value would be truncated; zcli verifies the stored value after writing and fails with a "too large" error and a pointer to the `pass` backend instead. Force `pass` for large secrets: `ZCLI_SECRETS_BACKEND=pass`.
+
+The macOS Keychain and the Linux `pass` backend impose no practical cap.
 
 ## A complete flow
 

--- a/website/content/docs/shipping.smd
+++ b/website/content/docs/shipping.smd
@@ -57,7 +57,7 @@ zcli.builtin(.github_upgrade, .{
 }),
 ```
 
-`myapp upgrade` resolves the latest release (or an explicit version), downloads the right `{app}-{target}` artifact, verifies — minisign signature when a key is pinned, SHA-256 always — test-runs the new binary, then replaces itself atomically with a backup of the old one. `myapp upgrade --check` only reports. With `inform_out_of_date`, the app mentions new versions on startup: checked at most once per 24 hours, with a 3-second timeout so a dead network can never hang your users' commands.
+`myapp upgrade` resolves the latest release (or an explicit version), downloads the right `{app}-{target}` artifact, verifies — minisign signature when a key is pinned, SHA-256 always — test-runs the new binary, then replaces itself atomically with a backup of the old one. Version comparison uses real semver ordering (`std.SemanticVersion`), so pre-release precedence is handled correctly. A bare `myapp upgrade` **never downgrades**: it refuses any target that isn't newer, even with `--force`; to move to an older release, name it explicitly (`myapp upgrade 1.2.0`). `myapp upgrade --check` only reports whether a newer version exists — it never modifies anything. With `inform_out_of_date`, the app mentions new versions on startup: checked at most once per 24 hours, with a 3-second timeout so a dead network can never hang your users' commands.
 
 ## Shell completions
 
@@ -68,7 +68,7 @@ myapp completions install          # detects bash, zsh, or fish
 myapp completions generate zsh     # or print the script to stdout
 ```
 
-Completion data — commands, subcommands, flags — is generated from the same registry as everything else, at build time.
+Completion data is generated from the same registry as everything else, so it's always in sync with your commands. For **bash, zsh, and fish** alike the scripts complete commands and subcommands (**including aliases**), flags, the **values of enum options**, and fall back to **file completion** for positionals. The bash script uses the `bash-completion` package's helpers when present but ships a fallback so it works without it — installing `bash-completion` is still recommended for the best experience.
 
 ## Generated docs
 


### PR DESCRIPTION
Syncs the README, `docs/`, and website guides with the behavior that shipped in the July 2026 plugin-audit fixes (#233–#238). Docs only — no Zig source touched. Every claim was verified against `packages/core/src/plugins/` before writing.

## What changed

**Secrets** (`website/content/docs/secrets.smd`)
- Documented per-backend value size limits: Windows Credential Manager **2560 bytes** (`credential_manager_windows.zig` `CRED_MAX_CREDENTIAL_BLOB_SIZE = 5*512`); Linux Secret Service **~6 KiB raw** (`linux_secret_service.zig` `max_encoded_len = 8192`, base64 → 6144 raw), cleanly rejected with `SecretTooLarge` + a `pass` hint via verify-after-store — never truncated. macOS Keychain and `pass` uncapped.
- Added the UTF-8-only secret-name rule (`plugin.zig` `validateName`) and the `ZCLI_SECRETS_BACKEND=secret-service|pass` override (`linux.zig`).
- Dropped the stale `{app_name}:{name}` Windows target-name format (encoding is now length-prefixed).

**Config** (`website/content/docs/config.smd`)
- Windows discovery via `%APPDATA%`/`%USERPROFILE%` (`plugin.zig:468-476`), plus the multi-candidate notice (`plugin.zig:516-554`).
- Full-type coercion (bools, all int widths, floats, enums incl. optionals, custom `parse`, arrays) and loud **stderr warnings** on malformed / out-of-range values (lenient skip, never a crash or silent trust) — `plugin.zig` header + `warnParse`.

**Upgrade** (`website/content/docs/shipping.smd`)
- Real semver ordering (`std.SemanticVersion`); bare `upgrade` **never downgrades** even with `--force`; explicit version still allows it; `--check` only reports (`plugin.zig:209-244`).

**Completions** (`website/content/docs/shipping.smd`)
- Enum-value completion, command aliases, and positional file fallback across bash/zsh/fish; bash works without the `bash-completion` package (fallback), still recommended (`bash.zig`, `fish.zig`, `zsh.zig`).

**Phantom link fix** (`README.md`, `docs/PLUGINS.md`)
- `zcli.sh/plugins/#config` pointed at an anchor that doesn't exist on the plugins page; retargeted to the dedicated config guide `zcli.sh/docs/config/`.

## Already correct (left as-is)
- Help/version streams: `testing.smd` already asserts `--help`/`--version` on **stdout**; no guide claimed the old stderr behavior.
- `not_found` error suggestions correctly documented as stderr.
- README config precedence already listed env and full-type coercion.

## Verification
- Website builds clean with the prebuilt zine (`~/.local/bin/zine release -o …` → exit 0, no SuperHTML errors) after running `sync-site-data.sh`.
- `git diff --stat`: only README / docs / website files (5 files, +26/-7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)