### PR TITLE
refactor(plugins): declare applyConfigDefaults in the plugin hook contract

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -801,6 +801,15 @@ pub fn preExecute(context: anytype, args: zcli.ParsedArgs) !?zcli.ParsedArgs { }
 pub fn postExecute(context: anytype, result: anytype) !void { }
 pub fn onError(context: anytype, err: anyerror) !bool { }
 
+// Fill option fields from a lower-precedence source (e.g. a config file) after
+// CLI + env parsing but before required/dependency validation. `provided` has
+// one flag per Options field (declaration order), true when CLI or the field's
+// env fallback already set it — the hook MUST skip those fields, which is what
+// makes CLI > env > config hold. `options` is mutated in place; no error union,
+// so a malformed source warns-and-skips rather than bricking the command. Any
+// values written must outlive execution (zcli_config uses a ContextData arena).
+pub fn applyConfigDefaults(context: anytype, comptime OptionsType: type, options: *OptionsType, provided: []const bool) void { }
+
 // Plugin can provide commands (also app-agnostic, so `context: anytype`)
 pub const commands = struct {
     pub const help = struct {
@@ -832,9 +841,10 @@ const cmd_registry = try zcli.generate(b, exe, zcli_dep, .{
 1. Plugins are sorted by priority at compile time — a plugin may declare `pub const priority: i32` (default 50); higher values run first, and ties keep registration order
 2. All `handleGlobalOption` hooks called for each global option
 3. All `preExecute` hooks called before command execution
-4. Command executes
-5. All `postExecute` hooks called after successful execution
-6. On error, `onError` hooks called until one handles the error
+4. All `applyConfigDefaults` hooks called after CLI/env parse — filling options no higher-precedence source set — then required/dependency/exclusive validation runs
+5. Command executes
+6. All `postExecute` hooks called after successful execution
+7. On error, `onError` hooks called until one handles the error
 
 **Built-in Plugins:**
 

--- a/packages/core/src/plugin_types.zig
+++ b/packages/core/src/plugin_types.zig
@@ -208,6 +208,12 @@ pub fn hasOnError(comptime T: type) bool {
     return @hasDecl(T, "onError");
 }
 
+/// Check if a type has an applyConfigDefaults hook. See `hook_names` below for
+/// the full contract.
+pub fn hasApplyConfigDefaults(comptime T: type) bool {
+    return @hasDecl(T, "applyConfigDefaults");
+}
+
 /// Check if a type has command extensions
 pub fn hasCommands(comptime T: type) bool {
     return @hasDecl(T, "commands");
@@ -224,6 +230,33 @@ pub fn getPriority(comptime T: type) i32 {
 /// The lifecycle hooks detected by exact name above. Kept next to the has*
 /// functions so a new hook is added to both or the validator complains about
 /// nothing.
+///
+/// Signatures (all take `context: anytype` because plugins compile independently
+/// of the host app):
+///
+///   transformArgs(context, args: []const []const u8) !zcli.TransformResult
+///   handleGlobalOption(context, name: []const u8, value: anytype) !void
+///   preParse(context, args: []const []const u8) ![]const []const u8
+///   postParse(context, args: zcli.ParsedArgs) !?zcli.ParsedArgs
+///   preExecute(context, args: zcli.ParsedArgs) !?zcli.ParsedArgs
+///   postExecute(context, result: anytype) !void
+///   onError(context, err: anyerror) !bool
+///
+///   applyConfigDefaults(context, comptime OptionsType: type,
+///                       options: *OptionsType, provided: []const bool) void
+///     Fills option fields from a lower-precedence source (e.g. a config file)
+///     after CLI + env parsing but before required/dependency/exclusive
+///     validation. `provided` has one flag per Options field, in field-
+///     declaration order, true when the CLI or the field's env fallback already
+///     set it. The precedence obligation: the hook MUST skip any field whose
+///     `provided` flag is true — this single check is what makes
+///     CLI > env > hook hold. `options` is mutated in place; `provided` is a
+///     read-only view. The hook does not return an error union — a malformed or
+///     unreadable source is a warning-and-skip, never a hard failure (a config
+///     typo must not brick every command). Any values it writes into `options`
+///     (e.g. coerced strings/arrays) must outlive the command's execution;
+///     the built-in zcli_config plugin allocates them from a parse arena tied
+///     to its ContextData so they die with `deinitContextData`.
 const hook_names = [_][]const u8{
     "transformArgs",
     "handleGlobalOption",
@@ -232,6 +265,7 @@ const hook_names = [_][]const u8{
     "preExecute",
     "postExecute",
     "onError",
+    "applyConfigDefaults",
 };
 
 /// Non-hook decl names that are part of the plugin contract (never flagged).
@@ -252,6 +286,10 @@ const contract_names = hook_names ++ [_][]const u8{
 /// with a pointer at the hook it resembles.
 pub fn validatePlugin(comptime Plugin: type) void {
     comptime {
+        // The per-decl edit-distance DP over every hook name is cheap
+        // individually but adds up across a plugin with many decls; give it
+        // headroom above the 1000 default so adding a hook name never trips it.
+        @setEvalBranchQuota(10_000);
         if (@typeInfo(Plugin) != .@"struct") return;
         for (@typeInfo(Plugin).@"struct".decls) |decl| {
             if (isContractName(decl.name)) continue;
@@ -384,6 +422,28 @@ test "validatePlugin accepts a well-formed plugin with helpers" {
     comptime validatePlugin(Plugin);
 }
 
+test "editDistance flags an applyConfigDefaults typo" {
+    comptime {
+        // The transposition the typo-guard exists to catch: this misspelling
+        // compiles fine but would never be dispatched (hooks match by exact name).
+        std.debug.assert(editDistance("applyConfigDefualts", "applyConfigDefaults") == 2);
+        // A far-off helper in the same plugin must stay clear of the guard.
+        std.debug.assert(editDistance("applyFromJsonScoped", "applyConfigDefaults") > 2);
+    }
+}
+
+test "validatePlugin accepts a well-formed applyConfigDefaults hook" {
+    const Plugin = struct {
+        pub const plugin_id = "cfg_plugin";
+        pub fn applyConfigDefaults(context: anytype, comptime OptionsType: type, options: *OptionsType, provided: []const bool) void {
+            _ = context;
+            _ = options;
+            _ = provided;
+        }
+    };
+    comptime validatePlugin(Plugin);
+}
+
 test "validatePlugin accepts ContextData paired with a valid plugin_id" {
     const Plugin = struct {
         pub const plugin_id = "my_plugin";
@@ -431,6 +491,7 @@ pub fn PluginEntry(comptime T: type) type {
         pub const has_pre_execute = hasPreExecute(T);
         pub const has_post_execute = hasPostExecute(T);
         pub const has_on_error = hasOnError(T);
+        pub const has_apply_config_defaults = hasApplyConfigDefaults(T);
         pub const has_commands = hasCommands(T);
         pub const priority = getPriority(T);
 


### PR DESCRIPTION
## What

The `applyConfigDefaults` hook — called by the registry (`compiled.zig`, in the option-resolution pipeline, receiving a `provided: []const bool` bitset since #238) — was **duck-typed only**. It's dispatched by `@hasDecl(Plugin, "applyConfigDefaults")` exactly like every other hook, but it was declared and documented **nowhere** in `plugin_types.zig` alongside `transformArgs`, `handleGlobalOption`, `preExecute`, `onError`, etc. The July 2026 plugin audit flagged this: a plugin author reading `plugin_types.zig` had no way to discover the hook or its contract, and a signature typo fails in confusing ways (the hook silently never fires).

## The formalization mechanism

Matched the existing hook contract mechanism verbatim — no invention:

- **`hasApplyConfigDefaults` helper + `PluginEntry.has_apply_config_defaults` field**, mirroring every other `has*` hook.
- **Added to `hook_names`**, so the existing comptime typo-guard (`validatePlugin`'s edit-distance backstop against silently-dead hooks) now covers it — a misspelled `applyConfigDefualts` is now a `@compileError` pointing at the real name, same as the other hooks.
- **Full contract documented** next to the other signatures: when it runs (after CLI+env parse, before required/dependency/exclusive validation), the precedence obligation (skip any field whose `provided` flag is true → CLI > env > config), the `void` return / warn-and-skip error semantics, and the lifetime rule (written values must outlive execution — `zcli_config` allocates from a ContextData parse arena reclaimed by `deinitContextData`).
- Mirrored into `docs/DESIGN.md`'s hook table + execution-order list.

Comptime validation **did already exist** for the other hooks (the edit-distance typo-guard in `validatePlugin`); this extends it rather than inventing a new one.

## Contract mismatches found

None — the `zcli_config` implementation already matched: `void` return (registry calls it without `try`), reads `provided` without mutating, writes coerced array values from the parse arena. The only surprise was a comptime **branch-quota** trip: adding the 20-char hook name pushed `validatePlugin`'s per-decl edit-distance DP over the 1000 default when validating the config plugin's many decls, fixed with `@setEvalBranchQuota`.

## Test evidence

- `zig build test` → exit 0 (1973/1975 pass, 2 skipped).
- Added two compile-contract tests in `plugin_types.zig` matching the existing `validatePlugin`/`editDistance` test precedent.
- Grepped: the only remaining reference in `registry/` is the single dispatch site — no second undocumented duck-typed spelling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)