### PR TITLE
chore(ci): validate fish completions in CI, widen output-contract lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,20 +23,44 @@ jobs:
       - name: Check formatting
         run: zig fmt --check packages projects examples build.zig
 
-      # Plugins must route ALL output and process exit through the command
-      # context (context.stdout()/stderr()/exit()/fail()), never std.debug.print
-      # or std.process.exit: those bypass the framework's buffered streams (so
-      # output is silently dropped on exit) and defeat stream overrides. Test
-      # files are exempt — they legitimately use std.testing plumbing.
-      - name: No std.debug.print / std.process.exit in plugins
+      # Output-contract invariant: runtime code must route ALL output and
+      # process exit through the command context (context.stdout()/stderr()/
+      # exit()/fail()), never std.debug.print or std.process.exit. Those bypass
+      # the framework's buffered streams — output is silently dropped when the
+      # process exits without flushing — and defeat stream overrides.
+      #
+      # Scope widened beyond plugins (PR #237) to all of packages/core/src plus
+      # the CLI's own commands, both non-test. Exempt, with reasons:
+      #   - *_test.zig and the two mixed files with in-file test blocks
+      #     (options/array_utils.zig, commands/add/_generate.zig): test
+      #     diagnostics, not runtime output.
+      #   - comment / doc-example / multiline-string ('\\') lines: not code.
+      #   - context.zig: THE sanctioned exit — it flushes buffered output first.
+      #   - registry/compiled.zig: the CLI entry point's exit(1) after a reported
+      #     error, which runs only once executeWithStdio's `defer stdio.flush()`
+      #     has fired and the console has been restored.
+      #   - build_utils/: runs at build time (*std.Build) — no io, no context,
+      #     no buffered stream exists; std.debug.print is the build-time channel.
+      - name: No std.debug.print / std.process.exit outside the context (output contract)
+        shell: bash
         run: |
-          if grep -rnE 'std\.debug\.print|std\.process\.exit' \
+          offenders=$(grep -rnE 'std\.debug\.print|std\.process\.exit' \
                --include='*.zig' \
                --exclude='*_test.zig' \
-               packages/core/src/plugins/; then
-            echo "::error::plugins must use context streams/exit, not std.debug.print/std.process.exit"
+               packages/core/src/ projects/zcli/src/commands/ \
+             | grep -vE ':[0-9]+:[[:space:]]*(///?|\\\\)' \
+             | grep -vE 'packages/core/src/context\.zig:' \
+             | grep -vE 'packages/core/src/registry/compiled\.zig:' \
+             | grep -vE 'packages/core/src/build_utils/' \
+             | grep -vE 'packages/core/src/options/array_utils\.zig:' \
+             | grep -vE 'projects/zcli/src/commands/add/_generate\.zig:' \
+             || true)
+          if [ -n "$offenders" ]; then
+            echo "::error::route output/exit through the command context (context.stdout()/stderr()/exit()/fail()), not std.debug.print/std.process.exit:"
+            echo "$offenders"
             exit 1
           fi
+          echo "output contract holds: no raw std.debug.print/std.process.exit in runtime code"
 
   # The framework (root build.zig.zon) and the CLI (projects/zcli/build.zig.zon)
   # ship in lockstep and MUST declare the same version — the CLI's `--version`
@@ -129,11 +153,25 @@ jobs:
         with:
           version: 0.16.0
 
+      # No CI runner (nor a typical dev box) ships fish, so the completion
+      # suite's `fish --no-execute` validation had never once run — the fish
+      # generator's only coverage was escaping unit tests. Install it on the
+      # cheapest leg (Linux) so the real-shell branch actually exercises fish,
+      # and set ZCLI_REQUIRE_FISH=1 so a missing binary here is a hard failure
+      # rather than a silent per-shell skip (guarding against regression to
+      # never-validated). Other OS legs leave the flag unset — fish stays
+      # optional there.
+      - name: Install fish (Linux — enables the completion suite's fish branch)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends fish
+
       # Runs the test suites for every package (packages/*) AND projects/zcli's
       # own unit tests on all three OSes. Windows is a first-class leg now that
       # the interactive `testing` harness compiles there (ConPTY backend); the
       # terminal stack is libc-free, so this guards portability across the board.
       - name: Run tests
+        env:
+          ZCLI_REQUIRE_FISH: ${{ runner.os == 'Linux' && '1' || '' }}
         run: zig build test
 
   windows-release-build:

--- a/packages/core/src/doc_gen_main.zig
+++ b/packages/core/src/doc_gen_main.zig
@@ -23,6 +23,12 @@ pub fn main(init: std.process.Init) !void {
     const commands = registry.command_info;
     const global_opts = registry.global_options_info;
 
+    // Route progress through the io model, not std.debug.print — buffered here
+    // and flushed at the end, consistent with the framework's output contract.
+    var err_buf: [512]u8 = undefined;
+    var stderr = std.Io.File.stderr().writer(io, &err_buf);
+    const errw = &stderr.interface;
+
     for (formats) |format| {
         const dir = if (formats.len > 1)
             try std.fmt.allocPrint(allocator, "{s}/{s}", .{ output_dir, format })
@@ -41,8 +47,9 @@ pub fn main(init: std.process.Init) !void {
             try writeMarkdown(allocator, io, dir, commands, global_opts);
         }
 
-        std.debug.print("Generated {s} docs in {s}/\n", .{ format, dir });
+        try errw.print("Generated {s} docs in {s}/\n", .{ format, dir });
     }
+    try errw.flush();
 }
 
 // ============================================================================

--- a/packages/core/src/options/array_utils.zig
+++ b/packages/core/src/options/array_utils.zig
@@ -285,10 +285,7 @@ test "parseOptions with array of strings (filter option)" {
     // Test case 1: No filter options provided
     {
         const args = [_][]const u8{"--all"};
-        const parsed = options.parseOptions(TestOptions, allocator, &args, null) catch |err| {
-            std.debug.print("Parse error: {any}\n", .{err});
-            return error.ParseFailed;
-        };
+        const parsed = try options.parseOptions(TestOptions, allocator, &args, null);
         defer options.cleanupOptions(TestOptions, parsed.options, allocator);
 
         try std.testing.expect(parsed.options.all == true);
@@ -299,10 +296,7 @@ test "parseOptions with array of strings (filter option)" {
     // Test case 2: Single filter option
     {
         const args = [_][]const u8{ "--filter", "status=running" };
-        const parsed = options.parseOptions(TestOptions, allocator, &args, null) catch |err| {
-            std.debug.print("Parse error: {any}\n", .{err});
-            return error.ParseFailed;
-        };
+        const parsed = try options.parseOptions(TestOptions, allocator, &args, null);
         defer options.cleanupOptions(TestOptions, parsed.options, allocator);
 
         try std.testing.expect(parsed.options.all == false);
@@ -313,10 +307,7 @@ test "parseOptions with array of strings (filter option)" {
     // Test case 3: Multiple filter options
     {
         const args = [_][]const u8{ "--filter", "status=running", "--filter", "name=web" };
-        const parsed = options.parseOptions(TestOptions, allocator, &args, null) catch |err| {
-            std.debug.print("Parse error: {any}\n", .{err});
-            return error.ParseFailed;
-        };
+        const parsed = try options.parseOptions(TestOptions, allocator, &args, null);
         defer options.cleanupOptions(TestOptions, parsed.options, allocator);
 
         try std.testing.expect(parsed.options.filter.len == 2);
@@ -327,10 +318,7 @@ test "parseOptions with array of strings (filter option)" {
     // Test case 4: Mixed options with filters
     {
         const args = [_][]const u8{ "--all", "--filter", "status=exited", "--quiet" };
-        const parsed = options.parseOptions(TestOptions, allocator, &args, null) catch |err| {
-            std.debug.print("Parse error: {any}\n", .{err});
-            return error.ParseFailed;
-        };
+        const parsed = try options.parseOptions(TestOptions, allocator, &args, null);
         defer options.cleanupOptions(TestOptions, parsed.options, allocator);
 
         try std.testing.expect(parsed.options.all == true);
@@ -352,10 +340,7 @@ test "array options default initialization" {
 
     // Parse with no arguments - should use defaults
     const args = [_][]const u8{};
-    const parsed = options.parseOptions(TestOptions, allocator, &args, null) catch |err| {
-        std.debug.print("Parse error: {any}\n", .{err});
-        return error.ParseFailed;
-    };
+    const parsed = try options.parseOptions(TestOptions, allocator, &args, null);
     defer options.cleanupOptions(TestOptions, parsed.options, allocator);
 
     // All array options should be empty but valid (not null/undefined)
@@ -387,10 +372,7 @@ test "basic array options iteration" {
     // Test with no options provided
     {
         const args = [_][]const u8{};
-        const parsed = options.parseOptions(TestOptions, allocator, &args, null) catch |err| {
-            std.debug.print("Parse error: {any}\n", .{err});
-            return error.ParseFailed;
-        };
+        const parsed = try options.parseOptions(TestOptions, allocator, &args, null);
         defer options.cleanupOptions(TestOptions, parsed.options, allocator);
 
         // This should not crash even with default empty arrays
@@ -410,10 +392,7 @@ test "basic array options iteration" {
     // Test with array options provided
     {
         const args = [_][]const u8{ "--filter", "test=value", "--env", "FOO=bar" };
-        const parsed = options.parseOptions(TestOptions, allocator, &args, null) catch |err| {
-            std.debug.print("Parse error: {any}\n", .{err});
-            return error.ParseFailed;
-        };
+        const parsed = try options.parseOptions(TestOptions, allocator, &args, null);
         defer options.cleanupOptions(TestOptions, parsed.options, allocator);
 
         try std.testing.expect(parsed.options.filter.len == 1);
@@ -449,10 +428,7 @@ test "actual container ls options parsing" {
     // Test the exact case that was causing segfault
     {
         const args = [_][]const u8{"--all"};
-        const parsed = options.parseOptions(ContainerLsOptions, allocator, &args, null) catch |err| {
-            std.debug.print("Parse error: {any}\n", .{err});
-            return error.ParseFailed;
-        };
+        const parsed = try options.parseOptions(ContainerLsOptions, allocator, &args, null);
         defer options.cleanupOptions(ContainerLsOptions, parsed.options, allocator);
 
         try std.testing.expect(parsed.options.all == true);

--- a/packages/core/src/plugin_completions_test.zig
+++ b/packages/core/src/plugin_completions_test.zig
@@ -300,6 +300,26 @@ fn runExit(a: std.mem.Allocator, argv: []const []const u8) u8 {
     };
 }
 
+/// Whether the environment demands that the fish branch actually run (i.e. fish
+/// MUST be present). Set by the CI job that installs fish so a missing binary
+/// there turns from a silent skip into a hard failure — the fish generator has
+/// never once been validated against real fish otherwise (no runner ships it).
+///
+/// The test root module has no direct env access under the 0.16 explicit-IO
+/// model (env arrives via `std.process.Init`, which unit tests don't get), so
+/// we read the flag the same way we reach every other shell here: by spawning
+/// one. A spawned child inherits our environment by default, so `bash -c` echoes
+/// the value back. bash is guaranteed present on the (Linux) job that sets the
+/// flag; anywhere without bash this returns false, which only relaxes the
+/// requirement — it can never spuriously demand fish.
+fn ciRequiresFish(a: std.mem.Allocator) bool {
+    const bash_sh = findShell("bash") orelse return false;
+    const result = std.process.run(a, io, .{
+        .argv = &.{ bash_sh, "-c", "printf %s \"$ZCLI_REQUIRE_FISH\"" },
+    }) catch return false;
+    return std.mem.eql(u8, std.mem.trim(u8, result.stdout, " \t\r\n"), "1");
+}
+
 test "shell syntax - bash -n / zsh -n / fish --no-execute accept generated scripts" {
     const bash_sh = findShell("bash");
     const zsh_sh = findShell("zsh");
@@ -313,6 +333,15 @@ test "shell syntax - bash -n / zsh -n / fish --no-execute accept generated scrip
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const a = arena.allocator();
+
+    // No CI runner ships fish, so this is the ONE job that installs it — refuse
+    // to let the fish branch skip there, or the fish generator regresses to
+    // never-validated (its only other coverage is escaping unit tests). Anywhere
+    // the flag is unset (dev machines, the other OS legs) fish stays optional.
+    if (fish_sh == null and ciRequiresFish(a)) {
+        std.debug.print("ZCLI_REQUIRE_FISH=1 but no fish binary found in the known locations\n", .{});
+        return error.FishRequiredButMissing;
+    }
 
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();


### PR DESCRIPTION
Two CI follow-ups from the plugin/completions audit.

## Item 1 — fish completion validation actually runs somewhere

PR #235 added a real-shell validation test (`bash -n` / `zsh -n` / `fish --no-execute` on generated completion scripts), but **no CI runner nor a typical dev box ships fish** — so the `fish --no-execute` branch had never once executed. The fish generator's only coverage was escaping unit tests.

- Install fish on the **Linux unit-test leg** (`sudo apt-get install -y fish`) — the cheapest job that runs the completion suite — so the real-shell branch actually exercises fish.
- Add a **`ZCLI_REQUIRE_FISH=1`** gate, set only on that leg via `env:`, that turns a missing fish binary from a silent per-shell skip into a **hard failure** (`error.FishRequiredButMissing`). This is the whole point: it prevents regression back to never-validated. Other OS legs leave the flag unset, so fish stays optional there.
- The test reads the flag by spawning bash to echo it — a spawned child inherits the parent environment — because the test root module has no direct env access under 0.16's explicit-IO model (env arrives via `std.process.Init`, which unit tests don't get). Anywhere without bash this returns false, so it can only ever relax the requirement, never spuriously demand fish.

Verified locally end-to-end with `brew install fish`: passes with fish present (`ZCLI_REQUIRE_FISH=1 zig build test` → 0); with fish hidden, the flag turns it into a hard failure; without the flag, it skips cleanly.

## Item 2 — widen the plugin output-contract lint

PR #237 grepped `packages/core/src/plugins/` for `std.debug.print` / `std.process.exit`. This widens the scope to **all of `packages/core/src` + `projects/zcli/src/commands`** (both non-test).

**Survey (fixed vs allowlisted):**

| Site | Verdict |
|------|---------|
| `doc_gen_main.zig:44` | **FIXED** — build-tool `main` with `io` available; status line now routes through a flushed io stderr writer. |
| `options/array_utils.zig` (8 test-block prints) | **FIXED** — redundant `catch { print; return error }` collapsed to plain `try` (propagates the real error with location; no lost detail). |
| `context.zig:256` | allowlisted — THE sanctioned exit: flushes buffered output before `std.process.exit`. |
| `registry/compiled.zig:624` | allowlisted — CLI entry's `exit(1)` after a reported error, reached only once `executeWithStdio`'s `defer stdio.flush()` has fired + console restored. |
| `build_utils/plugin_system.zig`, `build_utils/main.zig` | allowlisted — build-time code (`*std.Build`): no io, no context, no buffered stream exists; `std.debug.print` is the build-time channel. |
| `commands/add/_generate.zig:285` | allowlisted — test-only `expectContains` assertion helper in a mixed file. |
| doc-comment / help-text / scaffold-string lines (`parser.zig`, `guide.zig`, `init.zig`) | filtered — not code. |

**Borderline call I'm flagging:** `guard.zig:166` (packages/terminal) is a `std.process.exit` in a signal handler that has already restored the terminal and re-raised the signal — no context is reachable in an async-signal context, and a buffered writer would be unsafe there. Legitimate, and outside the widened scope (packages/terminal), so not linted.

The lint stays a simple readable grep: match the two calls, filter comment/string lines, subtract the documented allowlist, fail with the offending lines if anything remains. Verified locally: passes clean, and catches an injected `std.debug.print` in an in-scope file.

## Verify
- Root `zig build test` → exit 0 (with `ZCLI_REQUIRE_FISH=1` and fish present).
- `zig build e2e` → green (an initial run had 4 signal-KILL/TERM crashes from concurrent-build resource pressure on the heavy scaffold+build tiers; a clean re-run passed 0 — unrelated to output routing, which these changes don't touch).
- Lint simulated locally: passes on the clean tree, catches an injected violation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)