### PR TITLE
fix(testing): report option for snapshot assertions, unify quiet/loud paths

### DIFF
--- a/packages/testing/examples/snapshot_example.zig
+++ b/packages/testing/examples/snapshot_example.zig
@@ -8,6 +8,9 @@
 //!     codes — the real thing, end to end.
 //!   * `expectSnapshot` compares output against a golden file, with dynamic
 //!     content (UUIDs, timestamps, addresses) masked so goldens don't churn.
+//!     It also drives the update path (writing the golden) and the
+//!     mismatch/missing error paths — kept noise-free here via
+//!     `.report = false`, a first-class quiet switch on `SnapshotOptions`.
 //!
 //! `zig build examples` runs every `test` below. Because a package-test
 //! environment has no CLI binary of its own to point `runSubprocess` at, the
@@ -72,15 +75,18 @@ test "runSubprocess sees a non-zero exit" {
 //     a missing golden returns error.SnapshotMissing.
 //   * Update (`.{ .update = true }`): WRITE the golden instead of comparing.
 //     Thread this from a build option in a real project —
-//     `zig build test -Dupdate-snapshots` — and prints a confirmation line.
+//     `zig build test -Dupdate-snapshots` — and it prints a confirmation line.
 //
-// The update and mismatch paths intentionally write to stderr (that's the
-// human-facing diagnostic real callers want). To keep THIS example's build step
-// quiet, the test below pre-seeds the golden by hand and then exercises only the
-// compare-match path — the interesting part (masking makes a match survive
-// changing UUIDs/timestamps) without the diagnostic noise.
+// The update, mismatch, and missing paths print human-facing diagnostics to
+// stderr — exactly what you want when driving them by hand. But an *always-on*
+// example that exercises the update path would spew that confirmation line into
+// `zig build examples`, which trips the build runner into echoing a misleading
+// `failed command: …` even though every test passed. So these examples pass
+// `.report = false` on the paths they drive on purpose: a first-class quiet
+// switch on `SnapshotOptions`. In your own project you'd leave it at the loud
+// default and let the diagnostics guide you.
 
-test "expectSnapshot compare path: masking makes a match stable across runs" {
+test "expectSnapshot round-trip: update writes the golden, compare then matches" {
     const allocator = std.testing.allocator;
     const io = std.testing.io;
 
@@ -91,22 +97,19 @@ test "expectSnapshot compare path: masking makes a match stable across runs" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    // Pre-seed the golden the harness would look up for this file+name. It stores
-    // the *masked* form: the real UUID/timestamp become [UUID]/[TIMESTAMP]. (In a
-    // real project you'd generate this once with `.update = true` instead of
-    // writing it by hand.)
-    try tmp.dir.createDirPath(io, "tests/snapshots/snapshot_example");
-    try tmp.dir.writeFile(io, .{
-        .sub_path = "tests/snapshots/snapshot_example/profile.txt",
-        .data = "user id=[UUID] created [TIMESTAMP]",
-    });
+    // First run: `.update = true` WRITES the golden (masked form). This is the
+    // real update workflow — no hand-seeding. `.report = false` keeps the
+    // confirmation line out of the examples build; drop it in a real project.
+    // `@src()` tells the harness which file this is (it derives the snapshot
+    // subdirectory `snapshot_example` from the file name).
+    const first = "user id=550e8400-e29b-41d4-a716-446655440000 created 2024-01-15T10:30:00Z";
+    try testing.expectSnapshot(allocator, io, tmp.dir, first, @src(), "profile", .{ .update = true, .report = false });
 
-    // Compare mode: a run with a DIFFERENT UUID and timestamp still MATCHES,
-    // because both are masked before comparison — only the stable structure is
-    // asserted. `@src()` tells the harness which file this is (it derives the
-    // snapshot subdirectory `snapshot_example` from the file name).
-    const output = "user id=00000000-1111-2222-3333-444444444444 created 2025-09-09T00:00:00Z";
-    try testing.expectSnapshot(allocator, io, tmp.dir, output, @src(), "profile", .{});
+    // Later run: a DIFFERENT UUID and timestamp still MATCHES against the golden
+    // just written, because both are masked before comparison — only the stable
+    // structure is asserted. A match prints nothing, so the loud default is fine.
+    const later = "user id=00000000-1111-2222-3333-444444444444 created 2025-09-09T00:00:00Z";
+    try testing.expectSnapshot(allocator, io, tmp.dir, later, @src(), "profile", .{});
 }
 
 test "SnapshotOptions.ansi=false compares only visible text" {
@@ -118,14 +121,26 @@ test "SnapshotOptions.ansi=false compares only visible text" {
 
     // With `.ansi = false`, escape codes are stripped before comparison, so a
     // color change doesn't churn the golden — only the rendered text matters.
-    // Pre-seed the golden as the stripped text, then compare a differently-colored
-    // string against it: still a match.
-    try tmp.dir.createDirPath(io, "tests/snapshots/snapshot_example");
-    try tmp.dir.writeFile(io, .{
-        .sub_path = "tests/snapshots/snapshot_example/message.txt",
-        .data = "ERROR: nope",
-    });
+    // Write the golden from one colored string, then compare a differently-colored
+    // string against it: still a match once both are stripped.
+    try testing.expectSnapshot(allocator, io, tmp.dir, "\x1b[31mERROR\x1b[0m: nope", @src(), "message", .{ .ansi = false, .update = true, .report = false });
     try testing.expectSnapshot(allocator, io, tmp.dir, "\x1b[33mERROR\x1b[0m: nope", @src(), "message", .{ .ansi = false });
+}
+
+test "expectSnapshot compare path: mismatch and missing goldens error" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // Seed a golden via the update path, then feed a genuinely different value:
+    // that's `error.SnapshotMismatch` (in a loud run it also prints a diff box).
+    try testing.expectSnapshot(allocator, io, tmp.dir, "stable output", @src(), "diagnostics", .{ .update = true, .report = false });
+    try std.testing.expectError(error.SnapshotMismatch, testing.expectSnapshot(allocator, io, tmp.dir, "changed output", @src(), "diagnostics", .{ .report = false }));
+
+    // A golden that was never written is `error.SnapshotMissing`.
+    try std.testing.expectError(error.SnapshotMissing, testing.expectSnapshot(allocator, io, tmp.dir, "anything", @src(), "never-written", .{ .report = false }));
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/testing/src/snapshot.zig
+++ b/packages/testing/src/snapshot.zig
@@ -12,6 +12,15 @@ pub const SnapshotOptions = struct {
     /// `@import("build_options")`). zcli style is explicit configuration;
     /// there is no ambient environment-variable check.
     update: bool = false,
+    /// Whether to print human-facing diagnostics on the update, mismatch, and
+    /// missing paths (the update-confirmation line and the diff/missing boxes).
+    /// Defaults to `true` because interactive diagnostics are the right default
+    /// for humans debugging a failing snapshot. Set `false` when a test
+    /// deliberately drives those paths and expects them (asserting the returned
+    /// error) — writing to stderr in an otherwise-passing run makes Zig's build
+    /// runner echo a misleading `failed command: …` even though every test
+    /// passed.
+    report: bool = true,
 };
 
 /// Unified snapshot testing function with configurable options.
@@ -19,6 +28,12 @@ pub const SnapshotOptions = struct {
 /// `snapshot_root` is the directory `tests/snapshots/...` paths are resolved
 /// against — pass `std.Io.Dir.cwd()` in a normal test suite (the package
 /// root, when run via `zig build test`).
+/// By default real callers get the human-facing diagnostics on the update,
+/// mismatch, and missing paths (the update confirmation and the diff/missing
+/// boxes). Tests that deliberately drive those paths — and assert the returned
+/// error rather than reading the diagnostics — pass `.{ .report = false }` so a
+/// passing run stays quiet (writing to stderr here would otherwise make the
+/// build runner echo `failed command: …` even though every test passed).
 pub fn expectSnapshot(
     allocator: std.mem.Allocator,
     io: std.Io,
@@ -28,24 +43,7 @@ pub fn expectSnapshot(
     comptime snapshot_name: []const u8,
     options: SnapshotOptions,
 ) !void {
-    // Real callers get the human-facing diagnostics (the update confirmation and
-    // the mismatch/missing boxes). This module's own tests, which deliberately
-    // drive the update and error paths, call the impl with `report = false` so a
-    // passing run stays quiet (writing to stderr here would otherwise make the
-    // build runner echo `failed command: …` even though every test passed).
-    return expectSnapshotImpl(allocator, io, snapshot_root, actual, location, snapshot_name, options, true);
-}
-
-fn expectSnapshotImpl(
-    allocator: std.mem.Allocator,
-    io: std.Io,
-    snapshot_root: std.Io.Dir,
-    actual: []const u8,
-    comptime location: std.builtin.SourceLocation,
-    comptime snapshot_name: []const u8,
-    options: SnapshotOptions,
-    comptime report: bool,
-) !void {
+    const report = options.report;
     // Build snapshot file path based on test file location
     const test_file_path = location.file;
     const snapshot_dir = comptime getSnapshotDir(test_file_path);
@@ -529,22 +527,22 @@ test "expectSnapshot round-trip: update writes, compare matches, mismatch and mi
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    // The update and error paths are driven through the quiet impl so this
+    // The update and error paths are driven with `.report = false` so this
     // passing test doesn't spew the update confirmation and diff boxes (which
     // would also trip the build runner into printing `failed command: …`).
 
     // Update mode creates the snapshot file (ANSI preserved by default).
-    try expectSnapshotImpl(a, io, tmp.dir, "hello \x1b[1mworld\x1b[0m", @src(), "roundtrip", .{ .update = true }, false);
+    try expectSnapshot(a, io, tmp.dir, "hello \x1b[1mworld\x1b[0m", @src(), "roundtrip", .{ .update = true, .report = false });
 
-    // Compare mode passes against what was just written (public entry point;
-    // a match prints nothing regardless).
+    // Compare mode passes against what was just written (a match prints nothing
+    // regardless, so the default loud `report` is fine here).
     try expectSnapshot(a, io, tmp.dir, "hello \x1b[1mworld\x1b[0m", @src(), "roundtrip", .{});
 
     // A differing value is a mismatch.
-    try testing.expectError(error.SnapshotMismatch, expectSnapshotImpl(a, io, tmp.dir, "different", @src(), "roundtrip", .{}, false));
+    try testing.expectError(error.SnapshotMismatch, expectSnapshot(a, io, tmp.dir, "different", @src(), "roundtrip", .{ .report = false }));
 
     // A snapshot that was never written is its own error.
-    try testing.expectError(error.SnapshotMissing, expectSnapshotImpl(a, io, tmp.dir, "x", @src(), "never-written", .{}, false));
+    try testing.expectError(error.SnapshotMissing, expectSnapshot(a, io, tmp.dir, "x", @src(), "never-written", .{ .report = false }));
 }
 
 test "expectSnapshot with ansi=false compares stripped content" {
@@ -553,7 +551,7 @@ test "expectSnapshot with ansi=false compares stripped content" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try expectSnapshotImpl(a, io, tmp.dir, "\x1b[31mred\x1b[0m text", @src(), "stripped", .{ .ansi = false, .update = true }, false);
+    try expectSnapshot(a, io, tmp.dir, "\x1b[31mred\x1b[0m text", @src(), "stripped", .{ .ansi = false, .update = true, .report = false });
     // Different coloring, same visible text: still a match once stripped.
     try expectSnapshot(a, io, tmp.dir, "\x1b[32mred\x1b[0m text", @src(), "stripped", .{ .ansi = false });
 }


### PR DESCRIPTION
Stacked on #243; merge that first.

## Summary

`packages/testing`'s `expectSnapshot` always wrote diagnostics to stderr on its update/mismatch/missing paths. Any stderr in an otherwise-passing test run makes Zig's build runner echo a misleading `failed command: …` even when the test step passes. The package dodged this internally via a private `expectSnapshotImpl(report=false)`, but consumers had no way to. Consequence: `examples/snapshot_example.zig` (added in #243) couldn't exercise the snapshot-*update* path — it hand-seeded the golden and only demonstrated compare-match.

This gives consumers a first-class quiet switch and collapses the two parallel implementations into one.

## API shape

Added `report: bool = true` to `SnapshotOptions` — loud by default, since interactive diagnostics are the right default for humans debugging a failing snapshot. Set `.report = false` when a test deliberately drives the update/error paths and asserts the returned error instead of reading the diagnostics.

The public `expectSnapshot` now reads `options.report`; the private `expectSnapshotImpl` (which took a separate `comptime report: bool`) is **removed**. The package's own snapshot round-trip tests are re-routed through the public API with `.report = false` — no back-compat shim, per repo policy.

## Consumer impact

- `SnapshotOptions` gains one defaulted field; every existing `expectSnapshot(... .{})` call is unchanged (stays loud). No call site required an edit.
- Grepped the repo: the only real `expectSnapshot`/`SnapshotOptions` consumer is `packages/testing` itself. `projects/zcli` and its `zig build e2e` harness use `runCommand`/`runSubprocess`/the PTY harness and **do not** touch snapshot code (the `zcli_testing.runCommand` hits in `projects/zcli/test/e2e.zig` are inside `\\` scaffold string literals the CLI *emits*, not live calls). So the e2e harness does not consume snapshot code — `zig build e2e` was not exercised for this change.
- `examples/snapshot_example.zig` now genuinely drives: (1) the update path writing the golden on first run, (2) a masked re-compare that matches despite changed UUID/timestamp, (3) `ansi=false` update+compare, and (4) mismatch + missing error paths — all noise-free with `.report = false`, replacing the hand-seeding. Doc header, inline comments updated.

## Test plan

- `cd packages/testing && zig build test` — clean, exit 0, no `failed command:`.
- `cd packages/testing && zig build examples` — clean, exit 0, no `failed command:`.
- Repo root `zig build test` — all subprojects pass (ghauth, notes, zcli, tasks, oauth-device, repostat), exit 0.
- `zig build e2e`: not run — the e2e harness does not consume snapshot code (see consumer impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)