### PR TITLE
refactor(vterm): drop the demo CLI's unused vterm import

### DIFF
--- a/packages/vterm/example/build.zig
+++ b/packages/vterm/example/build.zig
@@ -10,7 +10,10 @@ pub fn build(b: *std.Build) void {
     const vterm_dep = b.dependency("vterm", .{ .target = target, .optimize = optimize });
     const vterm_mod = vterm_dep.module("vterm");
 
-    // Build the example CLI application
+    // Build the example CLI application. This is the *application under test*,
+    // not part of the vterm demo — a plain CLI that emits ANSI output, exactly
+    // like a real program you'd point vterm at. It deliberately does NOT depend
+    // on vterm (the tests do); a real CLI you test with vterm wouldn't either.
     const exe = b.addExecutable(.{
         .name = "demo-cli",
         .root_module = b.createModule(.{
@@ -19,7 +22,6 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    exe.root_module.addImport("vterm", vterm_mod);
     b.installArtifact(exe);
 
     // Create run command


### PR DESCRIPTION
Follow-up to #240 (already merged).

The example's `demo-cli` is the **application under test**, not part of the vterm demo — it never imports or uses vterm (the tests do). The exe's `addImport("vterm", ...)` in `build.zig` was dead wiring that made the CLI *look* like it depended on vterm when it doesn't, muddying the example's central point.

Remove it and note the role in a comment. A real CLI you'd test with vterm wouldn't depend on vterm either, so a faithful example keeps the app-under-test vterm-free.

`zig build test`: **20/20 pass** — the exe still builds, proving the import was unused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)