### PR TITLE
feat(completions): complete positional args instead of dumping files

### DIFF
--- a/packages/core/src/plugin_completions_test.zig
+++ b/packages/core/src/plugin_completions_test.zig
@@ -32,13 +32,26 @@ const add_options = [_]zcli.OptionInfo{
     .{ .name = "force", .short = 'f', .description = "Skip confirmation" },
 };
 
+const statuses = [_][]const u8{ "open", "done" };
+
+// `edit` takes a plain (non-enum) id → completions show a hint, not files.
+const edit_args = [_]zcli.ArgInfo{
+    .{ .name = "id", .description = "Task ID" },
+};
+// `list` takes an enum status → completions offer the choices as values.
+const list_args = [_]zcli.ArgInfo{
+    .{ .name = "status", .description = "Filter by status", .enum_values = &statuses },
+};
+
 /// A representative tree: root leaves (add/list/edit) with an alias and enum
 /// option, plus a nested group (sprint create / sprint list). `edit`'s
-/// description contains an apostrophe — the adversarial case for fish.
+/// description contains an apostrophe — the adversarial case for fish. `edit`
+/// and `list` declare positional args (a plain id and an enum status) to
+/// exercise positional-argument completion.
 const commands = [_]zcli.CommandInfo{
     .{ .path = &.{"add"}, .description = "Add a task", .options = &add_options, .aliases = &.{"a"} },
-    .{ .path = &.{"list"}, .description = "List tasks" },
-    .{ .path = &.{"edit"}, .description = "Edit a task's title" },
+    .{ .path = &.{"list"}, .description = "List tasks", .args = &list_args },
+    .{ .path = &.{"edit"}, .description = "Edit a task's title", .args = &edit_args },
     .{ .path = &.{ "sprint", "create" }, .description = "Create a sprint" },
     .{ .path = &.{ "sprint", "list" }, .description = "List sprints" },
 };
@@ -207,6 +220,12 @@ test "bash.generate - emits a root case and single-word case subjects" {
     // Enum values are completable via compgen -W.
     try std.testing.expect(contains(script, "low medium high"));
 
+    // A leaf's enum positional is offered at its command path...
+    try std.testing.expect(contains(script, "\"list\")"));
+    try std.testing.expect(contains(script, "open done"));
+    // ...and the blanket file fallback is gone (no more CWD dump for positionals).
+    try std.testing.expect(!contains(script, "compgen -f"));
+
     // bash-completion fallback present.
     try std.testing.expect(contains(script, "declare -F _init_completion"));
 }
@@ -224,6 +243,14 @@ test "zsh.generate - compdef header, describe, and enum action" {
     try std.testing.expect(contains(script, ":priority:(low medium high)"));
     // Alias appears as an alternation in the case pattern.
     try std.testing.expect(contains(script, "add|a)"));
+
+    // A plain positional force-displays its description as a hint via _message -r
+    // (an empty action would render nothing without a `format` zstyle set).
+    try std.testing.expect(contains(script, "'1: : _message -r \"Task ID\"'"));
+    // An enum positional offers its choices as an action group.
+    try std.testing.expect(contains(script, "'1:Filter by status:(open done)'"));
+    // The blanket file fallback is gone.
+    try std.testing.expect(!contains(script, "_files"));
 }
 
 test "fish.generate - escapes apostrophes and uses positional conditions" {
@@ -243,6 +270,12 @@ test "fish.generate - escapes apostrophes and uses positional conditions" {
     try std.testing.expect(contains(script, "-x -a 'low medium high'"));
     // Alias offered alongside the command name in a single -a argument.
     try std.testing.expect(contains(script, "-a 'add a'"));
+
+    // A leaf suppresses file completion at its first positional (`-f` at the
+    // command's own path condition).
+    try std.testing.expect(contains(script, "complete -c tasks -f -n '__fish_tasks_using_command edit'"));
+    // An enum positional additionally offers its choices.
+    try std.testing.expect(contains(script, "__fish_tasks_using_command list' -a 'open done'"));
 }
 
 test "generators - empty command set still yields a valid skeleton" {
@@ -366,6 +399,7 @@ test "functional bash - COMPREPLY at root and at depth 2" {
         \\
         \\echo "ROOT:$(run tasks '')"
         \\echo "DEPTH2:$(run tasks sprint '')"
+        \\echo "LISTARG:$(run tasks list '')"
         \\
     , .{script_path});
     const harness_path = try writeTemp(a, tmp.dir, "zcli_func_harness.bash", harness);
@@ -377,14 +411,17 @@ test "functional bash - COMPREPLY at root and at depth 2" {
 
     var root_line: ?[]const u8 = null;
     var depth2_line: ?[]const u8 = null;
+    var listarg_line: ?[]const u8 = null;
     var lines = std.mem.splitScalar(u8, out, '\n');
     while (lines.next()) |line| {
         if (std.mem.startsWith(u8, line, "ROOT:")) root_line = line["ROOT:".len..];
         if (std.mem.startsWith(u8, line, "DEPTH2:")) depth2_line = line["DEPTH2:".len..];
+        if (std.mem.startsWith(u8, line, "LISTARG:")) listarg_line = line["LISTARG:".len..];
     }
 
     try std.testing.expect(root_line != null);
     try std.testing.expect(depth2_line != null);
+    try std.testing.expect(listarg_line != null);
 
     // Root completions include every top-level command.
     try std.testing.expect(contains(root_line.?, "add"));
@@ -397,4 +434,8 @@ test "functional bash - COMPREPLY at root and at depth 2" {
     try std.testing.expect(contains(depth2_line.?, "create"));
     try std.testing.expect(contains(depth2_line.?, "list"));
     try std.testing.expect(!contains(depth2_line.?, "add"));
+
+    // `tasks list <TAB>` completes the enum positional's values, NOT files.
+    try std.testing.expect(contains(listarg_line.?, "open"));
+    try std.testing.expect(contains(listarg_line.?, "done"));
 }

--- a/packages/core/src/plugins/zcli_completions/bash.zig
+++ b/packages/core/src/plugins/zcli_completions/bash.zig
@@ -87,9 +87,16 @@ pub fn generate(
 
     try writer.writeAll("    if [[ -n \"$completions\" ]]; then\n");
     try writer.writeAll("        COMPREPLY=($(compgen -W \"$completions\" -- \"$cur\"))\n");
-    try writer.writeAll("    else\n");
-    // Positional fallback: offer files for leaf commands with no further subcommands.
-    try writer.writeAll("        COMPREPLY=($(compgen -f -- \"$cur\"))\n");
+    if (hasPositionalEnums(root)) {
+        // Positional value completion for leaf commands. Keyed on the exact
+        // command path — i.e. the first positional slot — since bash has no way
+        // to display a descriptive hint, only candidate values. Non-enum
+        // positionals intentionally offer nothing rather than dumping files.
+        try writer.writeAll("    else\n");
+        try writer.writeAll("        case \"$key\" in\n");
+        try writePositionalCases(arena, writer, root);
+        try writer.writeAll("        esac\n");
+    }
     try writer.writeAll("    fi\n");
     try writer.writeAll("    return 0\n");
     try writer.writeAll("}\n\n");
@@ -135,6 +142,34 @@ fn writeCommandCases(arena: std.mem.Allocator, writer: anytype, node: *const tre
         try writer.writeAll("            ;;\n");
     }
     for (node.children) |child| try writeCommandCases(arena, writer, child);
+}
+
+/// Emit a `"path")` case offering the enum values of a leaf command's FIRST
+/// positional. Matching on the exact command path means the case fires when the
+/// cursor sits at that first positional. Leaves whose first positional is not an
+/// enum contribute no case (they complete nothing — deliberately not files).
+fn writePositionalCases(arena: std.mem.Allocator, writer: anytype, node: *const tree.CommandNode) !void {
+    if (node.isLeaf() and node.args.len > 0) {
+        if (node.args[0].enum_values) |values| {
+            try writer.print("            \"{s}\")\n", .{try joinPath(arena, node.path)});
+            try writer.writeAll("                COMPREPLY=($(compgen -W \"");
+            for (values, 0..) |v, idx| {
+                if (idx > 0) try writer.writeByte(' ');
+                try writer.writeAll(v);
+            }
+            try writer.writeAll("\" -- \"$cur\"))\n");
+            try writer.writeAll("                ;;\n");
+        }
+    }
+    for (node.children) |child| try writePositionalCases(arena, writer, child);
+}
+
+/// True if any leaf command declares an enum as its first positional — i.e. we
+/// need a positional `case "$key"` block to offer those values.
+fn hasPositionalEnums(node: *const tree.CommandNode) bool {
+    if (node.isLeaf() and node.args.len > 0 and node.args[0].enum_values != null) return true;
+    for (node.children) |child| if (hasPositionalEnums(child)) return true;
+    return false;
 }
 
 /// True if any command option OR global option is an enum with values — i.e. we

--- a/packages/core/src/plugins/zcli_completions/fish.zig
+++ b/packages/core/src/plugins/zcli_completions/fish.zig
@@ -78,6 +78,15 @@ fn writeNode(
     app_name: []const u8,
     node: *const tree.CommandNode,
 ) !void {
+    // Leaf positional completion. The `using_command` condition matches only when
+    // the token sequence equals this exact path — i.e. the cursor is at the first
+    // positional. `-f` there suppresses fish's default file completion (so a
+    // command that takes an id doesn't dump the CWD); an enum arg additionally
+    // offers its choices.
+    if (node.isLeaf() and node.path.len > 0) {
+        try writePositional(arena, writer, app_name, node);
+    }
+
     // Offer this node's children as subcommands, conditioned on being exactly at
     // this node's path (empty path for the root → the bare `-c` condition).
     for (node.children) |child| {
@@ -105,6 +114,36 @@ fn writeNode(
     }
 
     for (node.children) |child| try writeNode(arena, writer, app_name, child);
+}
+
+/// Emit the leaf's first-positional completion: always `-f` (no file dump) at
+/// the command's own path, plus `-a`/`-d` for an enum first positional.
+fn writePositional(
+    arena: std.mem.Allocator,
+    writer: anytype,
+    app_name: []const u8,
+    node: *const tree.CommandNode,
+) !void {
+    try writer.print("complete -c {s} -f", .{app_name});
+    try writeCondition(arena, writer, app_name, node.path);
+
+    if (node.args.len > 0) {
+        const arg = node.args[0];
+        if (arg.enum_values) |values| {
+            try writer.writeAll(" -a '");
+            for (values, 0..) |v, idx| {
+                if (idx > 0) try writer.writeByte(' ');
+                const esc = try escape.fish(arena, v);
+                try writer.writeAll(esc);
+            }
+            try writer.writeAll("'");
+            if (arg.description) |d| {
+                const esc = try escape.fish(arena, d);
+                try writer.print(" -d '{s}'", .{esc});
+            }
+        }
+    }
+    try writer.writeAll("\n");
 }
 
 /// Emit one `complete` directive for an option. `path` null means global (no

--- a/packages/core/src/plugins/zcli_completions/zsh.zig
+++ b/packages/core/src/plugins/zcli_completions/zsh.zig
@@ -105,29 +105,53 @@ fn writeArgsDispatch(
     try writer.print("{s}esac\n", .{indent});
 }
 
-/// Emit the `_arguments` call for a leaf command (its options + a file fallback
-/// for positionals).
+/// Emit the `_arguments` call for a leaf command: its options plus a spec for
+/// each declared positional. Enum positionals offer their choices; every other
+/// positional shows its name/description as a hint (an empty action = describe
+/// but complete nothing). There is deliberately NO file fallback — a command
+/// that takes an id or an enum should not dump the working directory.
 fn writeLeafArguments(
     arena: std.mem.Allocator,
     writer: anytype,
     indent: []const u8,
     node: *const tree.CommandNode,
 ) !void {
+    var specs = std.ArrayList([]const u8).empty;
+    try appendOptionSpecs(arena, &specs, node.options);
+    try appendPositionalSpecs(arena, &specs, node.args);
+
+    // Nothing declared → nothing to complete for this command.
+    if (specs.items.len == 0) return;
+
     // Namespace the context so option state doesn't leak between commands.
     const ctx = try std.mem.join(arena, "-", node.path);
     try writer.print("{s}        curcontext=\"${{curcontext%:*:*}}:{s}:\"\n", .{ indent, ctx });
     try writer.print("{s}        _arguments -S \\\n", .{indent});
     const spec_indent = try std.mem.concat(arena, u8, &.{ indent, "            " });
-    try writeOptionSpecs(arena, writer, spec_indent, node.options);
-    // Positional fallback: complete files for any remaining args.
-    try writer.print("{s}'*::arg:_files'\n", .{spec_indent});
+    for (specs.items, 0..) |spec, i| {
+        const cont = if (i + 1 < specs.items.len) " \\" else "";
+        try writer.print("{s}'{s}'{s}\n", .{ spec_indent, spec, cont });
+    }
 }
 
-/// Emit `_arguments` option specs (one line per form, `\`-continued) at `indent`.
+/// Emit `_arguments` option specs (one `\`-continued line per form) at `indent`.
+/// Used by the top-level `_arguments` where fixed specs always follow, so every
+/// line keeps its trailing backslash.
 fn writeOptionSpecs(
     arena: std.mem.Allocator,
     writer: anytype,
     indent: []const u8,
+    options: []const zcli.OptionInfo,
+) !void {
+    var specs = std.ArrayList([]const u8).empty;
+    try appendOptionSpecs(arena, &specs, options);
+    for (specs.items) |spec| try writer.print("{s}'{s}' \\\n", .{ indent, spec });
+}
+
+/// Append one `_arguments` spec string (unquoted, unindented) per option form.
+fn appendOptionSpecs(
+    arena: std.mem.Allocator,
+    specs: *std.ArrayList([]const u8),
     options: []const zcli.OptionInfo,
 ) !void {
     for (options) |opt| {
@@ -135,14 +159,82 @@ fn writeOptionSpecs(
         const action = try optionAction(arena, opt);
 
         if (opt.short) |short| {
-            try writer.print("{s}'-{c}", .{ indent, short });
-            if (esc_desc) |d| try writer.print("[{s}]", .{d});
-            try writer.print("{s}' \\\n", .{action});
+            const spec = if (esc_desc) |d|
+                try std.fmt.allocPrint(arena, "-{c}[{s}]{s}", .{ short, d, action })
+            else
+                try std.fmt.allocPrint(arena, "-{c}{s}", .{ short, action });
+            try specs.append(arena, spec);
         }
-        try writer.print("{s}'--{s}", .{ indent, opt.name });
-        if (esc_desc) |d| try writer.print("[{s}]", .{d});
-        try writer.print("{s}' \\\n", .{action});
+        const spec = if (esc_desc) |d|
+            try std.fmt.allocPrint(arena, "--{s}[{s}]{s}", .{ opt.name, d, action })
+        else
+            try std.fmt.allocPrint(arena, "--{s}{s}", .{ opt.name, action });
+        try specs.append(arena, spec);
     }
+}
+
+/// Append one positional `_arguments` spec per declared arg. `pos` is the 1-based
+/// index, or `*` for a variadic arg that soaks up the rest:
+///   'N:message:(a b c)'          → an enum arg; offer its choices
+///   'N: : _message -r "message"' → any other arg; force-display a hint
+///
+/// Non-enum positionals use `_message -r` rather than an empty action because an
+/// empty action's message only renders when the user has a `format`/`descriptions`
+/// zstyle set (most don't) — so it would silently show nothing. `_message -r`
+/// displays unconditionally. There is deliberately no `_files` fallback.
+fn appendPositionalSpecs(
+    arena: std.mem.Allocator,
+    specs: *std.ArrayList([]const u8),
+    args: []const zcli.ArgInfo,
+) !void {
+    for (args, 1..) |arg, idx| {
+        const pos = if (arg.is_variadic)
+            try arena.dupe(u8, "*")
+        else
+            try std.fmt.allocPrint(arena, "{d}", .{idx});
+
+        const msg = arg.description orelse arg.name;
+
+        const spec = if (arg.enum_values) |values| blk: {
+            const esc_msg = try escape.zsh(arena, msg);
+            const group = try enumActionGroup(arena, values);
+            break :blk try std.fmt.allocPrint(arena, "{s}:{s}:{s}", .{ pos, esc_msg, group });
+        } else blk: {
+            // Build `pos: : _message -r "<msg>"`, then dance single quotes so the
+            // whole token is safe inside the outer '…' the caller wraps it in. The
+            // message sits in double quotes (dq-escaped); its single quotes are
+            // handled by the dance — two non-overlapping escape layers.
+            const raw = try std.fmt.allocPrint(arena, "{s}: : _message -r \"{s}\"", .{ pos, try dquoteEscape(arena, msg) });
+            break :blk try danceSingleQuotes(arena, raw);
+        };
+        try specs.append(arena, spec);
+    }
+}
+
+/// Escape for placement inside a zsh double-quoted string: backslash-escape the
+/// four chars zsh expands there (`\`, `"`, `$`, `` ` ``).
+fn dquoteEscape(arena: std.mem.Allocator, s: []const u8) ![]const u8 {
+    var out = std.ArrayList(u8).empty;
+    for (s) |c| {
+        switch (c) {
+            '\\', '"', '$', '`' => {
+                try out.append(arena, '\\');
+                try out.append(arena, c);
+            },
+            else => try out.append(arena, c),
+        }
+    }
+    return out.items;
+}
+
+/// Replace each single quote with the `'\''` sequence so the string is safe to
+/// place inside an outer `'…'` (the classic shell single-quote dance).
+fn danceSingleQuotes(arena: std.mem.Allocator, s: []const u8) ![]const u8 {
+    var out = std.ArrayList(u8).empty;
+    for (s) |c| {
+        if (c == '\'') try out.appendSlice(arena, "'\\''") else try out.append(arena, c);
+    }
+    return out.items;
 }
 
 /// The zsh `_arguments` action suffix for an option:
@@ -151,22 +243,27 @@ fn writeOptionSpecs(
 ///   ":name:(a b c)"             → takes one of the enum values
 fn optionAction(arena: std.mem.Allocator, opt: zcli.OptionInfo) ![]const u8 {
     if (opt.enum_values) |values| {
-        var out = std.ArrayList(u8).empty;
-        try out.appendSlice(arena, ":");
-        try out.appendSlice(arena, opt.name);
-        try out.appendSlice(arena, ":(");
-        for (values, 0..) |v, idx| {
-            if (idx > 0) try out.append(arena, ' ');
-            const esc = try escape.zsh(arena, v);
-            try out.appendSlice(arena, esc);
-        }
-        try out.appendSlice(arena, ")");
-        return out.items;
+        const group = try enumActionGroup(arena, values);
+        return std.mem.concat(arena, u8, &.{ ":", opt.name, ":", group });
     }
     if (opt.takes_value) {
         return std.mem.concat(arena, u8, &.{ ":", opt.name, ":" });
     }
     return "";
+}
+
+/// A parenthesised, space-separated zsh action group of escaped enum values,
+/// e.g. `(low medium high)`. The parens are literal zsh spec syntax, so only the
+/// individual values are escaped — never the group as a whole.
+fn enumActionGroup(arena: std.mem.Allocator, values: []const []const u8) ![]const u8 {
+    var out = std.ArrayList(u8).empty;
+    try out.append(arena, '(');
+    for (values, 0..) |v, idx| {
+        if (idx > 0) try out.append(arena, ' ');
+        try out.appendSlice(arena, try escape.zsh(arena, v));
+    }
+    try out.append(arena, ')');
+    return out.items;
 }
 
 /// Emit `_describe` entries (`'name:desc'`, aliases as separate entries) for a


### PR DESCRIPTION
## What

Shell completions for a leaf command's positional arguments used to fall back to blanket **file completion** — `tasks edit <TAB>` dumped the working directory when what's actually expected is a task id. This drives positional completion off the declared `ArgInfo` (`name`, `description`, `enum_values`, `is_variadic`), which the build already populates but the generators threw away.

## Behavior now

`tasks edit <TAB>` (a `struct { id: u32 }` arg, `meta.args = .{ .id = "Task ID" }`):

- **zsh** — `_arguments` emits a spec per position:
  - enum arg → offers its choices, e.g. `'1:Filter by status:(open done)'`
  - any other arg → force-displays a hint via `_message -r`, e.g. `'1: : _message -r "Task ID"'`. (An *empty* action renders nothing unless the user has a `format`/`descriptions` zstyle set — most don't — so `_message -r`, which displays unconditionally, is required.)
  - handles every position; no `_files` fallback.
- **bash** — at the command's exact path (the first positional slot), an enum arg's choices are offered via `compgen -W`; other positionals complete nothing. `compgen -f` removed.
- **fish** — `-f` at the leaf's path condition suppresses the default file dump; enum args add `-a` choices.

### Cross-shell honesty

The **visible hint is zsh-only** — bash and fish have no message facility in their completion systems (candidates only), so non-enum positionals complete *nothing* there (files are suppressed, but no hint is possible). Real id/value completion — the thing that would make bash/fish useful here too — is a separate follow-up: a dynamic `__complete` callback that returns actual values (tracked as "Tier 2").

## Escaping

The zsh `_message -r` argument uses a clean two-layer scheme (double-quote the message, then single-quote-dance the whole spec — non-overlapping layers). Verified against a description containing an apostrophe, colon, and `$`: renders literally and passes `zsh -n`.

## Testing

- Fixture now declares a plain id arg on `edit` and an enum status arg on `list`.
- Per-shell structural assertions, including negative `!_files` / `!compgen -f`.
- Functional bash: `tasks list <TAB>` yields the enum values.
- The suite's real-shell checks (`bash -n` / `zsh -n` / functional bash) run against the new output.
- Verified end-to-end in a real interactive zsh (`expect`): `tasks edit <TAB>` shows the `Task ID` hint in a bare `zsh -f` **and** with a format style set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)