### PR TITLE
fix(help): exec+group section order, group-help coverage, options-block decision

### DIFF
--- a/packages/core/src/plugins/zcli_help/plugin.zig
+++ b/packages/core/src/plugins/zcli_help/plugin.zig
@@ -265,21 +265,9 @@ fn showHelp(context: anytype, help_type: HelpType, to_stdout: bool) !void {
         }
     }
 
-    // Show commands/subcommands
-    switch (help_type) {
-        .app, .root => {
-            try showCommandList(context, &fmt, .top_level);
-        },
-        .command_group => |group_name| {
-            try showCommandList(context, &fmt, .{ .subcommands_of = group_name });
-        },
-        .command => {
-            // Show subcommands if any
-            try showSubcommands(context, &fmt);
-        },
-    }
-
-    // Show options (for non-root commands)
+    // Show options (for non-root commands) — the command's own contract comes
+    // before navigation to any children, so OPTIONS precedes the subcommand
+    // list below for a command that is both executable and a group.
     if (help_type == .command) {
         try fmt.write("<header>OPTIONS:</header>\n", .{});
         if (context.command_module_info) |module_info| {
@@ -291,6 +279,27 @@ fn showHelp(context: anytype, help_type: HelpType, to_stdout: bool) !void {
             }
         }
         try fmt.write("    <flag>--help</flag>, <flag>-h</flag>{s:<6} Show this help message\n\n", .{""});
+    }
+
+    // Show commands/subcommands (last: navigation to children)
+    switch (help_type) {
+        .app, .root => {
+            try showCommandList(context, &fmt, .top_level);
+        },
+        .command_group => |group_name| {
+            try showCommandList(context, &fmt, .{ .subcommands_of = group_name });
+        },
+        .command => {
+            // Show subcommands if any
+            const had_subcommands = try showSubcommands(context, &fmt);
+            // For a command that is both executable and a group, point at its
+            // children — mirrors the group/app "run --help for more" footer.
+            if (had_subcommands) {
+                const cmd_path = try std.mem.join(context.allocator, " ", context.command_path);
+                defer context.allocator.free(cmd_path);
+                try fmt.write("Run '<command>{s}</command> <command>{s}</command> <subcommand> <flag>--help</flag>' for more information on a subcommand.\n\n", .{ app_name, cmd_path });
+            }
+        },
     }
 
     // Show global options (for app and root help)
@@ -643,8 +652,9 @@ fn generateUsage(context: anytype) ![]const u8 {
     return try al.toOwnedSlice(context.allocator);
 }
 
-/// Show available subcommands for the current command
-fn showSubcommands(context: anytype, fmt: anytype) !void {
+/// Show available subcommands for the current command. Returns whether any were
+/// displayed, so the caller can render a follow-up hint only when they exist.
+fn showSubcommands(context: anytype, fmt: anytype) !bool {
     const command_infos = context.getAvailableCommandInfo();
     var displayed_names: std.ArrayList([]const u8) = .empty;
     defer displayed_names.deinit(context.allocator);
@@ -713,6 +723,7 @@ fn showSubcommands(context: anytype, fmt: anytype) !void {
     if (has_commands) {
         try fmt.write("\n", .{});
     }
+    return has_commands;
 }
 
 /// Generate args pattern from command module info (e.g., "IMAGE [COMMAND] [ARG...]")
@@ -1105,6 +1116,106 @@ test "showCommandList: dedups, sorts alphabetically, and renders aliases" {
 
     // The nested subcommand does not leak into the top-level list.
     try std.testing.expect(std.mem.indexOf(u8, out, "sub") == null);
+}
+
+// ============================================================================
+// showHelp(.command): section ordering + options-less rendering
+// ============================================================================
+
+/// Render `.command` help (to stdout) and return the captured buffer.
+fn renderCommandHelp(ctx: anytype, aw: *std.Io.Writer.Allocating) ![]const u8 {
+    try showHelp(ctx, .command, true);
+    try ctx.stdout().flush();
+    return aw.written();
+}
+
+test "showHelp .command orders sections ARGUMENTS -> OPTIONS -> COMMANDS for an exec+group command" {
+    const allocator = std.testing.allocator;
+
+    const Ctx = zcli.TestContext(&.{});
+    var stdio: zcli.Stdio = undefined;
+    stdio.init(std.testing.io);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    stdio.stdout_override = &aw.writer;
+
+    const environ = std.process.Environ.Map.init(allocator);
+    var ctx = Ctx.init(allocator, std.testing.io, &stdio, &environ);
+    defer ctx.deinit();
+
+    // `server` is both executable (has its own args + options) AND a group (a
+    // `server status` subcommand exists) — the exact case whose ordering this
+    // fix pins down.
+    ctx.app_name = "myapp";
+    ctx.command_path = &.{"server"};
+    ctx.command_module_info = .{
+        .has_args = true,
+        .args_fields = &.{
+            .{ .name = "target", .is_optional = false, .is_array = false, .type_name = "[]const u8", .description = "The target" },
+        },
+        .has_options = true,
+        .options_fields = &.{
+            .{ .name = "force", .is_optional = false, .is_array = false, .type_name = "bool", .default_value = "false", .description = "Force it" },
+        },
+    };
+    ctx.plugin_command_info = &.{
+        .{ .path = &.{"server"}, .description = "Manage the server" },
+        .{ .path = &.{ "server", "status" }, .description = "Show status" },
+    };
+
+    const out = try renderCommandHelp(&ctx, &aw);
+
+    const i_args = std.mem.indexOf(u8, out, "ARGUMENTS:").?;
+    const i_opts = std.mem.indexOf(u8, out, "OPTIONS:").?;
+    const i_cmds = std.mem.indexOf(u8, out, "COMMANDS:").?;
+    // The command's own contract first (arguments, then options), navigation to
+    // children last.
+    try std.testing.expect(i_args < i_opts);
+    try std.testing.expect(i_opts < i_cmds);
+
+    // The subcommand and the follow-up hint both render under COMMANDS.
+    try std.testing.expect(std.mem.indexOf(u8, out, "status") != null);
+    const i_hint = std.mem.indexOf(u8, out, "for more information on a subcommand").?;
+    try std.testing.expect(i_hint > i_cmds);
+}
+
+test "showHelp .command renders a clean OPTIONS block for an options-less command" {
+    const allocator = std.testing.allocator;
+
+    const Ctx = zcli.TestContext(&.{});
+    var stdio: zcli.Stdio = undefined;
+    stdio.init(std.testing.io);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    stdio.stdout_override = &aw.writer;
+
+    const environ = std.process.Environ.Map.init(allocator);
+    var ctx = Ctx.init(allocator, std.testing.io, &stdio, &environ);
+    defer ctx.deinit();
+
+    // A leaf command with `Options = struct {}` and no subcommands: the OPTIONS
+    // block still lists the implicit --help (it IS an option; every CLI shows
+    // -h). Decision (a) from the audit — locked here so the single-line OPTIONS
+    // block is intentional, not accidental.
+    ctx.app_name = "myapp";
+    ctx.command_path = &.{"noop"};
+    ctx.command_module_info = .{ .has_args = false, .has_options = false };
+    ctx.plugin_command_info = &.{
+        .{ .path = &.{"noop"}, .description = "Does nothing" },
+    };
+
+    const out = try renderCommandHelp(&ctx, &aw);
+
+    // The OPTIONS header is present and immediately followed by the --help line
+    // (no blank line between them, no stray trailing blanks — the block is one
+    // header + one entry).
+    const opts_at = std.mem.indexOf(u8, out, "OPTIONS:\n").?;
+    const after = out[opts_at + "OPTIONS:\n".len ..];
+    try std.testing.expect(std.mem.startsWith(u8, std.mem.trimLeft(u8, after, " "), "--help"));
+    // With no declared options and no subcommands, --help is the only OPTIONS
+    // entry and no COMMANDS section renders.
+    try std.testing.expect(std.mem.indexOf(u8, out, "--help") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "COMMANDS:") == null);
 }
 
 // ============================================================================

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -982,6 +982,59 @@ test "scaffolded project builds, runs, and round-trips add command" {
         try expectOk(r);
         try expectContains(r.stdout, "TODO: Implement server status");
     }
+    {
+        // `server` is both executable (a landing execute) AND a group (it has
+        // `server status`). Its `--help` renders command help whose sections run
+        // OPTIONS before COMMANDS — the command's own contract first, navigation
+        // to children last — and closes with a "run <sub> --help" hint under the
+        // subcommand list. Explicit help → stdout.
+        var r = try run(proj, &.{ demo_bin, "server", "--help" });
+        defer r.deinit();
+        try expectOk(r);
+        const i_opts = std.mem.indexOf(u8, r.stdout, "OPTIONS:") orelse return error.NoOptionsSection;
+        const i_cmds = std.mem.indexOf(u8, r.stdout, "COMMANDS:") orelse return error.NoCommandsSection;
+        try testing.expect(i_opts < i_cmds);
+        try expectContains(r.stdout, "status"); // the subcommand
+        // The follow-up hint lands under the subcommand list.
+        const i_hint = std.mem.indexOf(u8, r.stdout, "for more information on a subcommand") orelse return error.NoSubcommandHint;
+        try testing.expect(i_hint > i_cmds);
+    }
+
+    // A pure command group (no `--with-landing`): bare `demo cfg` isn't runnable
+    // on its own, so it resolves to CommandNotFound → the help plugin's onError
+    // detects the group and renders group help. That help path threads through
+    // onError, which is exactly the real-plugin group rendering the audit found
+    // untested (only a mock covered it).
+    {
+        var r = try run(proj, &.{ zcli_exe, "add", "group", "cfg", "-d", "Configuration" });
+        defer r.deinit();
+        try expectOk(r);
+    }
+    {
+        var r = try run(proj, &.{ zcli_exe, "add", "command", "cfg/show", "-d", "Show configuration" });
+        defer r.deinit();
+        try expectOk(r);
+    }
+    {
+        var r = try run(proj, &.{ "zig", "build" });
+        defer r.deinit();
+        try expectOk(r);
+    }
+    {
+        // Bare group invocation. A pure group's CommandNotFound is handled by the
+        // help plugin (shows help, doesn't propagate), so the process exits 0 —
+        // but the rendered group help (header + USAGE + subcommand list) is
+        // error-triggered, so it goes to STDERR (#236 convention), keeping a
+        // piped stdout clean.
+        var r = try run(proj, &.{ demo_bin, "cfg" });
+        defer r.deinit();
+        try expectOk(r);
+        try expectContains(r.stderr, "is a command group");
+        try expectContains(r.stderr, "SUBCOMMANDS:");
+        try expectContains(r.stderr, "show"); // the subcommand under cfg
+        // Group help is an error reaction → stderr only. stdout stays empty.
+        try testing.expect(r.stdout.len == 0);
+    }
 
     // `add plugin` drops a file into the convention-discovered src/plugins/ dir
     // (init wired `.plugins_dir`). The generated skeleton must compile and be


### PR DESCRIPTION
Polishes the `zcli_help` plugin — the three P3 leftovers from the July 2026 audit that PR #236 deliberately deferred.

## Item 1 — Section ordering for an exec+group command
`.command` help now renders **ARGUMENTS → OPTIONS → COMMANDS** (was ARGUMENTS → COMMANDS → OPTIONS). The command's own contract comes first; navigation to children comes last. For a command that is both executable and a group, a one-line `Run '<app> <cmd> <subcommand> --help' for more information on a subcommand.` hint now follows the subcommand list (mirrors the existing group/app footer). `showSubcommands` returns whether it rendered anything, so the hint only appears when subcommands actually exist. Locked by a unit test (`showHelp .command orders sections …`) and an e2e assertion on the scaffolded `server` group.

## Item 2 — Options-less OPTIONS block (decision)
**Kept as-is (decision a).** A command with `Options = struct {}` still lists the implicit `--help` under an OPTIONS header — `--help` *is* an option and every CLI shows `-h`. The rendering is already clean (header + one line, no stray blank lines or malformed spacing), so there was nothing to fix. Added a unit test locking the single-entry block so it reads as a decision, not an accident. The `--help` line itself is untouched.

## Item 3 — Real group-help coverage
The audit found the real plugin's `.command_group` rendering + the `onError` group-detection walk were covered only by a mock `TestHelpPlugin`. Added an e2e test that scaffolds a **pure** command group (no landing execute) with a subcommand, invokes the bare group, and asserts the **real** rendered group output (`is a command group` header, `USAGE`, `SUBCOMMANDS` list) threads through `onError` to **stderr** (#236 convention) with an empty stdout. Finding: a pure group's bare invocation is *handled* by the help plugin (help shown, error not propagated), so the process exits **0** with the help on stderr — the test asserts exactly that.

## Test evidence
- Root `zig build test`: exit 0 (all packages + examples green).
- `zig build e2e` (projects/zcli): **30/30 pass** (run `-j1` locally to avoid an unrelated parallel-compile OOM flake in the heavy build-and-run tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)