### PR TITLE
fix(prompts): surface EOF as error.EndOfStream instead of returning empty input

### DIFF
--- a/packages/prompts/examples/README.md
+++ b/packages/prompts/examples/README.md
@@ -42,3 +42,8 @@ zig build examples          # binaries land in zig-out/bin/prompts-<name>
   stdin isn't a TTY, so the examples also work when piped
   (e.g. `printf '2\n' | zig-out/bin/prompts-select`). The live-only features
   (`preview`, custom cursor glyphs) are simply skipped in that mode.
+- **EOF is an error, not an empty answer.** When stdin closes with nothing left
+  to read (a closed pipe, `</dev/null`, or an exhausted redirect), every prompt
+  returns `error.EndOfStream` instead of an empty entry. That keeps a closed
+  stream distinguishable from a submitted blank line, so a re-prompt loop can
+  break on it rather than spin forever — see `password.zig` for the idiom.

--- a/packages/prompts/examples/password.zig
+++ b/packages/prompts/examples/password.zig
@@ -2,18 +2,16 @@
 //!
 //! Options: `mask` sets the glyph shown per typed *grapheme* (default `*`;
 //! set it to something like `0` or a bullet). The prompt itself does no
-//! validation — do that at the call site. This example re-prompts (up to
-//! `max_tries`) until the input meets a minimum length. The retry cap matters
-//! for the non-TTY fallback: there, exhausted (EOF) input reads back as empty
-//! every time, so an unbounded loop would spin — the cap makes it give up
-//! cleanly instead.
+//! validation — do that at the call site. This example re-prompts until the
+//! input meets a minimum length. The loop is unbounded and still safe on a
+//! closed stdin: a prompt on exhausted (EOF) input returns `error.EndOfStream`
+//! rather than an empty string, so the loop breaks instead of spinning.
 
 const std = @import("std");
 const Prompts = @import("prompts");
 const common = @import("common.zig");
 
 const min_len = 8;
-const max_tries = 3;
 
 pub fn main(init: std.process.Init) !void {
     var t: common.Io = .{};
@@ -22,26 +20,25 @@ pub fn main(init: std.process.Init) !void {
 
     const p: Prompts = .{ .writer = t.w(), .reader = t.r(), .allocator = init.gpa };
 
-    var tries: usize = 0;
-    while (tries < max_tries) : (tries += 1) {
-        const secret = p.password(.{
+    const secret = while (true) {
+        const entry = p.password(.{
             .message = "Choose a password:",
             .mask = '*', // try '0' or a bullet for a different look
-        }) catch |err| {
-            try t.w().print("\n({s})\n", .{@errorName(err)});
-            return;
+        }) catch |err| switch (err) {
+            // Closed stdin or user abort: stop, don't re-prompt a dead stream.
+            error.EndOfStream, error.Interrupted, error.UserAborted => {
+                try t.w().print("\n({s})\n", .{@errorName(err)});
+                return;
+            },
+            else => return err,
         };
-        defer init.gpa.free(secret);
 
-        if (secret.len < min_len) {
-            try t.w().print("\n  Too short — need at least {d} characters. Try again.\n", .{min_len});
-            continue;
-        }
+        if (entry.len >= min_len) break entry;
+        init.gpa.free(entry);
+        try t.w().print("\n  Too short — need at least {d} characters. Try again.\n", .{min_len});
+    };
+    defer init.gpa.free(secret);
 
-        // Don't print the secret back — just prove we captured it.
-        try t.w().print("\nGot a password of {d} character(s).\n", .{secret.len});
-        return;
-    }
-
-    try t.w().writeAll("\nGave up after too many attempts.\n");
+    // Don't print the secret back — just prove we captured it.
+    try t.w().print("\nGot a password of {d} character(s).\n", .{secret.len});
 }

--- a/packages/prompts/src/confirm.zig
+++ b/packages/prompts/src/confirm.zig
@@ -18,8 +18,9 @@ pub const ConfirmConfig = struct {
     interrupt_keys: []const terminal.Key = &.{},
 };
 
-/// Prompt for yes/no confirmation. Returns the answer, or `error.Interrupted`
-/// if the user presses one of `config.interrupt_keys`.
+/// Prompt for yes/no confirmation. Returns the answer, `error.Interrupted`
+/// if the user presses one of `config.interrupt_keys`, or `error.EndOfStream`
+/// if stdin closes with no answer to submit.
 pub fn confirm(p: Prompts, config: ConfirmConfig) !bool {
     const writer = p.writer;
     const reader = p.reader;
@@ -29,7 +30,9 @@ pub fn confirm(p: Prompts, config: ConfirmConfig) !bool {
 
     if (!is_tty) {
         try writer.print("{s}{s} {s} ", .{ config.prefix, config.message, hint });
-        const first = terminal.key.readByteFn(reader) catch return config.default;
+        // A closed stdin (nothing to read) errors; a submitted blank line
+        // (leading '\n') takes the default like an empty text entry.
+        const first = terminal.key.readByteFn(reader) catch return error.EndOfStream;
         // Read rest of line
         while (true) {
             const b = terminal.key.readByteFn(reader) catch break;
@@ -174,17 +177,17 @@ test "non-TTY: empty input uses default false" {
     try std.testing.expect(result == false);
 }
 
-test "non-TTY: EOF uses default" {
+test "non-TTY: EOF errors instead of using default" {
     var input = "".*;
     var input_reader: std.Io.Reader = .fixed(&input);
     var output: [256]u8 = undefined;
     var output_writer: std.Io.Writer = .fixed(&output);
 
-    const result = try confirm(.{ .writer = &output_writer, .reader = &input_reader, .allocator = std.testing.allocator }, .{
+    // A closed stdin surfaces rather than silently taking the default.
+    try std.testing.expectError(error.EndOfStream, confirm(.{ .writer = &output_writer, .reader = &input_reader, .allocator = std.testing.allocator }, .{
         .message = "Continue?",
         .default = true,
-    });
-    try std.testing.expect(result == true);
+    }));
 }
 
 test "prompt shows Y/n when default is true" {

--- a/packages/prompts/src/editor.zig
+++ b/packages/prompts/src/editor.zig
@@ -19,7 +19,8 @@ pub const EditorConfig = struct {
     io: std.Io,
 };
 
-/// Launch the user's editor for multiline input. Returns owned string.
+/// Launch the user's editor for multiline input. Returns owned string, or
+/// `error.EndOfStream` if stdin closes with no input to submit.
 pub fn editor(p: Prompts, config: EditorConfig) ![]u8 {
     const writer = p.writer;
     const reader = p.reader;
@@ -28,7 +29,7 @@ pub fn editor(p: Prompts, config: EditorConfig) ![]u8 {
 
     if (!is_tty) {
         try writer.print("{s}{s}", .{ config.prefix, config.message });
-        // Non-TTY: read all remaining input
+        // Non-TTY: read all remaining input until EOF.
         try writer.writeAll("\n");
         var buf = std.ArrayList(u8).empty;
         errdefer buf.deinit(allocator);
@@ -36,9 +37,9 @@ pub fn editor(p: Prompts, config: EditorConfig) ![]u8 {
             const byte = terminal.key.readByteFn(reader) catch break;
             try buf.append(allocator, byte);
         }
-        if (buf.items.len == 0) {
-            if (config.default) |def| return try allocator.dupe(u8, def);
-        }
+        // Nothing typed on a closed stdin surfaces rather than masquerading as
+        // an empty document (the `default` is pre-fill content, not a fallback).
+        if (buf.items.len == 0) return error.EndOfStream;
         return try buf.toOwnedSlice(allocator);
     }
 
@@ -121,6 +122,36 @@ test "EditorConfig defaults" {
     const cfg = EditorConfig{ .message = "Edit:", .io = std.testing.io };
     try std.testing.expect(cfg.default == null);
     try std.testing.expectEqualStrings(".txt", cfg.extension);
+}
+
+test "non-TTY: EOF with no input errors" {
+    const allocator = std.testing.allocator;
+    var input = "".*;
+    var input_reader: std.Io.Reader = .fixed(&input);
+    var output: [256]u8 = undefined;
+    var output_writer: std.Io.Writer = .fixed(&output);
+
+    try std.testing.expectError(error.EndOfStream, editor(.{ .writer = &output_writer, .reader = &input_reader, .allocator = allocator }, .{
+        .message = "Edit:",
+        .default = "prefill",
+        .io = std.testing.io,
+    }));
+}
+
+test "non-TTY: reads piped multiline input" {
+    const allocator = std.testing.allocator;
+    var input = "line one\nline two".*;
+    var input_reader: std.Io.Reader = .fixed(&input);
+    var output: [256]u8 = undefined;
+    var output_writer: std.Io.Writer = .fixed(&output);
+
+    const result = try editor(.{ .writer = &output_writer, .reader = &input_reader, .allocator = allocator }, .{
+        .message = "Edit:",
+        .io = std.testing.io,
+    });
+    defer allocator.free(result);
+
+    try std.testing.expectEqualStrings("line one\nline two", result);
 }
 
 fn renderFrame(app: *ui.App, ctx: Prompts.ThemeContext, config: EditorConfig) !void {

--- a/packages/prompts/src/multi_select.zig
+++ b/packages/prompts/src/multi_select.zig
@@ -18,7 +18,8 @@ pub const MultiSelectConfig = struct {
     unicode: bool = true,
 };
 
-/// Prompt to select multiple items. Returns owned slice of selected indices.
+/// Prompt to select multiple items. Returns owned slice of selected indices,
+/// or `error.EndOfStream` if stdin closes with no line to submit.
 pub fn multiSelect(p: Prompts, config: MultiSelectConfig) ![]usize {
     const writer = p.writer;
     const reader = p.reader;
@@ -36,7 +37,8 @@ pub fn multiSelect(p: Prompts, config: MultiSelectConfig) ![]usize {
         }
         try writer.writeAll("> ");
 
-        const line = readLine(reader, allocator) catch return collectDefaults(allocator, config);
+        // A submitted blank line accepts the defaults; a closed stdin errors.
+        const line = try readLine(reader, allocator);
         defer allocator.free(line);
         if (line.len == 0) return collectDefaults(allocator, config);
 
@@ -210,11 +212,17 @@ pub fn frameNode(
     return ui.column(a, .{ .width = .{ .len = usable } }, rows.items);
 }
 
+/// Read a line byte by byte until newline. Returns `error.EndOfStream` if the
+/// stream closes before any byte is read; a partial line terminated by EOF is
+/// returned as the submitted line.
 fn readLine(reader: anytype, allocator: std.mem.Allocator) ![]u8 {
     var buf = std.ArrayList(u8).empty;
     errdefer buf.deinit(allocator);
     while (true) {
-        const byte = terminal.key.readByteFn(reader) catch return try buf.toOwnedSlice(allocator);
+        const byte = terminal.key.readByteFn(reader) catch {
+            if (buf.items.len == 0) return error.EndOfStream;
+            return try buf.toOwnedSlice(allocator);
+        };
         if (byte == '\n') break;
         if (byte != '\r') try buf.append(allocator, byte);
     }
@@ -287,6 +295,21 @@ test "non-TTY: no defaults returns empty" {
     defer allocator.free(result);
 
     try std.testing.expectEqual(@as(usize, 0), result.len);
+}
+
+test "non-TTY: EOF errors instead of returning defaults" {
+    const allocator = std.testing.allocator;
+    var input = "".*;
+    var input_reader: std.Io.Reader = .fixed(&input);
+    var output: [1024]u8 = undefined;
+    var output_writer: std.Io.Writer = .fixed(&output);
+
+    // A blank line accepts defaults, but a closed stdin surfaces instead.
+    try std.testing.expectError(error.EndOfStream, multiSelect(.{ .writer = &output_writer, .reader = &input_reader, .allocator = allocator }, .{
+        .message = "Pick:",
+        .choices = &.{ "a", "b", "c" },
+        .defaults = &.{ true, false, true },
+    }));
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/prompts/src/number.zig
+++ b/packages/prompts/src/number.zig
@@ -22,8 +22,9 @@ pub const NumberConfig = struct {
     interrupt_keys: []const terminal.Key = &.{},
 };
 
-/// Prompt for numeric input. Returns the entered number, or `error.Interrupted`
-/// if the user presses one of `config.interrupt_keys`.
+/// Prompt for numeric input. Returns the entered number, `error.Interrupted`
+/// if the user presses one of `config.interrupt_keys`, or `error.EndOfStream`
+/// if stdin closes with no line to submit.
 pub fn number(p: Prompts, config: NumberConfig) !i64 {
     const writer = p.writer;
     const reader = p.reader;
@@ -177,7 +178,7 @@ fn persistLine(app: *ui.App, config: NumberConfig, input: []const u8) !void {
 
 fn readNumberNonTty(reader: anytype, config: NumberConfig) !i64 {
     var buf: [32]u8 = undefined;
-    const line = readLine(reader, &buf);
+    const line = try readLine(reader, &buf);
     if (line.len == 0) {
         return config.default orelse return error.InvalidNumber;
     }
@@ -187,11 +188,16 @@ fn readNumberNonTty(reader: anytype, config: NumberConfig) !i64 {
 /// Read a line (sans trailing newline) into the caller-owned `buf`, returning
 /// the filled slice. The slice borrows `buf`, so it stays valid as long as the
 /// caller's buffer does — never return a slice into a local buffer from here.
-/// Stops at '\n', on read error/EOF, or when `buf` is full.
-fn readLine(reader: anytype, buf: []u8) []const u8 {
+/// Stops at '\n' or when `buf` is full. Returns `error.EndOfStream` if the
+/// stream closes before any byte is read; a partial line terminated by EOF is
+/// returned as-is.
+fn readLine(reader: anytype, buf: []u8) ![]const u8 {
     var len: usize = 0;
     while (len < buf.len) {
-        const byte = terminal.key.readByteFn(reader) catch break;
+        const byte = terminal.key.readByteFn(reader) catch {
+            if (len == 0) return error.EndOfStream;
+            break;
+        };
         if (byte == '\n') break;
         if (byte != '\r') {
             buf[len] = byte;
@@ -258,6 +264,20 @@ test "non-TTY: empty input with no default errors" {
 
     try std.testing.expectError(error.InvalidNumber, number(.{ .writer = &writer_stream, .reader = &reader_stream, .allocator = std.testing.allocator }, .{
         .message = "Port:",
+    }));
+}
+
+test "non-TTY: EOF errors instead of falling back to the default" {
+    var input = "".*;
+    var reader_stream: std.Io.Reader = .fixed(&input);
+    var output: [256]u8 = undefined;
+    var writer_stream: std.Io.Writer = .fixed(&output);
+
+    // A closed stdin surfaces even when a default exists — a retry loop would
+    // otherwise spin forever re-prompting a dead stream.
+    try std.testing.expectError(error.EndOfStream, number(.{ .writer = &writer_stream, .reader = &reader_stream, .allocator = std.testing.allocator }, .{
+        .message = "Port:",
+        .default = 3000,
     }));
 }
 

--- a/packages/prompts/src/password.zig
+++ b/packages/prompts/src/password.zig
@@ -16,7 +16,8 @@ pub const PasswordConfig = struct {
     prefix: []const u8 = "? ",
 };
 
-/// Prompt for password input with masking. Returns owned string.
+/// Prompt for password input with masking. Returns owned string, or
+/// `error.EndOfStream` if stdin closes with no line to submit.
 pub fn password(p: Prompts, config: PasswordConfig) ![]u8 {
     const writer = p.writer;
     const reader = p.reader;
@@ -26,7 +27,7 @@ pub fn password(p: Prompts, config: PasswordConfig) ![]u8 {
     if (!is_tty) {
         // Non-TTY: read line (no masking possible)
         try writer.print("{s}{s} ", .{ config.prefix, config.message });
-        const line = readLine(reader, allocator) catch return try allocator.dupe(u8, "");
+        const line = try readLine(reader, allocator);
         try writer.writeAll("\n");
         return line;
     }
@@ -104,11 +105,17 @@ fn persistLine(app: *ui.App, config: PasswordConfig, input: []const u8) !void {
     try app.emit("{s}", .{line});
 }
 
+/// Read a line byte by byte until newline. Returns `error.EndOfStream` if the
+/// stream closes before any byte is read; a partial line terminated by EOF is
+/// returned as the submitted line.
 fn readLine(reader: anytype, allocator: std.mem.Allocator) ![]u8 {
     var buf = std.ArrayList(u8).empty;
     errdefer buf.deinit(allocator);
     while (true) {
-        const byte = terminal.key.readByteFn(reader) catch return try buf.toOwnedSlice(allocator);
+        const byte = terminal.key.readByteFn(reader) catch {
+            if (buf.items.len == 0) return error.EndOfStream;
+            return try buf.toOwnedSlice(allocator);
+        };
         if (byte == '\n') break;
         if (byte != '\r') try buf.append(allocator, byte);
     }
@@ -135,19 +142,17 @@ test "non-TTY: reads password line" {
     try std.testing.expectEqualStrings("secret123", result);
 }
 
-test "non-TTY: EOF returns empty" {
+test "non-TTY: EOF errors instead of returning empty" {
     const allocator = std.testing.allocator;
     var input = "".*;
     var input_reader: std.Io.Reader = .fixed(&input);
     var output: [256]u8 = undefined;
     var output_writer: std.Io.Writer = .fixed(&output);
 
-    const result = try password(.{ .writer = &output_writer, .reader = &input_reader, .allocator = allocator }, .{
+    // A closed stdin must not masquerade as an empty password.
+    try std.testing.expectError(error.EndOfStream, password(.{ .writer = &output_writer, .reader = &input_reader, .allocator = allocator }, .{
         .message = "Password:",
-    });
-    defer allocator.free(result);
-
-    try std.testing.expectEqualStrings("", result);
+    }));
 }
 
 test "prompt shows message" {

--- a/packages/prompts/src/search.zig
+++ b/packages/prompts/src/search.zig
@@ -16,7 +16,9 @@ pub const SearchConfig = struct {
     unicode: bool = true,
 };
 
-/// Prompt with search filtering. Returns the index of the selected item in the original choices array.
+/// Prompt with search filtering. Returns the index of the selected item in the
+/// original choices array, or `error.EndOfStream` if stdin closes with no line
+/// to submit.
 pub fn search(p: Prompts, config: SearchConfig) !usize {
     const writer = p.writer;
     const reader = p.reader;
@@ -31,7 +33,7 @@ pub fn search(p: Prompts, config: SearchConfig) !usize {
             try writer.print("  {d}) {s}\n", .{ i, choice });
         }
         try writer.writeAll("> ");
-        const line = readLine(reader, allocator) catch return 0;
+        const line = try readLine(reader, allocator);
         defer allocator.free(line);
         const num = std.fmt.parseInt(usize, line, 10) catch return 0;
         if (num >= 1 and num <= config.choices.len) return num - 1;
@@ -219,11 +221,17 @@ pub fn frameNode(
     return ui.column(a, .{ .width = .{ .len = usable } }, rows.items);
 }
 
+/// Read a line byte by byte until newline. Returns `error.EndOfStream` if the
+/// stream closes before any byte is read; a partial line terminated by EOF is
+/// returned as the submitted line.
 fn readLine(reader: anytype, allocator: std.mem.Allocator) ![]u8 {
     var buf = std.ArrayList(u8).empty;
     errdefer buf.deinit(allocator);
     while (true) {
-        const byte = terminal.key.readByteFn(reader) catch return try buf.toOwnedSlice(allocator);
+        const byte = terminal.key.readByteFn(reader) catch {
+            if (buf.items.len == 0) return error.EndOfStream;
+            return try buf.toOwnedSlice(allocator);
+        };
         if (byte == '\n') break;
         if (byte != '\r') try buf.append(allocator, byte);
     }
@@ -258,6 +266,18 @@ test "buildFiltered filters by substring" {
 test "SearchConfig defaults" {
     const cfg = SearchConfig{ .message = "Pick:", .choices = &.{ "a", "b" } };
     try std.testing.expectEqualStrings("? ", cfg.prefix);
+}
+
+test "non-TTY: EOF errors instead of defaulting to index 0" {
+    var input = "".*;
+    var input_reader: std.Io.Reader = .fixed(&input);
+    var output: [1024]u8 = undefined;
+    var output_writer: std.Io.Writer = .fixed(&output);
+
+    try std.testing.expectError(error.EndOfStream, search(.{ .writer = &output_writer, .reader = &input_reader, .allocator = std.testing.allocator }, .{
+        .message = "Pick:",
+        .choices = &.{ "a", "b" },
+    }));
 }
 
 const FrameHarness = struct {

--- a/packages/prompts/src/select.zig
+++ b/packages/prompts/src/select.zig
@@ -22,8 +22,9 @@ pub const SelectConfig = struct {
     interrupt_keys: []const terminal.Key = &.{},
 };
 
-/// Prompt to select one item from a list. Returns the chosen index, or
-/// `error.Interrupted` if the user presses one of `config.interrupt_keys`.
+/// Prompt to select one item from a list. Returns the chosen index,
+/// `error.Interrupted` if the user presses one of `config.interrupt_keys`, or
+/// `error.EndOfStream` if stdin closes with no line to submit.
 pub fn select(p: Prompts, config: SelectConfig) !usize {
     const writer = p.writer;
     const reader = p.reader;
@@ -37,7 +38,7 @@ pub fn select(p: Prompts, config: SelectConfig) !usize {
             try writer.print("  {d}) {s}\n", .{ i, choice });
         }
         try writer.writeAll("> ");
-        const line = readLine(reader, p.allocator) catch return 0;
+        const line = try readLine(reader, p.allocator);
         defer p.allocator.free(line);
         const num = std.fmt.parseInt(usize, line, 10) catch return 0;
         if (num >= 1 and num <= config.choices.len) return num - 1;
@@ -162,11 +163,17 @@ pub fn frameNode(
     return ui.column(a, .{ .width = .{ .len = usable } }, rows.items);
 }
 
+/// Read a line byte by byte until newline. Returns `error.EndOfStream` if the
+/// stream closes before any byte is read; a partial line terminated by EOF is
+/// returned as the submitted line.
 fn readLine(reader: anytype, allocator: std.mem.Allocator) ![]u8 {
     var buf = std.ArrayList(u8).empty;
     errdefer buf.deinit(allocator);
     while (true) {
-        const byte = terminal.key.readByteFn(reader) catch return try buf.toOwnedSlice(allocator);
+        const byte = terminal.key.readByteFn(reader) catch {
+            if (buf.items.len == 0) return error.EndOfStream;
+            return try buf.toOwnedSlice(allocator);
+        };
         if (byte == '\n') break;
         if (byte != '\r') try buf.append(allocator, byte);
     }
@@ -207,6 +214,18 @@ test "non-TTY: invalid number returns 0" {
     });
 
     try std.testing.expectEqual(@as(usize, 0), result);
+}
+
+test "non-TTY: EOF errors instead of defaulting to index 0" {
+    var input = "".*;
+    var input_reader: std.Io.Reader = .fixed(&input);
+    var output: [1024]u8 = undefined;
+    var output_writer: std.Io.Writer = .fixed(&output);
+
+    try std.testing.expectError(error.EndOfStream, select(.{ .writer = &output_writer, .reader = &input_reader, .allocator = std.testing.allocator }, .{
+        .message = "Pick:",
+        .choices = &.{ "a", "b" },
+    }));
 }
 
 test "non-TTY: shows numbered choices" {

--- a/packages/prompts/src/text.zig
+++ b/packages/prompts/src/text.zig
@@ -32,8 +32,9 @@ pub const TextConfig = struct {
     interrupt_keys: []const terminal.Key = &.{},
 };
 
-/// Prompt for text input. Returns an owned string (caller frees), or
-/// `error.Interrupted` if the user presses one of `config.interrupt_keys`.
+/// Prompt for text input. Returns an owned string (caller frees),
+/// `error.Interrupted` if the user presses one of `config.interrupt_keys`, or
+/// `error.EndOfStream` if stdin closes with no line to submit.
 pub fn text(p: Prompts, config: TextConfig) ![]u8 {
     const writer = p.writer;
     const reader = p.reader;
@@ -47,12 +48,7 @@ pub fn text(p: Prompts, config: TextConfig) ![]u8 {
             try writer.print(" ({s})", .{def});
         }
         try writer.writeAll(" ");
-        const line = readLine(reader, allocator) catch {
-            return if (config.default) |def|
-                try allocator.dupe(u8, def)
-            else
-                try allocator.dupe(u8, "");
-        };
+        const line = try readLine(reader, allocator);
         defer allocator.free(line);
         if (line.len == 0) {
             if (config.default) |def| return try allocator.dupe(u8, def);
@@ -167,12 +163,18 @@ fn persistLine(app: *ui.App, config: TextConfig, input: []const u8) !void {
     try app.emit("{s}", .{line});
 }
 
-/// Read a line from a reader byte by byte until newline.
+/// Read a line from a reader byte by byte until newline. Returns
+/// `error.EndOfStream` if the stream closes before any byte is read (nothing to
+/// submit); a partial line terminated by EOF (bytes but no trailing newline) is
+/// returned as the submitted line.
 fn readLine(reader: anytype, allocator: std.mem.Allocator) ![]u8 {
     var buf = std.ArrayList(u8).empty;
     errdefer buf.deinit(allocator);
     while (true) {
-        const byte = terminal.key.readByteFn(reader) catch return try buf.toOwnedSlice(allocator);
+        const byte = terminal.key.readByteFn(reader) catch {
+            if (buf.items.len == 0) return error.EndOfStream;
+            return try buf.toOwnedSlice(allocator);
+        };
         if (byte == '\n') break;
         if (byte != '\r') try buf.append(allocator, byte);
     }
@@ -216,20 +218,34 @@ test "text: non-TTY uses default on empty input" {
     try std.testing.expectEqualStrings("world", result);
 }
 
-test "text: non-TTY uses default on EOF" {
+test "text: non-TTY EOF errors even with a default" {
     const allocator = std.testing.allocator;
     var input = "".*;
     var input_reader: std.Io.Reader = .fixed(&input);
     var output: [256]u8 = undefined;
     var output_writer: std.Io.Writer = .fixed(&output);
 
-    const result = try text(.{ .writer = &output_writer, .reader = &input_reader, .allocator = allocator }, .{
+    // EOF is distinct from an empty submission: it must surface, not silently
+    // fall back to the default (a retry loop would spin forever otherwise).
+    try std.testing.expectError(error.EndOfStream, text(.{ .writer = &output_writer, .reader = &input_reader, .allocator = allocator }, .{
         .message = "Name:",
         .default = "fallback",
+    }));
+}
+
+test "text: non-TTY partial line without trailing newline still submits" {
+    const allocator = std.testing.allocator;
+    var input = "typed".*;
+    var input_reader: std.Io.Reader = .fixed(&input);
+    var output: [256]u8 = undefined;
+    var output_writer: std.Io.Writer = .fixed(&output);
+
+    const result = try text(.{ .writer = &output_writer, .reader = &input_reader, .allocator = allocator }, .{
+        .message = "Name:",
     });
     defer allocator.free(result);
 
-    try std.testing.expectEqualStrings("fallback", result);
+    try std.testing.expectEqualStrings("typed", result);
 }
 
 test "text: prompt message appears in output" {

--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -149,11 +149,16 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         defaults[i] = choice.default;
     }
     const p = context.prompts();
-    const selected = try p.multiSelect(.{
+    const selected = p.multiSelect(.{
         .message = "Select built-in plugins to include:",
         .choices = &choices,
         .defaults = &defaults,
-    });
+    }) catch |err| switch (err) {
+        // Non-interactive invocation (piped/closed stdin): take the preselected
+        // defaults rather than aborting — `init` must work in scripts and CI.
+        error.EndOfStream => try collectDefaultPlugins(allocator, &defaults),
+        else => return err,
+    };
     defer allocator.free(selected);
 
     // Build the `zcli.builtin(...)` registration lines for build.zig.
@@ -478,6 +483,25 @@ const AgentsResult = enum { created, appended, refreshed };
 /// has no zcli section yet.
 /// Render `s` escaped for the inside of a double-quoted Zig/zon string
 /// literal (same rule as the registry codegen's escapeStringLiteral).
+/// Owned slice of the indices whose `defaults` bit is set — the non-interactive
+/// fallback for the plugin picker (mirrors what `multiSelect` returns for a
+/// submitted-defaults selection).
+fn collectDefaultPlugins(allocator: std.mem.Allocator, defaults: []const bool) ![]usize {
+    var list = std.ArrayList(usize).empty;
+    errdefer list.deinit(allocator);
+    for (defaults, 0..) |on, i| {
+        if (on) try list.append(allocator, i);
+    }
+    return list.toOwnedSlice(allocator);
+}
+
+test "collectDefaultPlugins returns only the preselected indices" {
+    const allocator = std.testing.allocator;
+    const selected = try collectDefaultPlugins(allocator, &.{ true, false, true, false });
+    defer allocator.free(selected);
+    try std.testing.expectEqualSlices(usize, &.{ 0, 2 }, selected);
+}
+
 fn escapeStringLiteral(allocator: std.mem.Allocator, s: []const u8) ![]u8 {
     var aw: std.Io.Writer.Allocating = .init(allocator);
     defer aw.deinit();


### PR DESCRIPTION
**Stacked on #243; merge that first.**

## Problem

Line-reading prompts returned `""` (or the config default) when stdin hit EOF, indistinguishable from the user submitting a blank line. A caller-side retry loop (re-prompt until valid) therefore spins forever on a closed/exhausted stdin. `examples/password.zig` worked around this with a bounded `max_tries` cap plus a header comment explaining the trap.

## Change

Every prompt now returns **`error.EndOfStream`** when stdin closes with nothing left to submit. Chosen because it's already the codebase's EOF error (`packages/terminal/src/key.zig`) and it mirrors the existing `error.Interrupted` convention for interrupt keys — no new error type, no deprecated alias, no dual path.

Semantics preserved:
- A **submitted blank line** still takes the config `default` (text/number/confirm/multi_select).
- A **partial line** terminated by EOF (bytes with no trailing newline) is still returned as the submission.

## Prompts / paths affected

All eight prompt types, non-TTY fallback paths (the TTY/`readKey`/`readEvent` paths already propagated EOF via `try`):

| Prompt | Before on EOF | After on EOF |
| --- | --- | --- |
| `text` | `""` or default | `error.EndOfStream` |
| `password` | `""` | `error.EndOfStream` |
| `confirm` | default | `error.EndOfStream` |
| `number` | default or `error.InvalidNumber` | `error.EndOfStream` |
| `select` / `search` | index `0` | `error.EndOfStream` |
| `multi_select` | defaults | `error.EndOfStream` |
| `editor` | default or `""` | `error.EndOfStream` (no input) |

Each per-file `readLine` helper now returns `error.EndOfStream` only when **zero bytes** were read before EOF; a partial line is returned as-is.

## Call-site update

`projects/zcli/src/commands/init.zig` — the plugin picker relied on `multiSelect` returning the preselected defaults on a non-interactive stdin (comment: "Falls back to the preselected defaults when stdin is not a TTY"). It now catches `error.EndOfStream` and falls back to those defaults explicitly (via a new `collectDefaultPlugins` helper) so `zcli init` still works in scripts / CI. This was the source of 12 failing e2e tests before the fix.

The `add` wizard call sites already do `catch |e| { if (e == error.Interrupted) ... ; return e; }`, so `error.EndOfStream` propagates and aborts the wizard cleanly instead of looping — no change needed.

## Examples

- `examples/password.zig`: the bounded `max_tries` workaround becomes the idiomatic **unbounded** retry loop that breaks on `error.EndOfStream` / `error.Interrupted` / `error.UserAborted`.
- `examples/README.md`: replaced the trap wording with an "EOF is an error, not an empty answer" note.
- Other examples already handle prompt errors (catch-and-report or `else => return err`), so EOF surfaces consistently — no changes needed.

## Test plan

- Updated the per-prompt EOF unit tests from "returns empty / default" to `expectError(error.EndOfStream, ...)`; added partial-line-still-submits and piped-multiline tests where relevant; added `collectDefaultPlugins` test.
- `cd packages/prompts && zig build && zig build test && zig build examples` — all pass.
- Repo root `zig build test` — pass.
- `projects/zcli` `zig build e2e` — pass (was 12 failing before the init fix).
- Piped smoke test: `./zig-out/bin/prompts-password </dev/null` prints `? Choose a password:` then `(EndOfStream)` and exits promptly; a short-then-EOF run re-prompts once then breaks cleanly (no spin); valid piped input captures the password.

🤖 Generated with [Claude Code](https://claude.com/claude-code)