### PR TITLE
docs(website): note doc-gen theme match, enum choices, reproducible dates

### DIFF
--- a/website/content/docs/build.smd
+++ b/website/content/docs/build.smd
@@ -109,7 +109,7 @@ zcli.generateDocs(b, cmd_registry, zcli_dep, .{
 });
 ```
 
-Run it with `zig build docs` (it's off the default step, so ordinary builds stay fast). Each format gets a subdirectory: `docs/markdown/`, `docs/man/` (a section-1 page per command), and `docs/html/` — a styled static site with navigation. Because it reads the same registry your binary compiles from, generated docs can't drift from the commands they describe.
+Run it with `zig build docs` (it's off the default step, so ordinary builds stay fast). Each format gets a subdirectory: `docs/markdown/`, `docs/man/` (a section-1 page per command), and `docs/html/` — a static site styled to match this documentation, dark and terminal-native, with breadcrumb navigation. Enum-typed options and arguments list their valid choices in every format, and man-page dates honor `SOURCE_DATE_EPOCH` so the output is byte-for-byte reproducible. Because it reads the same registry your binary compiles from, generated docs can't drift from the commands they describe.
 
 ## Built-in plugin tags
 


### PR DESCRIPTION
## Summary

Follow-up to #250. The website already documented doc generation (`docs/build.smd` → "Docs generation", cross-referenced from `docs/shipping.smd`), but the description predated the recent doc-gen improvements. This updates the build-integration page to reflect what shipped:

- The `docs/html/` output is now **styled to match this documentation** (dark, terminal-native) with breadcrumb navigation — was described as just "a styled static site with navigation."
- **Enum-typed options/arguments** list their valid choices in every format.
- **Man-page dates** honor `SOURCE_DATE_EPOCH`, so output is byte-for-byte reproducible.

One-paragraph prose change, no API/link/template edits. Content ships in `docs/build.smd` since that's the primary doc-gen section; `shipping.smd`'s short cross-reference didn't need the detail.

## Test plan

- [x] `zine release -f` builds the site clean (after `sync-site-data.sh`)
- [x] New text renders in `public/docs/build/index.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)