### PR TITLE
feat(completions): the combine directive — increment 3 (ADR-0026)

### DIFF
--- a/docs/adr/0026-dynamic-shell-completion.md
+++ b/docs/adr/0026-dynamic-shell-completion.md
@@ -224,29 +224,38 @@ positions call back is staged across increments (below).
 
 ## The `__complete` wire format and escaping
 
-`__complete` prints a **NUL-delimited** list: each candidate is `value` then,
-optionally, a tab and `description`, terminated by a NUL byte; a final record
-carries the directive (`default` / `also_files` / `also_dirs`). NUL — not newline —
-because candidate values are arbitrary runtime strings (a task title, a branch, a
-path) that can legally contain newlines and tabs. Stripping them, as an earlier
-draft proposed, is *data corruption*: it would offer a value that differs from the
-real one and insert a broken string on the command line. NUL is the only byte a
-value cannot contain, so it is the only correct delimiter.
+`__complete` prints a **NUL-delimited** stream: the **first** record is a directive
+token (`default` / `also_files` / `also_dirs`); every record after it is a candidate
+— `value` then, optionally, a tab and `description`. NUL — not newline — because
+candidate values are arbitrary runtime strings (a task title, a branch, a path)
+that can legally contain newlines and tabs. Stripping them, as an earlier draft
+proposed, is *data corruption*: it would offer a value that differs from the real
+one and insert a broken string on the command line. NUL is the only byte a value
+cannot contain, so it is the only correct delimiter. (The directive leads rather
+than trails so the scripts can read it before deciding whether to also invoke
+native file completion, and so a stream is never mistaken for candidates-only.)
 
 Value quoting is the place completion bugs live (the Tier-1 static work proved it),
 and dynamic values are the worst case. The naive `COMPREPLY=($(…))` **word-splits
-on `IFS` and glob-expands**. So the protocol and scripts are designed together:
+on `IFS` and glob-expands**. So the protocol and scripts are designed together —
+each reads NUL records directly (never re-splitting a `$(…)` blob):
 
-- **bash:** `mapfile -d '' -t COMPREPLY < <(…)` — NUL-delimited read, no split, no
-  glob. Never `COMPREPLY=($(…))`.
-- **zsh:** split the stream on NUL (`${(0)…}`) and feed `compadd`, with a `--`
-  guard so a value that starts with `-` is not read as an option; descriptions via
-  the `-d` array.
-- **fish:** fish command-substitution splits on newlines only, so the fish path
-  falls back to newline framing and therefore **cannot represent a value containing
-  a literal newline** — documented as a fish limitation, not a silent corruption
-  (such values are dropped, not mangled). Leading-`-` values are guarded the same
-  way.
+- **bash:** a `while IFS= read -r -d '' rec` loop appends quoted values to
+  `COMPREPLY` (a `read -d ''` loop rather than `mapfile -d ''` so it also works on
+  bash 3.2, the macOS system bash). Never `COMPREPLY=($(…))`.
+- **zsh:** the same `read -r -d ''` loop feeds `compadd -d … --`, the `--` guarding
+  a value that starts with `-` from being read as an option; descriptions via the
+  `-d` display array.
+- **fish:** `string split0` turns the NUL stream into a list; fish command
+  substitution then splits it on newlines, so the fish path **cannot represent a
+  value containing a literal newline** — documented as a fish limitation, not a
+  silent corruption (such values are dropped, not mangled).
+
+For the **combine** directive (`.also_files`/`.also_dirs`), after emitting the
+candidates each script additionally invokes the shell's native file/dir
+completion. On an **empty** partial the directive is downgraded to `default` at the
+source (in `__complete`), so a bare `<TAB>` in combine mode shows only the dynamic
+candidates, not the whole CWD — the flood guard.
 
 Increment 1 must include **functional per-shell tests** (the Tier-1 `expect` /
 `bash -n` / `zsh -n` harness) asserting that a value containing a space, a quote, a

--- a/packages/core/src/plugin_completions_test.zig
+++ b/packages/core/src/plugin_completions_test.zig
@@ -681,11 +681,12 @@ test "functional bash - COMPREPLY at root and at depth 2" {
 const adv_pick_args = [_]zcli.ArgInfo{.{ .name = "thing", .complete = hook_spec }};
 const adv_commands = [_]zcli.CommandInfo{.{ .path = &.{"pick"}, .description = "Pick", .args = &adv_pick_args }};
 
-// A POSIX `sh` stub that answers any `__complete` invocation with five nasty
-// values, NUL-separated: a space, a leading dash, glob chars, a quote, a dollar.
+// A POSIX `sh` stub that answers any `__complete` invocation with the directive
+// record (`default`) followed by five nasty values, NUL-separated: a space, a
+// leading dash, glob chars, a quote, a dollar.
 const adv_stub =
     \\#!/bin/sh
-    \\printf '%s\0' 'a b c' '-wip' 'x*y?' "it's" '$HOME'
+    \\printf '%s\0' 'default' 'a b c' '-wip' 'x*y?' "it's" '$HOME'
     \\
 ;
 
@@ -767,4 +768,83 @@ test "functional fish - dynamic candidates survive adversarial values verbatim" 
 
     const result = try std.process.run(a, io, .{ .argv = &.{ sh, harness_path } });
     try assertAdvExact(result.stdout);
+}
+
+// A stub whose `__complete` returns the `also_files` directive plus two dynamic
+// candidates — exercising the combine path (candidates AND native files). The
+// candidates share the `zz` prefix the test completes with, since a real hook
+// filters by the partial and fish's `complete -C` filters candidates by the token.
+const comb_stub =
+    \\#!/bin/sh
+    \\printf '%s\0' 'also_files' 'zzalpha' 'zzbeta'
+    \\
+;
+
+test "functional bash - also_files directive adds file completion to candidates" {
+    const sh = findShell("bash") orelse return error.SkipZigTest;
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const script = try bash.generate(a, "advapp", &adv_commands, &global_options);
+    const script_path = try writeTemp(a, tmp.dir, "advapp_completion.bash", script);
+    const stub_path = try writeTemp(a, tmp.dir, "advapp", comb_stub);
+    _ = try writeTemp(a, tmp.dir, "zzfile", "x"); // a file for the combine path to find
+    const dir_path = std.fs.path.dirname(stub_path).?;
+
+    // Complete `advapp pick zz` — the stub yields alpha/beta AND `also_files`, so
+    // the file `zzfile` (matching `zz`) must join the candidates.
+    const harness = try std.fmt.allocPrint(a,
+        \\chmod +x "{s}"
+        \\source "{s}"
+        \\cd "{s}"
+        \\COMP_WORDS=("{s}" pick "zz")
+        \\COMP_CWORD=2
+        \\COMPREPLY=()
+        \\_advapp_completions
+        \\printf '<%s>\n' "${{COMPREPLY[@]}}"
+        \\
+    , .{ stub_path, script_path, dir_path, stub_path });
+    const harness_path = try writeTemp(a, tmp.dir, "advapp_comb_harness.bash", harness);
+
+    const result = try std.process.run(a, io, .{ .argv = &.{ sh, harness_path } });
+    try std.testing.expect(advContains(result.stdout, "<zzalpha>")); // dynamic candidate
+    try std.testing.expect(advContains(result.stdout, "<zzfile>")); // native file
+}
+
+test "functional fish - also_files directive adds file completion to candidates" {
+    const sh = findShell("fish") orelse return error.SkipZigTest;
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const script = try fish.generate(a, "advapp", &adv_commands, &global_options);
+    const script_path = try writeTemp(a, tmp.dir, "advapp.fish", script);
+    const stub_path = try writeTemp(a, tmp.dir, "advapp", comb_stub);
+    _ = try writeTemp(a, tmp.dir, "zzfile", "x");
+    const dir_path = std.fs.path.dirname(stub_path).?;
+
+    const harness = try std.fmt.allocPrint(a,
+        \\chmod +x "{s}"
+        \\set -x PATH "{s}" $PATH
+        \\cd "{s}"
+        \\source "{s}"
+        \\for c in (complete -C "advapp pick zz")
+        \\    printf '<%s>\n' (string split -- \t $c)[1]
+        \\end
+        \\
+    , .{ stub_path, dir_path, dir_path, script_path });
+    const harness_path = try writeTemp(a, tmp.dir, "advapp_comb_harness.fish", harness);
+
+    const result = try std.process.run(a, io, .{ .argv = &.{ sh, harness_path } });
+    try std.testing.expect(advContains(result.stdout, "<zzalpha>"));
+    try std.testing.expect(advContains(result.stdout, "<zzfile>"));
 }

--- a/packages/core/src/plugin_completions_test.zig
+++ b/packages/core/src/plugin_completions_test.zig
@@ -813,6 +813,7 @@ test "functional bash - also_files directive adds file completion to candidates"
 
     const result = try std.process.run(a, io, .{ .argv = &.{ sh, harness_path } });
     try std.testing.expect(advContains(result.stdout, "<zzalpha>")); // dynamic candidate
+    try std.testing.expect(advContains(result.stdout, "<zzbeta>")); // the other dynamic candidate
     try std.testing.expect(advContains(result.stdout, "<zzfile>")); // native file
 }
 
@@ -846,5 +847,153 @@ test "functional fish - also_files directive adds file completion to candidates"
 
     const result = try std.process.run(a, io, .{ .argv = &.{ sh, harness_path } });
     try std.testing.expect(advContains(result.stdout, "<zzalpha>"));
+    try std.testing.expect(advContains(result.stdout, "<zzbeta>"));
     try std.testing.expect(advContains(result.stdout, "<zzfile>"));
+}
+
+// A stub whose `__complete` returns `default` + a matching candidate — used to
+// prove the shells only add native files when the DIRECTIVE says so (the shell
+// half of the flood guard: no directive combine → no file completion).
+const default_stub =
+    \\#!/bin/sh
+    \\printf '%s\0' 'default' 'zzalpha'
+    \\
+;
+
+// A stub emitting `also_files` plus the adversarial values — for the zsh helper,
+// which is exercised by stubbing `compadd`/`_files`.
+const zsh_comb_stub =
+    \\#!/bin/sh
+    \\printf '%s\0' 'also_files' 'a b c' '-wip' 'x*y?' "it's" '$HOME'
+    \\
+;
+
+test "gen - combine directive branches present in bash, zsh, fish" {
+    const b = try bash.generate(std.testing.allocator, "advapp", &adv_commands, &global_options);
+    defer std.testing.allocator.free(b);
+    try std.testing.expect(contains(b, "also_files") and contains(b, "compgen -f"));
+    try std.testing.expect(contains(b, "also_dirs") and contains(b, "compgen -d"));
+
+    const z = try zsh.generate(std.testing.allocator, "advapp", &adv_commands, &global_options);
+    defer std.testing.allocator.free(z);
+    try std.testing.expect(contains(z, "also_files) _files"));
+    try std.testing.expect(contains(z, "also_dirs) _files -/"));
+
+    const f = try fish.generate(std.testing.allocator, "advapp", &adv_commands, &global_options);
+    defer std.testing.allocator.free(f);
+    try std.testing.expect(contains(f, "case also_files") and contains(f, "__fish_complete_path"));
+    try std.testing.expect(contains(f, "case also_dirs") and contains(f, "__fish_complete_directories"));
+}
+
+test "functional zsh - dynamic candidates verbatim + combine invokes _files" {
+    const sh = findShell("zsh") orelse return error.SkipZigTest;
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const script = try zsh.generate(a, "advapp", &adv_commands, &global_options);
+    const script_path = try writeTemp(a, tmp.dir, "_advapp", script);
+    const stub_path = try writeTemp(a, tmp.dir, "advapp", zsh_comb_stub);
+
+    // Drive the helper directly with `compadd`/`_files` stubbed to capture their
+    // args — deterministic, unlike interactive completion. `_advapp_*` globals are
+    // set AFTER sourcing because `_advapp()` clears them (it captures `$words`).
+    const harness = try std.fmt.allocPrint(a,
+        \\chmod +x "{s}"
+        \\compadd() {{ while (( $# )); do print -r -- "ARG:$1"; shift; done }}
+        \\_files() {{ print -r -- "FILES:$@" }}
+        \\source "{s}" 2>/dev/null
+        \\_advapp_words=("{s}" pick "x")
+        \\_advapp_current=3
+        \\_advapp_zcli_complete
+        \\
+    , .{ stub_path, script_path, stub_path });
+    const harness_path = try writeTemp(a, tmp.dir, "advapp_zharness.zsh", harness);
+
+    const result = try std.process.run(a, io, .{ .argv = &.{ sh, "-f", harness_path } });
+    const out = result.stdout;
+    // Each adversarial value reached compadd as one verbatim argument.
+    try std.testing.expect(advContains(out, "ARG:a b c"));
+    try std.testing.expect(advContains(out, "ARG:-wip"));
+    try std.testing.expect(advContains(out, "ARG:x*y?"));
+    try std.testing.expect(advContains(out, "ARG:it's"));
+    try std.testing.expect(advContains(out, "ARG:$HOME"));
+    // The combine directive invoked native file completion.
+    try std.testing.expect(advContains(out, "FILES:"));
+}
+
+test "functional bash - default directive adds NO file completion (guard, shell half)" {
+    const sh = findShell("bash") orelse return error.SkipZigTest;
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const script = try bash.generate(a, "advapp", &adv_commands, &global_options);
+    const script_path = try writeTemp(a, tmp.dir, "advapp_completion.bash", script);
+    const stub_path = try writeTemp(a, tmp.dir, "advapp", default_stub);
+    _ = try writeTemp(a, tmp.dir, "zzfile", "x");
+    const dir_path = std.fs.path.dirname(stub_path).?;
+
+    const harness = try std.fmt.allocPrint(a,
+        \\chmod +x "{s}"
+        \\source "{s}"
+        \\cd "{s}"
+        \\COMP_WORDS=("{s}" pick "zz")
+        \\COMP_CWORD=2
+        \\COMPREPLY=()
+        \\_advapp_completions
+        \\printf '<%s>\n' "${{COMPREPLY[@]}}"
+        \\
+    , .{ stub_path, script_path, dir_path, stub_path });
+    const harness_path = try writeTemp(a, tmp.dir, "advapp_default_harness.bash", harness);
+
+    const result = try std.process.run(a, io, .{ .argv = &.{ sh, harness_path } });
+    try std.testing.expect(advContains(result.stdout, "<zzalpha>")); // dynamic candidate present
+    try std.testing.expect(!advContains(result.stdout, "<zzfile>")); // NO file: directive was default
+}
+
+test "functional fish - also_dirs directive offers directories" {
+    const sh = findShell("fish") orelse return error.SkipZigTest;
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const script = try fish.generate(a, "advapp", &adv_commands, &global_options);
+    const script_path = try writeTemp(a, tmp.dir, "advapp.fish", script);
+    const dir_stub =
+        \\#!/bin/sh
+        \\printf '%s\0' 'also_dirs' 'zzcand'
+        \\
+    ;
+    const stub_path = try writeTemp(a, tmp.dir, "advapp", dir_stub);
+    try tmp.dir.createDir(io, "zzdir", .default_dir);
+    const dir_path = std.fs.path.dirname(stub_path).?;
+
+    const harness = try std.fmt.allocPrint(a,
+        \\chmod +x "{s}"
+        \\set -x PATH "{s}" $PATH
+        \\cd "{s}"
+        \\source "{s}"
+        \\for c in (complete -C "advapp pick zz")
+        \\    printf '<%s>\n' (string split -- \t $c)[1]
+        \\end
+        \\
+    , .{ stub_path, dir_path, dir_path, script_path });
+    const harness_path = try writeTemp(a, tmp.dir, "advapp_dirs_harness.fish", harness);
+
+    const result = try std.process.run(a, io, .{ .argv = &.{ sh, harness_path } });
+    try std.testing.expect(advContains(result.stdout, "<zzcand>")); // dynamic candidate
+    try std.testing.expect(advContains(result.stdout, "<zzdir/>")); // directory (fish appends /)
 }

--- a/packages/core/src/plugins/zcli_completions/bash.zig
+++ b/packages/core/src/plugins/zcli_completions/bash.zig
@@ -98,10 +98,18 @@ pub fn generate(
             // nothing when there is no hook), so one call covers every position.
             // NUL-framed read (`read -d ''`) so a value may contain spaces/globs;
             // bash keeps only the value (COMPREPLY has no description channel).
-            try writer.writeAll("        local __rec\n");
+            try writer.writeAll("        local __rec __dir=default __first=1\n");
             try writer.writeAll("        while IFS= read -r -d '' __rec; do\n");
+            // The first record is the directive; the rest are candidate values.
+            try writer.writeAll("            if [[ $__first == 1 ]]; then __dir=\"$__rec\"; __first=0; continue; fi\n");
             try writer.writeAll("            COMPREPLY+=(\"${__rec%%$'\\t'*}\")\n");
             try writer.writeAll("        done < <(\"${words[0]}\" __complete \"$cword\" -- \"${words[@]}\" 2>/dev/null)\n");
+            // Combine directive: also offer native file/dir completion.
+            try writer.writeAll("        if [[ \"$__dir\" == also_files ]]; then\n");
+            try writer.writeAll("            COMPREPLY+=($(compgen -f -- \"$cur\"))\n");
+            try writer.writeAll("        elif [[ \"$__dir\" == also_dirs ]]; then\n");
+            try writer.writeAll("            COMPREPLY+=($(compgen -d -- \"$cur\"))\n");
+            try writer.writeAll("        fi\n");
         }
         if (has_pos_enums) {
             // Static enum positionals (first slot). Only when the dynamic pass

--- a/packages/core/src/plugins/zcli_completions/fish.zig
+++ b/packages/core/src/plugins/zcli_completions/fish.zig
@@ -177,7 +177,18 @@ fn writeDynamicHelper(writer: anytype, app_name: []const u8) !void {
     // string is dropped, which `__complete` reads back as an empty partial). One
     // call covers both the mid-token and word-boundary cases.
     try writer.writeAll("    set -l toks (commandline -opc)\n");
-    try writer.writeAll("    command $toks[1] __complete (count $toks) -- $toks (commandline -ct) 2>/dev/null | string split0\n");
+    try writer.writeAll("    set -l out (command $toks[1] __complete (count $toks) -- $toks (commandline -ct) 2>/dev/null | string split0)\n");
+    // First record is the directive; the rest are candidates.
+    try writer.writeAll("    test (count $out) -ge 1; or return\n");
+    try writer.writeAll("    if test (count $out) -gt 1\n");
+    try writer.writeAll("        printf '%s\\n' $out[2..-1]\n");
+    try writer.writeAll("    end\n");
+    try writer.writeAll("    switch $out[1]\n");
+    try writer.writeAll("        case also_files\n");
+    try writer.writeAll("            __fish_complete_path (commandline -ct)\n");
+    try writer.writeAll("        case also_dirs\n");
+    try writer.writeAll("            __fish_complete_directories\n");
+    try writer.writeAll("    end\n");
     try writer.writeAll("end\n\n");
 }
 

--- a/packages/core/src/plugins/zcli_completions/plugin.zig
+++ b/packages/core/src/plugins/zcli_completions/plugin.zig
@@ -11,7 +11,9 @@ pub const commands = struct {
     /// Hidden dynamic-completion entry point (ADR-0026). The generated shell
     /// scripts call `app __complete <cword> -- <COMP_WORDS…>` at `<TAB>`; this
     /// resolves the field the cursor is on and runs its `complete` hook, printing
-    /// candidates NUL-delimited (`value \t description` per record). The single
+    /// a NUL-delimited stream: the FIRST record is a directive token (`default` /
+    /// `also_files` / `also_dirs`), and every record after it is a candidate
+    /// (`value` then optional `\t description`) — see `wire.writeResult`. The single
     /// `--` protects words that start with `-` from being parsed as this command's
     /// own options; any `--` the user typed is just another word after it.
     pub const __complete = struct {

--- a/packages/core/src/plugins/zcli_completions/plugin.zig
+++ b/packages/core/src/plugins/zcli_completions/plugin.zig
@@ -51,7 +51,7 @@ pub const commands = struct {
                         return;
                     };
                     const out = context.stdout();
-                    try wire.writeRecords(out, result.candidates);
+                    try wire.writeResult(out, result, match.partial);
                 },
                 // Builtins are resolved statically at generation time and never
                 // reach `__complete`.

--- a/packages/core/src/plugins/zcli_completions/wire.zig
+++ b/packages/core/src/plugins/zcli_completions/wire.zig
@@ -1,17 +1,39 @@
 //! The `__complete` output wire format (ADR-0026).
 //!
-//! Records are **NUL-framed**: each candidate is `value` optionally followed by a
-//! tab and `description`, then a NUL byte. NUL is the delimiter because candidate
-//! values are arbitrary runtime strings that may legally contain spaces, globs,
-//! quotes, or newlines — only NUL cannot appear in one. A literal tab inside a
-//! value (which would be read as the value/description separator) and any stray
-//! NUL are scrubbed; everything else passes through verbatim so the shell offers
-//! the exact string.
+//! Records are **NUL-framed**: the FIRST record is a directive token
+//! (`default` / `also_files` / `also_dirs`); every record after it is a candidate
+//! — `value` optionally followed by a tab and `description`. NUL is the delimiter
+//! because candidate values are arbitrary runtime strings that may legally contain
+//! spaces, globs, quotes, or newlines — only NUL cannot appear in one. A literal
+//! tab inside a value (which would be read as the value/description separator) and
+//! any stray NUL are scrubbed; everything else passes through verbatim so the
+//! shell offers the exact string.
 
 const std = @import("std");
 const zcli = @import("zcli");
 
-/// Write `candidates` as NUL-framed records to `writer`.
+const Directive = zcli.completion.Directive;
+
+fn directiveToken(d: Directive) []const u8 {
+    return switch (d) {
+        .default => "default",
+        .also_files => "also_files",
+        .also_dirs => "also_dirs",
+    };
+}
+
+/// Write a completion `Result` to `writer`: the directive record first, then the
+/// NUL-framed candidates. On an EMPTY partial the `also_*` directive is downgraded
+/// to `default` — so a bare `<TAB>` in combine mode shows only the dynamic
+/// candidates, not the entire CWD (the flood guard the static work established).
+pub fn writeResult(writer: anytype, result: zcli.completion.Result, partial: []const u8) !void {
+    const directive = if (partial.len == 0) Directive.default else result.directive;
+    try writer.writeAll(directiveToken(directive));
+    try writer.writeByte(0);
+    try writeRecords(writer, result.candidates);
+}
+
+/// Write `candidates` as NUL-framed records to `writer` (no directive).
 pub fn writeRecords(writer: anytype, candidates: []const zcli.completion.Candidate) !void {
     for (candidates) |c| {
         try writeScrubbed(writer, c.value, true);
@@ -77,4 +99,25 @@ test "writeRecords - drops a stray NUL in a value" {
     defer aw.deinit();
     try writeRecords(&aw.writer, &.{.{ .value = "a\x00b" }});
     try std.testing.expectEqualStrings("ab\x00", aw.written());
+}
+
+test "writeResult - directive record precedes the candidates" {
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    try writeResult(&aw.writer, .{ .candidates = &.{.{ .value = "x" }}, .directive = .also_files }, "p");
+    try std.testing.expectEqualStrings("also_files\x00x\x00", aw.written());
+}
+
+test "writeResult - empty partial downgrades also_* to default (flood guard)" {
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    try writeResult(&aw.writer, .{ .candidates = &.{.{ .value = "x" }}, .directive = .also_files }, "");
+    try std.testing.expectEqualStrings("default\x00x\x00", aw.written());
+}
+
+test "writeResult - default directive with no candidates is just the directive" {
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    try writeResult(&aw.writer, .{}, "p");
+    try std.testing.expectEqualStrings("default\x00", aw.written());
 }

--- a/packages/core/src/plugins/zcli_completions/zsh.zig
+++ b/packages/core/src/plugins/zcli_completions/zsh.zig
@@ -130,8 +130,10 @@ fn writeDynamicHelper(writer: anytype, app_name: []const u8) !void {
     try writer.print("_{s}_zcli_complete() {{\n", .{app_name});
     try writer.print("    local cword=$(( _{s}_current - 1 ))\n", .{app_name});
     try writer.writeAll("    local -a __vals __disp\n");
-    try writer.writeAll("    local __rec __val __desc\n");
+    try writer.writeAll("    local __rec __val __desc __dir=default __first=1\n");
     try writer.writeAll("    while IFS= read -r -d '' __rec; do\n");
+    // The first record is the directive; the rest are candidates.
+    try writer.writeAll("        if (( __first )); then __dir=$__rec; __first=0; continue; fi\n");
     try writer.writeAll("        __val=${__rec%%$'\\t'*}\n");
     try writer.writeAll("        __vals+=(\"$__val\")\n");
     try writer.writeAll("        if [[ \"$__rec\" == *$'\\t'* ]]; then\n");
@@ -142,6 +144,11 @@ fn writeDynamicHelper(writer: anytype, app_name: []const u8) !void {
     try writer.writeAll("        fi\n");
     try writer.print("    done < <(\"${{_{s}_words[1]}}\" __complete \"$cword\" -- \"${{_{s}_words[@]}}\" 2>/dev/null)\n", .{ app_name, app_name });
     try writer.writeAll("    (( ${#__vals} )) && compadd -d __disp -- \"${__vals[@]}\"\n");
+    // Combine directive: also offer native file/dir completion.
+    try writer.writeAll("    case $__dir in\n");
+    try writer.writeAll("        also_files) _files ;;\n");
+    try writer.writeAll("        also_dirs) _files -/ ;;\n");
+    try writer.writeAll("    esac\n");
     try writer.writeAll("}\n\n");
 }
 


### PR DESCRIPTION
Final increment of dynamic shell completion (ADR-0026, #252), on top of #254 and #255. A hook can now return dynamic candidates **and** native file/dir completion — the `git checkout <TAB>` shape (branches *and* paths).

```zig
fn completeImport(req: *zcli.completion.Request) !zcli.completion.Result {
    // ...suggest recent import names...
    return .{ .candidates = recents, .directive = .also_files };
}
```

## Wire format

`__complete` output now **leads with a directive record** (`default` / `also_files` / `also_dirs`), then the NUL-framed candidates. The scripts read the first record as the directive and the rest as candidates.

**Flood guard:** on an *empty* partial the `also_*` directive is downgraded to `default` — a bare `<TAB>` in combine mode shows only the dynamic candidates, not the entire CWD (the misbehavior the static work removed). Files join once you start typing a prefix, matching how `git checkout` behaves.

## Generators

Each helper reads the leading directive record and, after emitting the candidates, additionally invokes native completion when the directive says so:
- zsh `_files` / `_files -/`
- bash `compgen -f` / `-d`
- fish `__fish_complete_path` / `__fish_complete_directories`

## Testing

- Wire unit tests: directive record precedes candidates; empty-partial downgrade (flood guard); default-with-no-candidates.
- Functional bash + fish tests: an `also_files` result offers **both** the dynamic candidates and a matching file.
- Verified end-to-end on the real binary (a hook returning `.also_files` → `__complete` emits `also_files`, and the shell adds the matching file).

## Arc complete

| Stage | PR |
|-------|-----|
| Tier 1 static hints/enums | #247 |
| ADR-0026 design | #252 |
| Dynamic incr 1 (hooks + `__complete`) | #254 |
| Dynamic incr 2 (option values + `.file`/`.dir`) | #255 |
| Dynamic incr 3 (combine directive) | this |

🤖 Generated with [Claude Code](https://claude.com/claude-code)