### PR TITLE
ci: build the static-musl release artifacts on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,50 @@ jobs:
         working-directory: projects/zcli
         run: zig build -Doptimize=ReleaseFast
 
+  # The release cross-compiles the static-musl Linux binaries (release.yml's
+  # build job, only on tag push), so PR CI never once built musl — and a
+  # musl-only build-graph panic in the secrets backend (fixed in 1931528)
+  # blocked the 0.19.0 release with a break PR CI could not have caught. This
+  # job closes that gap: it mirrors release.yml's build invocation EXACTLY
+  # (same `cd projects/zcli` + `zig build -Doptimize=ReleaseFast -Dtarget=…`
+  # per musl target) so the two can't drift and reopen the hole. x86_64 is a
+  # static binary the x64 runner can execute, so smoke-test it (mirrors the
+  # release's Smoke test step); aarch64 is build-only (can't run here).
+  linux-musl-release-build:
+    name: linux musl release build (${{ matrix.zig_target }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - zig_target: x86_64-linux-musl
+            smoke: true # static musl binary runs on the x64 runner
+          - zig_target: aarch64-linux-musl
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: 0.16.0
+
+      # Byte-for-byte the release build command (release.yml → build job → Build
+      # zcli). No test suite re-run — the `test` job already covers that; this
+      # only guards that the release-mode musl cross-compile links and starts.
+      - name: Build zcli (static musl, ReleaseFast)
+        working-directory: projects/zcli
+        run: zig build -Doptimize=ReleaseFast -Dtarget=${{ matrix.zig_target }}
+
+      # Prove the artifact the release would publish actually starts, on the
+      # target the runner can execute natively. Mirrors release.yml's smoke test.
+      - name: Smoke test the binary
+        if: matrix.smoke
+        working-directory: projects/zcli
+        run: |
+          ./zig-out/bin/zcli --version
+          ./zig-out/bin/zcli --help
+
   secrets:
     name: zcli_secrets backend (${{ matrix.os }})
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Gap

`release.yml` cross-compiles the `x86_64-linux-musl` and `aarch64-linux-musl` binaries **only at tag-push time**. PR CI never built musl at all — so the static-musl + secrets backend graph-construction panic (fixed in 1931528) blocked the 0.19.0 release with a failure PR CI could not possibly have caught. No Linux binaries shipped that release.

## Change

Adds one additive job, `linux-musl-release-build`, that runs on every PR/push:

- A 2-entry matrix (`x86_64-linux-musl`, `aarch64-linux-musl`) that invokes the release build **byte-for-byte**: `cd projects/zcli` then `zig build -Doptimize=ReleaseFast -Dtarget=<musl target>`. Pinning it to the same command as `release.yml`'s build job means the two can't drift and silently reopen the gap.
- `x86_64` is a static binary the x64 runner can execute, so it's smoke-tested (`--version` / `--help`), mirroring the release's own smoke-test step. `aarch64` is build-only (runner can't run it).
- No test suite re-run — the existing `test` job already covers that; this job only guards that the release-mode musl cross-compile links and starts.

Follows existing conventions: SHA-pinned `actions/checkout` + hash-pinned `mlugg/setup-zig` on the same `0.16.0` pin, default least-privilege permissions (inherits the workflow-level read), no ci.yml restructuring.

## Verification

- Cross-compiled both targets locally from macOS at ReleaseFast — both succeed (x86_64 exit 0; aarch64 produced a statically-linked aarch64 ELF). The linux binary can't be run locally; the CI job does the x86_64 smoke run on the x64 runner.
- `actionlint` reports no new findings (the 3 pre-existing shellcheck notes in the `secrets` job are unchanged from base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)