### PR TITLE
docs: remove removed --output formatting plugin remnants

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -325,7 +325,7 @@ jobs:
 
           - Core zcli framework
           - Build utilities for command generation
-          - Built-in plugins (help, version, not-found, completions, github-upgrade)
+          - Built-in plugins (help, version, not-found, completions, config, secrets, github-upgrade)
           - All supporting packages (vterm, markdown, etc.)
 
           ## Getting Started

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ The `zcli_config` plugin transparently loads option defaults from JSON, TOML, or
 ```json
 // .myapp.config.json
 {
-  "output": "json",         // global — applies to all commands
+  "verbose": true,          // global — applies to all commands
   "list": { "all": true }   // scoped — applies only to "myapp list"
 }
 ```
@@ -281,7 +281,7 @@ Discovery order and formats: [zcli.sh/docs/config](https://zcli.sh/docs/config/)
 
 ## Plugins
 
-Cross-cutting features are plugins, added in one line of `build.zig`: help, version, "did you mean?", shell completions (bash/zsh/fish), config files, `--output` formatting (json/table/plain), OS-keychain secrets, and self-upgrade via GitHub releases all ship in the box. Plugins hook the command lifecycle, register global options, expose typed data as `context.plugins.<id>`, and can ship commands of their own.
+Cross-cutting features are plugins, added in one line of `build.zig`: help, version, "did you mean?", shell completions (bash/zsh/fish), config files, OS-keychain secrets, and self-upgrade via GitHub releases all ship in the box. Plugins hook the command lifecycle, register global options, expose typed data as `context.plugins.<id>`, and can ship commands of their own.
 
 The full list and a guide to writing your own: [zcli.sh/plugins](https://zcli.sh/plugins/) (repo summary in [docs/PLUGINS.md](docs/PLUGINS.md)).
 

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -4,7 +4,7 @@
 > orientation; the website is the single source of truth for the built-in list,
 > config-file behavior, and the plugin-authoring contract.
 
-Plugins extend every command in an app with lifecycle hooks, global options, and their own commands. zcli ships with a set of built-ins — the help/version/not-found trio is what most apps start with, and completions, config files, `--output` formatting, OS-keychain secrets, and GitHub self-upgrade are opt-in. Enable them in `build.zig`:
+Plugins extend every command in an app with lifecycle hooks, global options, and their own commands. zcli ships with a set of built-ins — the help/version/not-found trio is what most apps start with, and completions, config files, OS-keychain secrets, and GitHub self-upgrade are opt-in. Enable them in `build.zig`:
 
 ```zig
 const cmd_registry = try zcli.generate(b, exe, zcli_dep, .{

--- a/examples/tasks/README.md
+++ b/examples/tasks/README.md
@@ -25,8 +25,8 @@ What it demonstrates:
 - **theme** — semantic colors and status badges via `context.theme`.
 - **A shared module** — `src/store.zig` (JSON persistence to `tasks.json`)
   registered once as a `shared_modules` entry in `build.zig`.
-- **Six built-in plugins** — `zcli.builtin(.help/.version/.not_found/
-  .completions/.output/.config, .{})`, including per-command defaults from
+- **Five built-in plugins** — `zcli.builtin(.help/.version/.not_found/
+  .completions/.config, .{})`, including per-command defaults from
   `.tasks.config.json`.
 - **Doc generation** — `zcli.generateDocs` writes markdown + HTML docs on
   every build.

--- a/website/content/docs/config.smd
+++ b/website/content/docs/config.smd
@@ -35,7 +35,7 @@ Top-level keys apply to every command; a table named after a command scopes valu
 
 ```toml
 # .myapp.config.toml
-output = "json"     # global — applies to all commands
+verbose = true      # global — applies to all commands
 
 [list]              # scoped — applies only to `myapp list`
 all = true

--- a/website/layouts/home.shtml
+++ b/website/layouts/home.shtml
@@ -138,7 +138,7 @@ Deploying api to staging
 <span class="c-prompt">$</span> <span class="c-cmd">myapp</span> users create <span class="c-flag">--help</span>
 <span class="c-mut">USAGE</span>  myapp users create &lt;name&gt; [options]
   <span class="c-flag">-a, --admin</span>     Grant admin role
-  <span class="c-flag">    --output</span>   json · table · plain
+  <span class="c-flag">    --role</span>     owner · admin · member
 <span class="c-ok">✔</span> generated from your command metadata<span class="cursor"></span></pre>
 				</div>
 			</div>


### PR DESCRIPTION
## What

zcli once shipped a `--output` (json/table/plain) output-formatting plugin (v0.1.0). It was deliberately removed — it's absent from the `Builtin` enum (`packages/core/src/build_utils/types.zig`) and from `packages/core/src/plugins/` — but several docs still advertised it as a shipped built-in. This sweeps the repo and corrects the present-tense claims. Historical CHANGELOG entries are left untouched.

## Ground truth

The actual 7 built-in plugins: `help`, `version`, `not_found`, `completions`, `config`, `secrets`, `github_upgrade`. No `output`.

## Changes

- **README.md** — dropped `--output` formatting from the "ships in the box" plugin list; changed the config-scoping JSON example's `"output": "json"` to `"verbose": true` so it no longer reads as the removed plugin's flag.
- **docs/PLUGINS.md** — dropped `--output` formatting from the opt-in built-in list.
- **examples/tasks/README.md** — "**Six** built-in plugins" listing `.output` was doubly wrong; corrected to "**Five**" and removed `.output`, matching the example's actual `build.zig` (`help/version/not_found/completions/config`).
- **website/layouts/home.shtml** — the `users create --help` terminal demo advertised `--output json · table · plain` as a framework-provided flag; replaced with a user-defined `--role owner · admin · member` enum option (same enum-choice help rendering, no false plugin claim).
- **website/content/docs/config.smd** — config example `output = "json"` → `verbose = true`, mirroring the README fix.
- **.github/workflows/release.yml** — completed the built-in plugin list to match the enum (added `config`, `secrets`; it already had no output remnant).

## Cross-checked but left alone (not remnants)

- **CHANGELOG.md** — v0.1.0 foundation entry lists the output plugin; historical, left intact per instructions.
- **docs/DESIGN.md:615** (`--format FMT Output format: json, table`), **DESIGN.md:457** (`output: enum { json, yaml }`), **errors.smd:330**, **security_test.zig**, **options/parser.zig**, **command_parser.zig**, **registry/tests.zig** — all user-defined `output`/`--format` option fields in illustrative command/parsing/constraint examples, not framework plugin claims.
- **validation.smd / DESIGN.md / ADR-0022** `--output-format requires --output` — option-constraint examples using a user's own options.
- **projects/zcli guide `output` topic** — the `zcli guide output` topic is about writing through `context.stdout()`/`stderr()`, unrelated to the removed plugin.
- **website/layouts/plugins.shtml** and **website/content/docs/build.smd** — already correct (7 plugins, no output).

## Verification

`zig build test` at root passes (all example + zcli test suites green). Edits are textual and don't touch the `@embedFile`'d `guide.zig` content. The website Zine build was not run (website/ builds via a separate prebuilt `zine` binary, not `zig build`); the `.shtml`/`.smd` edits are content-only, no template-directive changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)