### PR TITLE
fix(build): surface local plugin discovery failures loudly

### DIFF
--- a/packages/core/src/build_utils/command_tests.zig
+++ b/packages/core/src/build_utils/command_tests.zig
@@ -50,7 +50,7 @@ pub fn addCommandTests(
     //     backend). The real keychain plugin is what the app links and runs; this
     //     stands in only for `zig build test`.
     const local_plugins: []const PluginInfo =
-        if (config.plugins_dir) |dir| plugin_system.scanLocalPlugins(b, dir) catch &.{} else &.{};
+        if (config.plugins_dir) |dir| (plugin_system.scanLocalPlugins(b, dir) catch &.{}) orelse &.{} else &.{};
 
     var stub_plugins = std.ArrayList(*std.Build.Module).empty;
     defer stub_plugins.deinit(b.allocator);

--- a/packages/core/src/build_utils/main.zig
+++ b/packages/core/src/build_utils/main.zig
@@ -117,9 +117,28 @@ fn buildWithPlugins(b: *std.Build, exe: *std.Build.Step.Compile, zcli_dep: *std.
     const command_configs = config.command_configs orelse &.{};
     config_application.applyCommandConfigsToExecutable(b, exe, command_configs);
 
-    // 1. Discover local plugins
-    const local_plugins = if (config.plugins_dir) |dir|
-        plugin_system.scanLocalPlugins(b, dir) catch &.{}
+    // 1. Discover local plugins. A missing plugins_dir is optional (scan
+    //    returns null → no local plugins). Any real failure is surfaced loudly
+    //    with the offending path so a broken plugins_dir can't silently build
+    //    an app with zero plugins (mirrors the command-discovery reporting
+    //    below). We hard-fail via @panic because scanLocalPlugins returns an
+    //    error set (not GenerateError) and there is no recoverable state.
+    const local_plugins: []const types.PluginInfo = if (config.plugins_dir) |dir|
+        (plugin_system.scanLocalPlugins(b, dir) catch |err| switch (err) {
+            error.InvalidPath => {
+                logging.buildError("Plugin Discovery Error", dir, "Invalid plugins directory path.\nPath contains '..' which is not allowed for security reasons", "Please use a relative path without '..' or an absolute path");
+                std.debug.panic("Plugin discovery failed for '{s}': {s}", .{ dir, @errorName(err) });
+            },
+            error.AccessDenied => {
+                logging.buildError("Plugin Discovery Error", dir, "Access denied to plugins directory", "Please check file permissions for the directory");
+                std.debug.panic("Plugin discovery failed for '{s}': {s}", .{ dir, @errorName(err) });
+            },
+            error.OutOfMemory => @panic("OOM"),
+            else => {
+                logging.buildError("Plugin Discovery Error", dir, "Failed to discover plugins", "Check the plugins directory structure and file permissions");
+                std.debug.panic("Plugin discovery failed for '{s}': {s}", .{ dir, @errorName(err) });
+            },
+        }) orelse &.{}
     else
         &.{};
 

--- a/packages/core/src/build_utils/plugin_system.zig
+++ b/packages/core/src/build_utils/plugin_system.zig
@@ -8,11 +8,16 @@ const PluginInfo = types.PluginInfo;
 // PLUGIN SYSTEM - Discovery, management, and configuration
 // ============================================================================
 
-/// Scan local plugins directory and return plugin info
-pub fn scanLocalPlugins(b: *std.Build, plugins_dir: []const u8) ![]PluginInfo {
-    var plugins = std.ArrayList(PluginInfo).empty;
-    defer plugins.deinit(b.allocator);
-
+/// Scan local plugins directory and return plugin info.
+///
+/// Returns `null` when the configured `plugins_dir` simply does not exist —
+/// a local plugins directory is legitimately optional, so a missing one is a
+/// clean "no local plugins" outcome, NOT a failure. Every other failure
+/// (AccessDenied, NotDir, traversal in the path, an unreadable entry mid-scan,
+/// …) propagates as an error so the caller can surface it loudly instead of
+/// silently building with zero plugins. This missing-vs-broken split is made
+/// at the type level (`?[]PluginInfo`) rather than by catching everything.
+pub fn scanLocalPlugins(b: *std.Build, plugins_dir: []const u8) !?[]PluginInfo {
     // Validate plugins directory path
     if (std.mem.indexOf(u8, plugins_dir, "..") != null) {
         return error.InvalidPath;
@@ -20,16 +25,32 @@ pub fn scanLocalPlugins(b: *std.Build, plugins_dir: []const u8) ![]PluginInfo {
 
     // Try to open the plugins directory
     var dir = b.build_root.handle.openDir(b.graph.io, plugins_dir, .{ .iterate = true }) catch |err| {
-        // If directory doesn't exist, that's fine - just return empty list
+        // A missing directory is the one benign case: report it as `null` so
+        // the caller treats it as "no local plugins". Anything else (denied
+        // permissions, a file where a dir was expected, …) is a real error.
         if (err == error.FileNotFound) {
-            return &.{};
+            return null;
         }
         return err;
     };
     defer dir.close(b.graph.io);
 
+    return try scanInDir(b.allocator, b.graph.io, dir, plugins_dir);
+}
+
+/// Scan an already-open plugins directory handle. Split out of
+/// `scanLocalPlugins` so the entry-iteration and error-propagation behaviour
+/// can be unit-tested against a tmp dir without constructing a `*std.Build`
+/// (mirrors command_discovery's `discoverInDir` split). Real errors mid-scan
+/// (an unreadable subdirectory, a failing stat) propagate; the only skips are
+/// deliberate classification (non-plugin entries, invalid names, dirs without a
+/// plugin.zig).
+fn scanInDir(allocator: std.mem.Allocator, io: std.Io, dir: std.Io.Dir, plugins_dir: []const u8) ![]PluginInfo {
+    var plugins = std.ArrayList(PluginInfo).empty;
+    defer plugins.deinit(allocator);
+
     var iterator = dir.iterate();
-    while (try iterator.next(b.graph.io)) |entry| {
+    while (try iterator.next(io)) |entry| {
         switch (entry.kind) {
             .file => {
                 // Single-file plugins (e.g., auth.zig)
@@ -41,14 +62,14 @@ pub fn scanLocalPlugins(b: *std.Build, plugins_dir: []const u8) ![]PluginInfo {
                         continue;
                     }
 
-                    const import_name = try std.fmt.allocPrint(b.allocator, "plugins/{s}", .{plugin_name});
+                    const import_name = try std.fmt.allocPrint(allocator, "plugins/{s}", .{plugin_name});
                     // `entry.name` aliases the iterator's buffer, reused on the
                     // next `next()`, so `plugin_name` must be duped to outlive the
                     // scan (import_name/project_path already copy via allocPrint).
-                    const project_path = try std.fmt.allocPrint(b.allocator, "{s}/{s}", .{ plugins_dir, entry.name });
+                    const project_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ plugins_dir, entry.name });
 
-                    try plugins.append(b.allocator, PluginInfo{
-                        .name = try b.allocator.dupe(u8, plugin_name),
+                    try plugins.append(allocator, PluginInfo{
+                        .name = try allocator.dupe(u8, plugin_name),
                         .import_name = import_name,
                         .is_local = true,
                         .dependency = null,
@@ -65,18 +86,25 @@ pub fn scanLocalPlugins(b: *std.Build, plugins_dir: []const u8) ![]PluginInfo {
                     continue;
                 }
 
-                // Check if directory has a plugin.zig file
-                var subdir = dir.openDir(b.graph.io, entry.name, .{}) catch continue;
-                defer subdir.close(b.graph.io);
+                // Check if directory has a plugin.zig file. Failing to open a
+                // subdirectory we just enumerated is a real error (e.g.
+                // AccessDenied) — propagate it rather than silently skipping.
+                var subdir = try dir.openDir(io, entry.name, .{});
+                defer subdir.close(io);
 
-                _ = subdir.statFile(b.graph.io, "plugin.zig", .{}) catch continue; // Skip if no plugin.zig
+                // A missing plugin.zig legitimately means "this dir isn't a
+                // plugin" — skip it. Any other stat error propagates.
+                _ = subdir.statFile(io, "plugin.zig", .{}) catch |err| {
+                    if (err == error.FileNotFound) continue;
+                    return err;
+                };
 
-                const import_name = try std.fmt.allocPrint(b.allocator, "plugins/{s}/plugin", .{entry.name});
+                const import_name = try std.fmt.allocPrint(allocator, "plugins/{s}/plugin", .{entry.name});
                 // Dupe entry.name — it aliases the iterator's reused buffer.
-                const project_path = try std.fmt.allocPrint(b.allocator, "{s}/{s}/plugin.zig", .{ plugins_dir, entry.name });
+                const project_path = try std.fmt.allocPrint(allocator, "{s}/{s}/plugin.zig", .{ plugins_dir, entry.name });
 
-                try plugins.append(b.allocator, PluginInfo{
-                    .name = try b.allocator.dupe(u8, entry.name),
+                try plugins.append(allocator, PluginInfo{
+                    .name = try allocator.dupe(u8, entry.name),
                     .import_name = import_name,
                     .is_local = true,
                     .dependency = null,
@@ -87,7 +115,7 @@ pub fn scanLocalPlugins(b: *std.Build, plugins_dir: []const u8) ![]PluginInfo {
         }
     }
 
-    return plugins.toOwnedSlice(b.allocator);
+    return plugins.toOwnedSlice(allocator);
 }
 
 /// Combine local and external plugins into a single array
@@ -153,4 +181,88 @@ test "isValidPluginName: accepts plugin-ish names, rejects traversal and junk" {
     try testing.expect(!isValidPluginName("../escape"));
     try testing.expect(!isValidPluginName("a/b"));
     try testing.expect(!isValidPluginName("a\\b"));
+}
+
+/// Free everything `scanInDir` allocated for a result slice.
+fn freeScanResult(allocator: std.mem.Allocator, plugins: []PluginInfo) void {
+    for (plugins) |p| {
+        allocator.free(p.name);
+        allocator.free(p.import_name);
+        if (p.project_path) |pp| allocator.free(pp);
+    }
+    allocator.free(plugins);
+}
+
+test "scanInDir: discovers single-file and multi-file plugins, skips non-plugins" {
+    const io = testing.io;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // auth.zig — a single-file plugin.
+    try tmp.dir.writeFile(io, .{ .sub_path = "auth.zig", .data = "pub const foo = 1;" });
+    // metrics/plugin.zig — a multi-file plugin.
+    try tmp.dir.createDir(io, "metrics", .default_dir);
+    try tmp.dir.writeFile(io, .{ .sub_path = "metrics/plugin.zig", .data = "pub const foo = 1;" });
+    // notaplugin/ — a directory WITHOUT plugin.zig: must be skipped, not error.
+    try tmp.dir.createDir(io, "notaplugin", .default_dir);
+    try tmp.dir.writeFile(io, .{ .sub_path = "notaplugin/other.zig", .data = "pub const foo = 1;" });
+    // README.md — a non-.zig file: ignored.
+    try tmp.dir.writeFile(io, .{ .sub_path = "README.md", .data = "hi" });
+
+    var dir = try tmp.dir.openDir(io, ".", .{ .iterate = true });
+    defer dir.close(io);
+
+    const plugins = try scanInDir(testing.allocator, io, dir, "src/plugins");
+    defer freeScanResult(testing.allocator, plugins);
+
+    try testing.expectEqual(@as(usize, 2), plugins.len);
+
+    var saw_auth = false;
+    var saw_metrics = false;
+    for (plugins) |p| {
+        if (std.mem.eql(u8, p.name, "auth")) {
+            saw_auth = true;
+            try testing.expectEqualStrings("plugins/auth", p.import_name);
+            try testing.expectEqualStrings("src/plugins/auth.zig", p.project_path.?);
+        } else if (std.mem.eql(u8, p.name, "metrics")) {
+            saw_metrics = true;
+            try testing.expectEqualStrings("plugins/metrics/plugin", p.import_name);
+            try testing.expectEqualStrings("src/plugins/metrics/plugin.zig", p.project_path.?);
+        }
+    }
+    try testing.expect(saw_auth);
+    try testing.expect(saw_metrics);
+}
+
+test "scanInDir: empty directory yields no plugins" {
+    const io = testing.io;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var dir = try tmp.dir.openDir(io, ".", .{ .iterate = true });
+    defer dir.close(io);
+
+    const plugins = try scanInDir(testing.allocator, io, dir, "src/plugins");
+    defer freeScanResult(testing.allocator, plugins);
+
+    try testing.expectEqual(@as(usize, 0), plugins.len);
+}
+
+// NOTE: The real-error classification in `scanLocalPlugins` (traversal in the
+// path → error.InvalidPath; missing dir → null; AccessDenied/NotDir →
+// propagated) and the loud `@panic`/`buildError` reporting in
+// `main.buildWithPlugins` run only inside a `*std.Build` context, which cannot
+// be constructed in a unit test. `scanInDir` above covers the entry-iteration
+// and skip-vs-error behaviour; the outer classification is exercised by real
+// builds (`zig build`, examples, projects/zcli) and documented at the call
+// site. The path-traversal guard is a pure string check, tested next.
+
+test "scanLocalPlugins path guard: rejects traversal in plugins_dir" {
+    // The `..` check is a pure prefix of scanLocalPlugins, reachable without a
+    // filesystem or a *std.Build handle for the offending case.
+    try testing.expect(std.mem.indexOf(u8, "../evil", "..") != null);
+    try testing.expect(std.mem.indexOf(u8, "src/../plugins", "..") != null);
+    try testing.expect(std.mem.indexOf(u8, "src/plugins", "..") == null);
 }


### PR DESCRIPTION
## Problem

`buildWithPlugins` did `plugin_system.scanLocalPlugins(b, dir) catch &.{}`, swallowing **every** error from local plugin discovery. A missing `plugins_dir` is legitimately optional, but any *real* failure (`AccessDenied`, `NotDir`, path traversal, an unreadable entry mid-scan) silently built the app with **zero local plugins and no diagnostic** — the exact "silently dead plugins" failure shape that bit us in PR #51. The commands-discovery path right next to it already reports errors properly; this brings plugin discovery up to that quality.

## Fix

**Distinguish missing-vs-broken at the type level.** `scanLocalPlugins` now returns `?[]PluginInfo`:
- `null` -> the configured `plugins_dir` doesn't exist -> clean "no local plugins" outcome.
- Any other error propagates.

The call site in `buildWithPlugins` classifies the propagated errors and **hard-fails loudly**, mirroring the command-discovery reporting idiom:

| Error | Surfaced as |
|-------|-------------|
| `error.InvalidPath` (`..` in path) | `buildError` "Invalid plugins directory path" + panic w/ path + error name |
| `error.AccessDenied` | `buildError` "Access denied to plugins directory" + panic |
| `error.OutOfMemory` | `@panic("OOM")` |
| anything else (`NotDir`, mid-scan read error, ...) | `buildError` "Failed to discover plugins" + panic |

Every panic message includes the configured `plugins_dir` and `@errorName(err)`.

**Removed two internal swallows** inside the scan:
- A subdirectory we just enumerated failing to open now propagates (was `catch continue`).
- The `plugin.zig` stat only skips on `FileNotFound` (was a catch-all `catch continue`); any other stat error propagates.

**Extracted `scanInDir(allocator, io, dir, plugins_dir)`** from `scanLocalPlugins` — mirrors `command_discovery.discoverInDir` — so entry-iteration and skip-vs-error behaviour is unit-testable against a tmp dir without constructing a `*std.Build`.

## Tests

- `scanInDir` discovers single-file (`auth.zig`) and multi-file (`metrics/plugin.zig`) plugins, skips a dir without `plugin.zig` and non-`.zig` files (asserts import_name/project_path).
- Empty-directory case yields no plugins.
- Path-traversal guard string check.
- The `*std.Build`-bound classification/panic path can't be constructed in a unit test; it's documented at the call site and exercised by real builds.

## Verification

- `zig build test` at root — all package + example + `projects/zcli` suites pass.
- `zig build` at root (covers example subprocess builds) — exit 0.
- `projects/zcli` `zig build` — exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)