### PR TITLE
security: harden upgrade/secrets/http defaults (audit hardening)

### DIFF
--- a/packages/core/src/http.zig
+++ b/packages/core/src/http.zig
@@ -28,6 +28,13 @@
 //!   are kept across all redirects. (This is why the wrapper follows redirects
 //!   itself: as of 0.16, `std.http.Client`'s auto-follow re-sends every extra
 //!   header to the redirect target regardless of origin.)
+//! - **Credential headers never ride cleartext to a remote host.** A request
+//!   that carries one of those credential headers over a non-`https` scheme
+//!   fails with `error.InsecureCredentialTransport` — checked on every hop, so a
+//!   same-origin `http`→`http` redirect cannot smuggle a token onto the wire
+//!   either. The sole carve-out is loopback (`127.0.0.0/8`, `::1`, `localhost`),
+//!   which is a secure transport in practice (nothing on the wire) and is what
+//!   the loopback integration tests exercise; every real caller uses `https`.
 //! - **Each request has an overall timeout** (default `default_timeout`) so a
 //!   hung or dead server cannot make a command hang forever. See "Timeouts".
 //!
@@ -82,6 +89,11 @@ pub const Error = error{
     Timeout,
     /// A redirect chain exceeded `max_redirects`.
     TooManyRedirects,
+    /// A request carrying a credential header (`authorization`, `cookie`, or
+    /// `proxy-authorization`) targeted a non-`https` origin that is not
+    /// loopback. Refused fail-closed so a bearer token / cookie is never put on
+    /// the wire in cleartext to a remote host.
+    InsecureCredentialTransport,
 };
 
 /// Request headers that carry credentials. These are stripped from a request
@@ -117,6 +129,32 @@ fn sameOrigin(a: std.Uri, b: std.Uri) bool {
     const b_host = (b.host orelse return false).toRaw(&b_buf) catch return false;
     if (!std.ascii.eqlIgnoreCase(a_host, b_host)) return false;
     return (a.port orelse defaultPort(a.scheme)) == (b.port orelse defaultPort(b.scheme));
+}
+
+/// True when `host` is a loopback address — the one carve-out where a credential
+/// header may travel over cleartext `http`, because nothing leaves the machine.
+/// Covers the IPv4 loopback block `127.0.0.0/8`, the IPv6 loopback `::1` (with or
+/// without brackets), and the literal name `localhost`.
+fn isLoopbackHost(host: []const u8) bool {
+    if (std.ascii.eqlIgnoreCase(host, "localhost")) return true;
+    // IPv6 literal, possibly bracketed in a URI authority.
+    const h = std.mem.trim(u8, host, "[]");
+    if (std.Io.net.IpAddress.parse(h, 0)) |addr| {
+        return switch (addr) {
+            .ip4 => |v4| v4.bytes[0] == 127, // 127.0.0.0/8
+            .ip6 => |v6| std.mem.eql(u8, &v6.bytes, &([_]u8{0} ** 15 ++ [_]u8{1})), // ::1
+        };
+    } else |_| return false;
+}
+
+/// A credential-bearing request may go out only over `https`, or to a loopback
+/// host over any scheme. Returns false for anything else (cleartext to a remote
+/// host), which the request loop turns into `error.InsecureCredentialTransport`.
+fn credentialTransportOk(uri: std.Uri) bool {
+    if (std.ascii.eqlIgnoreCase(uri.scheme, "https")) return true;
+    var host_buf: [256]u8 = undefined;
+    const host = (uri.host orelse return false).toRaw(&host_buf) catch return false;
+    return isLoopbackHost(host);
 }
 
 /// The Location to follow for a redirect response, or null when the status is
@@ -333,6 +371,9 @@ pub const Client = struct {
         for (options.headers) |header| {
             if (isPrivilegedHeaderName(header.name)) headers.appendAssumeCapacity(header);
         }
+        // Whether any credential header is present at all — the guard below only
+        // needs to fire when a hop would actually put one on the wire.
+        const has_credentials = headers.items.len > safe_header_count;
 
         var current_method = method;
         var current_url: []const u8 = url;
@@ -343,6 +384,16 @@ pub const Client = struct {
 
         while (true) {
             const uri = try std.Uri.parse(current_url);
+
+            // Fail closed before opening the connection: a credential header must
+            // never travel in cleartext to a remote host. This covers the initial
+            // request and every same-origin `http`→`http` redirect hop (a hop that
+            // leaves the origin has already cleared `send_credentials`). `https`
+            // and loopback are the only origins allowed to carry credentials.
+            if (send_credentials and has_credentials and !credentialTransportOk(uri)) {
+                return Error.InsecureCredentialTransport;
+            }
+
             const hop_headers = headers.items[0..if (send_credentials)
                 headers.items.len
             else
@@ -485,6 +536,53 @@ test "sameOrigin requires scheme, host, and effective port to match" {
     try testing.expect(!sameOrigin(try parse("https://api.example.com/"), try parse("https://example.com/")));
     try testing.expect(!sameOrigin(try parse("https://api.example.com/"), try parse("https://api.example.com:8443/")));
     try testing.expect(!sameOrigin(try parse("http://127.0.0.1:8080/"), try parse("http://127.0.0.1:9090/")));
+}
+
+test "isLoopbackHost recognizes loopback names and addresses only" {
+    try testing.expect(isLoopbackHost("localhost"));
+    try testing.expect(isLoopbackHost("LocalHost"));
+    try testing.expect(isLoopbackHost("127.0.0.1"));
+    try testing.expect(isLoopbackHost("127.1.2.3")); // whole 127.0.0.0/8 block
+    try testing.expect(isLoopbackHost("::1"));
+    try testing.expect(isLoopbackHost("[::1]")); // bracketed IPv6 authority
+    try testing.expect(!isLoopbackHost("example.com"));
+    try testing.expect(!isLoopbackHost("10.0.0.1"));
+    try testing.expect(!isLoopbackHost("128.0.0.1"));
+    try testing.expect(!isLoopbackHost("localhost.evil.com"));
+    try testing.expect(!isLoopbackHost("::2"));
+}
+
+test "credentialTransportOk allows https and loopback, refuses cleartext to a remote host" {
+    const parse = std.Uri.parse;
+    // https anywhere is fine.
+    try testing.expect(credentialTransportOk(try parse("https://api.example.com/")));
+    try testing.expect(credentialTransportOk(try parse("https://127.0.0.1:8443/")));
+    // http only on loopback.
+    try testing.expect(credentialTransportOk(try parse("http://127.0.0.1:8080/")));
+    try testing.expect(credentialTransportOk(try parse("http://localhost:8080/")));
+    try testing.expect(credentialTransportOk(try parse("http://[::1]:8080/")));
+    // http to a remote host is refused — this is the leak the guard closes.
+    try testing.expect(!credentialTransportOk(try parse("http://api.example.com/")));
+    try testing.expect(!credentialTransportOk(try parse("http://10.0.0.5/")));
+}
+
+test "a credentialed request over cleartext to a remote host is refused before connecting" {
+    var client = Client.init(testing.allocator, testing.io, .{});
+    defer client.deinit();
+
+    // An authorization header over plain http to a non-loopback host must fail
+    // closed with InsecureCredentialTransport, without any network work.
+    const creds = [_]Header{.{ .name = "authorization", .value = "Bearer secret-token" }};
+    try testing.expectError(
+        Error.InsecureCredentialTransport,
+        client.request(.GET, "http://api.example.com/", .{ .headers = &creds }),
+    );
+    // A cookie header is guarded the same way.
+    const cookie = [_]Header{.{ .name = "cookie", .value = "session=abc" }};
+    try testing.expectError(
+        Error.InsecureCredentialTransport,
+        client.request(.GET, "http://api.example.com/", .{ .headers = &cookie }),
+    );
 }
 
 test "redirectTarget follows only real redirect statuses" {

--- a/packages/core/src/plugins/zcli_github_upgrade/plugin.zig
+++ b/packages/core/src/plugins/zcli_github_upgrade/plugin.zig
@@ -105,10 +105,35 @@ fn checkedRecently(last: ?i64, now_s: i64, interval_s: i64) bool {
     return now_s >= l and now_s - l < interval_s;
 }
 
+/// Render the unsigned-by-default warning shown when a real upgrade runs on a
+/// build with no pinned `public_key`. Factored out of `executeUpgrade` so the
+/// exact wording is unit-testable without a live command context or network.
+fn writeUnsignedWarning(w: *std.Io.Writer) !void {
+    try w.print(
+        \\warning: signature verification is not enabled for this build — only the
+        \\         SHA-256 checksum will be verified. checksums.txt ships in the same
+        \\         GitHub release as the binaries, so a compromised release publisher
+        \\         can replace both and this upgrade will trust the result. To close
+        \\         this gap, pin a minisign public key via the plugin's `public_key`
+        \\         config (see ADR-0023).
+        \\
+    , .{});
+}
+
 /// zcli-github-upgrade Plugin
 ///
 /// Provides self-upgrade functionality for CLI applications that release via GitHub.
 /// Downloads new versions from GitHub releases and atomically replaces the current binary.
+///
+/// SECURITY: `public_key` is the load-bearing integrity control. It is optional,
+/// but leaving it null means the upgrade authenticates a downloaded binary only
+/// against `checksums.txt` — a file that ships in the same release as the binary
+/// it describes. A compromised release publisher can therefore swap both the
+/// binary and its checksum and the upgrade will trust the swap. Pinning a
+/// minisign public key (ADR-0023) authenticates the checksums under a key held
+/// off the release pipeline and makes verification fail closed. Builds without a
+/// pinned key emit a runtime warning on every real upgrade. Set `public_key`
+/// for any app whose releases are signed.
 /// Plugin configuration
 pub const Config = struct {
     /// GitHub repository in format "owner/repo" (required)
@@ -154,6 +179,12 @@ pub fn init(config: Config) type {
     return struct {
         const Self = @This();
         const plugin_config = config;
+
+        /// Test-only accessor for the resolved comptime config, so tests can
+        /// assert which security branch a given instantiation takes.
+        fn pluginConfigForTest() Config {
+            return plugin_config;
+        }
 
         /// Commands provided by this plugin
         pub const commands = struct {
@@ -212,6 +243,21 @@ pub fn init(config: Config) type {
                 // directly would discard everything we just wrote to the
                 // buffered stdout — context.exit flushes first.
                 context.exit(0);
+            }
+
+            // Unsigned-by-default notice. `public_key` is the load-bearing
+            // integrity control: with no pinned key the upgrade authenticates
+            // only against `checksums.txt`, which ships in the same release as
+            // the binaries — a compromised release publisher can swap both and
+            // this command will trust the swap. The signing key (ADR-0023)
+            // lives off the release pipeline, so pinning it is the only defense
+            // against that class of attack. Zig has no non-fatal comptime
+            // print (`@compileLog` halts the build), so the warning is emitted
+            // at runtime, once, gated on the comptime config — it costs
+            // nothing when a key is pinned and cannot be missed by an operator
+            // running an actual upgrade.
+            if (comptime plugin_config.public_key == null) {
+                try writeUnsignedWarning(context.stderr());
             }
 
             // Perform upgrade
@@ -974,6 +1020,33 @@ test "writeCheckResult - --check output reaches stdout (was silently dropped)" {
         defer a.free(out);
         try std.testing.expectEqualStrings("You are already on version: 1.5.0\n", out);
     }
+}
+
+test "writeUnsignedWarning - names the control and how to fix it" {
+    const a = std.testing.allocator;
+    var aw = std.Io.Writer.Allocating.init(a);
+    defer aw.deinit();
+    try writeUnsignedWarning(&aw.writer);
+    const out = aw.written();
+
+    // It must be a warning, name checksum-only verification as the effect,
+    // explain the same-release threat, and tell the operator how to pin a key.
+    try std.testing.expect(std.mem.startsWith(u8, out, "warning:"));
+    try std.testing.expect(std.mem.indexOf(u8, out, "SHA-256 checksum") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "checksums.txt") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "public_key") != null);
+}
+
+test "unsigned notice is gated on the comptime public_key config" {
+    // The notice fires only when no key is pinned. These two instantiations
+    // pin the branch each build takes: with a key, the warning path is dead
+    // code the compiler prunes; without one, it is live. Asserting on the
+    // comptime predicate the runtime `if` uses keeps that contract from
+    // silently inverting.
+    const Signed = init(.{ .repo = "owner/app", .public_key = "KEY" });
+    const Unsigned = init(.{ .repo = "owner/app" });
+    try std.testing.expect(comptime Signed.pluginConfigForTest().public_key != null);
+    try std.testing.expect(comptime Unsigned.pluginConfigForTest().public_key == null);
 }
 
 test "isNewerVersion - semantic comparison" {

--- a/packages/core/src/plugins/zcli_secrets/linux_pass.zig
+++ b/packages/core/src/plugins/zcli_secrets/linux_pass.zig
@@ -29,7 +29,7 @@ pub fn get(
     const path = try entryPath(allocator, service, name);
     defer allocator.free(path);
 
-    var out = subprocess.run(allocator, io, environ, &.{ "pass", "show", path }, null) catch |e|
+    var out = subprocess.run(allocator, io, environ, &showArgv(path), null) catch |e|
         return mapError(e);
     defer out.deinit();
 
@@ -84,9 +84,7 @@ pub fn set(
     const store_attempts = 8;
     var attempt: usize = 0;
     while (true) : (attempt += 1) {
-        var out = subprocess.run(allocator, io, environ, &.{
-            "pass", "insert", "--multiline", "--force", path,
-        }, encoded) catch |e| return mapError(e);
+        var out = subprocess.run(allocator, io, environ, &insertArgv(path), encoded) catch |e| return mapError(e);
         defer out.deinit();
 
         if (out.ok()) return;
@@ -107,7 +105,7 @@ pub fn delete(
     const path = try entryPath(allocator, service, name);
     defer allocator.free(path);
 
-    var out = subprocess.run(allocator, io, environ, &.{ "pass", "rm", "--force", path }, null) catch |e|
+    var out = subprocess.run(allocator, io, environ, &rmArgv(path), null) catch |e|
         return mapError(e);
     defer out.deinit();
 
@@ -120,6 +118,22 @@ pub fn delete(
 /// The `pass` entry path for a secret: `zcli/<app>/<name>`.
 fn entryPath(allocator: std.mem.Allocator, service: []const u8, name: []const u8) ![]u8 {
     return std.fmt.allocPrint(allocator, "zcli/{s}/{s}", .{ service, name });
+}
+
+// argv builders. `--` terminates `pass`'s option parsing so the entry path is
+// always taken as a positional, never as a flag — belt-and-suspenders alongside
+// the plugin boundary already rejecting a leading-dash name, and the path being
+// prefixed `zcli/`. `pass` is a bash script that passes its args through
+// `getopt`, which honours `--`. Isolating the argv here keeps the terminator's
+// placement (immediately before `path`) unit-testable without spawning `pass`.
+fn showArgv(path: []const u8) [4][]const u8 {
+    return .{ "pass", "show", "--", path };
+}
+fn insertArgv(path: []const u8) [6][]const u8 {
+    return .{ "pass", "insert", "--multiline", "--force", "--", path };
+}
+fn rmArgv(path: []const u8) [5][]const u8 {
+    return .{ "pass", "rm", "--force", "--", path };
 }
 
 /// `pass` reports a missing entry as "Error: <path> is not in the password
@@ -154,6 +168,22 @@ test "entry path is namespaced under zcli/" {
     const p = try entryPath(a, "myapp", "token");
     defer a.free(p);
     try std.testing.expectEqualStrings("zcli/myapp/token", p);
+}
+
+test "pass argv places `--` immediately before the entry path" {
+    const path = "zcli/app/token";
+    // Each `pass` subcommand must terminate options with `--` right before the
+    // path, so a path is never re-interpreted as a flag.
+    inline for (.{ showArgv(path), insertArgv(path), rmArgv(path) }) |argv| {
+        const last = argv.len - 1;
+        try std.testing.expectEqualStrings("--", argv[last - 1]);
+        try std.testing.expectEqualStrings(path, argv[last]);
+        try std.testing.expectEqualStrings("pass", argv[0]);
+    }
+    // Full spellings, so an accidental flag reorder is caught.
+    try std.testing.expectEqualSlices([]const u8, &.{ "pass", "show", "--", path }, &showArgv(path));
+    try std.testing.expectEqualSlices([]const u8, &.{ "pass", "insert", "--multiline", "--force", "--", path }, &insertArgv(path));
+    try std.testing.expectEqualSlices([]const u8, &.{ "pass", "rm", "--force", "--", path }, &rmArgv(path));
 }
 
 test "isNotFound matches pass's missing-entry message" {

--- a/packages/core/src/plugins/zcli_secrets/linux_secret_service.zig
+++ b/packages/core/src/plugins/zcli_secrets/linux_secret_service.zig
@@ -7,6 +7,16 @@
 //! backend, this *executes `secret-tool`* rather than linking `libsecret`, so a
 //! zcli binary stays static and musl-clean (see ADR-0010). The value is
 //! base64-encoded (see `subprocess.encodeValue`).
+//!
+//! Note on argument terminators: unlike the `pass` backend, the argv here take
+//! no `--` terminator. The user-controlled `name` is passed as an attribute
+//! *value* (`account <name>`), which follows a keyword token rather than sitting
+//! in option position, and `secret-tool` is a GOption program whose subcommand
+//! grammar (`store`/`lookup`/`clear` as the first arg) does not cleanly accept a
+//! `--` before those keyword/value triples. The plugin boundary's leading-dash
+//! rejection already prevents a `name` from being read as a flag, so no `--` is
+//! needed — and none is added rather than one whose placement GOption may not
+//! honour.
 
 const std = @import("std");
 const subprocess = @import("subprocess.zig");

--- a/packages/core/src/plugins/zcli_secrets/plugin.zig
+++ b/packages/core/src/plugins/zcli_secrets/plugin.zig
@@ -65,6 +65,12 @@
 //! - It must not contain a NUL byte — the macOS/Linux backends key on C strings,
 //!   where an embedded NUL silently truncates the key. (A NUL is also invalid
 //!   UTF-16 target material.)
+//! - It must not contain a `/` or a `..`, and must not begin with `-`. The
+//!   `pass` backend maps a name into a filesystem path (`zcli/<app>/<name>`), so
+//!   a slash or `..` would let a name escape its per-app namespace; and the
+//!   Linux backends pass the name as a subprocess argument, where a leading dash
+//!   could be misread as an option flag. These are rejected on every OS so the
+//!   contract stays uniform, not just where the concern bites.
 //!
 //! Beyond the name, backends differ on how large a value they accept, and each
 //! that has a cap fails with `SecretTooLarge` above it:
@@ -144,8 +150,8 @@ comptime {
 /// The single, backend-agnostic error set every `get`/`set`/`delete` maps into.
 /// Command code catches these on every OS — see the module doc.
 pub const Error = error{
-    /// A secret name is not valid UTF-8, or contains a NUL byte. Rejected up
-    /// front, before any backend call.
+    /// A secret name is unsafe: not valid UTF-8, or it contains a NUL, a `/`,
+    /// a `..`, or begins with `-`. Rejected up front, before any backend call.
     InvalidSecretName,
     /// The value exceeds what the active backend can store.
     SecretTooLarge,
@@ -158,9 +164,29 @@ pub const Error = error{
     OutOfMemory,
 };
 
+/// Validate a secret `name` at the plugin boundary — once, for every backend —
+/// so a name either works on every OS or is rejected on every OS, and so no
+/// backend ever receives a name that could escape its intended key space or its
+/// subprocess argv.
+///
+/// Rejected:
+///   - an embedded NUL — the macOS/Linux backends key on C strings, where a NUL
+///     silently truncates the key (and it is invalid UTF-16 target material);
+///   - invalid UTF-8 — Windows stores the name as UTF-16, so a name that
+///     "works" on macOS/Linux would fail only there;
+///   - a `/` — the `pass` backend builds a filesystem path `zcli/<app>/<name>`,
+///     so a slash would let a name write outside its per-app namespace;
+///   - `..` anywhere — same path-traversal concern for the `pass` backend, and
+///     meaningless to the keychain backends;
+///   - a leading `-` — the Linux backends pass the name as a subprocess
+///     argument, where a leading dash could be parsed as an option flag by
+///     `pass`/`secret-tool` (defense in depth alongside the `--` terminator).
 fn validateName(name: []const u8) Error!void {
     if (std.mem.indexOfScalar(u8, name, 0) != null) return Error.InvalidSecretName;
     if (!std.unicode.utf8ValidateSlice(name)) return Error.InvalidSecretName;
+    if (std.mem.indexOfScalar(u8, name, '/') != null) return Error.InvalidSecretName;
+    if (std.mem.indexOf(u8, name, "..") != null) return Error.InvalidSecretName;
+    if (name.len > 0 and name[0] == '-') return Error.InvalidSecretName;
 }
 
 /// Surface a native backend's raised error to the user, then collapse it into
@@ -252,12 +278,28 @@ test "plugin exposes the storage surface" {
 test "validateName rejects an embedded NUL and invalid UTF-8" {
     try validateName("token"); // ok
     try validateName(""); // ok (empty is a valid, if odd, key)
-    try validateName("café/ключ/名前"); // multibyte UTF-8 is fine
+    try validateName("café-ключ-名前"); // multibyte UTF-8 is fine
+    try validateName("my.token"); // a single dot is fine
+    try validateName("has-dash"); // an interior/trailing dash is fine
     try testing.expectError(Error.InvalidSecretName, validateName("to\x00ken"));
     // A lone continuation byte is not valid UTF-8 — rejected on every OS rather
     // than working on macOS/Linux and failing only on Windows's UTF-16 store.
     try testing.expectError(Error.InvalidSecretName, validateName("bad\xffname"));
     try testing.expectError(Error.InvalidSecretName, validateName(&[_]u8{0x80}));
+}
+
+test "validateName rejects path-escape and option-flag names" {
+    // A `/` — would let a name escape its per-app namespace in the `pass`
+    // backend's `zcli/<app>/<name>` filesystem path.
+    try testing.expectError(Error.InvalidSecretName, validateName("a/b"));
+    try testing.expectError(Error.InvalidSecretName, validateName("/etc/passwd"));
+    // `..` anywhere — path traversal for the `pass` backend.
+    try testing.expectError(Error.InvalidSecretName, validateName(".."));
+    try testing.expectError(Error.InvalidSecretName, validateName("a..b"));
+    // A leading `-` — could be parsed as an option flag by the subprocess
+    // backends (`pass`/`secret-tool`).
+    try testing.expectError(Error.InvalidSecretName, validateName("-rf"));
+    try testing.expectError(Error.InvalidSecretName, validateName("--force"));
 }
 
 test "mapBackendError collapses every backend taxonomy into the shared set" {


### PR DESCRIPTION
Three security-hardening items from the audit, one small commit each.

## 1. upgrade plugin — unsigned-by-default warning
`public_key` is the load-bearing integrity control: with no pinned minisign key, `upgrade` authenticates a binary only against `checksums.txt`, which ships in the same release as the binary — a compromised publisher can swap both. The plugin now emits a clear warning, once per real upgrade, whenever it is wired without a `public_key`, naming checksum-only verification as the effect and how to pin a key.

**Mechanism:** runtime warning gated on the comptime `public_key == null`. Zig has no non-fatal comptime print (`@compileLog` halts the build), so a build-time notice would either be fatal or noisy. The runtime notice costs nothing when a key is pinned (dead-code-pruned branch) and cannot be missed by an operator running an actual upgrade. `public_key` is now documented as the load-bearing control in the plugin doc comment.

## 2. secrets — name validation + argument terminators
`validateName` (shared by `get`/`set`/`delete` on every backend) now also rejects `/`, `..`, and a leading `-` (NUL and invalid UTF-8 were already rejected), via the existing `InvalidSecretName` error. Added `--` before the entry-path positional in every `pass` argv (`show`/`insert`/`rm`).

**secret-tool takes no `--`:** the user-controlled `name` is passed as an attribute *value* (`account <name>`) following a keyword token, not in option position, and secret-tool's GOption subcommand grammar does not cleanly accept a `--` there — the leading-dash rejection already covers that vector. Injection posture unchanged (argv spawn, no shell).

## 3. http client — TLS guard for credentialed requests
A credential header (`authorization`/`cookie`/`proxy-authorization`) over a non-`https` origin now fails closed with `InsecureCredentialTransport`, checked on **every hop** (initial request + same-origin `http`→`http` redirect). 

**Loopback policy:** cleartext credentials are permitted only to loopback (`127.0.0.0/8`, `::1`, `localhost`) — a secure transport in practice and what the loopback integration tests legitimately exercise. Every real caller (upgrade plugin) already hardcodes `https`.

## Tests
- secrets: name-validation rejections for all four classes (`/`, `..`, leading `-`, NUL/invalid-UTF-8) + positive cases; `pass` argv places `--` immediately before the path across all three subcommands.
- http: `isLoopbackHost` / `credentialTransportOk` matrices; credentialed cleartext-to-remote request refused before connecting (authorization + cookie).
- upgrade: `writeUnsignedWarning` wording asserted; comptime gate asserted for signed vs unsigned instantiation.

`zig build test` green (1482/1484, 2 pre-existing platform skips). Live macOS Keychain secrets round-trip (`test-secrets-live`) 7/7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)