### PR TITLE
fix(help): drop bogus [ARGS...] for commands with empty Args

### DIFF
--- a/packages/core/build.zig
+++ b/packages/core/build.zig
@@ -146,6 +146,7 @@ pub fn build(b: *std.Build) void {
         "src/plugin_completions_test.zig",
         "src/plugin_github_upgrade_test.zig",
         "src/plugin_pipeline_test.zig",
+        "src/plugins/zcli_help/plugin.zig",
         "src/plugins/zcli_config/plugin.zig",
         "src/plugin_config_integration_test.zig",
     };

--- a/packages/core/src/plugins/zcli_help/plugin.zig
+++ b/packages/core/src/plugins/zcli_help/plugin.zig
@@ -219,8 +219,11 @@ fn showHelp(context: anytype, help_type: HelpType, to_stdout: bool) !void {
                 // Root command can be invoked directly
                 try fmt.write("    <command>{s}</command> [OPTIONS]", .{app_name});
                 if (context.command_module_info) |module_info| {
-                    if (module_info.has_args) {
-                        try writer.writeAll(" [ARGS...]");
+                    // Only render the positionals the root's Args actually
+                    // declares; an empty `Args = struct {}` yields no pattern.
+                    if (generateArgsPattern(module_info, context) catch null) |pattern| {
+                        defer context.allocator.free(pattern);
+                        try writer.print(" {s}", .{pattern});
                     }
                 }
                 try writer.writeAll("\n");
@@ -635,15 +638,15 @@ fn generateUsage(context: anytype) ![]const u8 {
         }
 
         if (has_args) {
+            // An empty `Args = struct {}` still sets has_args (the decl exists),
+            // but has no fields — generateArgsPattern returns null for it, so no
+            // placeholder is rendered. A non-empty Args always yields a pattern of
+            // its real, named positionals; there is no generic `[ARGS...]` case.
             if (context.command_module_info) |module_info| {
                 if (generateArgsPattern(module_info, context) catch null) |pattern| {
                     defer context.allocator.free(pattern);
                     try buf_writer.print(" {s}", .{pattern});
-                } else {
-                    try buf_writer.writeAll(" [ARGS...]");
                 }
-            } else {
-                try buf_writer.writeAll(" [ARGS...]");
             }
         }
     }
@@ -1211,7 +1214,7 @@ test "showHelp .command renders a clean OPTIONS block for an options-less comman
     // header + one entry).
     const opts_at = std.mem.indexOf(u8, out, "OPTIONS:\n").?;
     const after = out[opts_at + "OPTIONS:\n".len ..];
-    try std.testing.expect(std.mem.startsWith(u8, std.mem.trimLeft(u8, after, " "), "--help"));
+    try std.testing.expect(std.mem.startsWith(u8, std.mem.trimStart(u8, after, " "), "--help"));
     // With no declared options and no subcommands, --help is the only OPTIONS
     // entry and no COMMANDS section renders.
     try std.testing.expect(std.mem.indexOf(u8, out, "--help") != null);
@@ -1276,6 +1279,62 @@ test "generateUsage: a command with subcommands shows COMMAND, not its options" 
 
     try std.testing.expect(std.mem.indexOf(u8, usage, "remote") != null);
     try std.testing.expect(std.mem.indexOf(u8, usage, "COMMAND") != null);
+}
+
+test "generateUsage: an empty Args struct renders no [ARGS...] placeholder" {
+    const allocator = std.testing.allocator;
+
+    const Ctx = zcli.TestContext(&.{});
+    var stdio: zcli.Stdio = undefined;
+    stdio.init(std.testing.io);
+    const environ = std.process.Environ.Map.init(allocator);
+    var ctx = Ctx.init(allocator, std.testing.io, &stdio, &environ);
+    defer ctx.deinit();
+    // Strip color so the usage line is plain text we can match exactly.
+    ctx.theme.caps = .{ .capability = .no_color, .is_tty = false, .color_enabled = false };
+
+    ctx.app_name = "tasks";
+    ctx.command_path = &.{"list"};
+    // `Args = struct {}` sets has_args (the decl exists) with zero fields — the
+    // regression: this used to fall through to a bogus `[ARGS...]`.
+    ctx.command_module_info = .{ .has_args = true, .has_options = false };
+
+    const usage = try generateUsage(&ctx);
+    defer allocator.free(usage);
+
+    // Exact line: no positionals, no [ARGS...] tail.
+    try std.testing.expectEqualStrings("tasks list", usage);
+}
+
+test "generateUsage: a command with real args renders their names, not [ARGS...]" {
+    const allocator = std.testing.allocator;
+
+    const Ctx = zcli.TestContext(&.{});
+    var stdio: zcli.Stdio = undefined;
+    stdio.init(std.testing.io);
+    const environ = std.process.Environ.Map.init(allocator);
+    var ctx = Ctx.init(allocator, std.testing.io, &stdio, &environ);
+    defer ctx.deinit();
+    ctx.theme.caps = .{ .capability = .no_color, .is_tty = false, .color_enabled = false };
+
+    ctx.app_name = "tasks";
+    ctx.command_path = &.{"add"};
+    // A required positional plus an optional varargs tail — both spellings.
+    ctx.command_module_info = .{
+        .has_args = true,
+        .args_fields = &.{
+            .{ .name = "title", .is_optional = false, .is_array = false, .type_name = "[]const u8" },
+            .{ .name = "tags", .is_optional = true, .is_array = true, .type_name = "[][]const u8" },
+        },
+        .has_options = false,
+    };
+
+    const usage = try generateUsage(&ctx);
+    defer allocator.free(usage);
+
+    // Exact line: real, uppercased arg names with their optionality — never
+    // the generic [ARGS...] fallback.
+    try std.testing.expectEqualStrings("tasks add TITLE [TAGS...]", usage);
 }
 
 // Note: Integration tests for handleGlobalOption and help command execution


### PR DESCRIPTION
## Bug

Per-command help printed a spurious `[ARGS...]` for commands whose `Args` struct is empty:

```
$ tasks list --help
USAGE: tasks list [OPTIONS] [ARGS...]   ← list takes no positionals
```

## Root cause

`command_module_info.has_args` is set from `@hasDecl(Module, "Args")` (registry/compiled.zig), so it's `true` for an empty `Args = struct {}` (the decl exists, zero fields). The usage-line logic in `zcli_help/plugin.zig` treated `has_args` as "render a placeholder"; `generateArgsPattern` correctly returns `null` for a field-less Args, so it fell through to a hardcoded `[ARGS...]` fallback. That fallback fires *only* in the empty-args case — it was never correct.

## Fix

Render positionals solely from `generateArgsPattern`, which already emits the real, named args (with correct optionality) for a non-empty `Args` and `null` for an empty one. Dropped the `[ARGS...]` fallback. Applied to both the per-command usage line (`generateUsage`) and the root usage line, which shared the same flaw. Minimal, localized to the usage-line logic (does not touch `generateOptionsHelp`).

## After

```
tasks list [OPTIONS]              # empty Args → no placeholder
tasks add  [OPTIONS] [TITLE]      # optional positional
tasks done [OPTIONS] ID           # required positional
```

## Tests

- Added exact-line assertions in `zcli_help/plugin.zig`: empty `Args` → `tasks list` (no `[ARGS...]`); real args → `tasks add TITLE [TAGS...]`.
- Verified both tests **fail without the fix** (the empty-Args test produces the buggy `tasks list [ARGS...]`).
- Wired `src/plugins/zcli_help/plugin.zig` into the core `test` step — its 15 inline tests were never run by any build step, which is how this regression slipped through. That also surfaced a bit-rotted `std.mem.trimLeft`→`trimStart` (0.16 rename) in one existing test, fixed here.

## Verification

- `zig build test` (root + core): green.
- `zig build e2e` (projects/zcli): green.
- Rebuilt `examples/tasks` and confirmed the corrected usage lines above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)