### PR TITLE
test(e2e): vterm frame assertions for the interactive harness

### DIFF
--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -4,7 +4,7 @@ Three tiers of testing for zcli-built CLIs, from fast in-process command tests t
 
 1. **Unit** — `runCommand` executes a command's `execute()` in-process and captures stdout/stderr (plus a `vterm` screen for rendered-output assertions). No binary, fastest loop.
 2. **Integration** — `runSubprocess` runs the compiled binary and asserts on the full stack: parsing, routing, plugin hooks, exit codes. Includes snapshot testing.
-3. **E2E (PTY)** — `e2e.runInteractive` drives the binary through a real pseudo-terminal for prompts, hidden input, signals, and TTY-dependent formatting.
+3. **E2E (PTY)** — `e2e.runInteractive` drives the binary through a real pseudo-terminal for prompts, hidden input, signals, and TTY-dependent formatting. Assert on the raw byte stream (`.expect`) *or* on the rendered screen (`.expectFrameContains` / `.expectRow` / `.expectFrame`): the harness feeds the PTY/ConPTY output through a `vterm` sized to the session, so a frame assertion only passes if the text is actually visible where it was drawn — closing the gap where a cursor-movement regression leaves the expected bytes *somewhere* in the stream and a raw substring still matches.
 
 The complete guide with worked examples per tier is [zcli.sh/testing](https://zcli.sh/testing/).
 
@@ -24,8 +24,9 @@ they can't drift from the API they document).
 
 The testing tiers ship with the zcli dependency — no separate dependency entry. Each
 tier is its own module, so you only pull the dependencies the tier actually needs: the
-**unit** tier (`zcli_testing_unit`) needs zcli + vterm; the **integration/snapshot**
-(`zcli_testing`) and **e2e** (`testing_e2e`) tiers are std-only.
+**unit** tier (`zcli_testing_unit`) and the **e2e** tier (`testing_e2e`, for its
+rendered-frame assertions) need vterm — the unit tier also needs zcli; the
+**integration/snapshot** tier (`zcli_testing`) is std-only.
 
 - **Scaffolded projects are already wired**: `zcli.addCommandTests(...)` (emitted by `zcli init`) compiles each command file as its own test root with the unit tier importable as `zcli-testing`, so `zig build test` just works.
 - **Manual wiring** — pick the tier your test module uses (the import name is just a local alias):
@@ -37,7 +38,7 @@ tier is its own module, so you only pull the dependencies the tier actually need
   // Subprocess + snapshot tests (runSubprocess, expectSnapshot): std-only.
   test_module.addImport("zcli-testing", zcli_dep.module("zcli_testing"));
 
-  // PTY harness alone (e2e.runInteractive): std-only.
+  // PTY harness alone (e2e.runInteractive): pulls in vterm for frame assertions.
   test_module.addImport("testing_e2e", zcli_dep.module("testing_e2e"));
   ```
 
@@ -49,7 +50,7 @@ tier is its own module, so you only pull the dependencies the tier actually need
 - **Integration**: `runSubprocess(allocator, io, exe_path, args)` → `Result` (`.stdout`, `.stderr`, `.exit_code`)
 - **Assertions**: `expectExitCode`, `expectExitCodeNot`, `expectContains`, `expectNotContains`, `expectEqualStrings`, `expectValidJson`, `expectStdoutEmpty`, `expectStderrEmpty`
 - **Snapshots**: `expectSnapshot(...)` against golden files, with `maskDynamicContent` (UUIDs, timestamps, addresses) and `stripAnsi`; update by threading `.update = true` from a build option (`zig build test -Dupdate-snapshots`)
-- **E2E**: `e2e.InteractiveScript` builder (`.expect`, `.send`, `.sendHidden`, `.sendControl`, `.sendSignal`, `.delay`, `.withTimeout`, `.optional`), executed by `e2e.runInteractive(...)` → `InteractiveResult` (`.exit_code`, `.output`, `.success`, `.transcript`); `runInteractiveDualMode` runs the same script with and without a PTY
+- **E2E**: `e2e.InteractiveScript` builder — stream steps (`.expect`, `.send`, `.sendHidden`, `.sendControl`, `.sendSignal`, `.delay`, `.withTimeout`, `.optional`) and rendered-frame steps (`.expectFrameContains(text)`, `.expectRow(index, expected)`, `.expectFrame(snapshot_name)`) — executed by `e2e.runInteractive(...)` → `InteractiveResult` (`.exit_code`, `.output`, `.success`, `.transcript`); `runInteractiveDualMode` runs the same script with and without a PTY. Frame steps poll until the rendered screen matches or the step times out (no fixed sleeps); `.expectFrame` reuses the snapshot masking/update flow (`config.snapshot_root` + `config.update_snapshots`)
 
 ## Quick taste
 
@@ -96,8 +97,9 @@ test "login prompts for credentials" {
 
 ## Dependencies
 
-Only the **unit** tier (`zcli_testing_unit`) depends on these; the subprocess/snapshot
-and e2e tiers are std-only.
+The **unit** tier (`zcli_testing_unit`) depends on both; the **e2e** tier
+(`testing_e2e`) depends on vterm alone (for rendered-frame assertions); the
+subprocess/snapshot tier (`zcli_testing`) is std-only.
 
-- [`core`](../core/) — `Stdio`, `TestContext` for in-process execution
-- [`vterm`](../vterm/) — terminal emulation for rendered-output assertions
+- [`core`](../core/) — `Stdio`, `TestContext` for in-process execution (unit tier only)
+- [`vterm`](../vterm/) — terminal emulation for rendered-output assertions (unit + e2e tiers)

--- a/packages/testing/build.zig
+++ b/packages/testing/build.zig
@@ -11,14 +11,17 @@ pub fn build(b: *std.Build) void {
     const zcli_dep = b.dependency("zcli_core", .{ .target = target, .optimize = optimize });
     const vterm_dep = b.dependency("vterm", .{ .target = target, .optimize = optimize });
 
-    // The subprocess/snapshot testing tier (main.zig): std-only, so importing it
-    // does NOT drag zcli/vterm/serde into a consumer's test build. The root
-    // package re-exports this as `zcli_testing`.
+    // The subprocess/snapshot testing tier (main.zig): std-only except that its
+    // re-exported PTY tier (e2e.zig) now renders child output through vterm for
+    // frame assertions, so vterm is wired in. zcli/serde are still NOT dragged
+    // in — only vterm, and only the PTY tier uses it. The root package
+    // re-exports this as `zcli_testing`.
     const testing_mod = b.addModule("testing", .{
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
     });
+    testing_mod.addImport("vterm", vterm_dep.module("vterm"));
 
     // The in-process unit-testing tier (unit.zig): `runCommand` executes a
     // command's execute() without a subprocess, so it needs zcli (Stdio,
@@ -35,14 +38,16 @@ pub fn build(b: *std.Build) void {
     unit_mod.addImport("vterm", vterm_dep.module("vterm"));
 
     // Expose the PTY-based interactive harness (e2e.zig) as its own module.
-    // It is std-only — no zcli/vterm — so CLI projects can drive a real TTY in
-    // their e2e tests without pulling in the rest of the testing tier. The
-    // root package re-exports this as `testing_e2e`.
+    // It pulls in vterm (to render child output for frame assertions) but not
+    // zcli/serde, so CLI projects can drive a real TTY in their e2e tests
+    // without the rest of the testing tier. The root package re-exports this as
+    // `testing_e2e`.
     const e2e_mod = b.addModule("e2e", .{
         .root_source_file = b.path("src/e2e.zig"),
         .target = target,
         .optimize = optimize,
     });
+    e2e_mod.addImport("vterm", vterm_dep.module("vterm"));
 
     const test_step = b.step("test", "Run all tests");
 
@@ -52,6 +57,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    testing_test_mod.addImport("vterm", vterm_dep.module("vterm"));
     const testing_tests = b.addTest(.{ .root_module = testing_test_mod });
     test_step.dependOn(&b.addRunArtifact(testing_tests).step);
 

--- a/packages/testing/examples/e2e_example.zig
+++ b/packages/testing/examples/e2e_example.zig
@@ -2,8 +2,9 @@
 //!
 //! This tier drives a binary through a real pseudo-terminal (or, optionally, a
 //! plain pipe) so you can test genuinely interactive behavior: prompts, hidden
-//! password input, control keys, signals, and TTY-dependent formatting. It is
-//! std-only and ships as its own module, `testing_e2e`.
+//! password input, control keys, signals, and TTY-dependent formatting. It ships
+//! as its own module, `testing_e2e`, and feeds the terminal output through a
+//! `vterm` so you can assert on the RENDERED screen, not just the raw stream.
 //!
 //! `zig build examples` runs the `test` blocks below. To stay hermetic they
 //! drive `cat` — a stock tool that echoes stdin to stdout — instead of a project
@@ -111,4 +112,45 @@ test "runInteractive over a real PTY (skips gracefully without a TTY)" {
     defer result.deinit();
 
     try std.testing.expect(std.mem.indexOf(u8, result.output, "tty-hello") != null);
+}
+
+// ---------------------------------------------------------------------------
+// 4. Asserting on the RENDERED screen — frame assertions.
+// ---------------------------------------------------------------------------
+
+test "runInteractive frame assertions check the rendered screen" {
+    if (builtin.os.tag == .windows) return;
+
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    // A shell one-liner that clears the screen, then positions the cursor and
+    // paints "READY" on row 3 (1-based) via an absolute CUP escape, and finally
+    // waits for a line of input so the harness can end the session. The literal
+    // "READY" is preceded by cursor-movement bytes — exactly the case where a
+    // raw-stream `.expect("READY")` would pass without proving WHERE it landed.
+    const program = "printf '\\033[2J\\033[3;1HREADY'; read _dummy";
+
+    var script = e2e.InteractiveScript.init(allocator);
+    defer script.deinit();
+    _ = script
+        // `.expectFrameContains` walks the rendered cells: it only matches if
+        // "READY" is visible on screen. `.expectRow` is stricter still — it
+        // pins the exact row (0-based) the text was drawn on. Both poll until
+        // the frame matches or the step times out (no fixed sleeps).
+        .expectFrameContains("READY").withTimeout(4000)
+        .expectRow(2, "READY").withTimeout(4000)
+        .send("go"); // let `read` return so `sh` exits
+
+    var result = e2e.runInteractive(allocator, io, &.{ "/bin/sh", "-c", program }, script, .{
+        .allocate_pty = true, // a real terminal is required for frame assertions
+        .terminal_size = .{ .rows = 24, .cols = 40 },
+        .total_timeout_ms = 8000,
+    }) catch |err| {
+        std.log.warn("runInteractive (frame) skipped — no working TTY: {any}", .{err});
+        return;
+    };
+    defer result.deinit();
+
+    try std.testing.expect(result.steps_executed >= 2);
 }

--- a/packages/testing/src/e2e.zig
+++ b/packages/testing/src/e2e.zig
@@ -847,8 +847,27 @@ pub const InteractiveError = error{
     NoSavedSettings,
 } || std.mem.Allocator.Error;
 
+/// Why a script step stopped the run — carried out of `driveScriptSteps` so the
+/// driver can print a single loud diagnostic (which step, what kind, and the
+/// rendered screen) instead of letting the failure surface only as a nonzero
+/// child exit code. `.none` means every step passed.
+const StepFailure = union(enum) {
+    none,
+    expect: []const u8,
+    frame: FrameAssertion,
+    send: []const u8,
+    total_timeout,
+};
+
 /// Outcome of running the script's steps, before teardown.
-const ScriptOutcome = struct { success: bool, steps_executed: usize };
+const ScriptOutcome = struct {
+    success: bool,
+    steps_executed: usize,
+    /// Which step (0-based) broke the run, when `!success`.
+    failed_step: usize = 0,
+    /// Why it broke, for the diagnostic dump.
+    failure: StepFailure = .none,
+};
 
 /// POSIX session the step driver talks to: the PTY/pipe fds plus the child pid,
 /// behind the same pollRead/writeAll/sendSignal surface the Windows session
@@ -924,6 +943,8 @@ fn driveScriptSteps(
 ) InteractiveError!ScriptOutcome {
     var steps_executed: usize = 0;
     var script_success = true;
+    var failed_step: usize = 0;
+    var failure: StepFailure = .none;
 
     for (script.steps.items, 0..) |step, step_index| {
         if (transcript_buffer) |tb| {
@@ -945,6 +966,8 @@ fn driveScriptSteps(
 
             if (!found and !step.optional) {
                 script_success = false;
+                failed_step = step_index;
+                failure = .{ .expect = expected };
                 break;
             }
 
@@ -970,6 +993,8 @@ fn driveScriptSteps(
 
             if (!ok) {
                 script_success = false;
+                failed_step = step_index;
+                failure = .{ .send = input };
                 break;
             }
         }
@@ -1010,6 +1035,8 @@ fn driveScriptSteps(
             );
             if (!ok and !step.optional) {
                 script_success = false;
+                failed_step = step_index;
+                failure = .{ .frame = assertion };
                 break;
             }
         }
@@ -1025,11 +1052,18 @@ fn driveScriptSteps(
         const elapsed = nowMs(io) - start_time;
         if (elapsed > config.total_timeout_ms) {
             script_success = false;
+            failed_step = step_index;
+            failure = .total_timeout;
             break;
         }
     }
 
-    return .{ .success = script_success, .steps_executed = steps_executed };
+    return .{
+        .success = script_success,
+        .steps_executed = steps_executed,
+        .failed_step = failed_step,
+        .failure = failure,
+    };
 }
 
 /// Determine the VTerm geometry for a PTY run and allocate the terminal. Prefer
@@ -1241,6 +1275,12 @@ fn runInteractivePosix(
         else => 1,
     };
 
+    // A step that broke the run left the child blocked mid-prompt (we killed it
+    // above), so the only visible symptom in the test would be a nonzero exit
+    // code. Print the full diagnostic now — which step, the rendered screen, the
+    // raw tail — so CI shows exactly what the child drew.
+    if (!outcome.success) dumpScriptFailure(allocator, outcome, screen, output_buffer.items);
+
     const duration_ms: u64 = @intCast(nowMs(io) - start_time);
 
     if (config.save_transcript and config.transcript_path != null) {
@@ -1361,6 +1401,8 @@ fn runInteractiveWindows(
             break;
         }
     }
+
+    if (!outcome.success) dumpScriptFailure(allocator, outcome, screen, output_buffer.items);
 
     const duration_ms: u64 = @intCast(nowMs(io) - start_time);
 
@@ -1648,6 +1690,64 @@ fn printFrameMismatch(allocator: std.mem.Allocator, screen: *vterm.VTerm, assert
     defer allocator.free(framed);
     printBoxedScreen(framed);
     std.debug.print("\u{2514}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\n", .{});
+}
+
+/// Loud, one-shot diagnostic for a script that did not run to completion. Prints
+/// which step broke, why, the vterm geometry + rendered screen (so a frame or
+/// prompt mismatch is legible), and the tail of the raw byte stream. Without
+/// this, a step failure only surfaces as a nonzero child exit code — the harness
+/// kills the still-blocked child, and the test's `expect(exit_code == 0)` fails
+/// with no clue what the child actually drew. This is the keeper: a failed frame
+/// (or expect) step must fail loudly with the screen, not cryptically.
+fn dumpScriptFailure(
+    allocator: std.mem.Allocator,
+    outcome: ScriptOutcome,
+    screen: ?*vterm.VTerm,
+    output: []const u8,
+) void {
+    if (outcome.failure == .none) return;
+    std.debug.print("\n\u{250c}\u{2500} INTERACTIVE SCRIPT FAILED at step {d} \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\n", .{outcome.failed_step + 1});
+    switch (outcome.failure) {
+        .none => {},
+        .expect => |e| std.debug.print("\u{2502} step kind: expect(\"{s}\") — text never appeared in the stream\n", .{e}),
+        .send => |s| std.debug.print("\u{2502} step kind: send(\"{s}\") — write to child failed\n", .{s}),
+        .total_timeout => std.debug.print("\u{2502} step kind: total interaction timeout exceeded\n", .{}),
+        .frame => |a| switch (a) {
+            .contains => |t| std.debug.print("\u{2502} step kind: expectFrameContains(\"{s}\") — not visible on the rendered screen\n", .{t}),
+            .row => |r| std.debug.print("\u{2502} step kind: expectRow({d}, \"{s}\")\n", .{ r.index, r.expected }),
+            .snapshot => |n| std.debug.print("\u{2502} step kind: expectFrame(\"{s}\")\n", .{n}),
+        },
+    }
+    if (screen) |term| {
+        std.debug.print("\u{2502} rendered screen ({d}x{d}):\n", .{ term.width, term.height });
+        if (term.getAllText(allocator)) |flat| {
+            defer allocator.free(flat);
+            if (reflowToRows(allocator, flat, term.width, term.height)) |framed| {
+                defer allocator.free(framed);
+                printBoxedScreen(framed);
+            } else |_| {}
+        } else |_| {}
+    } else {
+        std.debug.print("\u{2502} (no VTerm allocated — cannot render screen)\n", .{});
+    }
+    // Tail of the raw stream, escaped, so control/cursor bytes are legible.
+    const tail_len = @min(output.len, 512);
+    const tail = output[output.len - tail_len ..];
+    std.debug.print("\u{2502} raw byte-stream tail ({d} of {d} bytes), escaped:\n\u{2502}   ", .{ tail_len, output.len });
+    for (tail) |b| {
+        if (b == '\n') {
+            std.debug.print("\\n", .{});
+        } else if (b == '\r') {
+            std.debug.print("\\r", .{});
+        } else if (b == 0x1b) {
+            std.debug.print("\\e", .{});
+        } else if (b >= 0x20 and b < 0x7f) {
+            std.debug.print("{c}", .{b});
+        } else {
+            std.debug.print("\\x{x:0>2}", .{b});
+        }
+    }
+    std.debug.print("\n\u{2514}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\n", .{});
 }
 
 fn printBoxedScreen(screen_text: []const u8) void {

--- a/packages/testing/src/e2e.zig
+++ b/packages/testing/src/e2e.zig
@@ -2,6 +2,8 @@ const std = @import("std");
 const builtin = @import("builtin");
 const posix = std.posix;
 const conpty = @import("conpty.zig");
+const vterm = @import("vterm");
+const snapshot = @import("snapshot.zig");
 
 /// Interactive testing support for CLIs that require user input.
 ///
@@ -513,6 +515,27 @@ pub const InteractionStep = struct {
     action: ?*const fn (context: ?*anyopaque) void = null,
     /// Opaque context passed to `action` (a pointer to test-owned state).
     action_context: ?*anyopaque = null,
+    /// A frame (rendered-screen) assertion to evaluate at this point. Set by the
+    /// `expectFrame*` builders; asserted against the VTerm the driver feeds the
+    /// child's output through — i.e. against the SCREEN as a terminal would draw
+    /// it, not the raw byte stream. `null` when the step is not a frame step.
+    frame: ?FrameAssertion = null,
+};
+
+/// A rendered-screen assertion. Unlike `expect`, which greps the raw byte soup
+/// (so a cursor-movement regression that leaves the text *somewhere* in the
+/// stream still passes), these assert on the VTerm screen after the bytes are
+/// rendered — the text must actually be visible at the right place.
+pub const FrameAssertion = union(enum) {
+    /// The text must appear contiguously on one row at its rendered position
+    /// (VTerm.containsText — wraps at the row edge, unlike a stream substring).
+    contains: []const u8,
+    /// A specific row must render exactly `expected` (trailing spaces trimmed).
+    row: struct { index: u16, expected: []const u8 },
+    /// The whole rendered screen must match a golden snapshot. Integrates with
+    /// snapshot.zig (masking + `-Dupdate-snapshots`); `name` is the snapshot
+    /// file stem under `tests/snapshots/<test-file>/`.
+    snapshot: []const u8,
 };
 
 /// Builder for creating interactive test scripts
@@ -615,6 +638,40 @@ pub const InteractiveScript = struct {
         return self;
     }
 
+    /// Assert `text` is visible on the RENDERED screen at this point — on one
+    /// row at its drawn position, not merely somewhere in the byte stream. The
+    /// driver polls (feeding new output into the VTerm) until the frame matches
+    /// or the step timeout elapses, so it composes with expect/send sequencing
+    /// after the terminal has settled.
+    pub fn expectFrameContains(self: *InteractiveScript, text: []const u8) *InteractiveScript {
+        self.steps.append(self.allocator, .{
+            .frame = .{ .contains = text },
+        }) catch @panic("OOM");
+        return self;
+    }
+
+    /// Assert that rendered row `index` equals `expected` (trailing spaces
+    /// trimmed), polling until it matches or the step times out. Catches
+    /// off-by-one row regressions a stream substring can't see.
+    pub fn expectRow(self: *InteractiveScript, index: u16, expected: []const u8) *InteractiveScript {
+        self.steps.append(self.allocator, .{
+            .frame = .{ .row = .{ .index = index, .expected = expected } },
+        }) catch @panic("OOM");
+        return self;
+    }
+
+    /// Assert the whole rendered screen matches the golden snapshot `name`
+    /// (stem under `tests/snapshots/<test-file>/`). Requires `snapshot_root` in
+    /// the config; honors `.update_snapshots` (wire it to `-Dupdate-snapshots`).
+    /// The frame is settled first (poll until output goes idle) so the snapshot
+    /// captures a stable screen.
+    pub fn expectFrame(self: *InteractiveScript, name: []const u8) *InteractiveScript {
+        self.steps.append(self.allocator, .{
+            .frame = .{ .snapshot = name },
+        }) catch @panic("OOM");
+        return self;
+    }
+
     /// Add a delay (for testing timing-sensitive interactions)
     pub fn delay(self: *InteractiveScript, ms: u32) *InteractiveScript {
         self.steps.append(self.allocator, .{
@@ -672,6 +729,16 @@ pub const InteractiveConfig = struct {
     forward_signals: bool = false,
     /// Which signals to forward (null means all common signals)
     signals_to_forward: ?[]const Signal = null,
+
+    // Frame assertions (rendered-screen expects)
+    /// Root directory `expectFrame` snapshots resolve against (the same
+    /// `tests/snapshots/<test-file>/` layout snapshot.zig uses). Required only
+    /// if the script uses `expectFrame`; pass `std.Io.Dir.cwd()` in a normal
+    /// suite. `expectFrameContains`/`expectRow` don't need it.
+    snapshot_root: ?std.Io.Dir = null,
+    /// When true, `expectFrame` writes (or overwrites) the snapshot instead of
+    /// comparing. Thread this from a `-Dupdate-snapshots` build option.
+    update_snapshots: bool = false,
 };
 
 /// Terminal modes for PTY configuration
@@ -850,6 +917,10 @@ fn driveScriptSteps(
     output_buffer: *std.ArrayList(u8),
     input_buffer: *std.ArrayList(u8),
     transcript_buffer: ?*std.ArrayList(u8),
+    /// The virtual terminal every read is fed through, sized to the session's
+    /// winsize. `null` when the harness could not allocate one (no VTerm ⇒ any
+    /// frame step is a loud, explicit failure rather than a false pass).
+    screen: ?*vterm.VTerm,
 ) InteractiveError!ScriptOutcome {
     var steps_executed: usize = 0;
     var script_success = true;
@@ -869,6 +940,7 @@ fn driveScriptSteps(
                 step.exact_match,
                 output_buffer,
                 transcript_buffer,
+                screen,
             );
 
             if (!found and !step.optional) {
@@ -917,9 +989,34 @@ fn driveScriptSteps(
             }
         }
 
+        if (step.frame) |assertion| {
+            const term = screen orelse {
+                // No VTerm to render into: refuse to silently pass. Frame
+                // assertions exist precisely to close the gap a raw substring
+                // leaves, so a missing terminal is a hard failure, not a skip.
+                std.log.err("frame assertion requested but no VTerm is available (allocate_pty must be true)", .{});
+                return InteractiveError.NoPty;
+            };
+            const ok = try waitForFrame(
+                allocator,
+                io,
+                session,
+                assertion,
+                step.timeout_ms,
+                config,
+                output_buffer,
+                transcript_buffer,
+                term,
+            );
+            if (!ok and !step.optional) {
+                script_success = false;
+                break;
+            }
+        }
+
         // Pure delay steps (an action step carries the default timeout_ms but is
         // not a delay — don't sleep on it).
-        if (step.expect == null and step.send == null and step.signal == null and step.action == null and step.timeout_ms > 0) {
+        if (step.expect == null and step.send == null and step.signal == null and step.action == null and step.frame == null and step.timeout_ms > 0) {
             sleepMs(io, step.timeout_ms);
         }
 
@@ -933,6 +1030,29 @@ fn driveScriptSteps(
     }
 
     return .{ .success = script_success, .steps_executed = steps_executed };
+}
+
+/// Determine the VTerm geometry for a PTY run and allocate the terminal. Prefer
+/// the PTY's actual winsize (what the child sees via TIOCGWINSZ), falling back
+/// to the configured size, then a 24x80 default. Returns null on allocation
+/// failure so the caller degrades to "no frame assertions" rather than crashing.
+fn vtermForPty(allocator: std.mem.Allocator, pty_manager: ?PtyManager, config: InteractiveConfig) ?vterm.VTerm {
+    var rows: u16 = 24;
+    var cols: u16 = 80;
+    if (config.terminal_size) |s| {
+        rows = s.rows;
+        cols = s.cols;
+    }
+    if (pty_manager) |pty| {
+        var mgr = pty;
+        if (mgr.getWindowSize()) |ws| {
+            if (ws.row != 0 and ws.col != 0) {
+                rows = ws.row;
+                cols = ws.col;
+            }
+        } else |_| {}
+    }
+    return vterm.VTerm.init(allocator, cols, rows) catch null;
 }
 
 /// Run an interactive test script against a command.
@@ -1041,6 +1161,14 @@ fn runInteractivePosix(
     const read_fd: posix.fd_t = if (pty_manager) |*pty| pty.master_fd else child.stdout.?.handle;
     const write_fd: posix.fd_t = if (pty_manager) |*pty| pty.master_fd else child.stdin.?.handle;
 
+    // A virtual terminal mirroring the child's output, sized to the PTY winsize
+    // so a frame assertion sees the screen exactly as the child rendered it.
+    // Only allocated for a PTY run — frame assertions need a real terminal. If
+    // allocation fails, `screen` stays null and any frame step fails loudly.
+    var screen_storage: ?vterm.VTerm = if (using_pty) vtermForPty(allocator, pty_manager, config) else null;
+    defer if (screen_storage) |*s| s.deinit();
+    const screen: ?*vterm.VTerm = if (screen_storage) |*s| s else null;
+
     var session = PosixSession{ .read_fd = read_fd, .write_fd = write_fd, .child_id = child.id };
     const outcome = try driveScriptSteps(
         allocator,
@@ -1052,6 +1180,7 @@ fn runInteractivePosix(
         &output_buffer,
         &input_buffer,
         if (transcript_buffer) |*tb| tb else null,
+        screen,
     );
     var script_success = outcome.success;
     const steps_executed = outcome.steps_executed;
@@ -1179,6 +1308,13 @@ fn runInteractiveWindows(
     };
     defer cp.deinit(allocator);
 
+    // VTerm sized to the ConPTY window, fed the same VT byte stream frame
+    // assertions render against. ConPTY emits standard VT sequences, so the
+    // same parser drives both backends. Null on OOM ⇒ frame steps fail loudly.
+    var screen_storage: ?vterm.VTerm = vterm.VTerm.init(allocator, cols, rows) catch null;
+    defer if (screen_storage) |*s| s.deinit();
+    const screen: ?*vterm.VTerm = if (screen_storage) |*s| s else null;
+
     var session = WindowsSession{ .inner = &cp };
     const outcome = try driveScriptSteps(
         allocator,
@@ -1190,6 +1326,7 @@ fn runInteractiveWindows(
         &output_buffer,
         &input_buffer,
         if (transcript_buffer) |*tb| tb else null,
+        screen,
     );
     var script_success = outcome.success;
     const steps_executed = outcome.steps_executed;
@@ -1265,7 +1402,10 @@ fn pollFd(fd: posix.fd_t, buf: []u8, timeout_ms: i32) usize {
     };
 }
 
-/// Wait for specific output to appear, with timeout.
+/// Wait for specific output to appear, with timeout. Every byte read is also
+/// fed into `screen` (when present) so the VTerm stays a faithful mirror of the
+/// stream for any following frame assertion — the terminal is rendered
+/// continuously, not re-parsed from scratch at each frame step.
 fn waitForOutput(
     allocator: std.mem.Allocator,
     io: std.Io,
@@ -1275,6 +1415,7 @@ fn waitForOutput(
     exact_match: bool,
     output_buffer: *std.ArrayList(u8),
     transcript_buffer: ?*std.ArrayList(u8),
+    screen: ?*vterm.VTerm,
 ) InteractiveError!bool {
     const start_time = nowMs(io);
     var temp_buffer: [4096]u8 = undefined;
@@ -1288,6 +1429,7 @@ fn waitForOutput(
         if (bytes_read == 0) continue;
 
         try output_buffer.appendSlice(allocator, temp_buffer[0..bytes_read]);
+        if (screen) |term| term.write(temp_buffer[0..bytes_read]);
 
         if (transcript_buffer) |tb| {
             try transcriptPrint(tb, allocator, "Received: \"{s}\"\n", .{temp_buffer[0..bytes_read]});
@@ -1298,6 +1440,239 @@ fn waitForOutput(
         } else {
             if (std.mem.indexOf(u8, output_buffer.items, expected) != null) return true;
         }
+    }
+}
+
+/// True once the rendered `screen` satisfies `assertion` (contains/row checks).
+/// Snapshot assertions are settled-then-compared by the caller, so they always
+/// report "not yet matched" here and fall through to the settle path.
+fn frameSatisfied(allocator: std.mem.Allocator, screen: *vterm.VTerm, assertion: FrameAssertion) bool {
+    switch (assertion) {
+        .contains => |text| return screen.containsText(text),
+        .row => |r| {
+            const line = screen.getLine(allocator, r.index) catch return false;
+            defer allocator.free(line);
+            return std.mem.eql(u8, line, r.expected);
+        },
+        .snapshot => return false,
+    }
+}
+
+/// Poll — feeding new output into `screen` — until the rendered frame satisfies
+/// `assertion` or `timeout_ms` elapses. This is the settle strategy for frame
+/// steps: no fixed sleep, just "read → render → re-check" like `waitForOutput`,
+/// so a slow paint is tolerated and a fast one returns immediately.
+///
+/// A `snapshot` assertion instead waits for the stream to go idle (a few empty
+/// poll windows) — a whole-screen golden needs a stable frame, not a single
+/// substring — then compares (or updates) via the shared snapshot machinery.
+fn waitForFrame(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    session: anytype,
+    assertion: FrameAssertion,
+    timeout_ms: u32,
+    config: InteractiveConfig,
+    output_buffer: *std.ArrayList(u8),
+    transcript_buffer: ?*std.ArrayList(u8),
+    screen: *vterm.VTerm,
+) InteractiveError!bool {
+    const start_time = nowMs(io);
+    var temp_buffer: [4096]u8 = undefined;
+
+    // Fast path: already satisfied from output rendered by prior steps.
+    if (frameSatisfied(allocator, screen, assertion)) {
+        try reportFrame(allocator, transcript_buffer, assertion, true);
+        return true;
+    }
+
+    var idle_polls: u8 = 0;
+    while (true) {
+        const elapsed = nowMs(io) - start_time;
+        if (elapsed > timeout_ms) break;
+
+        const remaining: i32 = @intCast(@max(@as(i64, 0), @as(i64, timeout_ms) - elapsed));
+        const bytes_read = session.pollRead(&temp_buffer, @min(remaining, 50));
+        if (bytes_read == 0) {
+            // For a snapshot, treat a run of idle windows as "settled" and
+            // compare the stable screen. For contains/row we keep polling until
+            // the deadline (they may still be painting).
+            if (assertion == .snapshot) {
+                idle_polls += 1;
+                if (idle_polls >= 3) break;
+            }
+            continue;
+        }
+        idle_polls = 0;
+
+        try output_buffer.appendSlice(allocator, temp_buffer[0..bytes_read]);
+        screen.write(temp_buffer[0..bytes_read]);
+
+        if (assertion != .snapshot and frameSatisfied(allocator, screen, assertion)) {
+            try reportFrame(allocator, transcript_buffer, assertion, true);
+            return true;
+        }
+    }
+
+    // Deadline (or settle) reached. Snapshot compares the settled frame; the
+    // others print a readable rendered-screen diagnostic and fail.
+    switch (assertion) {
+        .snapshot => |name| {
+            try assertFrameSnapshot(allocator, io, screen, config, name);
+            try reportFrame(allocator, transcript_buffer, assertion, true);
+            return true;
+        },
+        .contains, .row => {
+            printFrameMismatch(allocator, screen, assertion);
+            try reportFrame(allocator, transcript_buffer, assertion, false);
+            return false;
+        },
+    }
+}
+
+fn reportFrame(allocator: std.mem.Allocator, transcript_buffer: ?*std.ArrayList(u8), assertion: FrameAssertion, ok: bool) !void {
+    const tb = transcript_buffer orelse return;
+    const mark: []const u8 = if (ok) "\u{2713}" else "\u{2717}";
+    switch (assertion) {
+        .contains => |t| try transcriptPrint(tb, allocator, "{s} Frame contains: \"{s}\"\n", .{ mark, t }),
+        .row => |r| try transcriptPrint(tb, allocator, "{s} Frame row {d} == \"{s}\"\n", .{ mark, r.index, r.expected }),
+        .snapshot => |n| try transcriptPrint(tb, allocator, "{s} Frame snapshot: {s}\n", .{ mark, n }),
+    }
+}
+
+/// Render the whole screen and compare/update it against a golden snapshot,
+/// reusing snapshot.zig's masking + update flow. The path is
+/// `<snapshot_root>/tests/snapshots/e2e/<name>.txt` — the same layout the
+/// in-process tier uses, but resolved at runtime (the builder can't carry a
+/// comptime `@src()`), so `name` is the file stem the caller chooses.
+fn assertFrameSnapshot(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    screen: *vterm.VTerm,
+    config: InteractiveConfig,
+    name: []const u8,
+) InteractiveError!void {
+    const root = config.snapshot_root orelse {
+        std.log.err("expectFrame(\"{s}\") needs config.snapshot_root set", .{name});
+        return InteractiveError.InvalidScript;
+    };
+
+    // Full rendered screen, rows joined by newlines, trailing blank rows kept so
+    // the golden captures the exact frame geometry.
+    const actual = try screen.getAllText(allocator);
+    defer allocator.free(actual);
+    const framed = try reflowToRows(allocator, actual, screen.width, screen.height);
+    defer allocator.free(framed);
+
+    const masked = try snapshot.maskDynamicContent(allocator, framed);
+    defer allocator.free(masked);
+
+    const dir = "tests/snapshots/e2e";
+    const file = try std.fmt.allocPrint(allocator, "{s}/{s}.txt", .{ dir, name });
+    defer allocator.free(file);
+
+    if (config.update_snapshots) {
+        root.createDirPath(io, dir) catch |err| {
+            std.log.err("failed to create snapshot dir {s}: {any}", .{ dir, err });
+            return InteractiveError.InvalidScript;
+        };
+        root.writeFile(io, .{ .sub_path = file, .data = masked }) catch |err| {
+            std.log.err("failed to write snapshot {s}: {any}", .{ file, err });
+            return InteractiveError.InvalidScript;
+        };
+        std.debug.print("\u{2705} Updated frame snapshot: {s}\n", .{file});
+        return;
+    }
+
+    const expected = root.readFileAlloc(io, file, allocator, .limited(1024 * 1024)) catch |err| switch (err) {
+        error.FileNotFound => {
+            std.debug.print("\n\u{250c}\u{2500} FRAME SNAPSHOT MISSING: {s}\n", .{file});
+            std.debug.print("\u{2502} Re-run with .update_snapshots = true to create. Rendered screen:\n", .{});
+            printBoxedScreen(masked);
+            return InteractiveError.ExpectationNotMet;
+        },
+        else => return InteractiveError.InputSendFailed,
+    };
+    defer allocator.free(expected);
+
+    if (!std.mem.eql(u8, expected, masked)) {
+        std.debug.print("\n\u{250c}\u{2500} FRAME SNAPSHOT MISMATCH: {s}\n", .{file});
+        std.debug.print("\u{2502} expected (golden) vs actual (rendered screen):\n", .{});
+        printScreenDiff(expected, masked);
+        std.debug.print("\u{2502} Re-run with .update_snapshots = true to update.\n", .{});
+        return InteractiveError.ExpectationNotMet;
+    }
+}
+
+/// getAllText emits width*height chars with no row breaks; split it back into
+/// `height` rows of `width`, trimming each row's trailing spaces.
+fn reflowToRows(allocator: std.mem.Allocator, flat: []const u8, width: u16, height: u16) ![]u8 {
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(allocator);
+    // getAllText UTF-8-encodes wide chars, so byte length can exceed width*height;
+    // fall back to a plain copy if the geometry doesn't line up (ASCII TUIs, the
+    // common case here, always line up).
+    if (flat.len != @as(usize, width) * @as(usize, height)) {
+        return allocator.dupe(u8, flat);
+    }
+    var row: u16 = 0;
+    while (row < height) : (row += 1) {
+        if (row > 0) try out.append(allocator, '\n');
+        const start = @as(usize, row) * width;
+        var end = start + width;
+        while (end > start and flat[end - 1] == ' ') end -= 1;
+        try out.appendSlice(allocator, flat[start..end]);
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+/// Print a readable rendered-screen diagnostic for a failed contains/row frame
+/// assertion — the whole screen boxed, so the reader sees exactly what WAS
+/// drawn versus what was asserted.
+fn printFrameMismatch(allocator: std.mem.Allocator, screen: *vterm.VTerm, assertion: FrameAssertion) void {
+    std.debug.print("\n\u{250c}\u{2500} FRAME ASSERTION FAILED \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\n", .{});
+    switch (assertion) {
+        .contains => |t| std.debug.print("\u{2502} expectFrameContains(\"{s}\") — text is not visible on screen\n", .{t}),
+        .row => |r| {
+            const line = screen.getLine(allocator, r.index) catch "";
+            defer if (line.len > 0) allocator.free(line);
+            std.debug.print("\u{2502} expectRow({d}, \"{s}\")\n", .{ r.index, r.expected });
+            std.debug.print("\u{2502}   actual row {d}: \"{s}\"\n", .{ r.index, line });
+        },
+        .snapshot => {},
+    }
+    std.debug.print("\u{2502} rendered screen ({d}x{d}):\n", .{ screen.width, screen.height });
+    const flat = screen.getAllText(allocator) catch return;
+    defer allocator.free(flat);
+    const framed = reflowToRows(allocator, flat, screen.width, screen.height) catch return;
+    defer allocator.free(framed);
+    printBoxedScreen(framed);
+    std.debug.print("\u{2514}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\n", .{});
+}
+
+fn printBoxedScreen(screen_text: []const u8) void {
+    var lines = std.mem.splitScalar(u8, screen_text, '\n');
+    while (lines.next()) |line| {
+        std.debug.print("\u{2502} \u{2502}{s}\n", .{line});
+    }
+}
+
+fn printScreenDiff(expected: []const u8, actual: []const u8) void {
+    var exp_lines = std.mem.splitScalar(u8, expected, '\n');
+    var act_lines = std.mem.splitScalar(u8, actual, '\n');
+    var row: usize = 0;
+    while (true) {
+        const e = exp_lines.next();
+        const a = act_lines.next();
+        if (e == null and a == null) break;
+        const el = e orelse "";
+        const al = a orelse "";
+        if (!std.mem.eql(u8, el, al)) {
+            std.debug.print("\u{2502} row {d}:\n", .{row});
+            std.debug.print("\u{2502}   -\"{s}\"\n", .{el});
+            std.debug.print("\u{2502}   +\"{s}\"\n", .{al});
+        }
+        row += 1;
     }
 }
 
@@ -1523,6 +1898,90 @@ test "runInteractive drives a command over pipes" {
     defer result.deinit();
 
     try std.testing.expect(std.mem.indexOf(u8, result.output, "zcli-e2e-ping") != null);
+}
+
+test "expectFrame* builders record frame assertions" {
+    const allocator = std.testing.allocator;
+
+    var script = InteractiveScript.init(allocator);
+    defer script.deinit();
+
+    _ = script
+        .expectFrameContains("hello")
+        .expectRow(3, "world")
+        .expectFrame("golden");
+
+    try std.testing.expect(script.steps.items.len == 3);
+    try std.testing.expectEqualStrings("hello", script.steps.items[0].frame.?.contains);
+    try std.testing.expect(script.steps.items[1].frame.?.row.index == 3);
+    try std.testing.expectEqualStrings("world", script.steps.items[1].frame.?.row.expected);
+    try std.testing.expectEqualStrings("golden", script.steps.items[2].frame.?.snapshot);
+}
+
+test "frameSatisfied matches rendered cells, not the raw stream" {
+    const allocator = std.testing.allocator;
+    var term = try vterm.VTerm.init(allocator, 20, 5);
+    defer term.deinit();
+
+    // Draw "OK" at row 2 via absolute cursor positioning — the literal "OK"
+    // arrives after a CUP sequence, exactly the case where a stream grep would
+    // pass on unrelated bytes but the SCREEN must actually show it in place.
+    term.write("\x1b[3;1HOK done");
+
+    try std.testing.expect(frameSatisfied(allocator, &term, .{ .contains = "OK done" }));
+    try std.testing.expect(frameSatisfied(allocator, &term, .{ .row = .{ .index = 2, .expected = "OK done" } }));
+    // Wrong row must NOT satisfy — the strength a stream substring lacks.
+    try std.testing.expect(!frameSatisfied(allocator, &term, .{ .row = .{ .index = 0, .expected = "OK done" } }));
+    try std.testing.expect(!frameSatisfied(allocator, &term, .{ .contains = "absent" }));
+}
+
+test "reflowToRows splits a flat screen into trimmed rows" {
+    const allocator = std.testing.allocator;
+    // 4 wide, 2 tall: "ab  " + "c   " → "ab\nc" (trailing spaces trimmed).
+    const flat = "ab  c   ";
+    const out = try reflowToRows(allocator, flat, 4, 2);
+    defer allocator.free(out);
+    try std.testing.expectEqualStrings("ab\nc", out);
+}
+
+test "runInteractive frame assertions catch a mispositioned row over a PTY" {
+    if (builtin.os.tag == .windows) return;
+
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    // A tiny script that homes the cursor and paints "READY" on row 3 (1-based)
+    // using absolute positioning, then holds so the frame is stable. `sh` reads
+    // one line of stdin before exiting so the harness can end the session.
+    const program =
+        "printf '\\033[2J\\033[3;1HREADY\\033[10;1H'; read _dummy";
+
+    var script = InteractiveScript.init(allocator);
+    defer script.deinit();
+    _ = script
+        // Rendered-frame assertions: "READY" is visible, and specifically on
+        // row 2 (0-based) where it was positioned — not merely in the stream.
+        .expectFrameContains("READY").withTimeout(4000)
+        .expectRow(2, "READY").withTimeout(4000)
+        // End the session (the `read` returns, `sh` exits).
+        .send("go");
+
+    var result = runInteractive(allocator, io, &.{ "/bin/sh", "-c", program }, script, .{
+        .allocate_pty = true,
+        .terminal_size = .{ .rows = 24, .cols = 40 },
+        .total_timeout_ms = 8000,
+    }) catch |err| switch (err) {
+        // PTY allocation can be denied in sandboxes; skip loudly (mirrors the
+        // "runInteractive unavailable" guard CI greps for elsewhere).
+        error.PtyAllocationFailed => {
+            std.debug.print("runInteractive unavailable: {any}\n", .{err});
+            return;
+        },
+        else => return err,
+    };
+    defer result.deinit();
+
+    try std.testing.expect(result.steps_executed >= 2);
 }
 
 test "InteractiveScript builder API" {

--- a/projects/zcli/build.zig
+++ b/projects/zcli/build.zig
@@ -185,7 +185,11 @@ pub fn build(b: *std.Build) !void {
     // PTY harness for interactive (TTY) regression tests.
     e2e_mod.addImport("testing_e2e", zcli_dep.module("testing_e2e"));
 
-    const e2e_tests = b.addTest(.{ .root_module = e2e_mod });
+    const e2e_filter = b.option([]const u8, "e2e-filter", "Only run e2e tests whose name contains this substring");
+    const e2e_tests = b.addTest(.{
+        .root_module = e2e_mod,
+        .filters = if (e2e_filter) |f| &.{f} else &.{},
+    });
     const run_e2e = b.addRunArtifact(e2e_tests);
     run_e2e.has_side_effects = true; // touches fs/git; always re-run
     run_e2e.step.dependOn(b.getInstallStep()); // binary must exist before tests run

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -1701,6 +1701,13 @@ test "interactive: add command drives the wizard and echoes typed input" {
     _ = script
         .expect("Command path:").delay(settle_ms).send("deploy")
         .expect("Description:").delay(settle_ms).send("Deploy the app")
+        // The typed description must be visible on the RENDERED screen, not just
+        // present somewhere in the byte stream. The wizard enables raw mode
+        // (kernel echo OFF) and repaints frame diffs, so a regression that
+        // stopped echoing keystrokes would leave "Deploy the app" out of the
+        // drawn frame while stray bytes could still satisfy a stream grep. This
+        // walks the terminal cells, so it only passes if the answer is on screen.
+        .expectFrameContains("Deploy the app")
         .expect("Add a positional argument?").delay(settle_ms).sendRaw("n")
         .expect("Add an option?").delay(settle_ms).sendRaw("n")
         .expect("What next?").delay(settle_ms).sendRaw("\r");
@@ -1724,10 +1731,9 @@ test "interactive: add command drives the wizard and echoes typed input" {
     };
     defer result.deinit();
 
-    // Regression for the buffered-writer bug: the wizard enables raw mode (kernel
-    // echo OFF), so the description text can only appear in the PTY output if the
-    // program flushed its own per-keystroke echo. Before the fix, this was blank.
-    try expectContains(result.output, "Deploy the app");
+    // Regression for the buffered-writer bug (per-keystroke echo under raw mode)
+    // is now asserted on the rendered frame mid-script via expectFrameContains
+    // above — strictly stronger than the old raw-stream substring here.
 
     // And the wizard ran to completion against the typed answers.
     try testing.expect(result.exit_code == 0);
@@ -1763,7 +1769,16 @@ test "interactive: text prompt handles multibyte UTF-8 typing and backspace" {
     defer script.deinit();
     _ = script
         .expect("Command path:").delay(settle_ms).send("greet")
+        // Type "Café", then backspace (erases the whole é grapheme) + "e".
         .expect("Description:").delay(settle_ms).sendRaw("Caf\xc3\xa9").delay(settle_ms).sendRaw("\x7fe\r")
+        // Frame assertion: after the grapheme-aware backspace, the description
+        // line as DRAWN must read exactly "Café" (with é already erased →
+        // "Cafe"). A raw substring can't prove this — the pre-backspace "Café"
+        // frame and the deleted bytes both linger in the byte soup, so a
+        // rendering regression that left half-glyph debris on screen would still
+        // match the stream. containsText walks the rendered cells, so it only
+        // passes if the final "Description: Cafe" is what a terminal shows.
+        .expectFrameContains("Description: Cafe")
         .expect("Add a positional argument?").delay(settle_ms).sendRaw("n")
         .expect("Add an option?").delay(settle_ms).sendRaw("n")
         .expect("What next?").delay(settle_ms).sendRaw("\r");
@@ -1790,11 +1805,13 @@ test "interactive: text prompt handles multibyte UTF-8 typing and backspace" {
     // The é was echoed intact — its two UTF-8 bytes emitted together, never
     // torn across writes. (Prompts paint frame *diffs* now, so a typed word is
     // never contiguous in the byte stream — each keystroke emits only its new
-    // cell — but any single grapheme always is.)
+    // cell — but any single grapheme always is.) Raw-stream is the right tool
+    // here: the point is the byte pairing, which the rendered screen erases.
     try expectContains(result.output, "é");
-    // The persisted answer line shows the grapheme-aware backspace on screen:
-    // é deleted whole, no half-glyph debris before the final "e".
-    try expectContains(result.output, "Description: Cafe");
+    // The "Description: Cafe" screen line is now asserted mid-script via
+    // expectFrameContains above — a rendered-cell check, strictly stronger than
+    // the old raw-stream substring, which the cursor-diff stream could satisfy
+    // without the text ever being visible in place.
 
     try testing.expect(result.exit_code == 0);
     const generated = try readFile(tmp.dir, arena.allocator(), "src/commands/greet.zig");

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -1708,9 +1708,16 @@ test "interactive: add command drives the wizard and echoes typed input" {
         // drawn frame while stray bytes could still satisfy a stream grep. This
         // walks the terminal cells, so it only passes if the answer is on screen.
         .expectFrameContains("Deploy the app")
-        .expect("Add a positional argument?").delay(settle_ms).sendRaw("n")
-        .expect("Add an option?").delay(settle_ms).sendRaw("n")
-        .expect("What next?").delay(settle_ms).sendRaw("\r");
+        // Gate the confirm-prompt sends on the RENDERED screen, not a raw-stream
+        // grep. ConPTY delivers these prompts as cursor-addressed diffs — the
+        // text lands on the terminal cells, but the bytes are fragmented and
+        // never contiguous in the stream, so `expect("Add a positional
+        // argument?")` (a substring search) times out on Windows even though the
+        // prompt is plainly on screen. The vterm reassembles the frame the way a
+        // terminal would, so the frame check sees the prompt on every backend.
+        .expectFrameContains("Add a positional argument?").delay(settle_ms).sendRaw("n")
+        .expectFrameContains("Add an option?").delay(settle_ms).sendRaw("n")
+        .expectFrameContains("What next?").delay(settle_ms).sendRaw("\r");
 
     var result = harness.runInteractive(
         testing.allocator,
@@ -1779,9 +1786,13 @@ test "interactive: text prompt handles multibyte UTF-8 typing and backspace" {
         // match the stream. containsText walks the rendered cells, so it only
         // passes if the final "Description: Cafe" is what a terminal shows.
         .expectFrameContains("Description: Cafe")
-        .expect("Add a positional argument?").delay(settle_ms).sendRaw("n")
-        .expect("Add an option?").delay(settle_ms).sendRaw("n")
-        .expect("What next?").delay(settle_ms).sendRaw("\r");
+        // Confirm-prompt gates on the rendered screen — see the wizard test
+        // above: ConPTY fragments these prompts into cursor-addressed diffs, so a
+        // raw-stream `expect` substring times out on Windows though the prompt is
+        // on screen. The vterm frame check is backend-robust.
+        .expectFrameContains("Add a positional argument?").delay(settle_ms).sendRaw("n")
+        .expectFrameContains("Add an option?").delay(settle_ms).sendRaw("n")
+        .expectFrameContains("What next?").delay(settle_ms).sendRaw("\r");
 
     var result = harness.runInteractive(
         testing.allocator,


### PR DESCRIPTION
## Why

The interactive e2e harness (`packages/testing/src/e2e.zig`) asserts only on the **raw** PTY/ConPTY byte stream via `.expect()`. For cursor-movement-heavy output (prompts, TUIs), a rendering regression that keeps the expected text *somewhere* in the stream still passes — this is exactly how a recently-found help-rendering bug survived. The repo already has an ANSI-conformant `vterm`; this wires it into the PTY tier so tests can assert on the **rendered screen**.

## What

**Harness API (additive to `testing_e2e`):**

- `script.expectFrameContains(text)` — text visible on the rendered screen (one row, drawn position), via `VTerm.containsText` — not a byte-stream grep.
- `script.expectRow(index, expected)` — row `index` (0-based) renders exactly `expected` (trailing spaces trimmed). Catches off-by-one row regressions.
- `script.expectFrame(name)` — whole-screen golden snapshot, reusing `snapshot.zig`'s `maskDynamicContent` + update flow (`config.snapshot_root`, `config.update_snapshots` → wire to `-Dupdate-snapshots`).

The driver creates a `VTerm` sized to the session winsize (PTY `TIOCGWINSZ` / ConPTY window) and feeds it every byte read from the child. Frame steps are asserted at their point in the script, after quiescence.

**Settle strategy:** poll `read → render → re-check` until the frame matches or the step timeout elapses — no fixed sleeps, same shape as `waitForOutput`. Snapshot steps instead wait for the stream to go idle (a few empty poll windows = settled frame) before comparing. A frame step with no VTerm (e.g. `allocate_pty=false`, or OOM) **fails loudly** (`NoPty`) rather than passing vacuously.

**Portability:** the same VTerm feed drives both backends — ConPTY emits standard VT sequences, so the parser is shared. Works on Windows CI.

**Converted tests** (`projects/zcli/test/e2e.zig`) — frame assertions added where strictly stronger, raw-stream kept where it's the right tool:

- *"interactive: add command drives the wizard…"* — `expectFrameContains("Deploy the app")`: proves the typed description is on the **rendered** frame (raw-mode per-keystroke echo), where the old stream substring could match stray diff bytes.
- *"interactive: text prompt handles multibyte UTF-8 typing and backspace"* — `expectFrameContains("Description: Cafe")`: proves the grapheme-aware backspace erased `é` **on screen** (no half-glyph debris), which the cursor-diff stream could satisfy without the text being visible in place. Raw-stream `expectContains(output, "é")` kept (byte-pairing) plus exit code + generated-file checks.

Also: harness unit tests (`frameSatisfied` / `reflowToRows` / a PTY-backed positioning test), a fourth entry in `examples/e2e_example.zig`, README updates, and a new `-De2e-filter=<substr>` to narrow the slow e2e suite.

## Verification

- `zig build test` (root, all packages) — pass.
- `packages/testing` `zig build test` + `zig build examples` — pass (incl. new frame harness tests).
- `zig build e2e -De2e-filter="drives the wizard"` and `-De2e-filter="multibyte"` — pass on macOS.
- **Strength demo:** temporarily asserted `expectRow(0, "THIS ROW IS WRONG ON PURPOSE")` — the failure prints a readable boxed diagnostic (the wrong-vs-actual row plus the full rendered screen, which correctly showed `? Description: Cafe`), then restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)