### PR TITLE
chore: code-organization cleanup (4 items)

### DIFF
--- a/docs/adr/0022-option-constraints.md
+++ b/docs/adr/0022-option-constraints.md
@@ -1,6 +1,6 @@
 # Option constraints: mutually-exclusive sets and dependencies
 
-Status: proposed
+Status: accepted (implemented)
 
 zcli derives a command's options from its `Options` struct: field type drives
 parsing, and a field is *required* when it has no default and can't be absent

--- a/docs/adr/0024-multi-value-options.md
+++ b/docs/adr/0024-multi-value-options.md
@@ -1,6 +1,6 @@
 # Multi-value options: comma-separated, not greedy space-separated
 
-Status: proposed
+Status: accepted (implemented)
 
 An array-typed option (`tags: [][]const u8`, `nums: []u32`, …) collects several
 values. Until now the only spelling was **repetition** — `--tag a --tag b`. Users

--- a/docs/adr/0026-dynamic-shell-completion.md
+++ b/docs/adr/0026-dynamic-shell-completion.md
@@ -1,6 +1,6 @@
 # Dynamic shell completion
 
-Status: proposed
+Status: accepted (implemented — all three increments shipped)
 
 Shell completion (the `zcli_completions` plugin) generates a static bash/zsh/fish
 script from the app's compiled command tree. It knows everything derivable at

--- a/packages/core/src/build_utils/code_generation.zig
+++ b/packages/core/src/build_utils/code_generation.zig
@@ -5,7 +5,7 @@ const module_names = @import("module_names.zig");
 
 const PluginInfo = types.PluginInfo;
 const DiscoveredCommands = types.DiscoveredCommands;
-const CommandInfo = types.CommandInfo;
+const DiscoveredCommand = types.DiscoveredCommand;
 const CommandType = types.CommandType;
 const BuildConfig = types.BuildConfig;
 
@@ -75,7 +75,7 @@ fn generateCommandImports(writer: anytype, commands: DiscoveredCommands) !void {
 }
 
 /// Generate group command imports recursively
-fn generateGroupImports(writer: anytype, _: []const u8, group_info: *const CommandInfo) !void {
+fn generateGroupImports(writer: anytype, _: []const u8, group_info: *const DiscoveredCommand) !void {
     if (group_info.subcommands) |subcommands| {
         const sorted = try types.sortedByName(subcommands.allocator, &subcommands);
         defer subcommands.allocator.free(sorted);
@@ -195,7 +195,7 @@ fn generatePureCommandGroups(writer: anytype, commands: DiscoveredCommands, allo
 }
 
 /// Recursively generate pure command group entries
-fn generatePureGroupsFromMap(writer: anytype, command_map: *const std.StringHashMap(CommandInfo), allocator: std.mem.Allocator) !void {
+fn generatePureGroupsFromMap(writer: anytype, command_map: *const std.StringHashMap(DiscoveredCommand), allocator: std.mem.Allocator) !void {
     const sorted = try types.sortedByName(allocator, command_map);
     defer allocator.free(sorted);
     for (sorted) |cmd_info| {
@@ -246,7 +246,7 @@ fn generateCommandRegistrations(writer: anytype, commands: DiscoveredCommands, a
             const module_name = try module_names.leafModuleName(allocator, cmd_name);
             defer allocator.free(module_name);
 
-            // Use the actual command path from CommandInfo (it's now an array)
+            // Use the actual command path from DiscoveredCommand (it's now an array)
             const command_path_str = try std.mem.join(allocator, " ", cmd_info.path);
             defer allocator.free(command_path_str);
             const command_path_lit = try escapeStringLiteral(allocator, command_path_str);
@@ -258,7 +258,7 @@ fn generateCommandRegistrations(writer: anytype, commands: DiscoveredCommands, a
 }
 
 /// Generate group command registrations recursively
-fn generateGroupRegistrations(writer: anytype, _: []const u8, group_info: *const CommandInfo, allocator: std.mem.Allocator) !void {
+fn generateGroupRegistrations(writer: anytype, _: []const u8, group_info: *const DiscoveredCommand, allocator: std.mem.Allocator) !void {
     if (group_info.subcommands) |subcommands| {
         const sorted = try types.sortedByName(allocator, &subcommands);
         defer allocator.free(sorted);
@@ -288,7 +288,7 @@ fn generateGroupRegistrations(writer: anytype, _: []const u8, group_info: *const
                 const module_name = try module_names.pathModuleName(allocator, subcmd_info.path);
                 defer allocator.free(module_name);
 
-                // Use the actual command path from the CommandInfo (it's now an array)
+                // Use the actual command path from the DiscoveredCommand (it's now an array)
                 const command_path_str = try std.mem.join(allocator, " ", subcmd_info.path);
                 defer allocator.free(command_path_str);
                 const command_path_lit = try escapeStringLiteral(allocator, command_path_str);
@@ -366,7 +366,7 @@ test "app metadata is escaped into valid string literals" {
 
     var commands = DiscoveredCommands{
         .allocator = allocator,
-        .root = std.StringHashMap(CommandInfo).init(allocator),
+        .root = std.StringHashMap(DiscoveredCommand).init(allocator),
     };
     defer commands.deinit();
 
@@ -399,7 +399,7 @@ test "plugin registry generation with imports" {
     // Create mock discovered commands
     var commands = DiscoveredCommands{
         .allocator = allocator,
-        .root = std.StringHashMap(CommandInfo).init(allocator),
+        .root = std.StringHashMap(DiscoveredCommand).init(allocator),
     };
     defer commands.deinit();
 
@@ -446,7 +446,7 @@ test "plugin name sanitization for imports" {
 
     var commands = DiscoveredCommands{
         .allocator = allocator,
-        .root = std.StringHashMap(CommandInfo).init(allocator),
+        .root = std.StringHashMap(DiscoveredCommand).init(allocator),
     };
     defer commands.deinit();
 
@@ -482,7 +482,7 @@ test "Context extension generation" {
 
     var commands = DiscoveredCommands{
         .allocator = allocator,
-        .root = std.StringHashMap(CommandInfo).init(allocator),
+        .root = std.StringHashMap(DiscoveredCommand).init(allocator),
     };
     defer commands.deinit();
 
@@ -525,7 +525,7 @@ test "pipeline composition ordering" {
 
     var commands = DiscoveredCommands{
         .allocator = allocator,
-        .root = std.StringHashMap(CommandInfo).init(allocator),
+        .root = std.StringHashMap(DiscoveredCommand).init(allocator),
     };
     defer commands.deinit();
 
@@ -566,7 +566,7 @@ test "Commands struct with plugin commands" {
 
     var commands = DiscoveredCommands{
         .allocator = allocator,
-        .root = std.StringHashMap(CommandInfo).init(allocator),
+        .root = std.StringHashMap(DiscoveredCommand).init(allocator),
     };
     defer commands.deinit();
 
@@ -574,7 +574,7 @@ test "Commands struct with plugin commands" {
     var hello_path = try allocator.alloc([]const u8, 1);
     hello_path[0] = try allocator.dupe(u8, "hello");
 
-    const hello_cmd = CommandInfo{
+    const hello_cmd = DiscoveredCommand{
         .name = try allocator.dupe(u8, "hello"),
         .path = hello_path,
         .file_path = try allocator.dupe(u8, "src/commands/hello.zig"),
@@ -619,7 +619,7 @@ test "empty plugin list handling" {
 
     var commands = DiscoveredCommands{
         .allocator = allocator,
-        .root = std.StringHashMap(CommandInfo).init(allocator),
+        .root = std.StringHashMap(DiscoveredCommand).init(allocator),
     };
     defer commands.deinit();
 
@@ -667,7 +667,7 @@ test "generated code structure validation" {
     // Create empty commands for simplicity
     var commands = DiscoveredCommands{
         .allocator = allocator,
-        .root = std.StringHashMap(CommandInfo).init(allocator),
+        .root = std.StringHashMap(DiscoveredCommand).init(allocator),
     };
     defer commands.deinit();
 

--- a/packages/core/src/build_utils/command_discovery.zig
+++ b/packages/core/src/build_utils/command_discovery.zig
@@ -5,7 +5,7 @@ const types = @import("discovery_types.zig");
 // Re-exported so runtime consumers (e.g. the `zcli tree` tool) can name the
 // types returned by discovery. discovery_types.zig is runtime-safe — the
 // std.Build-only build_utils/types.zig never enters the runtime module graph.
-pub const CommandInfo = types.CommandInfo;
+pub const DiscoveredCommand = types.DiscoveredCommand;
 pub const CommandType = types.CommandType;
 pub const DiscoveredCommands = types.DiscoveredCommands;
 
@@ -49,7 +49,7 @@ fn scanDirectory(
     allocator: std.mem.Allocator,
     io: std.Io,
     dir: std.Io.Dir,
-    commands: *std.StringHashMap(CommandInfo),
+    commands: *std.StringHashMap(DiscoveredCommand),
     current_path: []const []const u8, // Array of path components
     depth: u32,
     max_depth: u32,
@@ -107,7 +107,7 @@ fn scanDirectory(
                     try fs_path_list.append(allocator, entry.name);
                     const file_path = try std.mem.join(allocator, "/", fs_path_list.items);
 
-                    const command_info = CommandInfo{
+                    const command_info = DiscoveredCommand{
                         .name = try allocator.dupe(u8, name_without_ext),
                         .path = try path_list.toOwnedSlice(allocator),
                         .file_path = file_path,
@@ -137,7 +137,7 @@ fn scanDirectory(
                 defer subdir.close(io);
 
                 // Create subcommand map
-                var subcommands = std.StringHashMap(CommandInfo).init(allocator);
+                var subcommands = std.StringHashMap(DiscoveredCommand).init(allocator);
 
                 // Build new path as array of components
                 var new_path_list = std.ArrayList([]const u8).empty;
@@ -174,7 +174,7 @@ fn scanDirectory(
                     // Determine command type based on presence of index.zig
                     const command_type: CommandType = if (has_index) .optional_group else .pure_group;
 
-                    const command_info = CommandInfo{
+                    const command_info = DiscoveredCommand{
                         .name = try allocator.dupe(u8, entry.name),
                         .path = new_path,
                         .file_path = group_file_path,

--- a/packages/core/src/build_utils/command_tests.zig
+++ b/packages/core/src/build_utils/command_tests.zig
@@ -12,7 +12,7 @@ const command_discovery = @import("command_discovery.zig");
 const plugin_system = @import("plugin_system.zig");
 
 const DiscoveredCommands = types.DiscoveredCommands;
-const CommandInfo = types.CommandInfo;
+const DiscoveredCommand = types.DiscoveredCommand;
 const SharedModule = types.SharedModule;
 const PluginInfo = types.PluginInfo;
 
@@ -126,7 +126,7 @@ const Ctx = struct {
     testing_module: *std.Build.Module,
     shared_modules: []const SharedModule,
 
-    fn addMapTests(self: Ctx, map: *std.StringHashMap(CommandInfo)) void {
+    fn addMapTests(self: Ctx, map: *std.StringHashMap(DiscoveredCommand)) void {
         var it = map.iterator();
         while (it.next()) |entry| {
             const info = entry.value_ptr;
@@ -137,7 +137,7 @@ const Ctx = struct {
         }
     }
 
-    fn addOne(self: Ctx, info: *const CommandInfo) void {
+    fn addOne(self: Ctx, info: *const DiscoveredCommand) void {
         const b = self.b;
         const full_path = b.fmt("{s}/{s}", .{ self.commands_dir, info.file_path });
 

--- a/packages/core/src/build_utils/discovery_types.zig
+++ b/packages/core/src/build_utils/discovery_types.zig
@@ -20,15 +20,15 @@ pub const CommandType = enum {
 };
 
 /// Information about a discovered command
-pub const CommandInfo = struct {
+pub const DiscoveredCommand = struct {
     name: []const u8,
     path: []const []const u8, // Array of command path components
     file_path: []const u8, // Filesystem path for module loading
     command_type: CommandType,
     hidden: bool = false, // Whether this command should be hidden from help/completions
-    subcommands: ?std.StringHashMap(CommandInfo),
+    subcommands: ?std.StringHashMap(DiscoveredCommand),
 
-    pub fn deinit(self: *CommandInfo, allocator: std.mem.Allocator) void {
+    pub fn deinit(self: *DiscoveredCommand, allocator: std.mem.Allocator) void {
         // Free allocated strings
         allocator.free(self.name);
         allocator.free(self.file_path);
@@ -61,8 +61,8 @@ pub const CommandInfo = struct {
 /// completions — lists commands by name rather than by filesystem-iteration
 /// order. `zcli tree` sorts its own display nodes; help re-buckets command info
 /// through its own map and sorts there. Caller owns the returned slice.
-pub fn sortedByName(allocator: std.mem.Allocator, map: *const std.StringHashMap(CommandInfo)) ![]CommandInfo {
-    const entries = try allocator.alloc(CommandInfo, map.count());
+pub fn sortedByName(allocator: std.mem.Allocator, map: *const std.StringHashMap(DiscoveredCommand)) ![]DiscoveredCommand {
+    const entries = try allocator.alloc(DiscoveredCommand, map.count());
     errdefer allocator.free(entries);
 
     var it = map.iterator();
@@ -71,23 +71,23 @@ pub fn sortedByName(allocator: std.mem.Allocator, map: *const std.StringHashMap(
         entries[i] = entry.value_ptr.*;
     }
 
-    std.mem.sort(CommandInfo, entries, {}, lessByName);
+    std.mem.sort(DiscoveredCommand, entries, {}, lessByName);
     return entries;
 }
 
-fn lessByName(_: void, a: CommandInfo, b: CommandInfo) bool {
+fn lessByName(_: void, a: DiscoveredCommand, b: DiscoveredCommand) bool {
     return std.mem.lessThan(u8, a.name, b.name);
 }
 
 /// Container for all discovered commands
 pub const DiscoveredCommands = struct {
     allocator: std.mem.Allocator,
-    root: std.StringHashMap(CommandInfo),
+    root: std.StringHashMap(DiscoveredCommand),
 
     pub fn init(allocator: std.mem.Allocator) DiscoveredCommands {
         return DiscoveredCommands{
             .allocator = allocator,
-            .root = std.StringHashMap(CommandInfo).init(allocator),
+            .root = std.StringHashMap(DiscoveredCommand).init(allocator),
         };
     }
 

--- a/packages/core/src/build_utils/main.zig
+++ b/packages/core/src/build_utils/main.zig
@@ -6,7 +6,7 @@ const plugin_system = @import("plugin_system.zig");
 const command_discovery = @import("command_discovery.zig");
 const code_generation = @import("code_generation.zig");
 
-const CommandInfo = types.CommandInfo;
+const DiscoveredCommand = types.DiscoveredCommand;
 const BuildConfig = types.BuildConfig;
 const DiscoveredCommands = types.DiscoveredCommands;
 const GenerateConfig = types.GenerateConfig;

--- a/packages/core/src/build_utils/module_creation.zig
+++ b/packages/core/src/build_utils/module_creation.zig
@@ -5,7 +5,7 @@ const command_config_lookup = @import("command_config_lookup.zig");
 
 const PluginInfo = types.PluginInfo;
 const DiscoveredCommands = types.DiscoveredCommands;
-const CommandInfo = types.CommandInfo;
+const DiscoveredCommand = types.DiscoveredCommand;
 
 // ============================================================================
 // MODULE CREATION - Build-time module creation and linking
@@ -107,7 +107,7 @@ fn createGroupModules(
     registry_module: *std.Build.Module,
     zcli_module: *std.Build.Module,
     _: []const u8,
-    group_info: *const CommandInfo,
+    group_info: *const DiscoveredCommand,
     commands_dir: []const u8,
     shared_modules: []const types.SharedModule,
     command_configs: []const types.CommandConfig,

--- a/packages/core/src/build_utils/types.zig
+++ b/packages/core/src/build_utils/types.zig
@@ -4,13 +4,13 @@ const std = @import("std");
 // BUILD-TIME TYPES - Used across build utility modules
 //
 // Everything here may reference std.Build. The runtime-safe discovery types
-// (CommandType/CommandInfo/DiscoveredCommands) live in discovery_types.zig and
-// are re-exported below for build-time convenience — runtime code imports
+// (CommandType/DiscoveredCommand/DiscoveredCommands) live in discovery_types.zig
+// and are re-exported below for build-time convenience — runtime code imports
 // discovery_types.zig (via command_discovery) and never this file.
 // ============================================================================
 
 pub const CommandType = @import("discovery_types.zig").CommandType;
-pub const CommandInfo = @import("discovery_types.zig").CommandInfo;
+pub const DiscoveredCommand = @import("discovery_types.zig").DiscoveredCommand;
 pub const DiscoveredCommands = @import("discovery_types.zig").DiscoveredCommands;
 pub const sortedByName = @import("discovery_types.zig").sortedByName;
 

--- a/packages/core/src/options/parser.zig
+++ b/packages/core/src/options/parser.zig
@@ -13,36 +13,6 @@ const ZcliDiagnostic = diagnostic_errors.ZcliDiagnostic;
 const ResourceLimits = @import("../resource_limits.zig").ResourceLimits;
 const ResourceTracker = @import("../resource_limits.zig").ResourceTracker;
 
-/// Parse command-line options based on the provided Options struct type
-///
-/// ## Memory Management
-///
-/// Array fields will accumulate values and return owned slices that MUST be freed.
-/// The zcli framework generates automatic cleanup in the command registry, but if you're
-/// using parseOptions directly, you must free array fields manually.
-///
-/// ### Supported Array Types:
-/// - `[][]const u8` - Array of strings
-/// - `[]i32`, `[]u32`, `[]i64`, `[]u64` - Integer arrays
-/// - `[]i16`, `[]u16`, `[]i8`, `[]u8` - Small integer arrays
-/// - `[]f32`, `[]f64` - Float arrays
-///
-/// ### Manual Usage Example:
-/// ```zig
-/// const Options = struct {
-///     files: [][]const u8 = &.{},     // Array field - needs cleanup
-///     counts: []i32 = &.{},           // Array field - needs cleanup
-///     verbose: bool = false,          // Non-array field - no cleanup needed
-/// };
-///
-/// const parsed = try parseOptions(Options, allocator, args, null);
-/// defer allocator.free(parsed.options.files);  // REQUIRED
-/// defer allocator.free(parsed.options.counts); // REQUIRED
-/// ```
-///
-/// ### Automatic Cleanup (when using zcli framework):
-/// When commands are executed through the zcli framework, array cleanup is automatic.
-/// The generated command registry includes cleanup code that frees all array fields.
 /// Parse command-line options into a struct using default field names.
 ///
 /// This function parses command-line flags and options (e.g., --verbose, --output file.txt)
@@ -64,6 +34,12 @@ const ResourceTracker = @import("../resource_limits.zig").ResourceTracker;
 /// - Array options: `[][]const u8`, `[]i32` (--files a.txt b.txt)
 /// - Optional options: `?T` for any supported type T
 ///
+/// ### Supported Array Element Types:
+/// - `[][]const u8` - Array of strings
+/// - `[]i32`, `[]u32`, `[]i64`, `[]u64` - Integer arrays
+/// - `[]i16`, `[]u16`, `[]i8`, `[]u8` - Small integer arrays
+/// - `[]f32`, `[]f64` - Float arrays
+///
 /// ## Examples
 /// ```zig
 /// const Options = struct {
@@ -80,7 +56,10 @@ const ResourceTracker = @import("../resource_limits.zig").ResourceTracker;
 /// ```
 ///
 /// ## Memory Management
-/// **IMPORTANT**: Array options allocate memory. Always call `cleanupOptions` when done:
+/// **IMPORTANT**: Array options allocate memory. Array fields accumulate values and
+/// return owned slices that MUST be freed. When commands are executed through the zcli
+/// framework, array cleanup is automatic (the generated command registry frees all array
+/// fields). When calling `parseOptions` directly, always call `cleanupOptions` when done:
 /// ```zig
 /// const result = try parseOptions(Options, allocator, args, null);
 /// defer cleanupOptions(Options, result.options, allocator);
@@ -475,6 +454,47 @@ fn suggestLongOptions(
     return result;
 }
 
+/// Record a "boolean flag given a value" diagnostic and return its error.
+///
+/// Shared by every parsing path (long, negated `--no-`, short) so the diagnostic
+/// shape stays identical: a boolean flag never takes a value.
+fn booleanWithValueError(
+    diag: ?*?ZcliDiagnostic,
+    option_name: []const u8,
+    is_short: bool,
+    provided_value: []const u8,
+) error{BooleanOptionWithValue} {
+    if (diag) |d| d.* = .{ .OptionBooleanWithValue = .{
+        .option_name = option_name,
+        .is_short = is_short,
+        .provided_value = provided_value,
+    } };
+    return error.BooleanOptionWithValue;
+}
+
+/// Enforce at-most-once usage of a boolean flag, marking it seen on success.
+///
+/// Shared by every parsing path (long, negated `--no-`, bundled short, single
+/// short) so the duplicate diagnostic and its bookkeeping can't drift apart.
+/// On a repeat it records an `OptionDuplicate` diagnostic and returns the error;
+/// otherwise it sets the field's usage count to 1.
+fn markBooleanFlagOnce(
+    diag: ?*?ZcliDiagnostic,
+    option_counts: *std.StringHashMap(u32),
+    field_name: []const u8,
+    option_name: []const u8,
+    is_short: bool,
+) !void {
+    if ((option_counts.get(field_name) orelse 0) >= 1) {
+        if (diag) |d| d.* = .{ .OptionDuplicate = .{
+            .option_name = option_name,
+            .is_short = is_short,
+        } };
+        return error.DuplicateOption;
+    }
+    try option_counts.put(field_name, 1);
+}
+
 /// Parse a long option with metadata support (--option or --option=value)
 fn parseLongOptions(
     comptime OptionsType: type,
@@ -515,22 +535,8 @@ fn parseLongOptions(
             // including the contradictory `--flag --no-flag` pair, which shares this
             // field's count — is a usage error, not last-wins).
             if (comptime utils.isBooleanFlag(field.type)) {
-                if (option_value != null) {
-                    if (diag) |d| d.* = .{ .OptionBooleanWithValue = .{
-                        .option_name = option_name,
-                        .is_short = false,
-                        .provided_value = option_value.?,
-                    } };
-                    return error.BooleanOptionWithValue;
-                }
-                if ((option_counts.get(field.name) orelse 0) >= 1) {
-                    if (diag) |d| d.* = .{ .OptionDuplicate = .{
-                        .option_name = option_name,
-                        .is_short = false,
-                    } };
-                    return error.DuplicateOption;
-                }
-                try option_counts.put(field.name, 1);
+                if (option_value) |val| return booleanWithValueError(diag, option_name, false, val);
+                try markBooleanFlagOnce(diag, option_counts, field.name, option_name, false);
                 @field(result, field.name) = true;
                 return 1;
             }
@@ -586,22 +592,8 @@ fn parseLongOptions(
             // like the positive form, takes no value and must not repeat.
             if (utils.negatedLongNameMatchesField(meta, field.name, option_name)) {
                 found = true;
-                if (option_value != null) {
-                    if (diag) |d| d.* = .{ .OptionBooleanWithValue = .{
-                        .option_name = option_name,
-                        .is_short = false,
-                        .provided_value = option_value.?,
-                    } };
-                    return error.BooleanOptionWithValue;
-                }
-                if ((option_counts.get(field.name) orelse 0) >= 1) {
-                    if (diag) |d| d.* = .{ .OptionDuplicate = .{
-                        .option_name = option_name,
-                        .is_short = false,
-                    } };
-                    return error.DuplicateOption;
-                }
-                try option_counts.put(field.name, 1);
+                if (option_value) |val| return booleanWithValueError(diag, option_name, false, val);
+                try markBooleanFlagOnce(diag, option_counts, field.name, option_name, false);
                 @field(result, field.name) = false;
                 return 1;
             }
@@ -678,14 +670,7 @@ fn parseShortOptionsWithMeta(
 
                 if (matches) {
                     if (comptime utils.isBooleanFlag(field.type)) {
-                        if ((option_counts.get(field.name) orelse 0) >= 1) {
-                            if (diag) |d| d.* = .{ .OptionDuplicate = .{
-                                .option_name = options_part[ci .. ci + 1],
-                                .is_short = true,
-                            } };
-                            return error.DuplicateOption;
-                        }
-                        try option_counts.put(field.name, 1);
+                        try markBooleanFlagOnce(diag, option_counts, field.name, options_part[ci .. ci + 1], true);
                         @field(result, field.name) = true;
                     }
                     break;
@@ -708,14 +693,7 @@ fn parseShortOptionsWithMeta(
                 char_found = true;
 
                 if (comptime utils.isBooleanFlag(field.type)) {
-                    if ((option_counts.get(field.name) orelse 0) >= 1) {
-                        if (diag) |d| d.* = .{ .OptionDuplicate = .{
-                            .option_name = options_part[0..1],
-                            .is_short = true,
-                        } };
-                        return error.DuplicateOption;
-                    }
-                    try option_counts.put(field.name, 1);
+                    try markBooleanFlagOnce(diag, option_counts, field.name, options_part[0..1], true);
                     @field(result, field.name) = true;
                     return 1;
                 } else {

--- a/packages/core/src/plugins/zcli_help/plugin.zig
+++ b/packages/core/src/plugins/zcli_help/plugin.zig
@@ -21,7 +21,7 @@ pub const priority = 100;
 const NAME_COLUMN_WIDTH: usize = 16;
 
 // Helper struct for collecting command information
-const CommandInfo = struct {
+const CommandListEntry = struct {
     name: []const u8,
     description: ?[]const u8,
     is_group: bool,

--- a/packages/core/src/registry/tests.zig
+++ b/packages/core/src/registry/tests.zig
@@ -37,14 +37,14 @@ fn createTestCommands(allocator: std.mem.Allocator) !types.DiscoveredCommands {
     var commands = types.DiscoveredCommands.init(allocator);
 
     // Create a pure command group (no index.zig)
-    var network_subcommands = std.StringHashMap(types.CommandInfo).init(allocator);
+    var network_subcommands = std.StringHashMap(types.DiscoveredCommand).init(allocator);
 
     // Create path array properly
     var network_ls_path = try allocator.alloc([]const u8, 2);
     network_ls_path[0] = try allocator.dupe(u8, "network");
     network_ls_path[1] = try allocator.dupe(u8, "ls");
 
-    const network_ls = types.CommandInfo{
+    const network_ls = types.DiscoveredCommand{
         .name = try allocator.dupe(u8, "ls"),
         .path = network_ls_path,
         .file_path = try allocator.dupe(u8, "network/ls.zig"),
@@ -56,7 +56,7 @@ fn createTestCommands(allocator: std.mem.Allocator) !types.DiscoveredCommands {
     var network_path = try allocator.alloc([]const u8, 1);
     network_path[0] = try allocator.dupe(u8, "network");
 
-    const network_group = types.CommandInfo{
+    const network_group = types.DiscoveredCommand{
         .name = try allocator.dupe(u8, "network"),
         .path = network_path,
         .file_path = try allocator.dupe(u8, "network"), // No index.zig
@@ -66,12 +66,12 @@ fn createTestCommands(allocator: std.mem.Allocator) !types.DiscoveredCommands {
     try commands.root.put(try allocator.dupe(u8, "network"), network_group);
 
     // Create an optional command group (with index.zig)
-    var container_subcommands = std.StringHashMap(types.CommandInfo).init(allocator);
+    var container_subcommands = std.StringHashMap(types.DiscoveredCommand).init(allocator);
     var container_run_path = try allocator.alloc([]const u8, 2);
     container_run_path[0] = try allocator.dupe(u8, "container");
     container_run_path[1] = try allocator.dupe(u8, "run");
 
-    const container_run = types.CommandInfo{
+    const container_run = types.DiscoveredCommand{
         .name = try allocator.dupe(u8, "run"),
         .path = container_run_path,
         .file_path = try allocator.dupe(u8, "container/run.zig"),
@@ -83,7 +83,7 @@ fn createTestCommands(allocator: std.mem.Allocator) !types.DiscoveredCommands {
     var container_path = try allocator.alloc([]const u8, 1);
     container_path[0] = try allocator.dupe(u8, "container");
 
-    const container_group = types.CommandInfo{
+    const container_group = types.DiscoveredCommand{
         .name = try allocator.dupe(u8, "container"),
         .path = container_path,
         .file_path = try allocator.dupe(u8, "container/index.zig"),
@@ -96,7 +96,7 @@ fn createTestCommands(allocator: std.mem.Allocator) !types.DiscoveredCommands {
     var version_path = try allocator.alloc([]const u8, 1);
     version_path[0] = try allocator.dupe(u8, "version");
 
-    const version_cmd = types.CommandInfo{
+    const version_cmd = types.DiscoveredCommand{
         .name = try allocator.dupe(u8, "version"),
         .path = version_path,
         .file_path = try allocator.dupe(u8, "version.zig"),
@@ -210,14 +210,14 @@ test "nested pure command groups" {
     defer commands.deinit();
 
     // Create nested structure: docker -> compose (pure) -> up (leaf)
-    var compose_subcommands = std.StringHashMap(types.CommandInfo).init(allocator);
+    var compose_subcommands = std.StringHashMap(types.DiscoveredCommand).init(allocator);
 
     var compose_up_path = try allocator.alloc([]const u8, 3);
     compose_up_path[0] = try allocator.dupe(u8, "docker");
     compose_up_path[1] = try allocator.dupe(u8, "compose");
     compose_up_path[2] = try allocator.dupe(u8, "up");
 
-    const compose_up = types.CommandInfo{
+    const compose_up = types.DiscoveredCommand{
         .name = try allocator.dupe(u8, "up"),
         .path = compose_up_path,
         .file_path = try allocator.dupe(u8, "docker/compose/up.zig"),
@@ -231,7 +231,7 @@ test "nested pure command groups" {
     compose_path[0] = try allocator.dupe(u8, "docker");
     compose_path[1] = try allocator.dupe(u8, "compose");
 
-    const compose_group = types.CommandInfo{
+    const compose_group = types.DiscoveredCommand{
         .name = try allocator.dupe(u8, "compose"),
         .path = compose_path,
         .file_path = try allocator.dupe(u8, "docker/compose"),
@@ -240,13 +240,13 @@ test "nested pure command groups" {
     };
 
     // Docker is an optional group
-    var docker_subcommands = std.StringHashMap(types.CommandInfo).init(allocator);
+    var docker_subcommands = std.StringHashMap(types.DiscoveredCommand).init(allocator);
     try docker_subcommands.put(try allocator.dupe(u8, "compose"), compose_group);
 
     var docker_path = try allocator.alloc([]const u8, 1);
     docker_path[0] = try allocator.dupe(u8, "docker");
 
-    const docker_group = types.CommandInfo{
+    const docker_group = types.DiscoveredCommand{
         .name = try allocator.dupe(u8, "docker"),
         .path = docker_path,
         .file_path = try allocator.dupe(u8, "docker/index.zig"),
@@ -364,16 +364,16 @@ test "mixed command types in same parent" {
     defer commands.deinit();
 
     // Create a structure with both pure and optional groups at same level
-    var app_subcommands = std.StringHashMap(types.CommandInfo).init(allocator);
+    var app_subcommands = std.StringHashMap(types.DiscoveredCommand).init(allocator);
 
     // Pure group
-    var pure_subcommands = std.StringHashMap(types.CommandInfo).init(allocator);
+    var pure_subcommands = std.StringHashMap(types.DiscoveredCommand).init(allocator);
 
     var pure_cmd_path = try allocator.alloc([]const u8, 2);
     pure_cmd_path[0] = try allocator.dupe(u8, "pure");
     pure_cmd_path[1] = try allocator.dupe(u8, "list");
 
-    const pure_cmd = types.CommandInfo{
+    const pure_cmd = types.DiscoveredCommand{
         .name = try allocator.dupe(u8, "list"),
         .path = pure_cmd_path,
         .file_path = try allocator.dupe(u8, "pure/list.zig"),
@@ -385,7 +385,7 @@ test "mixed command types in same parent" {
     var pure_path = try allocator.alloc([]const u8, 1);
     pure_path[0] = try allocator.dupe(u8, "pure");
 
-    const pure_group = types.CommandInfo{
+    const pure_group = types.DiscoveredCommand{
         .name = try allocator.dupe(u8, "pure"),
         .path = pure_path,
         .file_path = try allocator.dupe(u8, "pure"),
@@ -395,13 +395,13 @@ test "mixed command types in same parent" {
     try app_subcommands.put(try allocator.dupe(u8, "pure"), pure_group);
 
     // Optional group
-    var optional_subcommands = std.StringHashMap(types.CommandInfo).init(allocator);
+    var optional_subcommands = std.StringHashMap(types.DiscoveredCommand).init(allocator);
 
     var optional_cmd_path = try allocator.alloc([]const u8, 2);
     optional_cmd_path[0] = try allocator.dupe(u8, "optional");
     optional_cmd_path[1] = try allocator.dupe(u8, "exec");
 
-    const optional_cmd = types.CommandInfo{
+    const optional_cmd = types.DiscoveredCommand{
         .name = try allocator.dupe(u8, "exec"),
         .path = optional_cmd_path,
         .file_path = try allocator.dupe(u8, "optional/exec.zig"),
@@ -413,7 +413,7 @@ test "mixed command types in same parent" {
     var optional_path = try allocator.alloc([]const u8, 1);
     optional_path[0] = try allocator.dupe(u8, "optional");
 
-    const optional_group = types.CommandInfo{
+    const optional_group = types.DiscoveredCommand{
         .name = try allocator.dupe(u8, "optional"),
         .path = optional_path,
         .file_path = try allocator.dupe(u8, "optional/index.zig"),

--- a/projects/zcli/src/commands/release.zig
+++ b/projects/zcli/src/commands/release.zig
@@ -1,41 +1,6 @@
 const std = @import("std");
 const zcli = @import("zcli");
 
-/// Maximum length for user input (version strings, branch names, etc.)
-const MAX_INPUT_LENGTH = 256;
-
-/// Read a line from stdin with validation and proper error handling
-/// Returns error.InputTooLong if input exceeds MAX_INPUT_LENGTH
-fn readLine(allocator: std.mem.Allocator, io: std.Io) ![]u8 {
-    var read_buf: [4096]u8 = undefined;
-    var reader = std.Io.File.stdin().reader(io, &read_buf);
-    const r = &reader.interface;
-
-    var line_buffer: [MAX_INPUT_LENGTH]u8 = undefined;
-    var i: usize = 0;
-
-    while (i < line_buffer.len) {
-        const byte = r.takeByte() catch break;
-
-        if (byte == '\n') break;
-        if (byte == '\r') continue;
-
-        line_buffer[i] = byte;
-        i += 1;
-    }
-
-    if (i == line_buffer.len) {
-        // Drain remaining input until newline
-        while (true) {
-            const byte = r.takeByte() catch break;
-            if (byte == '\n') break;
-        }
-        return error.InputTooLong;
-    }
-
-    return try allocator.dupe(u8, line_buffer[0..i]);
-}
-
 pub const meta = .{
     .description = "Create and manage project releases",
     .examples = &.{
@@ -122,6 +87,10 @@ const Version = struct {
 pub fn execute(args: Args, options: Options, context: anytype) !void {
     const allocator = context.allocator;
     var stdout = context.stdout();
+    // Framework prompt instance: shares this command's stdout/stdin (Stdio-
+    // injectable, so confirmations are testable) instead of a hand-rolled
+    // stdin read.
+    const prompts = context.prompts();
 
     const io = context.io;
 
@@ -167,30 +136,28 @@ pub fn execute(args: Args, options: Options, context: anytype) !void {
                     break :blk initial_version;
                 }
 
-                try stdout.print("Create initial release tag? [Y/n]: ", .{});
-                try stdout.flush(); // the prompt must reach the terminal before we block on stdin
-                const response = readLine(allocator, io) catch |read_err| {
-                    if (read_err == error.InputTooLong)
-                        return context.fail("✗ Input too long (max {d} characters)", .{MAX_INPUT_LENGTH});
-                    return read_err;
+                const create_it = prompts.confirm(.{
+                    .message = "Create initial release tag?",
+                    .default = true,
+                }) catch |perr| switch (perr) {
+                    error.EndOfStream => return context.fail("✗ Release requires a terminal to confirm (stdin closed).", .{}),
+                    else => return perr,
                 };
-                defer allocator.free(response);
-                const trimmed = std.mem.trim(u8, response, " \t\r\n");
-
-                if (std.mem.eql(u8, trimmed, "n") or std.mem.eql(u8, trimmed, "N")) {
+                if (!create_it) {
                     return context.fail("\nTo create manually:\n  git tag -a {s}-v0.1.0 -m \"Initial release\"", .{cli_name});
                 }
 
                 // If user provided explicit version, use it; otherwise prompt
                 const version_to_use = if (is_bump_type) blk2: {
-                    try stdout.print("  Initial version (default: 0.1.0): ", .{});
-                    try stdout.flush(); // the prompt must reach the terminal before we block on stdin
-                    const version_input = readLine(allocator, io) catch |read_err| {
-                        if (read_err == error.InputTooLong)
-                            return context.fail("✗ Input too long (max {d} characters)", .{MAX_INPUT_LENGTH});
-                        return read_err;
+                    const version_input = prompts.text(.{
+                        .message = "  Initial version",
+                        .default = "0.1.0",
+                    }) catch |perr| switch (perr) {
+                        error.EndOfStream => return context.fail("✗ Release requires a terminal to enter a version (stdin closed).", .{}),
+                        else => return perr,
                     };
-                    defer allocator.free(version_input);
+                    // Owned by the command arena; the trimmed slice escapes this
+                    // block so it must not be freed here.
                     const initial_version_str = std.mem.trim(u8, version_input, " \t\r\n");
                     break :blk2 if (initial_version_str.len == 0) "0.1.0" else initial_version_str;
                 } else args.version;
@@ -300,18 +267,15 @@ pub fn execute(args: Args, options: Options, context: anytype) !void {
 
     // 5.5. Confirm release (unless using --message flag or dry-run)
     if (options.message == null and !options.@"dry-run") {
-        try stdout.print("\nContinue with release {s}-v{s}? [Y/n]: ", .{ cli_name, new_version_str });
-        try stdout.flush(); // the prompt must reach the terminal before we block on stdin
-        const response = readLine(allocator, io) catch |read_err| {
-            if (read_err == error.InputTooLong)
-                return context.fail("✗ Input too long (max {d} characters)", .{MAX_INPUT_LENGTH});
-            return read_err;
+        const proceed = prompts.confirm(.{
+            .message = try std.fmt.allocPrint(allocator, "Continue with release {s}-v{s}?", .{ cli_name, new_version_str }),
+            .default = true,
+        }) catch |perr| switch (perr) {
+            error.EndOfStream => return context.fail("✗ Release requires a terminal to confirm (stdin closed).", .{}),
+            else => return perr,
         };
-        defer allocator.free(response);
-        const trimmed = std.mem.trim(u8, response, " \t\r\n");
-
-        // Default to yes - only abort if explicitly "n" or "N"
-        if (std.mem.eql(u8, trimmed, "n") or std.mem.eql(u8, trimmed, "N")) {
+        // Default to yes - only abort if the user explicitly declined.
+        if (!proceed) {
             try stdout.print("Release aborted.\n", .{});
             return;
         }
@@ -1010,18 +974,6 @@ test "tag name format with CLI name prefix" {
     defer allocator.free(tag_name2);
 
     try testing.expectEqualStrings("myapp-v0.1.0", tag_name2);
-}
-
-test "readLine - handles CRLF line endings" {
-    // Note: This test would require mocking stdin, which is complex in Zig
-    // The CRLF handling is covered by the implementation logic
-}
-
-test "readLine - MAX_INPUT_LENGTH constant is reasonable" {
-    // Verify the constant is set to a reasonable value
-    try testing.expect(MAX_INPUT_LENGTH == 256);
-    try testing.expect(MAX_INPUT_LENGTH > 0);
-    try testing.expect(MAX_INPUT_LENGTH < 65536); // Not too large
 }
 
 test "Version.parse - edge cases with whitespace" {

--- a/projects/zcli/src/commands/tree.zig
+++ b/projects/zcli/src/commands/tree.zig
@@ -9,7 +9,7 @@ const ThemeContext = zcli.theme.ThemeContext;
 // build actually wires up, with no rules duplicated here.
 const command_discovery = zcli.command_discovery;
 const CommandType = command_discovery.CommandType;
-const CommandInfo = command_discovery.CommandInfo;
+const DiscoveredCommand = command_discovery.DiscoveredCommand;
 
 pub const meta = .{
     .description = "Show the command tree discovered from src/commands",
@@ -121,7 +121,7 @@ fn nodesFromMap(
     arena: std.mem.Allocator,
     io: std.Io,
     dir: std.Io.Dir,
-    map: *const std.StringHashMap(CommandInfo),
+    map: *const std.StringHashMap(DiscoveredCommand),
 ) ![]const Node {
     var nodes = std.ArrayList(Node).empty;
 
@@ -726,7 +726,7 @@ test "nodesFromMap sorts, maps kinds, and enriches with metadata" {
     try tmp.dir.writeFile(io, .{ .sub_path = "users/list.zig", .data = "pub const meta = .{};" });
 
     // A discovery result as produced by the framework's discoverInDir.
-    var users_sub = std.StringHashMap(CommandInfo).init(arena);
+    var users_sub = std.StringHashMap(DiscoveredCommand).init(arena);
     try users_sub.put("list", .{
         .name = "list",
         .path = &.{ "users", "list" },
@@ -734,7 +734,7 @@ test "nodesFromMap sorts, maps kinds, and enriches with metadata" {
         .command_type = .leaf,
         .subcommands = null,
     });
-    var root = std.StringHashMap(CommandInfo).init(arena);
+    var root = std.StringHashMap(DiscoveredCommand).init(arena);
     try root.put("users", .{
         .name = "users",
         .path = &.{"users"},


### PR DESCRIPTION
Focused code-organization cleanup from a code-quality review. Four self-contained items, one commit each.

## 1. De-duplicate option-parser diagnostic blocks
`packages/core/src/options/parser.zig`: extracted `booleanWithValueError` and `markBooleanFlagOnce` helpers so the `OptionBooleanWithValue` (×2) and `OptionDuplicate` (×4) diagnostic-construction blocks — previously copy-pasted across the long, negated `--no-`, bundled-short, and single-short parsing paths — live in one place. Behavior identical; all 41 parser tests pass. Also merged the stitched-together `parseOptions` doc comment (a second block restarted mid-comment, repeating the memory-management section) into one clean docstring.

## 2. Rename the `CommandInfo` name collision
Three unrelated types shared the name. Renamed the fs-discovery one (`build_utils/discovery_types.zig`, re-exported via `zcli.command_discovery`) to `DiscoveredCommand` across build_utils, registry tests, command_tests, and the `zcli tree` consumer; renamed the private help-plugin collection helper to `CommandListEntry`. The public runtime introspection type (`zcli.CommandInfo`) is untouched. No deprecation aliases — clean rename.

## 3. Sync ADR statuses to reality
Audited all 26 ADR status lines. Three said `proposed` but are shipped — updated to `accepted (implemented)`, consistent with the existing status vocabulary. The other 23 were already `accepted` and verified accurate.

| ADR | Was | Now | Evidence |
|-----|-----|-----|----------|
| 0022 option constraints | proposed | accepted (implemented) | `meta.exclusive`/`.requires` in `options/utils.zig` + `OptionMutuallyExclusive` diagnostic |
| 0024 multi-value options | proposed | accepted (implemented) | comma-split arrays in `options/array_utils.zig` (`appendCsvToArrayListUnion`); help marks `(repeatable)` |
| 0026 dynamic shell completion | proposed | accepted (implemented — all three increments shipped) | `__complete` wire + option-value + `.also_files`/`.also_dirs` combine directive (PRs #254–#256) |

## 4. `zcli release` readLine dogfooding
`projects/zcli/src/commands/release.zig`: replaced the hand-rolled `readLine` over `std.Io.File.stdin()` with the framework's own `context.prompts()` — `.confirm` for the two `[Y/n]` gates and `.text` for the initial-version entry. Chose `context.prompts()` over `context.stdin()` because it's the established interactive-command idiom in `projects/zcli` (`init.zig`) and renders/reads the prompt for you. This restores Stdio-injection testability and fixes the EOF/error conflation (`takeByte() catch break` silently treated closed stdin like an empty answer; the prompts surface `error.EndOfStream`, now mapped to a clear "requires a terminal" failure). Also removed the dead `MAX_INPUT_LENGTH`/`readLine` + two placeholder tests, and a latent use-after-free where the trimmed version slice escaped its block after its backing buffer was freed.

## Verification
- Root `zig build test`: green (exit 0; 2085+ tests pass, 2 skipped).
- `projects/zcli` builds; its command tests (wired into root test) pass.
- `zig build e2e` (from projects/zcli): green (exit 0). Release e2e exercises `--dry-run`/`--message` paths, which bypass the interactive prompts — the confirm/text paths are not e2e-covered (can't drive a TTY confirmation non-interactively), so this is unit/build-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)