### PR TITLE
fix(tasks example): catch prompt EOF and use enum types for priority/status

### DIFF
--- a/examples/tasks/src/commands/add.zig
+++ b/examples/tasks/src/commands/add.zig
@@ -13,29 +13,17 @@ pub const meta = .{
     },
     .args = .{ .title = "Task title (omit for interactive mode)" },
     .options = .{
-        .priority = .{ .short = 'p', .description = "Priority: low, medium, high, critical", .complete = completePriority },
+        .priority = .{ .short = 'p', .description = "Task priority" },
         .points = .{ .description = "Story points" },
     },
 };
-
-/// Dynamic completion for `--priority` (ADR-0026). The field is a plain string,
-/// not an enum, so its choices can't be baked in statically — a hook offers them.
-fn completePriority(req: *zcli.completion.Request) !zcli.completion.Result {
-    const choices = [_][]const u8{ "low", "medium", "high", "critical" };
-    var out: std.ArrayList(zcli.completion.Candidate) = .empty;
-    for (choices) |ch| {
-        if (!std.mem.startsWith(u8, ch, req.partial)) continue;
-        try out.append(req.allocator, .{ .value = ch });
-    }
-    return .{ .candidates = try out.toOwnedSlice(req.allocator) };
-}
 
 pub const Args = struct {
     title: ?[]const u8 = null,
 };
 
 pub const Options = struct {
-    priority: []const u8 = "medium",
+    priority: store.Priority = .medium,
     points: ?u32 = null,
 };
 
@@ -48,26 +36,31 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
     var title: []const u8 = undefined;
     var title_owned: ?[]u8 = null;
     defer if (title_owned) |t| allocator.free(t);
-    var priority: store.Priority = .medium;
+    var priority: store.Priority = options.priority;
     var points: ?u32 = options.points;
 
     if (args.title) |t| {
         // Flag mode
         title = t;
-        priority = store.priorityFromString(options.priority) orelse .medium;
     } else {
         // Interactive mode
         const p = context.prompts();
 
-        title_owned = try p.text(.{
+        title_owned = p.text(.{
             .message = "Task title:",
-        });
+        }) catch |err| switch (err) {
+            error.EndOfStream => return context.fail("add requires an interactive terminal (stdin closed).", .{}),
+            else => return err,
+        };
         title = title_owned.?;
 
-        const priority_idx = try p.select(.{
+        const priority_idx = p.select(.{
             .message = "Priority:",
             .choices = &.{ "low", "medium", "high", "critical" },
-        });
+        }) catch |err| switch (err) {
+            error.EndOfStream => return context.fail("add requires an interactive terminal (stdin closed).", .{}),
+            else => return err,
+        };
         priority = switch (priority_idx) {
             0 => .low,
             1 => .medium,
@@ -76,12 +69,15 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
             else => .medium,
         };
 
-        const pts = try p.number(.{
+        const pts = p.number(.{
             .message = "Story points:",
             .default = 1,
             .min = 0,
             .max = 100,
-        });
+        }) catch |err| switch (err) {
+            error.EndOfStream => return context.fail("add requires an interactive terminal (stdin closed).", .{}),
+            else => return err,
+        };
         points = @intCast(pts);
     }
 

--- a/examples/tasks/src/commands/config.zig
+++ b/examples/tasks/src/commands/config.zig
@@ -55,22 +55,31 @@ pub fn execute(_: Args, _: Options, context: *Context) !void {
     try themed("Settings").bold().render(writer, &context.theme);
     try writer.writeAll("\r\n\r\n");
 
-    const priority_idx = try p.select(.{
+    const priority_idx = p.select(.{
         .message = "Default priority for new tasks:",
         .choices = &priorities,
-    });
+    }) catch |err| switch (err) {
+        error.EndOfStream => return context.fail("config requires an interactive terminal (stdin closed).", .{}),
+        else => return err,
+    };
 
-    const points = try p.number(.{
+    const points = p.number(.{
         .message = "Default story points:",
         .default = current.add.points,
         .min = 0,
         .max = 100,
-    });
+    }) catch |err| switch (err) {
+        error.EndOfStream => return context.fail("config requires an interactive terminal (stdin closed).", .{}),
+        else => return err,
+    };
 
-    const show_done = try p.confirm(.{
+    const show_done = p.confirm(.{
         .message = "Show completed tasks in 'list' by default?",
         .default = current.list.all,
-    });
+    }) catch |err| switch (err) {
+        error.EndOfStream => return context.fail("config requires an interactive terminal (stdin closed).", .{}),
+        else => return err,
+    };
 
     const new_config = Config{
         .add = .{ .priority = priorities[priority_idx], .points = @intCast(points) },

--- a/examples/tasks/src/commands/edit.zig
+++ b/examples/tasks/src/commands/edit.zig
@@ -61,12 +61,15 @@ pub fn execute(args: Args, _: Options, context: *Context) !void {
         const msg = try std.fmt.allocPrint(allocator, "Edit task #{d}:", .{task.id});
         defer allocator.free(msg);
 
-        const content = try p.editor(.{
+        const content = p.editor(.{
             .message = msg,
             .io = context.io,
             .default = initial,
             .extension = ".md",
-        });
+        }) catch |err| switch (err) {
+            error.EndOfStream => return context.fail("edit requires an interactive terminal (stdin closed).", .{}),
+            else => return err,
+        };
         defer allocator.free(content);
 
         const parsed_edit = parseEdit(content);

--- a/examples/tasks/src/commands/init.zig
+++ b/examples/tasks/src/commands/init.zig
@@ -28,27 +28,39 @@ pub fn execute(_: Args, _: Options, context: *Context) !void {
 
     const p = context.prompts();
 
-    const name = try p.text(.{
+    const name = p.text(.{
         .message = "Project name:",
         .default = "my-project",
-    });
+    }) catch |err| switch (err) {
+        error.EndOfStream => return context.fail("init requires an interactive terminal (stdin closed).", .{}),
+        else => return err,
+    };
     defer allocator.free(name);
 
-    const description = try p.text(.{
+    const description = p.text(.{
         .message = "Description:",
-    });
+    }) catch |err| switch (err) {
+        error.EndOfStream => return context.fail("init requires an interactive terminal (stdin closed).", .{}),
+        else => return err,
+    };
     defer allocator.free(description);
 
-    const method_idx = try p.select(.{
+    const method_idx = p.select(.{
         .message = "Methodology:",
         .choices = &.{ "Kanban", "Scrum", "None" },
-    });
+    }) catch |err| switch (err) {
+        error.EndOfStream => return context.fail("init requires an interactive terminal (stdin closed).", .{}),
+        else => return err,
+    };
     _ = method_idx;
 
-    const create_samples = try p.confirm(.{
+    const create_samples = p.confirm(.{
         .message = "Create sample tasks?",
         .default = true,
-    });
+    }) catch |err| switch (err) {
+        error.EndOfStream => return context.fail("init requires an interactive terminal (stdin closed).", .{}),
+        else => return err,
+    };
 
     var data = store.ProjectData{
         .name = name,

--- a/examples/tasks/src/commands/list.zig
+++ b/examples/tasks/src/commands/list.zig
@@ -8,7 +8,7 @@ pub const meta = .{
     .description = "List all tasks",
     .examples = &.{ "list", "list --status todo", "ls" },
     .options = .{
-        .status = .{ .short = 's', .description = "Filter by status: todo, in_progress, done" },
+        .status = .{ .short = 's', .description = "Filter by status" },
         .all = .{ .short = 'a', .description = "Show all tasks including done" },
     },
     .aliases = &.{"ls"},
@@ -17,7 +17,7 @@ pub const meta = .{
 pub const Args = struct {};
 
 pub const Options = struct {
-    status: ?[]const u8 = null,
+    status: ?store.Status = null,
     all: bool = false,
 };
 
@@ -32,7 +32,7 @@ pub fn execute(_: Args, options: Options, context: *Context) !void {
         return;
     }
 
-    const status_filter: ?store.Status = if (options.status) |s| store.statusFromString(s) else null;
+    const status_filter: ?store.Status = options.status;
 
     const w = context.stdout();
     const theme = &context.theme;

--- a/examples/tasks/src/commands/search.zig
+++ b/examples/tasks/src/commands/search.zig
@@ -34,10 +34,13 @@ pub fn execute(_: Args, _: Options, context: *Context) !void {
 
     const p = context.prompts();
 
-    const idx = try p.search(.{
+    const idx = p.search(.{
         .message = "Search tasks:",
         .choices = titles.items,
-    });
+    }) catch |err| switch (err) {
+        error.EndOfStream => return context.fail("search requires an interactive terminal (stdin closed).", .{}),
+        else => return err,
+    };
 
     const task = data.tasks[idx];
     const w = context.stdout();

--- a/examples/tasks/src/commands/sprint/create.zig
+++ b/examples/tasks/src/commands/sprint/create.zig
@@ -23,10 +23,13 @@ pub fn execute(args: Args, _: Options, context: *Context) !void {
 
     const name = if (args.name) |n| n else blk: {
         const p = context.prompts();
-        break :blk try p.text(.{
+        break :blk p.text(.{
             .message = "Sprint name:",
             .default = try std.fmt.allocPrint(allocator, "Sprint {d}", .{data.sprints.len + 1}),
-        });
+        }) catch |err| switch (err) {
+            error.EndOfStream => return context.fail("sprint create requires an interactive terminal (stdin closed).", .{}),
+            else => return err,
+        };
     };
 
     var sprints = std.ArrayList([]const u8).empty;


### PR DESCRIPTION
## Summary

- **EOF handling**: All 7 commands with interactive prompts (`add`, `config`, `edit`, `init`, `list`, `search`, `sprint/create`) now catch `error.EndOfStream` and call `context.fail()` with a friendly message instead of propagating the error up to produce a raw stack trace when stdin is closed or piped.
- **Enum types**: `add --priority` changed from `[]const u8 = "medium"` to `store.Priority = .medium`; `list --status` changed from `?[]const u8` to `?store.Status`. The framework now parses and validates these at the CLI layer, giving "did you mean" suggestions for typos. The manual `completePriority` hook, `priorityFromString` silent fallback, and `statusFromString` call-site are removed as superseded.

## Before / After

**EOF (stack trace → friendly message):**
```
# Before
$ ./zig-out/bin/tasks sprint create < /dev/null
? Sprint name: (Sprint 1) error: EndOfStream
/Users/.../std/Io/File.zig:475:5: 0x10233bf4f in readStreaming (tasks)
... (~30 frames) ...

# After
$ ./zig-out/bin/tasks sprint create < /dev/null
? Sprint name: (Sprint 1) sprint create requires an interactive terminal (stdin closed).
[exit 1]
```

**Enum validation (silent wrong value → error with suggestion):**
```
# Before
$ ./zig-out/bin/tasks add "x" --priority hgih
✔ Added task #1: x   ← silently added as .medium

# After
$ ./zig-out/bin/tasks add "x" --priority hgih
Error: Invalid value 'hgih' for option '--priority'. Expected one of: low, medium, high, critical. Did you mean 'high'?
Run 'tasks add --help' for usage.
[exit 1]

$ ./zig-out/bin/tasks add "x" --priority high
✔ Added task #2: x
```

## Call sites fixed

**EOF (finding 1):**
- `examples/tasks/src/commands/sprint/create.zig` — `p.text()`
- `examples/tasks/src/commands/init.zig` — `p.text()` ×2, `p.select()`, `p.confirm()`
- `examples/tasks/src/commands/add.zig` — `p.text()`, `p.select()`, `p.number()`
- `examples/tasks/src/commands/config.zig` — `p.select()`, `p.number()`, `p.confirm()`
- `examples/tasks/src/commands/edit.zig` — `p.editor()`
- `examples/tasks/src/commands/search.zig` — `p.search()`

**Enum types (finding 2):**
- `examples/tasks/src/commands/add.zig` — `Options.priority: store.Priority = .medium` (was `[]const u8 = "medium"`); removed `completePriority` hook and `priorityFromString` fallback
- `examples/tasks/src/commands/list.zig` — `Options.status: ?store.Status = null` (was `?[]const u8`); removed `statusFromString` call

## Test plan
- [x] `zig build` inside `examples/tasks` — clean
- [x] `zig build test` at repo root — all pass
- [x] `./zig-out/bin/tasks sprint create < /dev/null` → friendly message, exit 1, no trace
- [x] `./zig-out/bin/tasks add "x" --priority hgih` → "did you mean 'high'?", exit 1
- [x] `./zig-out/bin/tasks add "x" --priority high` → success
- [x] `./zig-out/bin/tasks list --status bda` → "did you mean 'todo'?", exit 1
- [x] `./zig-out/bin/tasks list --status todo` → filtered list, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)