### PR TITLE
config: notify when a project-local config is applied from cwd

### DIFF
--- a/packages/core/src/plugin_config_integration_test.zig
+++ b/packages/core/src/plugin_config_integration_test.zig
@@ -237,6 +237,139 @@ test "integration: env-provided value beats config" {
     config.deinitContextData(&ctx.plugins.zcli_config, alloc);
 }
 
+// --- Project-local config notice (security-audit finding: silent CWD load) ---
+//
+// Discovering `.{app}.config.{ext}` from the process cwd means an attacker-
+// controlled directory (e.g. a cloned repo) can silently supply defaults.
+// preExecute must print a one-line stderr notice naming the file whenever a
+// project-local config is actually loaded — but stay silent for an explicit
+// --config path and for the user-level (home/XDG) config, since those aren't
+// cwd-controlled by whatever directory the CLI happens to run in.
+
+test "integration: notice printed when a project-local (cwd) config is applied" {
+    var a = arena();
+    defer a.deinit();
+    const alloc = a.allocator();
+    const io = testing.io;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(io, .{ .sub_path = ".myapp.config.toml", .data = "count = 42\n" });
+
+    var orig_dir = try std.Io.Dir.cwd().openDir(io, ".", .{});
+    defer orig_dir.close(io);
+    try std.process.setCurrentDir(io, tmp.dir);
+    defer std.process.setCurrentDir(io, orig_dir) catch {};
+
+    var aw = std.Io.Writer.Allocating.init(alloc);
+    var environ = std.process.Environ.Map.init(alloc);
+    const cmd_path = [_][]const u8{};
+    var ctx = makeCtx(alloc, &environ, &cmd_path, &aw.writer);
+
+    const args = zcli.ParsedArgs.init(alloc);
+    _ = try config.preExecute(&ctx, args);
+
+    const written = aw.written();
+    try testing.expect(std.mem.indexOf(u8, written, "note:") != null);
+    try testing.expect(std.mem.indexOf(u8, written, "./.myapp.config.toml") != null);
+
+    config.deinitContextData(&ctx.plugins.zcli_config, alloc);
+}
+
+test "integration: no notice when no cwd config exists" {
+    var a = arena();
+    defer a.deinit();
+    const alloc = a.allocator();
+    const io = testing.io;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var orig_dir = try std.Io.Dir.cwd().openDir(io, ".", .{});
+    defer orig_dir.close(io);
+    try std.process.setCurrentDir(io, tmp.dir);
+    defer std.process.setCurrentDir(io, orig_dir) catch {};
+
+    var aw = std.Io.Writer.Allocating.init(alloc);
+    var environ = std.process.Environ.Map.init(alloc);
+    const cmd_path = [_][]const u8{};
+    var ctx = makeCtx(alloc, &environ, &cmd_path, &aw.writer);
+
+    const args = zcli.ParsedArgs.init(alloc);
+    _ = try config.preExecute(&ctx, args);
+
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "note:") == null);
+
+    config.deinitContextData(&ctx.plugins.zcli_config, alloc);
+}
+
+test "integration: no notice for an explicit --config path" {
+    var a = arena();
+    defer a.deinit();
+    const alloc = a.allocator();
+    const io = testing.io;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(io, .{ .sub_path = "myapp.json", .data = "{\"count\": 10}" });
+    const abs = try tmp.dir.realPathFileAlloc(io, "myapp.json", alloc);
+
+    var aw = std.Io.Writer.Allocating.init(alloc);
+    var environ = std.process.Environ.Map.init(alloc);
+    const cmd_path = [_][]const u8{};
+    var ctx = makeCtx(alloc, &environ, &cmd_path, &aw.writer);
+    ctx.plugins.zcli_config.custom_path = abs;
+
+    const args = zcli.ParsedArgs.init(alloc);
+    _ = try config.preExecute(&ctx, args);
+
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "note:") == null);
+
+    config.deinitContextData(&ctx.plugins.zcli_config, alloc);
+}
+
+test "integration: no notice for a user-level (XDG) config" {
+    if (@import("builtin").os.tag == .windows) return error.SkipZigTest; // XDG_CONFIG_HOME is POSIX-only
+    var a = arena();
+    defer a.deinit();
+    const alloc = a.allocator();
+    const io = testing.io;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // No cwd config here — force discovery down to the user-level path.
+    try tmp.dir.createDir(io, "myapp", .default_dir);
+    var app_dir = try tmp.dir.openDir(io, "myapp", .{});
+    defer app_dir.close(io);
+    try app_dir.writeFile(io, .{ .sub_path = "config.json", .data = "{\"count\": 10}" });
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const xdg_base_len = try tmp.dir.realPath(io, &path_buf);
+    const xdg_base = try alloc.dupe(u8, path_buf[0..xdg_base_len]);
+
+    var orig_dir = try std.Io.Dir.cwd().openDir(io, ".", .{});
+    defer orig_dir.close(io);
+    // Run from a directory with no `.myapp.config.*` of its own, so discovery
+    // must fall through to the user-level (XDG) branch.
+    var empty_tmp = testing.tmpDir(.{});
+    defer empty_tmp.cleanup();
+    try std.process.setCurrentDir(io, empty_tmp.dir);
+    defer std.process.setCurrentDir(io, orig_dir) catch {};
+
+    var aw = std.Io.Writer.Allocating.init(alloc);
+    var environ = std.process.Environ.Map.init(alloc);
+    try environ.put("XDG_CONFIG_HOME", xdg_base);
+    const cmd_path = [_][]const u8{};
+    var ctx = makeCtx(alloc, &environ, &cmd_path, &aw.writer);
+
+    const args = zcli.ParsedArgs.init(alloc);
+    _ = try config.preExecute(&ctx, args);
+    try testing.expect(ctx.plugins.zcli_config.format != null); // sanity: config was found
+
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "note:") == null);
+
+    config.deinitContextData(&ctx.plugins.zcli_config, alloc);
+}
+
 test "integration: multiple config files warn about ambiguity" {
     var a = arena();
     defer a.deinit();

--- a/packages/core/src/plugins/zcli_config/plugin.zig
+++ b/packages/core/src/plugins/zcli_config/plugin.zig
@@ -20,6 +20,12 @@ const zcli = @import("zcli");
 ///   3. {user config dir}/{app_name}/config.json / .toml / .yaml / .yml
 ///      ($XDG_CONFIG_HOME or ~/.config on POSIX; %APPDATA% on Windows)
 ///
+/// Case 2 is discovered from the process's cwd, which an attacker can control
+/// (e.g. a cloned repo containing a `.myapp.config.toml`) — so, unlike cases 1
+/// and 3, applying it prints a one-line `note:` to stderr naming the file.
+/// CLI/env still always win (see above), so this is a visibility fix, not a
+/// trust boundary change.
+///
 /// Coercion: a config scalar is stringified and run through the *same* value
 /// parser the CLI and env use, so every option type works from config — bools,
 /// all int widths, floats, enums (incl. optionals), custom `parse` types, and
@@ -73,7 +79,8 @@ pub fn preExecute(context: anytype, args: zcli.ParsedArgs) !?zcli.ParsedArgs {
     const stderr = context.stderr();
 
     var path_allocated = false;
-    const path = findConfigFile(allocator, context.io, context.environ, context.app_name, data.custom_path, stderr, &path_allocated) orelse return args;
+    var is_project_local = false;
+    const path = findConfigFile(allocator, context.io, context.environ, context.app_name, data.custom_path, stderr, &path_allocated, &is_project_local) orelse return args;
 
     const format = detectFormat(path) orelse {
         // Unrecognized extension — warn and skip
@@ -92,6 +99,15 @@ pub fn preExecute(context: anytype, args: zcli.ParsedArgs) !?zcli.ParsedArgs {
     data.loaded_path = path;
     data.path_allocated = path_allocated;
     data.format = format;
+
+    // Project-local config is discovered silently by cwd — the cwd is often
+    // outside the user's control (e.g. a freshly cloned repo), so surface that
+    // it's in effect. Global/user-level config lives in a path the user set up
+    // themselves and stays silent, as does an explicit --config (already visible
+    // on the command line). One line, once per invocation — not per option.
+    if (is_project_local) {
+        try stderr.print("note: applied config from ./{s}\n", .{path});
+    }
 
     return args;
 }
@@ -488,8 +504,9 @@ fn userConfigDir(allocator: std.mem.Allocator, environ: *const std.process.Envir
     return dir;
 }
 
-fn findConfigFile(allocator: std.mem.Allocator, io: std.Io, environ: *const std.process.Environ.Map, app_name: []const u8, custom_path: ?[]const u8, stderr: *std.Io.Writer, allocated: *bool) ?[]const u8 {
+fn findConfigFile(allocator: std.mem.Allocator, io: std.Io, environ: *const std.process.Environ.Map, app_name: []const u8, custom_path: ?[]const u8, stderr: *std.Io.Writer, allocated: *bool, is_project_local: *bool) ?[]const u8 {
     allocated.* = false;
+    is_project_local.* = false;
     const cwd = std.Io.Dir.cwd();
 
     if (custom_path) |p| {
@@ -502,7 +519,10 @@ fn findConfigFile(allocator: std.mem.Allocator, io: std.Io, environ: *const std.
     const extensions = [_][]const u8{ ".json", ".toml", ".yaml", ".yml" };
 
     // Project-local: ./.{app_name}.config.{ext}
-    if (firstExisting(allocator, io, cwd, stderr, "", app_name, &extensions, allocated)) |p| return p;
+    if (firstExisting(allocator, io, cwd, stderr, "", app_name, &extensions, allocated)) |p| {
+        is_project_local.* = true;
+        return p;
+    }
 
     // User-level: {config dir}/{app_name}/config.{ext}
     var base_allocated = false;
@@ -615,7 +635,8 @@ test "findConfigFile: returns null when no config exists" {
     var environ = std.process.Environ.Map.init(testing.allocator);
     defer environ.deinit();
     var allocated = false;
-    const result = findConfigFile(testing.allocator, testing.io, &environ, "nonexistent_xyz", null, nullWriter(), &allocated);
+    var is_project_local = false;
+    const result = findConfigFile(testing.allocator, testing.io, &environ, "nonexistent_xyz", null, nullWriter(), &allocated, &is_project_local);
     try testing.expect(result == null);
 }
 
@@ -623,7 +644,8 @@ test "findConfigFile: custom path returns null for missing file" {
     var environ = std.process.Environ.Map.init(testing.allocator);
     defer environ.deinit();
     var allocated = false;
-    const result = findConfigFile(testing.allocator, testing.io, &environ, "test", "/nonexistent/path.json", nullWriter(), &allocated);
+    var is_project_local = false;
+    const result = findConfigFile(testing.allocator, testing.io, &environ, "test", "/nonexistent/path.json", nullWriter(), &allocated, &is_project_local);
     try testing.expect(result == null);
 }
 


### PR DESCRIPTION
## Summary
- Security-audit finding (LOW, direnv-class): `zcli_config`'s plugin auto-loads a project-local `.{app}.config.{json,toml,yaml,yml}` from the process cwd with no indication — running a zcli-based CLI inside an attacker-controlled directory (e.g. a cloned repo) silently applies attacker-chosen defaults for any option not set via CLI/env. CLI/env always win and values are only type-coerced, so this stays LOW — visibility, not removal, is the fix.
- `preExecute` in `packages/core/src/plugins/zcli_config/plugin.zig` now prints a one-line `note: applied config from ./<path>` to stderr, once per invocation, only when a project-local (cwd) config file is actually loaded and applied. Global/user-level config (home/XDG) and an explicit `--config <path>` stay silent — those aren't cwd-controlled.
- No new plugin config option added; the plugin has no existing verbosity/quiet convention to hook into.

## Test plan
- [x] `zig build test` — all packages pass, including 4 new integration tests: notice fires for a cwd config, does not fire when no cwd config exists, does not fire for an explicit `--config` path, does not fire for a user-level (XDG) config.
- [x] `zig build build-examples`
- [x] `zig fmt --check` on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)