### PR TITLE
Make external Zig-package plugins a first-class extension point

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -108,6 +108,7 @@ pub fn build(b: *std.Build) void {
         .{ .name = "ghauth", .path = "examples/ghauth" },
         .{ .name = "oauth-device", .path = "examples/oauth-device" },
         .{ .name = "notes", .path = "examples/notes" },
+        .{ .name = "ext-plugin", .path = "examples/ext-plugin" },
     };
 
     // Add tests for each project that has them
@@ -149,6 +150,7 @@ pub fn build(b: *std.Build) void {
         .{ .name = "ghauth", .path = "examples/ghauth" },
         .{ .name = "oauth-device", .path = "examples/oauth-device" },
         .{ .name = "notes", .path = "examples/notes" },
+        .{ .name = "ext-plugin", .path = "examples/ext-plugin" },
         .{ .name = "vterm_example", .path = "packages/vterm/example" },
     };
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -146,18 +146,34 @@ Plugins can implement any of these lifecycle hooks:
 
 ### Plugin Integration
 
-Plugins are integrated in `build.zig`:
+Plugins are registered in `build.zig` one of three ways:
+
+- **Built-ins** that ship with zcli — use `zcli.builtin(<tag>, .{...})`.
+- **Third-party plugins shipped as their own Zig package** — depend on the
+  package with `b.dependency(...)` and pass it as `.dependency`. The package
+  must expose a module named `plugin`; see `examples/ext-plugin` for a complete
+  package + consumer pair.
+- **Project-local plugins** living in your own source tree — drop them under
+  `.plugins_dir` and they're auto-discovered (they are *not* listed in
+  `.plugins`). See ADR-0006.
 
 ```zig
-const zcli_build = @import("zcli");
+const zcli = @import("zcli");
+
+// A third-party plugin shipped as its own Zig package.
+const greet_plugin_dep = b.dependency("greet_plugin", .{ .target = target, .optimize = optimize });
 
 const cmd_registry = try zcli.generate(b, exe, zcli_dep, .{
     .commands_dir = "src/commands",
-    .plugins = &[_]zcli_build.PluginConfig{
-        .{ .name = "zcli_help", .path = "packages/core/src/plugins/zcli_help" },
-        .{ .name = "zcli_version", .path = "packages/core/src/plugins/zcli_version" },
-        .{ .name = "zcli_not_found", .path = "packages/core/src/plugins/zcli_not_found" },
+    .plugins = &.{
+        zcli.builtin(.help, .{}),
+        zcli.builtin(.version, .{}),
+        zcli.builtin(.not_found, .{}),
+        // External-package plugin: pass the dependency, not a path.
+        .{ .name = "greet", .dependency = greet_plugin_dep },
     },
+    // Project-local plugins under this directory are auto-discovered.
+    .plugins_dir = "src/plugins",
     .app_name = "myapp",
     .app_description = "My CLI application",
     // Note: Version is automatically read from build.zig.zon

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -828,10 +828,14 @@ Plugins are registered in build.zig:
 ```zig
 const cmd_registry = try zcli.generate(b, exe, zcli_dep, .{
     .plugins = &.{
-        zcli.builtin(.help, .{}),
+        zcli.builtin(.help, .{}),                                 // ships with zcli
         zcli.builtin(.not_found, .{}),
-        .{ .name = "my_plugin", .path = "src/plugins/my_plugin" }, // handrolled
+        // third-party plugin shipped as its own Zig package:
+        .{ .name = "my_plugin", .dependency = b.dependency("my_plugin", .{ .target = target, .optimize = optimize }) },
     },
+    // A plugin in your OWN source tree is auto-discovered instead — drop it
+    // under `.plugins_dir` (not listed here). See ADR-0006 and examples/ext-plugin.
+    .plugins_dir = "src/plugins",
     // ... other config
 });
 ```

--- a/examples/ext-plugin/build.zig
+++ b/examples/ext-plugin/build.zig
@@ -1,0 +1,57 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) !void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const zcli_dep = b.dependency("zcli", .{ .target = target, .optimize = optimize });
+    const zcli_module = zcli_dep.module("zcli");
+
+    // The external plugin, resolved as an ordinary Zig-package dependency. Its
+    // package exposes a module named `plugin`; `generate()` picks it up from
+    // this dependency (see the `.dependency = greet_plugin_dep` plugin entry
+    // below) and injects the `zcli` import into it.
+    const greet_plugin_dep = b.dependency("greet_plugin", .{ .target = target, .optimize = optimize });
+
+    const exe = b.addExecutable(.{
+        .name = "ext-plugin",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    exe.root_module.addImport("zcli", zcli_module);
+
+    const zcli = @import("zcli");
+    const cmd_registry = try zcli.generate(b, exe, zcli_dep, .{
+        .commands_dir = "src/commands",
+        .plugins = &.{
+            zcli.builtin(.help, .{}),
+            zcli.builtin(.version, .{}),
+            zcli.builtin(.not_found, .{}),
+            // A third-party plugin shipped as its own Zig package: pass the
+            // dependency, not a path. This is the first-class external-plugin
+            // extension point (contrast `.plugins_dir` for project-local
+            // plugins, and `zcli.builtin(...)` for the shipped ones).
+            .{ .name = "greet", .dependency = greet_plugin_dep },
+        },
+        .app_name = "ext-plugin",
+        .app_description = "Registering a plugin shipped as an external Zig package",
+    });
+    exe.root_module.addImport("command_registry", cmd_registry);
+
+    b.installArtifact(exe);
+
+    const run_cmd = b.addRunArtifact(exe);
+    run_cmd.step.dependOn(b.getInstallStep());
+    if (b.args) |args| run_cmd.addArgs(args);
+    const run_step = b.step("run", "Run the application");
+    run_step.dependOn(&run_cmd.step);
+
+    _ = zcli.addCommandTests(b, zcli_dep, .{
+        .commands_dir = "src/commands",
+        .target = target,
+        .optimize = optimize,
+    });
+}

--- a/examples/ext-plugin/build.zig.zon
+++ b/examples/ext-plugin/build.zig.zon
@@ -1,0 +1,21 @@
+.{
+    .name = .ext_plugin,
+    .version = "0.1.0",
+    .fingerprint = 0x3a14468c3dc8c9b6,
+    .minimum_zig_version = "0.16.0",
+    .dependencies = .{
+        // Local path because this example lives in-repo (so CI compiles it
+        // against unreleased changes as a drift-detector). Your own project
+        // fetches a released zcli — see the other examples.
+        .zcli = .{ .path = "../.." },
+        // A third-party plugin shipped as its OWN Zig package. Here it's a local
+        // path (it lives in this example's own tree); in the real world it would
+        // be `.url = "git+https://.../greet-plugin#<tag>"` with a hash.
+        .greet_plugin = .{ .path = "greet-plugin" },
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}

--- a/examples/ext-plugin/greet-plugin/build.zig
+++ b/examples/ext-plugin/greet-plugin/build.zig
@@ -1,0 +1,20 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    // Accept the target/optimize the consumer forwards via
+    // `b.dependency("greet_plugin", .{ .target = ..., .optimize = ... })`, so a
+    // plugin package with native code compiles for the CLI's target.
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    // Expose the plugin's entry point under the module name `plugin` — the
+    // contract `zcli.generate()` resolves via `dep.module("plugin")` for an
+    // external-package plugin. That's all a plugin package must do: the
+    // consuming CLI injects the `zcli` import when it registers the plugin, so
+    // this package deliberately has no zcli dependency of its own.
+    _ = b.addModule("plugin", .{
+        .root_source_file = b.path("plugin.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+}

--- a/examples/ext-plugin/greet-plugin/build.zig.zon
+++ b/examples/ext-plugin/greet-plugin/build.zig.zon
@@ -1,0 +1,11 @@
+.{
+    .name = .greet_plugin,
+    .version = "0.1.0",
+    .fingerprint = 0x05402306f619ef87,
+    .minimum_zig_version = "0.16.0",
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "plugin.zig",
+    },
+}

--- a/examples/ext-plugin/greet-plugin/plugin.zig
+++ b/examples/ext-plugin/greet-plugin/plugin.zig
@@ -1,0 +1,41 @@
+//! greet-plugin — a zcli plugin shipped as its OWN Zig package.
+//!
+//! This is the third-party-plugin distribution model: the plugin lives in a
+//! separate package (its own build.zig / build.zig.zon), and a consuming CLI
+//! opts in from build.zig with
+//!
+//!     const greet = b.dependency("greet_plugin", .{ .target = target, .optimize = optimize });
+//!     ... .plugins = &.{ ..., .{ .name = "greet", .dependency = greet } },
+//!
+//! The plugin source is identical to a project-local plugin — the only
+//! difference is where it lives and how it's registered. `zcli.generate()`
+//! injects the consumer's `zcli` import into this module, so this package needs
+//! no zcli dependency of its own (see greet-plugin/build.zig).
+
+const std = @import("std");
+const zcli = @import("zcli");
+
+/// Names this plugin's slot on the context: `context.plugins.greet`.
+pub const plugin_id = "greet";
+
+/// Per-run plugin state. Every field needs a default.
+pub const ContextData = struct {
+    enabled: bool = false,
+};
+
+/// A global `--greet` flag, shown in every command's `--help`.
+pub const global_options = [_]zcli.GlobalOption{
+    zcli.option("greet", bool, .{ .default = false, .description = "Greet before running the command" }),
+};
+
+pub fn handleGlobalOption(context: anytype, name: []const u8, value: anytype) !void {
+    if (std.mem.eql(u8, name, "greet")) context.plugins.greet.enabled = value;
+}
+
+/// preExecute runs before every command; return the (possibly rewritten) args,
+/// or null to halt.
+pub fn preExecute(context: anytype, args: zcli.ParsedArgs) !?zcli.ParsedArgs {
+    if (context.plugins.greet.enabled)
+        try context.stderr().writeAll("hello from the external greet plugin\n");
+    return args;
+}

--- a/examples/ext-plugin/src/commands/hello.zig
+++ b/examples/ext-plugin/src/commands/hello.zig
@@ -1,0 +1,24 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
+
+pub const meta = .{
+    .description = "Print a greeting",
+    .examples = &.{
+        "hello",
+        "hello Ada",
+        "--greet hello Ada", // the external plugin's global flag
+    },
+    .args = .{ .name = "Who to greet (default: world)" },
+};
+
+pub const Args = struct {
+    name: ?[]const u8 = null,
+};
+
+pub const Options = struct {};
+
+pub fn execute(args: Args, _: Options, context: *Context) !void {
+    try context.stdout().print("Hello, {s}!\n", .{args.name orelse "world"});
+    try context.stdout().flush();
+}

--- a/examples/ext-plugin/src/main.zig
+++ b/examples/ext-plugin/src/main.zig
@@ -1,0 +1,11 @@
+const std = @import("std");
+const registry = @import("command_registry");
+
+pub fn main(init: std.process.Init) !void {
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
+    var app = registry.init();
+    app.run(init.gpa, init.io, init.environ_map, args) catch |err| switch (err) {
+        error.CommandNotFound => std.process.exit(1),
+        else => return err,
+    };
+}

--- a/packages/core/src/build_utils/main.zig
+++ b/packages/core/src/build_utils/main.zig
@@ -14,32 +14,22 @@ const DocsConfig = types.DocsConfig;
 
 /// `generate()` failed because of a problem in the consuming project's
 /// configuration. A human-readable explanation has already been printed;
-/// propagate this out of `build()` to stop the build.
-pub const GenerateError = error{CommandDiscoveryFailed};
+/// propagate this out of `build()` to stop the build. Every failure path here
+/// returns one of these rather than exiting/panicking — a library must not kill
+/// the build process itself, and a config mistake must stop the build loudly
+/// instead of silently producing (say) a plugin-less binary.
+pub const GenerateError = error{
+    CommandDiscoveryFailed,
+    PluginDiscoveryFailed,
+    /// A `PluginConfig` set neither `path` nor `dependency` (or set both).
+    PluginConfigInvalid,
+};
 
-/// Link the native libraries the `zcli_secrets` plugin's backend needs for
-/// `target`. macOS: Security + CoreFoundation frameworks. Windows: advapi32.
-/// Linux links **nothing**: its backend reaches the Secret Service (via
-/// `secret-tool`) or `pass` by shelling out at runtime, not by linking, so a
-/// Linux build stays static and works on musl too (ADR-0010). Any other OS has
-/// no secure backend — registering the plugin there is a compile error in the
-/// plugin source. Exposed so the plugin's own test targets can link exactly the
-/// same way a registered app does.
-pub fn linkSecretsBackend(module: *std.Build.Module, target: std.Target) void {
-    switch (target.os.tag) {
-        .macos => {
-            module.linkFramework("Security", .{});
-            module.linkFramework("CoreFoundation", .{});
-        },
-        // Linux shells out (secret-tool / pass) — no library to link, and no
-        // musl incompatibility.
-        .linux => {},
-        .windows => {
-            module.linkSystemLibrary("advapi32", .{});
-        },
-        else => {},
-    }
-}
+/// Re-exported so the zcli_secrets plugin's own test targets (in
+/// packages/core/build.zig) link exactly the same way a registered app does.
+/// The definition lives in types.zig alongside `PluginConfig.link`, which is
+/// the mechanism `generate()` uses to apply it.
+pub const linkSecretsBackend = types.linkSecretsBackend;
 
 // ============================================================================
 // VERSION MANAGEMENT - Read version from build.zig.zon
@@ -119,24 +109,26 @@ fn buildWithPlugins(b: *std.Build, exe: *std.Build.Step.Compile, zcli_dep: *std.
 
     // 1. Discover local plugins. A missing plugins_dir is optional (scan
     //    returns null → no local plugins). Any real failure is surfaced loudly
-    //    with the offending path so a broken plugins_dir can't silently build
-    //    an app with zero plugins (mirrors the command-discovery reporting
-    //    below). We hard-fail via @panic because scanLocalPlugins returns an
-    //    error set (not GenerateError) and there is no recoverable state.
+    //    with the offending path, then propagated out of build() as a
+    //    GenerateError — a broken plugins_dir must stop the build, never
+    //    silently produce an app with zero plugins (mirrors the
+    //    command-discovery reporting below). OOM keeps the std.Build-wide
+    //    `@panic("OOM")` convention: not user-actionable, and loud already.
     const local_plugins: []const types.PluginInfo = if (config.plugins_dir) |dir|
         (plugin_system.scanLocalPlugins(b, dir) catch |err| switch (err) {
             error.InvalidPath => {
                 logging.buildError("Plugin Discovery Error", dir, "Invalid plugins directory path.\nPath contains '..' which is not allowed for security reasons", "Please use a relative path without '..' or an absolute path");
-                std.debug.panic("Plugin discovery failed for '{s}': {s}", .{ dir, @errorName(err) });
+                return error.PluginDiscoveryFailed;
             },
             error.AccessDenied => {
                 logging.buildError("Plugin Discovery Error", dir, "Access denied to plugins directory", "Please check file permissions for the directory");
-                std.debug.panic("Plugin discovery failed for '{s}': {s}", .{ dir, @errorName(err) });
+                return error.PluginDiscoveryFailed;
             },
             error.OutOfMemory => @panic("OOM"),
             else => {
                 logging.buildError("Plugin Discovery Error", dir, "Failed to discover plugins", "Check the plugins directory structure and file permissions");
-                std.debug.panic("Plugin discovery failed for '{s}': {s}", .{ dir, @errorName(err) });
+                std.debug.print("Error details: {any}\n", .{err});
+                return error.PluginDiscoveryFailed;
             },
         }) orelse &.{}
     else
@@ -235,34 +227,61 @@ pub fn generate(b: *std.Build, exe: *std.Build.Step.Compile, zcli_dep: *std.Buil
     const app_version = readVersionFromZon(b);
     const build_date = computeBuildDate(b);
 
-    // Convert plugin configs to PluginInfo array
+    // Convert plugin configs to PluginInfo array. Each explicit plugin is
+    // registered one of two ways (see PluginConfig): a built-in whose source
+    // lives inside the zcli package (`.path` set), or a third-party plugin
+    // shipped as its own Zig package (`.dependency` set). Exactly one must be
+    // set; getting it wrong stops the build loudly.
     var plugins = std.ArrayList(types.PluginInfo).empty;
     defer plugins.deinit(b.allocator);
 
     for (config.plugins) |plugin_config| {
-        plugins.append(b.allocator, .{
-            .name = plugin_config.name,
-            // Plugin path is relative to the zcli package, e.g.
+        if (plugin_config.dependency) |dep| {
+            if (plugin_config.path != null) {
+                logging.buildError("Plugin Config Error", plugin_config.name, "A plugin sets both '.path' and '.dependency'", "Use '.path' (via zcli.builtin) for a built-in, or '.dependency' for an external package — not both");
+                return error.PluginConfigInvalid;
+            }
+            // External package plugin: its module is resolved from the
+            // dependency in module_creation.addPluginModulesToRegistry via
+            // `dep.module("plugin")`; the registry imports it under the
+            // plugin's registration name.
+            plugins.append(b.allocator, .{
+                .name = plugin_config.name,
+                .import_name = plugin_config.name,
+                .is_local = false,
+                .dependency = dep,
+                .init = plugin_config.init,
+            }) catch @panic("OOM");
+        } else if (plugin_config.path) |path| {
+            // Built-in: path is relative to the zcli package, e.g.
             // "packages/core/src/plugins/zcli_help"; appending "/plugin" gives
-            // the import path.
-            .import_name = b.fmt("{s}/plugin", .{plugin_config.path}),
-            .is_local = true, // Plugins are local paths within the zcli package
-            .dependency = null, // No separate dependency needed
-            .init = plugin_config.init,
-        }) catch @panic("OOM");
+            // the import path resolved against the zcli dependency.
+            plugins.append(b.allocator, .{
+                .name = plugin_config.name,
+                .import_name = b.fmt("{s}/plugin", .{path}),
+                .is_local = true,
+                .dependency = null,
+                .init = plugin_config.init,
+            }) catch @panic("OOM");
+        } else {
+            logging.buildError("Plugin Config Error", plugin_config.name, "A plugin sets neither '.path' nor '.dependency'", "Register a built-in with zcli.builtin(), or an external package with '.dependency = b.dependency(...)'");
+            return error.PluginConfigInvalid;
+        }
     }
 
-    // Opt-in native linking. The secrets plugin's native backends call into an
-    // OS keychain, which requires dynamic linking. We add each platform's
-    // libraries to the executable ONLY when the secrets plugin is registered —
-    // so a CLI that does not opt in stays a static, libc-free single binary.
-    // This is the build half of ADR-0003's opt-in guarantee (the source half is
-    // the compile-time backend selection in the plugin). Registering the plugin
-    // for an unsupported OS is a compile error in the plugin source — there is
-    // no insecure file fallback — so `linkSecretsBackend` links nothing there.
+    // Opt-in native linking, driven by each plugin's own `.link` declaration —
+    // no plugin is special-cased by name here. A plugin whose backend calls into
+    // system libraries (the secrets plugin's OS keychain, or an external
+    // plugin's own native deps) sets `PluginConfig.link`; we apply it to the
+    // executable ONLY when that plugin is registered, so a CLI that does not opt
+    // in stays a static, libc-free single binary. This is the build half of
+    // ADR-0003's opt-in guarantee (the source half is the compile-time backend
+    // selection in the plugin). For the secrets plugin on an unsupported OS,
+    // registering it is a compile error in the plugin source (no insecure file
+    // fallback), and its `linkSecretsBackend` hook links nothing there.
     for (config.plugins) |plugin_config| {
-        if (std.mem.eql(u8, plugin_config.name, "zcli_secrets")) {
-            linkSecretsBackend(exe.root_module, exe.rootModuleTarget());
+        if (plugin_config.link) |linkFn| {
+            linkFn(exe.root_module, exe.rootModuleTarget());
         }
     }
 

--- a/packages/core/src/build_utils/plugin_system.zig
+++ b/packages/core/src/build_utils/plugin_system.zig
@@ -125,11 +125,11 @@ pub fn combinePlugins(b: *std.Build, local_plugins: []const PluginInfo, external
     }
 
     const total_len = local_plugins.len + external_plugins.len;
-    const combined = b.allocator.alloc(PluginInfo, total_len) catch {
-        logging.buildError("Plugin System", "memory allocation", "Failed to allocate memory for combined plugin array", "Reduce number of plugins or increase available memory");
-        std.debug.print("Attempted to allocate {} plugin entries.\n", .{total_len});
-        return &.{}; // Return empty slice on failure
-    };
+    // OOM here must never quietly drop every plugin and build a plugin-less
+    // binary — that is exactly the silent failure the discovery paths guard
+    // against. Panic, matching the std.Build-wide `@panic("OOM")` convention
+    // (allocation failure is loud and not user-actionable).
+    const combined = b.allocator.alloc(PluginInfo, total_len) catch @panic("OOM");
 
     // Copy local plugins first
     @memcpy(combined[0..local_plugins.len], local_plugins);

--- a/packages/core/src/build_utils/types.zig
+++ b/packages/core/src/build_utils/types.zig
@@ -99,10 +99,70 @@ pub const BuildConfig = struct {
     build_date: []const u8 = "",
 };
 
-/// Plugin configuration for external plugins
+/// The native libraries a plugin's backend needs, expressed as a hook the
+/// build applies to a module for a given `target`. See `linkSecretsBackend`
+/// for the shape a plugin fills in, and `PluginConfig.link` for how it's wired.
+pub const PluginLinkFn = *const fn (module: *std.Build.Module, target: std.Target) void;
+
+/// Link the native libraries the `zcli_secrets` plugin's backend needs for
+/// `target`. macOS: Security + CoreFoundation frameworks. Windows: advapi32.
+/// Linux links **nothing**: its backend reaches the Secret Service (via
+/// `secret-tool`) or `pass` by shelling out at runtime, not by linking, so a
+/// Linux build stays static and works on musl too (ADR-0010). Any other OS has
+/// no secure backend — registering the plugin there is a compile error in the
+/// plugin source. Exposed so the plugin's own test targets can link exactly the
+/// same way a registered app does.
+///
+/// This is a `PluginLinkFn`: `builtin(.secrets, ...)` wires it onto the plugin
+/// config's `.link` field, so `generate()` applies it via the general
+/// plugin-declared mechanism rather than a name special-case.
+pub fn linkSecretsBackend(module: *std.Build.Module, target: std.Target) void {
+    switch (target.os.tag) {
+        .macos => {
+            module.linkFramework("Security", .{});
+            module.linkFramework("CoreFoundation", .{});
+        },
+        // Linux shells out (secret-tool / pass) — no library to link, and no
+        // musl incompatibility.
+        .linux => {},
+        .windows => {
+            module.linkSystemLibrary("advapi32", .{});
+        },
+        else => {},
+    }
+}
+
+/// Plugin configuration. A plugin is registered one of two ways, mutually
+/// exclusive:
+///
+///   - **built-in** (`path` set): a plugin that ships inside the zcli package.
+///     Use `builtin()` — it fills in `name`/`path`/`link` for you.
+///   - **external package** (`dependency` set): a third-party plugin shipped
+///     as its own Zig package. The consumer does `b.dependency("my_plugin",
+///     .{...})` in build.zig and passes the result here; the package must
+///     expose a module named `plugin` (its entry point). `generate()` injects
+///     the consumer's `zcli` import into it, so the plugin package needs no
+///     zcli dependency of its own.
+///
+/// (A *project-local* plugin — one living in the consuming project's own
+/// source tree — is not registered here at all; it's auto-discovered via
+/// `GenerateConfig.plugins_dir`.)
 pub const PluginConfig = struct {
     name: []const u8,
-    path: []const u8,
+    /// Source path of a built-in plugin *within the zcli package* (e.g.
+    /// "packages/core/src/plugins/zcli_help"). Set by `builtin()`. Mutually
+    /// exclusive with `dependency`; exactly one must be set.
+    path: ?[]const u8 = null,
+    /// A third-party plugin shipped as its own Zig package: the consumer's
+    /// `b.dependency("my_plugin", .{...})`. Mutually exclusive with `path`.
+    dependency: ?*std.Build.Dependency = null,
+    /// Optional native-link hook. When a plugin's backend needs system
+    /// libraries or frameworks, it declares them here; `generate()` applies the
+    /// hook to the executable's root module exactly when the plugin is
+    /// registered — so a CLI that doesn't opt in stays a static single binary.
+    /// `builtin(.secrets, ...)` sets this to `linkSecretsBackend`; an external
+    /// plugin package can export its own `PluginLinkFn` and pass it here.
+    link: ?PluginLinkFn = null,
     /// Optional initialization code to call on the plugin
     /// Example: ".init(.{ .repo = \"user/repo\", .command_name = \"upgrade\" })"
     /// Will generate: const plugin = @import("name")<init_code>;
@@ -129,6 +189,16 @@ pub const Builtin = enum {
     pub fn pluginPath(comptime self: Builtin) []const u8 {
         return "packages/core/src/plugins/zcli_" ++ @tagName(self);
     }
+
+    /// The native-link hook a built-in needs, or null if it links nothing.
+    /// Only `secrets` reaches an OS keychain, so only it declares a hook;
+    /// `builtin()` copies this onto the plugin config's `.link` field.
+    pub fn linkHook(comptime self: Builtin) ?PluginLinkFn {
+        return switch (self) {
+            .secrets => &linkSecretsBackend,
+            else => null,
+        };
+    }
 };
 
 /// Register a built-in plugin in a `generate()` plugins list. Pass `.{}` as the
@@ -138,8 +208,11 @@ pub const Builtin = enum {
 /// .plugins = &.{
 ///     zcli.builtin(.help, .{}),
 ///     zcli.builtin(.github_upgrade, .{ .repo = "user/repo", .command_name = "upgrade" }),
-///     .{ .name = "my_plugin", .path = "src/plugins/my_plugin" }, // handrolled
+///     // A third-party plugin shipped as its own Zig package (see PluginConfig):
+///     .{ .name = "my_plugin", .dependency = b.dependency("my_plugin", .{ .target = target, .optimize = optimize }) },
 /// },
+/// // A plugin living in the consuming project's own tree is NOT listed here —
+/// // it's auto-discovered by dropping it under `.plugins_dir` (ADR-0006).
 /// ```
 ///
 /// The config struct is rendered to the plugin's `.init(.{ ... })` call at
@@ -149,6 +222,7 @@ pub fn builtin(comptime tag: Builtin, comptime config: anytype) PluginConfig {
     return .{
         .name = tag.pluginName(),
         .path = tag.pluginPath(),
+        .link = tag.linkHook(),
         .init = comptime initString(config),
     };
 }
@@ -224,3 +298,52 @@ pub const CommandTestsConfig = struct {
     /// includes the project's local plugins.
     plugins_dir: ?[]const u8 = null,
 };
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+const testing = std.testing;
+
+test "builtin(): produces a path-based PluginConfig, no dependency" {
+    const cfg = builtin(.help, .{});
+    try testing.expectEqualStrings("zcli_help", cfg.name);
+    try testing.expectEqualStrings("packages/core/src/plugins/zcli_help", cfg.path.?);
+    try testing.expectEqual(@as(?*std.Build.Dependency, null), cfg.dependency);
+    // help links nothing native.
+    try testing.expectEqual(@as(?PluginLinkFn, null), cfg.link);
+}
+
+test "builtin(.secrets): wires linkSecretsBackend onto .link" {
+    const cfg = builtin(.secrets, .{});
+    try testing.expectEqualStrings("zcli_secrets", cfg.name);
+    // The native-link needs are declared by the plugin's config, not by a
+    // name special-case in generate(). Only secrets declares a hook.
+    try testing.expect(cfg.link != null);
+    try testing.expectEqual(@as(PluginLinkFn, &linkSecretsBackend), cfg.link.?);
+}
+
+test "Builtin.linkHook: only secrets declares a native-link hook" {
+    inline for (@typeInfo(Builtin).@"enum".fields) |field| {
+        const tag = @field(Builtin, field.name);
+        const hook = comptime tag.linkHook();
+        if (tag == .secrets) {
+            try testing.expect(hook != null);
+        } else {
+            try testing.expectEqual(@as(?PluginLinkFn, null), hook);
+        }
+    }
+}
+
+test "PluginConfig: an external-package plugin sets .dependency, not .path" {
+    // The value a consumer writes for a third-party plugin shipped as a Zig
+    // package: name + dependency, no path. (A real *std.Build.Dependency can't
+    // be built in a unit test, so this exercises the field shape/defaults that
+    // generate() dispatches on; the end-to-end wiring is covered by the
+    // ext-plugin example under build-examples.)
+    const cfg = PluginConfig{ .name = "greet", .path = null };
+    try testing.expectEqualStrings("greet", cfg.name);
+    try testing.expectEqual(@as(?[]const u8, null), cfg.path);
+    try testing.expectEqual(@as(?*std.Build.Dependency, null), cfg.dependency);
+    try testing.expectEqual(@as(?PluginLinkFn, null), cfg.link);
+}

--- a/website/content/docs/build.smd
+++ b/website/content/docs/build.smd
@@ -40,8 +40,8 @@ The config:
 | `commands_dir` | required | directory scanned for command files |
 | `app_name` | required | your binary's name, used in help and errors |
 | `app_description` | required | one-liner shown at the top of `--help` |
-| `plugins` | `&.{}` | explicit plugin list — `zcli.builtin(...)` tags and `.{ .name, .path }` entries |
-| `plugins_dir` | `null` | a folder of your own plugins, auto-discovered |
+| `plugins` | `&.{}` | explicit plugin list — `zcli.builtin(...)` for shipped plugins, or `.{ .name, .dependency = b.dependency(...) }` for a third-party plugin shipped as its own Zig package |
+| `plugins_dir` | `null` | a folder of your own project-local plugins, auto-discovered |
 | `shared_modules` | `null` | modules importable from every command |
 
 **There is no version field.** The app version is read from `build.zig.zon`'s `.version` at build time — one source of truth, surfaced as `context.app_version` and `--version`.


### PR DESCRIPTION
## Problem

The external-plugin extension point was half-built. `generate()` hardcoded every explicit plugin as `.is_local = true, .dependency = null`, so the `dependency` branch of `addPluginModulesToRegistry` — the only path for a third-party plugin shipped as a Zig package — was **unreachable from the public API**. The only working consumer path was `plugins_dir` discovery. Two adjacent problems: the secrets plugin's native linking was a hardcoded `std.mem.eql(name, "zcli_secrets")` special-case (no hook for an external plugin needing system libs), and several build_utils failure paths were unsafe.

## Design

**Finding 1 — external plugins as Zig packages.** `PluginConfig` now carries a mutually-exclusive `.dependency: ?*std.Build.Dependency` alongside `.path`. A consumer does `b.dependency("my_plugin", .{...})` in their build.zig and passes it:

```zig
const greet = b.dependency("greet_plugin", .{ .target = target, .optimize = optimize });
.plugins = &.{
    zcli.builtin(.help, .{}),
    .{ .name = "greet", .dependency = greet },   // external package
},
```

The plugin package exposes a module named `plugin`; `generate()` resolves it via `dep.module("plugin")`, injects the consumer's `zcli` import, and imports it into the registry under the plugin's name. This makes the dormant `module_creation.zig` dependency branch reachable and correct. New end-to-end example **`examples/ext-plugin`** (a `greet-plugin` package + a consumer CLI) proves the path under CI (`build-examples` + `test`). The misleading `.path = "src/plugins/my_plugin" // handrolled` doc example is replaced with the two real paths (plugins_dir for project-local, dependency for external packages).

**Finding 2 — general native-link mechanism.** Removed the string special-case. `PluginConfig` gains an optional `.link: ?PluginLinkFn` hook, applied to the executable exactly when the plugin is registered. `builtin(.secrets, ...)` wires `linkSecretsBackend` via a new `Builtin.linkHook()`; an external plugin package can export and pass its own `PluginLinkFn`. `linkSecretsBackend` moved to `types.zig` (re-exported from `main.zig` for the plugin's own test targets). No plugin name is special-cased in core.

**Finding 3 — unified failure semantics.** Plugin-discovery failures now `return error.PluginDiscoveryFailed` (mirroring the existing `CommandDiscoveryFailed` pattern) instead of `@panic`. `combinePlugins` OOM now `@panic("OOM")` (loud, matches the std.Build-wide convention) instead of silently returning an empty slice and building a plugin-less binary. New `GenerateError` variants: `PluginDiscoveryFailed`, `PluginConfigInvalid` (the latter fires when a `PluginConfig` sets neither or both of `.path`/`.dependency`).

## Tests

- `zig build test` — pass (all subprojects, including new `ext-plugin`)
- `zig build build-examples` — pass
- New unit tests in `types.zig` for `builtin()`, `Builtin.linkHook()` (only `.secrets` declares a hook), and the external-package `PluginConfig` field shape.
- Manual: `ext-plugin --greet hello Ada` prints the command output plus the external plugin's `preExecute` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)