### PR TITLE
Unify global-option parsing through the single source of truth

### DIFF
--- a/packages/core/src/plugin_types.zig
+++ b/packages/core/src/plugin_types.zig
@@ -1,137 +1,97 @@
 const std = @import("std");
 const zcli = @import("zcli.zig");
 const identifier = @import("identifier.zig");
+const option_utils = @import("options/utils.zig");
+const custom_type = @import("custom_type.zig");
 const testing = std.testing;
 
 // ============================================================================
 // Core Plugin Types
 // ============================================================================
 
-/// Global option that can be registered by plugins
+/// Global option that can be registered by plugins.
+///
+/// A global option is parsed by the *same* pipeline command options, env, and
+/// config use (`option_utils.parseOptionValue`) — the single source of truth —
+/// so it supports the full type set: bool flags, integers, floats, enums,
+/// `[]const u8`, custom `parse` types, and optionals of those. There is no
+/// second, weaker parser.
 pub const GlobalOption = struct {
     name: []const u8,
     short: ?u8 = null,
     type: type,
-    default: DefaultValue,
+    /// The declared (or synthesized) default, type-erased so every GlobalOption
+    /// is one concrete struct type storable in a `[]const GlobalOption`. It
+    /// points at a comptime value of `type`; recover it with `defaultValue`. A
+    /// GlobalOption carries a `type` field, so it only ever exists at comptime.
+    default: *const anyopaque,
     description: []const u8,
     category: ?[]const u8 = null,
 
-    pub fn validate(self: @This(), value: anytype) !void {
-        // Default validation - can be overridden
-        _ = self;
-        _ = value;
-    }
-
-    pub fn getDefaultAsString(self: @This(), allocator: std.mem.Allocator) ![]const u8 {
-        return self.default.toString(allocator);
+    /// The stored default typed as `T` (which must be `self.type`).
+    pub fn defaultValue(comptime self: @This(), comptime T: type) T {
+        return @as(*const T, @ptrCast(@alignCast(self.default))).*;
     }
 };
 
-/// Union to store default values of different types
-pub const DefaultValue = union(enum) {
-    string: []const u8,
-    boolean: bool,
-    integer: i64,
-    unsigned: u64,
-    float: f64,
-    none,
-
-    pub fn toString(self: DefaultValue, allocator: std.mem.Allocator) ![]const u8 {
-        return switch (self) {
-            .string => |s| s,
-            .boolean => |b| if (b) "true" else "false",
-            .integer => |i| try std.fmt.allocPrint(allocator, "{d}", .{i}),
-            .unsigned => |u| try std.fmt.allocPrint(allocator, "{d}", .{u}),
-            .float => |f| try std.fmt.allocPrint(allocator, "{d}", .{f}),
-            .none => "",
-        };
-    }
-};
-
-/// Unified helper function for creating GlobalOptions with better ergonomics
-/// The types a global option may declare: bool, integers, floats, strings,
-/// and optionals of those — exactly what the registry's converter handles.
-fn validateGlobalOptionType(comptime name: []const u8, comptime T: type) void {
-    // Labeled switch: optionals re-dispatch on their child instead of
-    // duplicating the base-type arms — mirroring convertGlobalValue's
-    // recursion, so validator and converter agree on nested optionals.
-    const ok = blk: switch (@typeInfo(T)) {
-        .bool, .int, .float => true,
-        .pointer => |ptr| ptr.size == .slice and ptr.child == u8 and ptr.is_const,
-        .optional => |opt| continue :blk @typeInfo(opt.child),
+/// Whether `option_utils.parseOptionValue` can coerce a string into `T` — the
+/// single source of truth the CLI, env, and config already use. Mirrors that
+/// function's type switch exactly, so the declaration-time validator and the
+/// runtime converter never disagree. (`bool` is handled separately as a
+/// presence flag, so it is intentionally absent here.)
+fn parseableByOptionValue(comptime T: type) bool {
+    return switch (@typeInfo(T)) {
+        .int, .float, .@"enum" => true,
+        .pointer => |ptr| ptr.size == .slice and ptr.child == u8,
+        .optional => |opt| parseableByOptionValue(opt.child),
+        .@"struct", .@"union" => custom_type.isCustomParsed(T),
         else => false,
     };
-    if (!ok) {
-        @compileError("global option '" ++ name ++ "' has unsupported type `" ++ @typeName(T) ++
-            "`. Supported: bool, integers, floats, []const u8, and optionals of those.");
-    }
 }
 
+/// The types a global option may declare: a `bool` presence flag, or anything
+/// the shared option parser handles. Rejected at the point of declaration — not
+/// at some later use site with a baffling error.
+fn validateGlobalOptionType(comptime name: []const u8, comptime T: type) void {
+    if (T == bool or parseableByOptionValue(T)) return;
+    @compileError("global option '" ++ name ++ "' has unsupported type `" ++ @typeName(T) ++
+        "`. Supported: bool, integers, floats, enums, []const u8, custom `parse` types, and optionals of those.");
+}
+
+/// A synthesized default for a global option declared without one. Only read by
+/// introspection (`GlobalOption.defaultValue`); an absent global never fires its
+/// handler, so this value is never delivered to a plugin.
+fn zeroDefault(comptime T: type) T {
+    return switch (@typeInfo(T)) {
+        .optional => null,
+        .@"enum" => |e| @field(T, e.fields[0].name),
+        .pointer => "", // []const u8
+        else => std.mem.zeroes(T),
+    };
+}
+
+/// Unified helper for declaring a GlobalOption. The default is stored typed
+/// (as a comptime value of `T`), so there is no stringly default round-trip —
+/// `parseOptionValue` is the only value coercion the pipeline performs.
 pub fn option(comptime name: []const u8, comptime T: type, comptime config: anytype) GlobalOption {
-    // Reject types the global-option pipeline cannot convert, at the point
-    // of declaration — not at some later use site with a baffling error.
     comptime validateGlobalOptionType(name, T);
 
-    // Extract fields from config, providing defaults if not present
     const short = if (@hasField(@TypeOf(config), "short")) config.short else null;
     const description = if (@hasField(@TypeOf(config), "description")) config.description else "";
     const category = if (@hasField(@TypeOf(config), "category")) config.category else null;
-    const has_default = @hasField(@TypeOf(config), "default");
-    const default_value = if (!has_default) blk: {
-        // No default provided, create appropriate "zero" value
-        break :blk switch (@typeInfo(T)) {
-            .bool => DefaultValue{ .boolean = false },
-            .int => |int_info| if (int_info.signedness == .signed)
-                DefaultValue{ .integer = 0 }
-            else
-                DefaultValue{ .unsigned = 0 },
-            .float => DefaultValue{ .float = 0.0 },
-            .pointer => |ptr_info| if (ptr_info.size == .slice and ptr_info.child == u8)
-                DefaultValue{ .string = "" }
-            else
-                DefaultValue{ .none = {} },
-            .optional => DefaultValue{ .none = {} },
-            else => DefaultValue{ .none = {} },
-        };
-    } else blk: {
-        // Convert provided default to DefaultValue
-        const default_val = config.default;
-        break :blk switch (@TypeOf(default_val)) {
-            bool => DefaultValue{ .boolean = default_val },
-            comptime_int, u8, u16, u32, u64, usize => DefaultValue{ .unsigned = @as(u64, default_val) },
-            i8, i16, i32, i64, isize => DefaultValue{ .integer = @as(i64, default_val) },
-            f32, f64, comptime_float => DefaultValue{ .float = @as(f64, default_val) },
-            []const u8 => DefaultValue{ .string = default_val },
-            else => blk_inner: {
-                // Handle string literals and other pointer types
-                const type_info = @typeInfo(@TypeOf(default_val));
-                if (type_info == .pointer) {
-                    const ptr_info = type_info.pointer;
-                    // Handle both string slices and string literals
-                    if (ptr_info.child == u8 or @typeInfo(ptr_info.child) == .array) {
-                        const array_info = @typeInfo(ptr_info.child);
-                        if (array_info == .array and array_info.array.child == u8) {
-                            break :blk_inner DefaultValue{ .string = default_val };
-                        } else if (ptr_info.child == u8) {
-                            break :blk_inner DefaultValue{ .string = default_val };
-                        } else {
-                            @compileError("Unsupported pointer type: " ++ @typeName(@TypeOf(default_val)));
-                        }
-                    } else {
-                        @compileError("Unsupported pointer type: " ++ @typeName(@TypeOf(default_val)));
-                    }
-                } else {
-                    @compileError("Unsupported default value type: " ++ @typeName(@TypeOf(default_val)));
-                }
-            },
-        };
-    };
+    // Coerce the declared default (or a synthesized zero) to the field type once,
+    // at comptime, and hand back a pointer to that comptime value. Being
+    // comptime-known, the value has static lifetime.
+    const default_value: T = if (@hasField(@TypeOf(config), "default")) config.default else zeroDefault(T);
 
     return GlobalOption{
         .name = name,
         .short = short,
         .type = T,
-        .default = default_value,
+        // @ptrCast: a pointer to a slice-typed default (`*const []const u8`) is a
+        // double pointer that won't implicitly coerce to anyopaque; the cast is
+        // exact and `defaultValue` casts straight back to `*const T`.
+        .default = @ptrCast(&default_value),
         .description = description,
         .category = category,
     };

--- a/packages/core/src/registry/compiled.zig
+++ b/packages/core/src/registry/compiled.zig
@@ -36,21 +36,14 @@ fn reportParseError(context: anytype, diag: ?zcli.ZcliDiagnostic) !void {
     try stderr.flush();
 }
 
-/// Convert a global option's argv string to its declared type. Covers the
-/// full set plugin_types.option() accepts (validated at declaration, so the
-/// compile-error backstop here is unreachable for declared options).
+/// Convert a global option's argv string to its declared type through the
+/// single source of truth — the same `parseOptionValue` command options, env,
+/// and config use — so enums, ints, floats, strings, optionals, and custom
+/// `parse` types all coerce identically. A `bool` global is the one exception:
+/// it is a presence flag whose value is the sentinel "true" (no token consumed).
 fn convertGlobalValue(comptime T: type, value: []const u8) !T {
-    return switch (@typeInfo(T)) {
-        .bool => std.mem.eql(u8, value, "true"),
-        .int => try std.fmt.parseInt(T, value, 10),
-        .float => try std.fmt.parseFloat(T, value),
-        .optional => |opt| try convertGlobalValue(opt.child, value),
-        .pointer => |ptr| if (ptr.size == .slice and ptr.child == u8)
-            value
-        else
-            @compileError("Unsupported global option type: " ++ @typeName(T)),
-        else => @compileError("Unsupported global option type: " ++ @typeName(T)),
-    };
+    if (T == bool) return std.mem.eql(u8, value, "true");
+    return option_utils.parseOptionValue(T, value);
 }
 
 /// Errors that execute() reports to the user before returning them — the

--- a/packages/core/src/registry/tests.zig
+++ b/packages/core/src/registry/tests.zig
@@ -1095,9 +1095,15 @@ test "parse errors run onError with context.diagnostic populated" {
 // supported category (also exercising declaration-time type validation),
 // records what handleGlobalOption receives, and captures parse failures.
 const TypedGlobalsPlugin = struct {
+    // An enum-typed global exercises the single-source-of-truth parser: it is
+    // coerced by the same `parseOptionValue` a command option/env/config value
+    // is, so enums Just Work with no per-type ladder in the global pipeline.
+    const Mode = enum { fast, slow };
+
     var level: i64 = -1;
     var ratio: f64 = 0;
     var label: []const u8 = "";
+    var mode: ?Mode = null;
     var verbose: bool = false;
     var debug: bool = false;
     var captured_err: ?anyerror = null;
@@ -1108,6 +1114,7 @@ const TypedGlobalsPlugin = struct {
         level = -1;
         ratio = 0;
         label = "";
+        mode = null;
         verbose = false;
         debug = false;
         captured_err = null;
@@ -1119,6 +1126,7 @@ const TypedGlobalsPlugin = struct {
         zcli.option("level", i64, .{ .short = 'l', .description = "level" }),
         zcli.option("ratio", f64, .{ .description = "ratio" }),
         zcli.option("label", []const u8, .{ .description = "label" }),
+        zcli.option("mode", Mode, .{ .short = 'm', .default = .slow, .description = "mode" }),
         zcli.option("verbose", bool, .{ .short = 'v', .description = "verbose" }),
         zcli.option("debug", bool, .{ .short = 'd', .description = "debug" }),
     };
@@ -1132,6 +1140,8 @@ const TypedGlobalsPlugin = struct {
             ratio = value;
         } else if (comptime T == []const u8) {
             label = value;
+        } else if (comptime T == Mode) {
+            mode = value;
         } else if (comptime T == bool) {
             if (std.mem.eql(u8, name, "verbose")) verbose = value;
             if (std.mem.eql(u8, name, "debug")) debug = value;
@@ -1242,6 +1252,55 @@ test "global options: missing and invalid values produce diagnostics" {
     try testing.expectEqual(@as(?anyerror, error.OptionInvalidValue), TypedGlobalsPlugin.captured_err);
     try testing.expectEqualStrings("abc", TypedGlobalsPlugin.captured_diag.?.OptionInvalidValue.provided_value);
     try testing.expectEqualStrings("i64", TypedGlobalsPlugin.captured_diag.?.OptionInvalidValue.expected_type);
+}
+
+// An enum-typed global option now flows through the same parser command
+// options/env/config use — the capability the old bool/int/float/string
+// converter lacked. A good variant name coerces to the enum; a bad one produces
+// the standard OptionInvalidValue diagnostic; the declared default is retained
+// typed (no stringly round-trip).
+test "global options: enum-typed global parses, rejects, and defaults" {
+    const TestApp = typedGlobalsApp();
+    var app = TestApp.init();
+    const test_environ = std.process.Environ.Map.init(testing.allocator);
+
+    // A valid variant name coerces to the enum value.
+    TypedGlobalsPlugin.reset();
+    try runQuiet(&app, &test_environ, &.{ "--mode", "fast", "ping" });
+    try testing.expectEqual(@as(?TypedGlobalsPlugin.Mode, .fast), TypedGlobalsPlugin.mode);
+    try testing.expect(TypedGlobalsPlugin.command_ran);
+
+    // The short form reaches the same parser.
+    TypedGlobalsPlugin.reset();
+    try runQuiet(&app, &test_environ, &.{ "-m", "slow", "ping" });
+    try testing.expectEqual(@as(?TypedGlobalsPlugin.Mode, .slow), TypedGlobalsPlugin.mode);
+
+    // An unknown variant is the standard invalid-value diagnostic, not a
+    // silent miss — exactly as a command option would report it.
+    TypedGlobalsPlugin.reset();
+    try runQuiet(&app, &test_environ, &.{ "--mode", "sideways", "ping" });
+    try testing.expectEqual(@as(?anyerror, error.OptionInvalidValue), TypedGlobalsPlugin.captured_err);
+    try testing.expectEqualStrings("sideways", TypedGlobalsPlugin.captured_diag.?.OptionInvalidValue.provided_value);
+    try testing.expectEqualStrings("mode", TypedGlobalsPlugin.captured_diag.?.OptionInvalidValue.option_name);
+}
+
+// The typed default is stored as a comptime value of the option's type (no
+// stringly DefaultValue round-trip) and recovered with `defaultValue`.
+test "global options: defaultValue recovers the typed comptime default" {
+    const opts = TypedGlobalsPlugin.global_options;
+    // `mode` was declared `.default = .slow`.
+    inline for (opts) |opt| {
+        if (comptime std.mem.eql(u8, opt.name, "mode")) {
+            try testing.expectEqual(TypedGlobalsPlugin.Mode.slow, opt.defaultValue(opt.type));
+        }
+        // A global declared without a default gets a synthesized typed zero.
+        if (comptime std.mem.eql(u8, opt.name, "level")) {
+            try testing.expectEqual(@as(i64, 0), opt.defaultValue(opt.type));
+        }
+        if (comptime std.mem.eql(u8, opt.name, "label")) {
+            try testing.expectEqualStrings("", opt.defaultValue(opt.type));
+        }
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Finding
Global options were a second, parallel option system with a weaker parser and dead code. Command options/env/config all coerce through the single source of truth (`option_utils.parseOptionValue`, documented at `zcli.zig:85-103`); global options instead got a bool/int/float/string converter, a stringly `DefaultValue` round-trip with a ~70-line comptime ladder, and a `GlobalOption.validate` stub called from nowhere.

## Changes
1. **Route global-option values through `parseOptionValue`.** Global options now support the full type set — enums, ints, floats, strings, optionals, and custom `parse` types — identical to command options. `bool` stays a presence flag. Invalid values raise the standard `OptionInvalidValue` diagnostic. (`registry/compiled.zig`: `convertGlobalValue` 16 lines → 8.)
2. **Store typed comptime defaults.** The declared default is coerced to the option's type once at comptime and kept type-erased behind `default: *const anyopaque` + a `defaultValue(T)` accessor. Deleted the `DefaultValue` union, its `toString`, `getDefaultAsString`, and the entire `option()` default ladder.
3. **Deleted the dead `GlobalOption.validate`.**
4. `validateGlobalOptionType` now mirrors `parseOptionValue`'s supported set exactly, so the declaration-time check and the runtime converter never disagree.

Help rendering (`global_options_info` → `OptionInfo`) is unaffected — it never read `default`; `enum_values`/`takes_value` still derive from `global_opt.type`.

## Tests
Added to `registry/tests.zig` (extending the existing `TypedGlobalsPlugin`):
- enum-typed global parses a valid variant (long and short form)
- unknown variant produces the standard `OptionInvalidValue` diagnostic
- `defaultValue` recovers the typed comptime default (`.slow`), and a no-default global gets a synthesized typed zero

Existing ~6 global-option pipeline tests in `zcli.zig` and `registry/tests.zig` stay green unchanged (they pass `.default` and never inspected the stringly form).

## Verification
- `zig build test` — pass (core: 41/41 steps, 1526/1528 tests, 2 skipped baseline; full tree exit 0)
- `zig build build-examples` — pass

Production type-dispatch delta: **-47 lines** (113 removed, 66 added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)