### PR TITLE
fix(core): sanitize terminal escapes in echoed argv, add plugin coverage

### DIFF
--- a/packages/core/src/diagnostic_errors.zig
+++ b/packages/core/src/diagnostic_errors.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const levenshtein = @import("levenshtein.zig");
 const custom_type = @import("custom_type.zig");
+const Writer = std.Io.Writer;
 
 pub const ZcliError = error{
     // Argument parsing errors
@@ -317,6 +318,25 @@ fn humanType(type_name: []const u8) []const u8 {
     return "a value";
 }
 
+/// Write `s` to `w`, dropping C0 control bytes (0x00-0x1F) and DEL (0x7F)
+/// except `\t` (0x09) and `\n` (0x0A). Every diagnostic-rendering boundary
+/// runs the user-controlled slice of its message (an unknown command name,
+/// an unknown option name, a rejected argument/option value) through this
+/// before it reaches the terminal. Without it, a crafted value containing an
+/// ESC byte can smuggle a raw ANSI/OSC escape sequence — e.g. a window-title
+/// set or an OSC 52 clipboard write — straight through to the user's
+/// terminal. UTF-8 multibyte sequences pass through untouched: both
+/// continuation bytes (0x80-0xBF) and lead bytes (0xC0 and up) fall outside
+/// the stripped range.
+pub fn writeSanitized(w: *Writer, s: []const u8) Writer.Error!void {
+    for (s) |c| {
+        switch (c) {
+            0x00...0x08, 0x0B...0x1F, 0x7F => {}, // drop control bytes, incl. ESC (0x1b); \t/\n fall through below
+            else => try w.writeByte(c),
+        }
+    }
+}
+
 /// Get a user-friendly description of a diagnostic
 pub fn formatDiagnostic(diagnostic: ZcliDiagnostic, allocator: std.mem.Allocator) ![]u8 {
     return switch (diagnostic) {
@@ -612,6 +632,38 @@ test "invalid enum value messages carry a did-you-mean" {
         defer allocator.free(msg);
         try std.testing.expect(std.mem.indexOf(u8, msg, "Did you mean 'info'?") != null);
     }
+}
+
+test "writeSanitized strips ESC and other C0 control bytes" {
+    var aw: Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    try writeSanitized(&aw.writer, "before\x1bafter");
+    try std.testing.expectEqualStrings("beforeafter", aw.written());
+}
+
+test "writeSanitized neuters a full OSC escape sequence" {
+    var aw: Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    // OSC 0 (set window title), BEL-terminated — the ESC and BEL are the
+    // bytes a terminal parses as the start/end of the sequence; stripping
+    // them leaves inert text behind instead of a live escape sequence.
+    try writeSanitized(&aw.writer, "\x1b]0;pwned\x07");
+    try std.testing.expectEqualStrings("]0;pwned", aw.written());
+}
+
+test "writeSanitized drops DEL but preserves \\n and \\t" {
+    var aw: Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    try writeSanitized(&aw.writer, "a\tb\nc\x7fd");
+    try std.testing.expectEqualStrings("a\tb\ncd", aw.written());
+}
+
+test "writeSanitized leaves plain UTF-8 (including multibyte) untouched" {
+    var aw: Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    const s = "caf\xc3\xa9 \xe4\xbd\xa0\xe5\xa5\xbd \xf0\x9f\x9a\x80"; // "café 你好 🚀"
+    try writeSanitized(&aw.writer, s);
+    try std.testing.expectEqualStrings(s, aw.written());
 }
 
 test "expectedTypeName lists enum variants" {

--- a/packages/core/src/plugins/zcli_not_found/plugin.zig
+++ b/packages/core/src/plugins/zcli_not_found/plugin.zig
@@ -131,8 +131,13 @@ fn generateCommandNotFoundHelp(
 ) !void {
     var writer = context.stderr();
 
-    // Error header
-    try writer.print("Error: Unknown command '{s}'\n\n", .{attempted_command});
+    // Error header. `attempted_command` is the raw, mistyped argv joined back
+    // together — sanitize it so a crafted argument carrying an ANSI/OSC
+    // escape sequence (e.g. a title-bar set or clipboard write) can't reach
+    // the terminal raw.
+    try writer.print("Error: Unknown command '", .{});
+    try zcli.writeSanitized(writer, attempted_command);
+    try writer.print("'\n\n", .{});
 
     // Safety check for available_commands
     if (available_commands.len == 0) {
@@ -326,4 +331,234 @@ test "isCommandGroup detects prefixes but not leaves or unknowns" {
 fn freeSuggestions(allocator: std.mem.Allocator, suggestions: [][]const u8) void {
     for (suggestions) |s| allocator.free(s);
     allocator.free(suggestions);
+}
+
+// ===========================================================================
+// onError: the plugin's 3-case contract (see the module doc comment above)
+// ===========================================================================
+
+test "onError case 1: a close typo gets a 'did you mean' suggestion" {
+    // `onError` allocates (joins, suggestion dupes) and, like the production
+    // registry, relies on an arena being torn down wholesale rather than
+    // freeing each piece — so context.allocator is arena-backed here too,
+    // not the leak-checking testing.allocator directly.
+    const gpa = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(gpa);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const Ctx = zcli.TestContext(&.{});
+    var stdio: zcli.Stdio = undefined;
+    stdio.init(std.testing.io);
+    var aw: std.Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    stdio.stderr_override = &aw.writer;
+
+    const environ = std.process.Environ.Map.init(allocator);
+    var ctx = Ctx.init(allocator, std.testing.io, &stdio, &environ);
+    defer ctx.deinit();
+
+    ctx.command_path = &.{"serach"}; // typo of "search"
+    ctx.plugin_command_info = &.{
+        .{ .path = &.{"search"}, .description = "Search things" },
+        .{ .path = &.{"status"}, .description = "Show status" },
+    };
+
+    const handled = try onError(&ctx, error.CommandNotFound);
+    try ctx.stderr().flush();
+
+    // Case 1 is never "handled" — the error must keep propagating so the
+    // process exits non-zero (see the module doc comment).
+    try std.testing.expect(!handled);
+
+    const out = aw.written();
+    try std.testing.expect(std.mem.indexOf(u8, out, "Unknown command 'serach'") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "Did you mean 'search'?") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "Available commands:") != null);
+}
+
+test "onError case 1: a distant input gets no suggestion, just the command list" {
+    // `onError` allocates (joins, suggestion dupes) and, like the production
+    // registry, relies on an arena being torn down wholesale rather than
+    // freeing each piece — so context.allocator is arena-backed here too,
+    // not the leak-checking testing.allocator directly.
+    const gpa = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(gpa);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const Ctx = zcli.TestContext(&.{});
+    var stdio: zcli.Stdio = undefined;
+    stdio.init(std.testing.io);
+    var aw: std.Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    stdio.stderr_override = &aw.writer;
+
+    const environ = std.process.Environ.Map.init(allocator);
+    var ctx = Ctx.init(allocator, std.testing.io, &stdio, &environ);
+    defer ctx.deinit();
+
+    ctx.command_path = &.{"xyzzyplugh"}; // unrelated to any known command
+    ctx.plugin_command_info = &.{
+        .{ .path = &.{"search"}, .description = "Search things" },
+        .{ .path = &.{"status"}, .description = "Show status" },
+    };
+
+    const handled = try onError(&ctx, error.CommandNotFound);
+    try ctx.stderr().flush();
+
+    try std.testing.expect(!handled);
+
+    const out = aw.written();
+    try std.testing.expect(std.mem.indexOf(u8, out, "Unknown command 'xyzzyplugh'") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "Did you mean") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "Available commands:") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "search") != null);
+}
+
+test "onError case 2: a bare known group renders its subcommands and is handled" {
+    // `onError` allocates (joins, suggestion dupes) and, like the production
+    // registry, relies on an arena being torn down wholesale rather than
+    // freeing each piece — so context.allocator is arena-backed here too,
+    // not the leak-checking testing.allocator directly.
+    const gpa = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(gpa);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const Ctx = zcli.TestContext(&.{});
+    var stdio: zcli.Stdio = undefined;
+    stdio.init(std.testing.io);
+    var aw: std.Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    stdio.stderr_override = &aw.writer;
+
+    const environ = std.process.Environ.Map.init(allocator);
+    var ctx = Ctx.init(allocator, std.testing.io, &stdio, &environ);
+    defer ctx.deinit();
+
+    // "remote" is a strict prefix of two commands — a group, not a typo.
+    ctx.command_path = &.{"remote"};
+    ctx.plugin_command_info = &.{
+        .{ .path = &.{ "remote", "add" }, .description = "Add a remote" },
+        .{ .path = &.{ "remote", "remove" }, .description = "Remove a remote" },
+        .{ .path = &.{"status"}, .description = "Show status" },
+    };
+
+    const handled = try onError(&ctx, error.CommandNotFound);
+    try ctx.stderr().flush();
+
+    // Case 2 is handled — the registry must not also print its own group line.
+    try std.testing.expect(handled);
+
+    const out = aw.written();
+    try std.testing.expect(std.mem.indexOf(u8, out, "'remote' is a command group.") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "Subcommands:") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "add") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "remove") != null);
+    // Not a typo, so no "did you mean" noise.
+    try std.testing.expect(std.mem.indexOf(u8, out, "Did you mean") == null);
+}
+
+test "onError case 3: no command at all renders the top-level list and is handled" {
+    // `onError` allocates (joins, suggestion dupes) and, like the production
+    // registry, relies on an arena being torn down wholesale rather than
+    // freeing each piece — so context.allocator is arena-backed here too,
+    // not the leak-checking testing.allocator directly.
+    const gpa = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(gpa);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const Ctx = zcli.TestContext(&.{});
+    var stdio: zcli.Stdio = undefined;
+    stdio.init(std.testing.io);
+    var aw: std.Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    stdio.stderr_override = &aw.writer;
+
+    const environ = std.process.Environ.Map.init(allocator);
+    var ctx = Ctx.init(allocator, std.testing.io, &stdio, &environ);
+    defer ctx.deinit();
+
+    ctx.command_path = &.{}; // nothing named at all
+    ctx.plugin_command_info = &.{
+        .{ .path = &.{"search"}, .description = "Search things" },
+        .{ .path = &.{"status"}, .description = "Show status" },
+    };
+
+    const handled = try onError(&ctx, error.CommandNotFound);
+    try ctx.stderr().flush();
+
+    // Case 3 is handled — the registry's bare "No command specified" line is
+    // suppressed since this plugin already rendered the richer version.
+    try std.testing.expect(handled);
+
+    const out = aw.written();
+    try std.testing.expect(std.mem.indexOf(u8, out, "No command specified.") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "Available commands:") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "search") != null);
+}
+
+test "onError ignores errors other than CommandNotFound" {
+    // `onError` allocates (joins, suggestion dupes) and, like the production
+    // registry, relies on an arena being torn down wholesale rather than
+    // freeing each piece — so context.allocator is arena-backed here too,
+    // not the leak-checking testing.allocator directly.
+    const gpa = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(gpa);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const Ctx = zcli.TestContext(&.{});
+    var stdio: zcli.Stdio = undefined;
+    stdio.init(std.testing.io);
+    var aw: std.Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    stdio.stderr_override = &aw.writer;
+
+    const environ = std.process.Environ.Map.init(allocator);
+    var ctx = Ctx.init(allocator, std.testing.io, &stdio, &environ);
+    defer ctx.deinit();
+
+    const handled = try onError(&ctx, error.OptionUnknown);
+    try ctx.stderr().flush();
+
+    try std.testing.expect(!handled);
+    try std.testing.expectEqualStrings("", aw.written());
+}
+
+test "onError sanitizes a terminal-escape-laced attempted command" {
+    // `onError` allocates (joins, suggestion dupes) and, like the production
+    // registry, relies on an arena being torn down wholesale rather than
+    // freeing each piece — so context.allocator is arena-backed here too,
+    // not the leak-checking testing.allocator directly.
+    const gpa = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(gpa);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const Ctx = zcli.TestContext(&.{});
+    var stdio: zcli.Stdio = undefined;
+    stdio.init(std.testing.io);
+    var aw: std.Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    stdio.stderr_override = &aw.writer;
+
+    const environ = std.process.Environ.Map.init(allocator);
+    var ctx = Ctx.init(allocator, std.testing.io, &stdio, &environ);
+    defer ctx.deinit();
+
+    // A crafted argv carrying an OSC title-set sequence (ESC ] 0 ; ... BEL).
+    ctx.command_path = &.{"\x1b]0;pwned\x07"};
+    ctx.plugin_command_info = &.{
+        .{ .path = &.{"search"}, .description = "Search things" },
+    };
+
+    _ = try onError(&ctx, error.CommandNotFound);
+    try ctx.stderr().flush();
+
+    const out = aw.written();
+    try std.testing.expect(std.mem.indexOf(u8, out, "\x1b") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "]0;pwned") != null); // text survives, minus the escape
 }

--- a/packages/core/src/plugins/zcli_version/plugin.zig
+++ b/packages/core/src/plugins/zcli_version/plugin.zig
@@ -98,6 +98,131 @@ test "version plugin structure" {
     try std.testing.expect(@hasDecl(@This(), "isVersionRequested"));
 }
 
-// Note: behavioral coverage (—version prints and skips execution, -V, and the
-// onError path for --version on a bogus command) lives in
-// plugin_pipeline_test.zig, which registers this plugin in a real registry.
+// Note: end-to-end coverage (—version prints and skips execution, -V, and the
+// onError path for --version on a bogus command, running through a real
+// registry) lives in plugin_pipeline_test.zig. These tests instead exercise
+// this file's functions directly, driving `context` by hand.
+
+fn newTestCtx(allocator: std.mem.Allocator, stdio: *zcli.Stdio, environ: *const std.process.Environ.Map) zcli.TestContext(&.{@This()}) {
+    const Ctx = zcli.TestContext(&.{@This()});
+    var ctx = Ctx.init(allocator, std.testing.io, stdio, environ);
+    ctx.app_name = "myapp";
+    ctx.app_version = "2.3.4";
+    return ctx;
+}
+
+test "showVersion prints '<name> v<version>' to stdout" {
+    const allocator = std.testing.allocator;
+
+    var stdio: zcli.Stdio = undefined;
+    stdio.init(std.testing.io);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    stdio.stdout_override = &aw.writer;
+
+    const environ = std.process.Environ.Map.init(allocator);
+    var ctx = newTestCtx(allocator, &stdio, &environ);
+    defer ctx.deinit();
+
+    try showVersion(&ctx);
+    try ctx.stdout().flush();
+
+    try std.testing.expectEqualStrings("myapp v2.3.4\n", aw.written());
+}
+
+test "handleGlobalOption sets version_requested only for a true 'version' value" {
+    const allocator = std.testing.allocator;
+
+    var stdio: zcli.Stdio = undefined;
+    stdio.init(std.testing.io);
+    const environ = std.process.Environ.Map.init(allocator);
+    var ctx = newTestCtx(allocator, &stdio, &environ);
+    defer ctx.deinit();
+
+    // An unrelated global option is ignored.
+    try handleGlobalOption(&ctx, "color", true);
+    try std.testing.expect(!ctx.plugins.zcli_version.version_requested);
+
+    // `version` with a false value (shouldn't normally happen, but the
+    // handler only acts on `true`) leaves the flag unset.
+    try handleGlobalOption(&ctx, "version", false);
+    try std.testing.expect(!ctx.plugins.zcli_version.version_requested);
+
+    // `version` with true sets it.
+    try handleGlobalOption(&ctx, "version", true);
+    try std.testing.expect(ctx.plugins.zcli_version.version_requested);
+    try std.testing.expect(isVersionRequested(&ctx));
+}
+
+test "preExecute prints the version and stops execution when requested" {
+    const allocator = std.testing.allocator;
+
+    var stdio: zcli.Stdio = undefined;
+    stdio.init(std.testing.io);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    stdio.stdout_override = &aw.writer;
+
+    const environ = std.process.Environ.Map.init(allocator);
+    var ctx = newTestCtx(allocator, &stdio, &environ);
+    defer ctx.deinit();
+
+    ctx.plugins.zcli_version.version_requested = true;
+    const args = zcli.ParsedArgs{ .positional = &.{} };
+    const result = try preExecute(&ctx, args);
+    try ctx.stdout().flush();
+
+    // null tells the registry to stop — the command never runs.
+    try std.testing.expect(result == null);
+    try std.testing.expectEqualStrings("myapp v2.3.4\n", aw.written());
+}
+
+test "preExecute passes args through unchanged when version wasn't requested" {
+    const allocator = std.testing.allocator;
+
+    var stdio: zcli.Stdio = undefined;
+    stdio.init(std.testing.io);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    stdio.stdout_override = &aw.writer;
+
+    const environ = std.process.Environ.Map.init(allocator);
+    var ctx = newTestCtx(allocator, &stdio, &environ);
+    defer ctx.deinit();
+
+    const args = zcli.ParsedArgs{ .positional = &.{"greet"} };
+    const result = try preExecute(&ctx, args);
+    try ctx.stdout().flush();
+
+    try std.testing.expect(result != null);
+    try std.testing.expectEqual(@as(usize, 1), result.?.positional.len);
+    try std.testing.expectEqualStrings("", aw.written()); // nothing printed
+}
+
+test "onError prints the version and reports handled only when version was requested" {
+    const allocator = std.testing.allocator;
+
+    var stdio: zcli.Stdio = undefined;
+    stdio.init(std.testing.io);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    stdio.stdout_override = &aw.writer;
+
+    const environ = std.process.Environ.Map.init(allocator);
+    var ctx = newTestCtx(allocator, &stdio, &environ);
+    defer ctx.deinit();
+
+    // Not requested: CommandNotFound passes through untouched.
+    try std.testing.expect(!(try onError(&ctx, error.CommandNotFound)));
+    try std.testing.expectEqualStrings("", aw.written());
+
+    // A different error, even when requested, is not this plugin's to handle.
+    ctx.plugins.zcli_version.version_requested = true;
+    try std.testing.expect(!(try onError(&ctx, error.ArgumentInvalidValue)));
+    try std.testing.expectEqualStrings("", aw.written());
+
+    // Requested + CommandNotFound: prints the version and reports handled.
+    try std.testing.expect(try onError(&ctx, error.CommandNotFound));
+    try ctx.stdout().flush();
+    try std.testing.expectEqualStrings("myapp v2.3.4\n", aw.written());
+}

--- a/packages/core/src/registry/compiled.zig
+++ b/packages/core/src/registry/compiled.zig
@@ -21,7 +21,13 @@ fn reportParseError(context: anytype, diag: ?zcli.ZcliDiagnostic) !void {
     const d = diag orelse return;
     const message = zcli.formatDiagnostic(d, context.allocator) catch return;
     var stderr = context.stderr();
-    try stderr.print("Error: {s}\n", .{message});
+    // The message embeds user-controlled argv text (an unknown option name,
+    // a rejected argument/option value) alongside framework-authored prose —
+    // sanitize the whole rendered string so a crafted value can't smuggle a
+    // raw terminal escape sequence through.
+    try stderr.print("Error: ", .{});
+    try zcli.writeSanitized(stderr, message);
+    try stderr.print("\n", .{});
 
     // A one-line usage pointer, mirroring the not-found plugin's closing line.
     // Points at the resolved command's own --help when we're inside a command,

--- a/packages/core/src/registry/tests.zig
+++ b/packages/core/src/registry/tests.zig
@@ -1091,6 +1091,47 @@ test "parse errors run onError with context.diagnostic populated" {
     try testing.expectEqualStrings("count", DiagnosticCapturePlugin.captured.?.OptionInvalidValue.option_name);
 }
 
+// Fixture for the default (no onError plugin) rendering path: a command with
+// a typed option, so a bad value falls all the way through to
+// `reportParseError`'s own stderr message instead of being intercepted.
+const EscValueCommand = struct {
+    pub const meta = .{ .description = "command with a typed option, for escape-sanitization coverage" };
+    pub const Args = struct {};
+    pub const Options = struct { count: u32 = 1 };
+    pub fn execute(_: Args, _: Options, _: *zcli.Context) !void {}
+};
+
+test "reportParseError sanitizes a terminal-escape-laced option value" {
+    const TestApp = Registry.init(.{
+        .app_name = "diag-test",
+        .app_version = "1.0.0",
+        .app_description = "diagnostic pipeline test",
+    })
+        .register("ping", EscValueCommand)
+        .build();
+
+    var app = TestApp.init();
+    const test_environ = std.process.Environ.Map.init(testing.allocator);
+
+    var out_aw = std.Io.Writer.Allocating.init(testing.allocator);
+    defer out_aw.deinit();
+    var err_aw = std.Io.Writer.Allocating.init(testing.allocator);
+    defer err_aw.deinit();
+    var stdio: zcli.Stdio = undefined;
+    stdio.init(std.testing.io);
+    stdio.stdout_override = &out_aw.writer;
+    stdio.stderr_override = &err_aw.writer;
+
+    // A crafted option value carrying an OSC 52 clipboard-write sequence.
+    // No onError plugin is registered, so this reaches reportParseError's
+    // default "Error: ..." rendering.
+    try testing.expectError(error.OptionInvalidValue, app.executeWithStdio(testing.allocator, std.testing.io, &test_environ, &.{ "ping", "--count", "\x1b]52;c;cHduZWQ=\x07" }, &stdio));
+
+    const err_text = err_aw.written();
+    try testing.expect(std.mem.indexOf(u8, err_text, "\x1b") == null);
+    try testing.expect(std.mem.indexOf(u8, err_text, "Invalid value") != null);
+}
+
 // Fixture for the typed-global-options pipeline: declares one global of each
 // supported category (also exercising declaration-time type validation),
 // records what handleGlobalOption receives, and captures parse failures.

--- a/packages/core/src/zcli.zig
+++ b/packages/core/src/zcli.zig
@@ -109,6 +109,7 @@ pub const ZcliError = diagnostic_errors.ZcliError;
 pub const ZcliDiagnostic = diagnostic_errors.ZcliDiagnostic;
 pub const formatDiagnostic = diagnostic_errors.formatDiagnostic;
 pub const expectedTypeName = diagnostic_errors.expectedTypeName;
+pub const writeSanitized = diagnostic_errors.writeSanitized;
 
 /// Levenshtein edit-distance + nearest-match helpers, shared by the options
 /// parser (unknown-option suggestions) and the not-found plugin (unknown-command


### PR DESCRIPTION
## Summary
- LOW-severity finding: user-controlled argv (unknown commands, unknown options, rejected argument/option values) was echoed verbatim into diagnostic messages, letting a crafted value carry a raw ANSI/OSC escape sequence (e.g. window-title set, OSC 52 clipboard write) straight to the terminal.
- Added `diagnostic_errors.writeSanitized` (re-exported as `zcli.writeSanitized`) — a writer-based helper stripping C0 control bytes and DEL except `\n`/`\t` — and applied it at the two live diagnostic-rendering boundaries: `zcli_not_found`'s "Unknown command" header, and `reportParseError`'s default "Error: ..." rendering (covers every `Argument*`/`Option*` diagnostic in one place).
- Filled in thin test coverage the audit flagged: `zcli_not_found` gets behavioral coverage of its documented 3-case `onError` contract (unknown command w/ close-match suggestion, unknown command w/ distant input and no suggestion, bare group access, no command at all) plus a sanitization regression test; `zcli_version` gets direct behavioral tests for `showVersion`/`handleGlobalOption`/`preExecute`/`onError` (previously only a structure test in-file, though end-to-end coverage already existed in `plugin_pipeline_test.zig`).

## Test plan
- [x] `zig build test` — all packages/examples pass, no leaks
- [x] `zig build build-examples` — clean
- [x] `zig fmt --check` on all touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)