### PR TITLE
CI: ship ReleaseSafe artifacts, expose root e2e step, structural interactive-tier guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,14 +195,14 @@ jobs:
       # smoke step here would be redundant.
       - name: Build zcli (native Windows, ReleaseSafe)
         working-directory: projects/zcli
-        run: zig build -Doptimize=ReleaseSafe
+        run: zig build -Doptimize=ReleaseSafe -Dstrip=true
 
   # The release cross-compiles the static-musl Linux binaries (release.yml's
   # build job, only on tag push), so PR CI never once built musl — and a
   # musl-only build-graph panic in the secrets backend (fixed in 1931528)
   # blocked the 0.19.0 release with a break PR CI could not have caught. This
   # job closes that gap: it mirrors release.yml's build invocation EXACTLY
-  # (same `cd projects/zcli` + `zig build -Doptimize=ReleaseSafe -Dtarget=…`
+  # (same `cd projects/zcli` + `zig build -Doptimize=ReleaseSafe -Dstrip=true -Dtarget=…`
   # per musl target) so the two can't drift and reopen the hole. x86_64 is a
   # static binary the x64 runner can execute, so smoke-test it (mirrors the
   # release's Smoke test step); aarch64 is build-only (can't run here).
@@ -230,7 +230,7 @@ jobs:
       # only guards that the release-mode musl cross-compile links and starts.
       - name: Build zcli (static musl, ReleaseSafe)
         working-directory: projects/zcli
-        run: zig build -Doptimize=ReleaseSafe -Dtarget=${{ matrix.zig_target }}
+        run: zig build -Doptimize=ReleaseSafe -Dstrip=true -Dtarget=${{ matrix.zig_target }}
 
       # Prove the artifact the release would publish actually starts, on the
       # target the runner can execute natively. Mirrors release.yml's smoke test.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,23 +186,23 @@ jobs:
         with:
           version: 0.16.0
 
-      # Build the CLI natively in ReleaseFast — a real Windows toolchain catches
+      # Build the CLI natively in ReleaseSafe — a real Windows toolchain catches
       # native linking/ABI + optimize-mode issues that the release's
-      # cross-compile from Linux would not. This is the only ReleaseFast Windows
+      # cross-compile from Linux would not. This is the only ReleaseSafe Windows
       # coverage on PRs (release.yml cross-compiles and is tag-triggered). The
       # `test` job now runs the unit suites natively on Windows, and the `e2e`
       # job builds the binary (Debug) and exercises it end to end, so a separate
       # smoke step here would be redundant.
-      - name: Build zcli (native Windows, ReleaseFast)
+      - name: Build zcli (native Windows, ReleaseSafe)
         working-directory: projects/zcli
-        run: zig build -Doptimize=ReleaseFast
+        run: zig build -Doptimize=ReleaseSafe
 
   # The release cross-compiles the static-musl Linux binaries (release.yml's
   # build job, only on tag push), so PR CI never once built musl — and a
   # musl-only build-graph panic in the secrets backend (fixed in 1931528)
   # blocked the 0.19.0 release with a break PR CI could not have caught. This
   # job closes that gap: it mirrors release.yml's build invocation EXACTLY
-  # (same `cd projects/zcli` + `zig build -Doptimize=ReleaseFast -Dtarget=…`
+  # (same `cd projects/zcli` + `zig build -Doptimize=ReleaseSafe -Dtarget=…`
   # per musl target) so the two can't drift and reopen the hole. x86_64 is a
   # static binary the x64 runner can execute, so smoke-test it (mirrors the
   # release's Smoke test step); aarch64 is build-only (can't run here).
@@ -228,9 +228,9 @@ jobs:
       # Byte-for-byte the release build command (release.yml → build job → Build
       # zcli). No test suite re-run — the `test` job already covers that; this
       # only guards that the release-mode musl cross-compile links and starts.
-      - name: Build zcli (static musl, ReleaseFast)
+      - name: Build zcli (static musl, ReleaseSafe)
         working-directory: projects/zcli
-        run: zig build -Doptimize=ReleaseFast -Dtarget=${{ matrix.zig_target }}
+        run: zig build -Doptimize=ReleaseSafe -Dtarget=${{ matrix.zig_target }}
 
       # Prove the artifact the release would publish actually starts, on the
       # target the runner can execute natively. Mirrors release.yml's smoke test.
@@ -385,14 +385,11 @@ jobs:
       #
       # The interactive tests degrade to a skip — not a failure — where the
       # pseudo-terminal can't be allocated, so a green run could silently lose
-      # that coverage; grep the log to prove the tier actually ran on every OS.
+      # that coverage. ZCLI_REQUIRE_INTERACTIVE=1 makes the harness hard-fail
+      # instead of skip in that case, proving the tier actually ran on every OS.
       - name: Run e2e tests
         working-directory: projects/zcli
         shell: bash
-        run: |
-          set -eo pipefail
-          zig build e2e 2>&1 | tee e2e.log
-          if grep -q "runInteractive unavailable" e2e.log; then
-            echo "ERROR: interactive terminal tests were skipped (pseudo-terminal unavailable)"
-            exit 1
-          fi
+        env:
+          ZCLI_REQUIRE_INTERACTIVE: "1"
+        run: zig build e2e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,18 +141,14 @@ jobs:
 
       # Mirror ci.yml's e2e gate, guard included: the interactive tier degrades
       # to a skip (not a failure) where a pseudo-terminal can't be allocated, so
-      # grep the log to prove it actually ran — a release must not ship with that
-      # coverage silently dropped on any OS.
+      # ZCLI_REQUIRE_INTERACTIVE=1 makes the harness hard-fail instead — a
+      # release must not ship with that coverage silently dropped on any OS.
       - name: Run e2e tests
         working-directory: projects/zcli
         shell: bash
-        run: |
-          set -eo pipefail
-          zig build e2e 2>&1 | tee e2e.log
-          if grep -q "runInteractive unavailable" e2e.log; then
-            echo "ERROR: interactive terminal tests were skipped (pseudo-terminal unavailable)"
-            exit 1
-          fi
+        env:
+          ZCLI_REQUIRE_INTERACTIVE: "1"
+        run: zig build e2e
 
   build:
     name: Build ${{ matrix.target }}
@@ -197,7 +193,7 @@ jobs:
       - name: Build zcli
         run: |
           cd projects/zcli
-          zig build -Doptimize=ReleaseFast -Dtarget=${{ matrix.zig_target }}
+          zig build -Doptimize=ReleaseSafe -Dtarget=${{ matrix.zig_target }}
 
       - name: Package binary
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,7 +193,7 @@ jobs:
       - name: Build zcli
         run: |
           cd projects/zcli
-          zig build -Doptimize=ReleaseSafe -Dtarget=${{ matrix.zig_target }}
+          zig build -Doptimize=ReleaseSafe -Dstrip=true -Dtarget=${{ matrix.zig_target }}
 
       - name: Package binary
         shell: bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ From the repo root:
 - `zig build test` — the whole battery: every package's suite plus the meta-CLI's and every example's tests
 - `zig build test-<name>` — one subproject (`test-core`, `test-terminal`, `test-prompts`, `test-tasks`, …)
 - `zig build build-examples` / `build-cli` — compile the examples / the zcli binary
-- `cd projects/zcli && zig build e2e` — the meta-CLI's end-to-end suite (scaffolds real projects in temp dirs and drives the binary through a PTY; slow, not part of `test`)
+- `zig build e2e` — the meta-CLI's end-to-end suite (scaffolds real projects in temp dirs and drives the binary through a PTY; slow, not part of `test`; run it after prompt/render/help changes). Forwards to `projects/zcli`'s own `e2e` step; `cd projects/zcli && zig build e2e -De2e-filter=<substring>` to narrow it while iterating.
 - `zig build test-secrets` — compile+link the host's native secrets backend (forwarded from `packages/core`, like `benchmark`/`regression`; not part of `test`)
 
 `-Dtarget=` and `-Doptimize=` at the root propagate into the package test builds.

--- a/build.zig
+++ b/build.zig
@@ -188,6 +188,21 @@ pub fn build(b: *std.Build) void {
         build_cli_step.dependOn(&cli_build_run.step);
     }
 
+    // projects/zcli's end-to-end suite (builds scaffolded projects against the
+    // built zcli binary; slow — required after prompt/render/help changes) has
+    // no step at the root, so contributors running `zig build test` here never
+    // see it. It can't be forwarded with `top_level_steps.get` the way core's
+    // specialized steps are above: projects/zcli depends on this root package
+    // (`.zcli = .{ .path = "../.." }`), so b.dependency'ing it back here would
+    // be a package cycle — the same reason the test/build loops above run it
+    // as a subprocess instead. Forward it the same way: a subprocess `zig
+    // build e2e` from projects/zcli.
+    const e2e_step = b.step("e2e", "Run zcli's end-to-end tests (builds scaffolded projects; slow — run after prompt/render/help changes)");
+    const e2e_run = b.addSystemCommand(&.{b.graph.zig_exe});
+    e2e_run.addArgs(&.{ "build", "e2e" });
+    e2e_run.setCwd(b.path("projects/zcli"));
+    e2e_step.dependOn(&e2e_run.step);
+
     // Create a comprehensive build step that builds and tests everything
     const build_all_step = b.step("build-all", "Build and test all subprojects");
     build_all_step.dependOn(test_step);

--- a/packages/testing/src/e2e.zig
+++ b/packages/testing/src/e2e.zig
@@ -863,6 +863,20 @@ pub const InteractiveError = error{
     NoSavedSettings,
 } || std.mem.Allocator.Error;
 
+/// Whether the environment demands that the interactive (PTY) tier actually
+/// run — set by CI so a sandbox that can't allocate a PTY turns from a silent
+/// skip into a hard build failure. Replaces grepping the job log for
+/// `runInteractive unavailable`, which only proved the wording was still
+/// there, not that the harness could have caught a real regression in it.
+///
+/// Read via the threaded environ (`std.testing.environ`, populated by the
+/// 0.16 test runner from `std.process.Init`) rather than libc getenv — this
+/// runs inside `zig build test`/`zig build e2e` test binaries, which have no
+/// ambient ENV access of their own.
+pub fn interactiveRequired() bool {
+    return std.process.Environ.containsUnemptyConstant(std.testing.environ, "ZCLI_REQUIRE_INTERACTIVE");
+}
+
 /// Why a script step stopped the run — carried out of `driveScriptSteps` so the
 /// driver can print a single loud diagnostic (which step, what kind, and the
 /// rendered screen) instead of letting the failure surface only as a nonzero
@@ -2094,9 +2108,13 @@ test "runInteractive frame assertions catch a mispositioned row over a PTY" {
         .terminal_size = .{ .rows = 24, .cols = 40 },
         .total_timeout_ms = 8000,
     }) catch |err| switch (err) {
-        // PTY allocation can be denied in sandboxes; skip loudly (mirrors the
-        // "runInteractive unavailable" guard CI greps for elsewhere).
+        // PTY allocation can be denied in sandboxes; skip loudly, unless
+        // ZCLI_REQUIRE_INTERACTIVE=1 demands this tier actually run.
         error.PtyAllocationFailed => {
+            if (interactiveRequired()) {
+                std.debug.print("ZCLI_REQUIRE_INTERACTIVE=1 but a PTY could not be allocated: {any}\n", .{err});
+                return err;
+            }
             std.debug.print("runInteractive unavailable: {any}\n", .{err});
             return;
         },

--- a/projects/zcli/build.zig
+++ b/projects/zcli/build.zig
@@ -4,6 +4,11 @@ pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    // Debug info dominates binary size (~13 MB unstripped vs ~2 MB stripped
+    // for a static musl ReleaseSafe build). Release artifacts pass
+    // -Dstrip=true; local builds keep debug info for stack traces.
+    const strip = b.option(bool, "strip", "Omit debug info from the binary (release artifacts)") orelse false;
+
     // Get zcli dependency
     const zcli_dep = b.dependency("zcli", .{
         .target = target,
@@ -60,6 +65,7 @@ pub fn build(b: *std.Build) !void {
             .root_source_file = b.path("src/main.zig"),
             .target = target,
             .optimize = optimize,
+            .strip = strip,
         }),
     });
 

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -1390,9 +1390,16 @@ test "root zcli_theme declaration themes help output" {
             .{ .cwd = proj_abs, .allocate_pty = true, .total_timeout_ms = 20000, .env = env },
         ) catch |err| switch (err) {
             // PTY allocation can be denied in some sandboxes; skip rather than
-            // fail (CI greps the log for this line and fails if the tier
-            // silently skipped).
+            // fail here, unless ZCLI_REQUIRE_INTERACTIVE=1 demands this tier
+            // actually run.
             error.PtyAllocationFailed => {
+                // ZCLI_REQUIRE_INTERACTIVE=1 (set by CI) turns a PTY-unavailable
+                // sandbox from a silent skip into a hard failure, so the interactive
+                // tier can never regress to never-running without the build going red.
+                if (harness.interactiveRequired()) {
+                    std.debug.print("ZCLI_REQUIRE_INTERACTIVE=1 but a PTY could not be allocated: {any}\n", .{err});
+                    return err;
+                }
                 std.debug.print("runInteractive unavailable: {any}\n", .{err});
                 return;
             },
@@ -1424,6 +1431,13 @@ test "root zcli_theme declaration themes help output" {
             .{ .cwd = proj_abs, .allocate_pty = true, .total_timeout_ms = 20000, .env = env },
         ) catch |err| switch (err) {
             error.PtyAllocationFailed => {
+                // ZCLI_REQUIRE_INTERACTIVE=1 (set by CI) turns a PTY-unavailable
+                // sandbox from a silent skip into a hard failure, so the interactive
+                // tier can never regress to never-running without the build going red.
+                if (harness.interactiveRequired()) {
+                    std.debug.print("ZCLI_REQUIRE_INTERACTIVE=1 but a PTY could not be allocated: {any}\n", .{err});
+                    return err;
+                }
                 std.debug.print("runInteractive unavailable: {any}\n", .{err});
                 return;
             },
@@ -1796,10 +1810,17 @@ test "interactive: add command drives the wizard and echoes typed input" {
         .{ .cwd = proj_abs, .allocate_pty = true, .total_timeout_ms = 20000 },
     ) catch |err| switch (err) {
         // PTY allocation can be denied in some sandboxes; skip rather than fail
-        // (CI greps the log for this line and fails if the tier silently
-        // skipped). Every other error is a real harness/test failure — a
-        // catch-all here made harness bugs read as skips.
+        // here, unless ZCLI_REQUIRE_INTERACTIVE=1 demands this tier actually
+        // run. Every other error is a real harness/test failure — a catch-all
+        // here made harness bugs read as skips.
         error.PtyAllocationFailed => {
+            // ZCLI_REQUIRE_INTERACTIVE=1 (set by CI) turns a PTY-unavailable
+            // sandbox from a silent skip into a hard failure, so the interactive
+            // tier can never regress to never-running without the build going red.
+            if (harness.interactiveRequired()) {
+                std.debug.print("ZCLI_REQUIRE_INTERACTIVE=1 but a PTY could not be allocated: {any}\n", .{err});
+                return err;
+            }
             std.debug.print("runInteractive unavailable: {any}\n", .{err});
             return;
         },
@@ -1855,6 +1876,13 @@ test "interactive: a SIGTERM mid-prompt restores the terminal from raw mode" {
         .{ .cwd = proj_abs, .allocate_pty = true, .total_timeout_ms = 20000 },
     ) catch |err| switch (err) {
         error.PtyAllocationFailed => {
+            // ZCLI_REQUIRE_INTERACTIVE=1 (set by CI) turns a PTY-unavailable
+            // sandbox from a silent skip into a hard failure, so the interactive
+            // tier can never regress to never-running without the build going red.
+            if (harness.interactiveRequired()) {
+                std.debug.print("ZCLI_REQUIRE_INTERACTIVE=1 but a PTY could not be allocated: {any}\n", .{err});
+                return err;
+            }
             std.debug.print("runInteractive unavailable: {any}\n", .{err});
             return;
         },
@@ -1927,10 +1955,17 @@ test "interactive: text prompt handles multibyte UTF-8 typing and backspace" {
         .{ .cwd = proj_abs, .allocate_pty = true, .total_timeout_ms = 20000 },
     ) catch |err| switch (err) {
         // PTY allocation can be denied in some sandboxes; skip rather than fail
-        // (CI greps the log for this line and fails if the tier silently
-        // skipped). Every other error is a real harness/test failure — a
-        // catch-all here made harness bugs read as skips.
+        // here, unless ZCLI_REQUIRE_INTERACTIVE=1 demands this tier actually
+        // run. Every other error is a real harness/test failure — a catch-all
+        // here made harness bugs read as skips.
         error.PtyAllocationFailed => {
+            // ZCLI_REQUIRE_INTERACTIVE=1 (set by CI) turns a PTY-unavailable
+            // sandbox from a silent skip into a hard failure, so the interactive
+            // tier can never regress to never-running without the build going red.
+            if (harness.interactiveRequired()) {
+                std.debug.print("ZCLI_REQUIRE_INTERACTIVE=1 but a PTY could not be allocated: {any}\n", .{err});
+                return err;
+            }
             std.debug.print("runInteractive unavailable: {any}\n", .{err});
             return;
         },
@@ -1982,10 +2017,17 @@ test "interactive: init's plugin multi-select toggles an opt-in plugin" {
         .{ .cwd = proj_abs, .allocate_pty = true, .total_timeout_ms = 30000 },
     ) catch |err| switch (err) {
         // PTY allocation can be denied in some sandboxes; skip rather than fail
-        // (CI greps the log for this line and fails if the tier silently
-        // skipped). Every other error is a real harness/test failure — a
-        // catch-all here made harness bugs read as skips.
+        // here, unless ZCLI_REQUIRE_INTERACTIVE=1 demands this tier actually
+        // run. Every other error is a real harness/test failure — a catch-all
+        // here made harness bugs read as skips.
         error.PtyAllocationFailed => {
+            // ZCLI_REQUIRE_INTERACTIVE=1 (set by CI) turns a PTY-unavailable
+            // sandbox from a silent skip into a hard failure, so the interactive
+            // tier can never regress to never-running without the build going red.
+            if (harness.interactiveRequired()) {
+                std.debug.print("ZCLI_REQUIRE_INTERACTIVE=1 but a PTY could not be allocated: {any}\n", .{err});
+                return err;
+            }
             std.debug.print("runInteractive unavailable: {any}\n", .{err});
             return;
         },
@@ -2114,8 +2156,16 @@ test "dev builds, runs the app, restarts on change, survives a failed build, and
         .{ .cwd = proj_abs, .allocate_pty = true, .total_timeout_ms = 600000 },
     ) catch |err| switch (err) {
         // PTY allocation can be denied in some sandboxes; skip rather than fail
-        // (CI greps the log for this line). Every other error is a real failure.
+        // here, unless ZCLI_REQUIRE_INTERACTIVE=1 demands this tier actually
+        // run. Every other error is a real failure.
         error.PtyAllocationFailed => {
+            // ZCLI_REQUIRE_INTERACTIVE=1 (set by CI) turns a PTY-unavailable
+            // sandbox from a silent skip into a hard failure, so the interactive
+            // tier can never regress to never-running without the build going red.
+            if (harness.interactiveRequired()) {
+                std.debug.print("ZCLI_REQUIRE_INTERACTIVE=1 but a PTY could not be allocated: {any}\n", .{err});
+                return err;
+            }
             std.debug.print("runInteractive unavailable: {any}\n", .{err});
             return;
         },


### PR DESCRIPTION
## Summary
- Release binaries now build `-Doptimize=ReleaseSafe` instead of `ReleaseFast` — safety checks stay on in code that parses untrusted argv/config/network data and self-replaces its own binary (perf is irrelevant for a CLI). Updated `release.yml`'s build job and `ci.yml`'s two jobs that deliberately mirror it byte-for-byte (`linux-musl-release-build` and the native Windows build) so the mirror-guard comments stay true.
- Added a root `e2e` step to `build.zig` forwarding to `projects/zcli`'s own `e2e` step (as a subprocess — the same mechanism the root already uses to run `projects/zcli`'s `test`/`build`, since `projects/zcli` can't be a `b.dependency` here without a package cycle). `zig build --list-steps` now surfaces it; `CONTRIBUTING.md` updated.
- Replaced the "grep the job log for `runInteractive unavailable`" skip guard in `ci.yml` and `release.yml` with a structural one: a new `ZCLI_REQUIRE_INTERACTIVE=1` env var (mirroring the existing `ZCLI_REQUIRE_FISH` pattern) makes the e2e harness hard-fail instead of silently skipping when a PTY can't be allocated. Read via `std.testing.environ` (the threaded environ populated by the 0.16 test runner), not libc getenv. Both workflows' e2e steps now set it; the grep steps are deleted.

## Test plan
- [x] `zig build test` at repo root — passes (all packages + meta-CLI + examples)
- [x] `zig fmt --check packages projects examples build.zig` — clean
- [x] `cd projects/zcli && zig build e2e` — 31/31 tests pass
- [x] `zig build e2e` at repo root — forwards correctly, passes
- [x] `zig build --list-steps` — `e2e` step now listed with a description flagging it as slow / post prompt-render-help
- [x] `ZCLI_REQUIRE_INTERACTIVE=1 zig build e2e` locally (PTY available) — passes, confirms the env var is read and doesn't break the happy path. PTY-unavailable-with-the-flag-set can't be simulated locally; verified by direct probe that `std.testing.environ` correctly reflects a set env var inside a zig test binary (via a standalone throwaway test), and by code review that the new branch (`if (harness.interactiveRequired()) { ... return err; }`) returns an error instead of skipping, which fails `zig build e2e`.
- [x] `actionlint` on both workflow files — same 8 pre-existing shellcheck warnings as `main` (verified via `git stash`), no new issues introduced
- [x] Output-contract CI grep (no raw `std.debug.print`/`std.process.exit`) — unaffected, changed files aren't in its scanned paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)