### PR TITLE
docs: document sharing code between commands

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -208,6 +208,61 @@ Each discovered command is validated for:
 - **Structure**: Must be a valid Zig source file
 - **Depth**: Must not exceed maximum nesting depth
 
+## Sharing Code Between Commands
+
+Each discovered command file is compiled as its **own module rooted at that
+file**. A relative import of a sibling therefore reaches outside the module and
+fails to compile:
+
+```zig
+// in src/commands/tags.zig
+const registry = @import("../registry.zig");
+// error: import of file outside module path
+```
+
+Instead, declare the shared code as a module once and register it via
+`shared_modules`; every command can then import it by name:
+
+```zig
+// build.zig
+const store_module = b.createModule(.{
+    .root_source_file = b.path("src/store.zig"),
+    .target = target,
+    .optimize = optimize,
+});
+
+const cmd_registry = try zcli.generate(b, exe, zcli_dep, .{
+    .commands_dir = "src/commands",
+    .shared_modules = &[_]zcli.SharedModule{
+        .{ .name = "store", .module = store_module },
+    },
+    // ...
+});
+```
+
+```zig
+// in any command:
+const store = @import("store");
+```
+
+Pass the **same** `shared_modules` list to `addCommandTests` as well. The
+command-test stub only wires the shared modules you hand it, so a command that
+imports one won't compile under `zig build test` otherwise:
+
+```zig
+_ = zcli.addCommandTests(b, zcli_dep, .{
+    .commands_dir = "src/commands",
+    .target = target,
+    .optimize = optimize,
+    .shared_modules = &[_]zcli.SharedModule{
+        .{ .name = "store", .module = store_module },
+    },
+});
+```
+
+See `examples/tasks` for a full, compiling example (the `store` module shared
+across its commands).
+
 ## Registry Generation Process
 
 ### 1. Plugin Registry Integration

--- a/website/content/docs/build.smd
+++ b/website/content/docs/build.smd
@@ -58,7 +58,15 @@ Discovery and validation run at build time, so a malformed command is a compile 
 
 ## Shared modules
 
-Commands often share code — a storage layer, an API client. Declare it once and every command can import it by name:
+Each command file is compiled as its **own module rooted at that file**, so a relative import of a sibling reaches outside the module and fails to compile:
+
+```zig
+// in src/commands/tags.zig
+const registry = @import("../registry.zig");
+// error: import of file outside module path
+```
+
+Commands often share code — a storage layer, an API client. Declare it once as a module and every command can import it by name:
 
 ```zig
 const store_module = b.createModule(.{
@@ -97,6 +105,8 @@ _ = zcli.addCommandTests(b, zcli_dep, .{
 ```
 
 Then `zig build test` runs a test binary per command — a `test "creates a task"` block sitting right next to the `execute` it verifies.
+
+Pass `shared_modules` here too, matching what you gave `generate` — the command-test stub only wires the shared modules you hand it, so a command that imports one won't compile under `zig build test` otherwise.
 
 ## Docs generation
 


### PR DESCRIPTION
## What

Documents how to share code across command files in a zcli project — the `shared_modules` + import-by-name pattern.

## Why

Each command file compiles as its **own module rooted at that file**, so a newcomer's natural first attempt — `@import("../helper.zig")` — fails with a cryptic `import of file outside module path` and no pointer to the intended pattern. "Share a helper between two commands" is a first-hour task; this friction makes a batteries-included framework feel un-batteries-included.

The working pattern (register a `shared_modules` entry, import by name) was already shown on the website but never contrasted with the failing attempt, and the requirement to pass the same list to `addCommandTests` was demonstrated in an example but never stated — so passing it only to `generate()` silently breaks `zig build test`.

## Changes

- **`website/content/docs/build.smd`** — lead the "Shared modules" section with the failing snippet + its exact error; make the `addCommandTests` requirement explicit (the command-test stub only wires the modules you hand it).
- **`docs/BUILD.md`** — new "Sharing Code Between Commands" section (this in-repo doc had zero coverage), mirroring the website and pointing at `examples/tasks` as the compiling reference.

Docs-only; no code or API changes. `examples/tasks` already exercises the documented end state.

## Deferred (design calls, not doc fixes)

- Auto-wiring a `src/shared/` convention — a real feature, and the `import of file outside module path` error is emitted by the Zig compiler in the command file, which zcli's build code can't intercept.
- Making `addCommandTests` inherit `generate()`'s `shared_modules` — a breaking API redesign (the two are independent calls; `generate()`'s return feeds `generateDocs`) for what amounts to referencing one `const` twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)