### PR TITLE
scaffold: generate ReleaseSafe + stripped release builds for consumers

### DIFF
--- a/projects/zcli/src/commands/gh/add/workflow/release.zig
+++ b/projects/zcli/src/commands/gh/add/workflow/release.zig
@@ -84,7 +84,12 @@ pub fn execute(_: Args, _: Options, context: anytype) !void {
         \\          version: 0.16.0
         \\
         \\      - name: Build binary
-        \\        run: zig build -Doptimize=ReleaseFast -Dtarget=${{ matrix.zig_target }}
+        \\        # ReleaseSafe keeps runtime safety checks (bounds/overflow) in a
+        \\        # binary that parses untrusted input; -Dstrip=true drops debug info,
+        \\        # which dominates size. If your build.zig predates the `strip`
+        \\        # option, add: b.option(bool, "strip", "...") and `.strip = strip`
+        \\        # on the exe module.
+        \\        run: zig build -Doptimize=ReleaseSafe -Dstrip=true -Dtarget=${{ matrix.zig_target }}
         \\
         \\      - name: Get app name from build.zig.zon
         \\        id: appname

--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -247,6 +247,11 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         \\    const target = b.standardTargetOptions(.{{}});
         \\    const optimize = b.standardOptimizeOption(.{{}});
         \\
+        \\    // Debug info dominates binary size (roughly 10x on a static build).
+        \\    // Release builds pass -Dstrip=true (the generated release workflow
+        \\    // does); local builds keep debug info for stack traces.
+        \\    const strip = b.option(bool, "strip", "Omit debug info from the binary") orelse false;
+        \\
         \\    // Get zcli dependency
         \\    const zcli_dep = b.dependency("zcli", .{{
         \\        .target = target,
@@ -261,6 +266,7 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         \\            .root_source_file = b.path("src/main.zig"),
         \\            .target = target,
         \\            .optimize = optimize,
+        \\            .strip = strip,
         \\        }}),
         \\    }});
         \\


### PR DESCRIPTION
Follow-up to #281, which flipped zcli's own release artifacts to ReleaseSafe + `-Dstrip=true` — this applies the same defaults to what zcli generates for consumers' projects:

- **`zcli gh add workflow release` template**: builds with `zig build -Doptimize=ReleaseSafe -Dstrip=true -Dtarget=…` instead of ReleaseFast, with a comment explaining the reasoning and what to add if a pre-existing build.zig lacks the `strip` option.
- **`zcli init` build.zig template**: declares `-Dstrip` (default false) and wires `.strip` into the exe module, mirroring `projects/zcli/build.zig`. Local builds keep debug info; only release builds strip.

Projects scaffolded before this change that later generate the workflow will get a clear `zig build` error about the unknown `strip` option; the workflow comment tells them the two lines to add.

## Verification
- `zig build test` (projects/zcli) — pass
- Scaffolded a fresh project and built it with the exact workflow command: 288 KB stripped ReleaseSafe binary; default `zig build` unaffected, app runs
- Generated the release workflow in the scaffold and confirmed the emitted YAML
- Full `zig build e2e` — pass (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)