### PR TITLE
Dedupe editDistance and the ContextData/plugin_id error message

### DIFF
--- a/packages/core/src/context.zig
+++ b/packages/core/src/context.zig
@@ -18,11 +18,9 @@ const zcli = @import("zcli.zig");
 /// here. Plugins with ContextData MUST declare `pub const plugin_id = "unique_name";`
 pub fn pluginFieldName(comptime Plugin: type) [:0]const u8 {
     comptime {
-        if (!@hasDecl(Plugin, "plugin_id")) {
-            @compileError("plugin '" ++ @typeName(Plugin) ++ "' declares ContextData but no plugin_id. " ++
-                "ContextData is exposed as a typed field on context.plugins named by plugin_id. Add:\n" ++
-                "    pub const plugin_id = \"my_plugin\";");
-        }
+        // Backstop for direct ContextFor/TestContext use that bypasses plugin
+        // registration (see plugin_types.requirePluginId for the message).
+        zcli.plugin_types.requirePluginId(Plugin);
 
         const id: []const u8 = Plugin.plugin_id;
         var result: [id.len + 1]u8 = undefined;

--- a/packages/core/src/levenshtein.zig
+++ b/packages/core/src/levenshtein.zig
@@ -9,16 +9,19 @@ pub fn editDistance(a: []const u8, b: []const u8) usize {
 
     // For very long strings, use a practical limit to avoid excessive computation
     const max_practical_len = 256;
-    const a_len = @min(a.len, max_practical_len);
-    const b_len = @min(b.len, max_practical_len);
+    // Explicit usize annotations keep the loop bounds usize when the function
+    // runs at comptime (comptime-known @min/@max results otherwise narrow to
+    // tiny integer types, overflowing the `for (1..len + 1)` ranges below).
+    const a_len: usize = @min(a.len, max_practical_len);
+    const b_len: usize = @min(b.len, max_practical_len);
 
     // Use a more memory-efficient approach with two arrays instead of a full matrix
     // This reduces memory usage from O(n*m) to O(min(n,m))
 
     // Use two arrays instead of full matrix - more memory efficient
     // We'll work with the shorter string as columns to minimize memory usage
-    const shorter_len = @min(a_len, b_len);
-    const longer_len = @max(a_len, b_len);
+    const shorter_len: usize = @min(a_len, b_len);
+    const longer_len: usize = @max(a_len, b_len);
 
     const shorter_str = if (a_len <= b_len) a[0..a_len] else b[0..b_len];
     const longer_str = if (a_len <= b_len) b[0..b_len] else a[0..a_len];
@@ -67,6 +70,17 @@ test "editDistance basic" {
     try std.testing.expectEqual(@as(usize, 1), editDistance("hello", "helloo"));
     try std.testing.expectEqual(@as(usize, 2), editDistance("hello", "bell"));
     try std.testing.expectEqual(@as(usize, 4), editDistance("hello", "world"));
+}
+
+test "editDistance works at comptime" {
+    // plugin_types.validatePlugin runs this at comptime for the hook
+    // typo-guard, so comptime evaluation must keep working.
+    comptime {
+        std.debug.assert(editDistance("preExeucte", "preExecute") == 2);
+        std.debug.assert(editDistance("postExecute", "preExecute") == 3);
+        std.debug.assert(editDistance("preExecute", "preExecute") == 0);
+        std.debug.assert(editDistance("onErorr", "onError") == 2);
+    }
 }
 
 test "editDistance edge cases" {

--- a/packages/core/src/plugin_types.zig
+++ b/packages/core/src/plugin_types.zig
@@ -3,6 +3,7 @@ const zcli = @import("zcli.zig");
 const identifier = @import("identifier.zig");
 const option_utils = @import("options/utils.zig");
 const custom_type = @import("custom_type.zig");
+const levenshtein = @import("levenshtein.zig");
 const testing = std.testing;
 
 // ============================================================================
@@ -252,6 +253,20 @@ const contract_names = hook_names ++ [_][]const u8{
     "init",
 };
 
+/// The single source of the "ContextData without plugin_id" error, shared by
+/// `validatePlugin` (fires at plugin registration) and `context.pluginFieldName`
+/// (a backstop for direct `ContextFor`/`TestContext` use that bypasses
+/// registration, e.g. in tests).
+pub fn requirePluginId(comptime Plugin: type) void {
+    comptime {
+        if (@hasDecl(Plugin, "ContextData") and !@hasDecl(Plugin, "plugin_id")) {
+            @compileError("plugin '" ++ @typeName(Plugin) ++ "' declares ContextData but no plugin_id. " ++
+                "ContextData is exposed as a typed field on context.plugins named by plugin_id. Add:\n" ++
+                "    pub const plugin_id = \"my_plugin\";");
+        }
+    }
+}
+
 /// Comptime backstop against silently-dead hooks. Hooks are detected by exact
 /// name (`@hasDecl`), so a typo'd hook — `preExeucte` — compiles fine and
 /// simply never fires. Called by Registry.registerPlugin: any *function* decl
@@ -272,7 +287,7 @@ pub fn validatePlugin(comptime Plugin: type) void {
                 // Cheap length gate before the DP — comptime branch quota.
                 const len_diff = if (decl.name.len > hook.len) decl.name.len - hook.len else hook.len - decl.name.len;
                 if (len_diff > 2) continue;
-                if (editDistance(decl.name, hook) <= 2) {
+                if (levenshtein.editDistance(decl.name, hook) <= 2) {
                     @compileError("plugin function '" ++ decl.name ++ "' looks like a misspelling of the lifecycle hook '" ++ hook ++
                         "' and would never be called — hooks are detected by exact name. Fix the spelling, or rename the function away from the hook.");
                 }
@@ -284,11 +299,7 @@ pub fn validatePlugin(comptime Plugin: type) void {
         // whole contract here at the declaration — a helpful comptime error —
         // instead of letting it fail obscurely at the `context.plugins.<id>`
         // use-site (or silently getting no slot).
-        if (@hasDecl(Plugin, "ContextData") and !@hasDecl(Plugin, "plugin_id")) {
-            @compileError("plugin '" ++ @typeName(Plugin) ++ "' declares ContextData but no plugin_id. " ++
-                "ContextData is exposed as a typed field on context.plugins named by plugin_id. Add:\n" ++
-                "    pub const plugin_id = \"my_plugin\";");
-        }
+        requirePluginId(Plugin);
         // deinitContextData is the cleanup hook for ContextData and only runs
         // when ContextData exists — without it the function is silently dead,
         // the same failure shape as a misspelled lifecycle hook above.
@@ -358,33 +369,6 @@ fn isContractName(comptime name: []const u8) bool {
     return false;
 }
 
-/// Comptime Levenshtein distance (names here are short; the DP is tiny).
-fn editDistance(comptime a: []const u8, comptime b: []const u8) usize {
-    comptime {
-        var prev: [b.len + 1]usize = undefined;
-        for (0..b.len + 1) |j| prev[j] = j;
-        for (a, 0..) |ca, i| {
-            var curr: [b.len + 1]usize = undefined;
-            curr[0] = i + 1;
-            for (b, 0..) |cb, j| {
-                const cost: usize = if (ca == cb) 0 else 1;
-                curr[j + 1] = @min(@min(curr[j] + 1, prev[j + 1] + 1), prev[j] + cost);
-            }
-            prev = curr;
-        }
-        return prev[b.len];
-    }
-}
-
-test "editDistance catches the classic transposition typo" {
-    comptime {
-        std.debug.assert(editDistance("preExeucte", "preExecute") == 2);
-        std.debug.assert(editDistance("postExecute", "preExecute") == 3);
-        std.debug.assert(editDistance("preExecute", "preExecute") == 0);
-        std.debug.assert(editDistance("onErorr", "onError") == 2);
-    }
-}
-
 test "validatePlugin accepts a well-formed plugin with helpers" {
     const Plugin = struct {
         pub const plugin_id = "valid_plugin";
@@ -406,9 +390,9 @@ test "editDistance flags an applyConfigDefaults typo" {
     comptime {
         // The transposition the typo-guard exists to catch: this misspelling
         // compiles fine but would never be dispatched (hooks match by exact name).
-        std.debug.assert(editDistance("applyConfigDefualts", "applyConfigDefaults") == 2);
+        std.debug.assert(levenshtein.editDistance("applyConfigDefualts", "applyConfigDefaults") == 2);
         // A far-off helper in the same plugin must stay clear of the guard.
-        std.debug.assert(editDistance("applyFromJsonScoped", "applyConfigDefaults") > 2);
+        std.debug.assert(levenshtein.editDistance("applyFromJsonScoped", "applyConfigDefaults") > 2);
     }
 }
 


### PR DESCRIPTION
## Summary

**#317 — one `editDistance`.** Deletes `plugin_types.zig`'s private comptime Levenshtein implementation; the hook typo-guard in `validatePlugin` now calls `levenshtein.editDistance`. To make the shared function usable at comptime, its `@min`/`@max` length bindings gain explicit `usize` annotations — with comptime-known operands the results otherwise narrow to tiny integer types (`u3`, `u4`, ...) and overflow the `for (1..len + 1)` loop ranges. Runtime behavior is unchanged (annotations only). The old comptime test coverage moved into `levenshtein.zig` as `test "editDistance works at comptime"`.

**#318 — one error site.** Extracts `plugin_types.requirePluginId` as the single source of the "declares ContextData but no plugin_id" compile error. `validatePlugin` (fires first, at plugin registration) and `context.pluginFieldName` (backstop for direct `ContextFor`/`TestContext` use that bypasses registration) both call it, so the wording can never drift again.

Closes #317
Closes #318

## Verification

- Pre-fix, naively pointing the typo-guard at the runtime `editDistance` produced 18 comptime overflow errors across the workspace — confirming the guard exercises the shared function at comptime; post-fix the whole workspace compiles cleanly (all comptime asserts evaluate during analysis).
- Local *runtime* test execution could not complete on this machine: it was saturated by several concurrent builds (load avg 11+, near-zero free memory), and test binaries were repeatedly OOM-SIGKILLed or hit the 60s test-runner watchdog — including a 4-test `levenshtein.zig` binary that couldn't get scheduled. Please rely on CI for the run-phase results; the runtime code paths are annotation-only changes with unchanged existing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4