### PR TITLE
completions: escape command/option names in bash/zsh/fish generators

### DIFF
--- a/packages/core/src/plugin_completions_test.zig
+++ b/packages/core/src/plugin_completions_test.zig
@@ -460,10 +460,11 @@ test "bash.generate - emits a root case and single-word case subjects" {
     try std.testing.expect(!contains(script, "case \"$path_len\""));
     try std.testing.expect(!contains(script, "${cmd_path[@]}"));
 
-    // Root case: empty key offers the top-level commands.
-    try std.testing.expect(contains(script, "\"\")\n"));
+    // Root case: empty key offers the top-level commands. Patterns are
+    // single-quoted so a name can never be command-substituted at TAB.
+    try std.testing.expect(contains(script, "'')\n"));
     // Nested case: single-word subject "sprint".
-    try std.testing.expect(contains(script, "\"sprint\")"));
+    try std.testing.expect(contains(script, "'sprint')"));
 
     // Aliases surface alongside command names.
     try std.testing.expect(contains(script, "add a "));
@@ -472,7 +473,7 @@ test "bash.generate - emits a root case and single-word case subjects" {
     try std.testing.expect(contains(script, "low medium high"));
 
     // A leaf's enum positional is offered at its command path...
-    try std.testing.expect(contains(script, "\"list\")"));
+    try std.testing.expect(contains(script, "'list')"));
     try std.testing.expect(contains(script, "open done"));
     // ...and the blanket file fallback is gone (no more CWD dump for positionals).
     try std.testing.expect(!contains(script, "compgen -f"));
@@ -492,8 +493,8 @@ test "zsh.generate - compdef header, describe, and enum action" {
     try std.testing.expect(contains(script, "case $line[2] in"));
     // Enum option renders a value action group.
     try std.testing.expect(contains(script, ":priority:(low medium high)"));
-    // Alias appears as an alternation in the case pattern.
-    try std.testing.expect(contains(script, "add|a)"));
+    // Alias appears as an alternation in the case pattern (single-quoted).
+    try std.testing.expect(contains(script, "'add'|'a')"));
 
     // A plain positional force-displays its description as a hint via _message -r
     // (an empty action would render nothing without a `format` zstyle set).
@@ -1171,4 +1172,144 @@ test "functional fish - also_dirs directive offers directories" {
     const result = try std.process.run(a, io, .{ .argv = &.{ sh, harness_path } });
     try std.testing.expect(advContains(result.stdout, "<zzcand>")); // dynamic candidate
     try std.testing.expect(advContains(result.stdout, "<zzdir/>")); // directory (fish appends /)
+}
+
+// ============================================================================
+// Layer 4: adversarial command/option/alias NAMES (issue #290)
+//
+// Names — unlike descriptions — flow into `case` patterns (bash/zsh) and spec
+// operands (zsh `_arguments`, fish `-a`/`-l`). Bash expands `case` patterns
+// (command substitution included) before matching, so a name like `$(cmd)`
+// runs `cmd` on every TAB. These fixtures embed both a quote (breaks a quoted
+// context → parse error if unescaped) and a `$(touch …)` command substitution
+// (executes at TAB if unescaped) in every name-bearing position.
+// ============================================================================
+
+const pwn_file_spec: zcli.completion.Spec = .file;
+
+// A `.file` option so it emits a `$prev` value case (`'--<name>'|'-o')`) without
+// dragging an enum's `compgen -W` re-expansion (a separate, out-of-scope vector)
+// into the command-substitution assertion.
+const adv_name_opts = [_]zcli.OptionInfo{
+    .{ .name = "o'p$(touch PWNED_opt)", .short = 'o', .description = "danger opt", .takes_value = true, .complete = pwn_file_spec },
+};
+
+// A group (`g'p…`) whose case pattern carries the name, with a leaf child
+// (`l'f…`) plus an adversarial alias — the leaf name + alias land in the command
+// list and in zsh's `case $line[N]` alternation.
+const adv_name_commands = [_]zcli.CommandInfo{
+    .{
+        .path = &.{ "g'p$(touch PWNED_grp)", "l'f$(touch PWNED_leaf)" },
+        .description = "danger",
+        .options = &adv_name_opts,
+        .aliases = &.{"a'x$(touch PWNED_alias)"},
+    },
+};
+
+test "gen - adversarial NAMES are escaped, never emitted raw in a case/spec" {
+    // Every generator must escape the embedded quote (the `'\''` bash/zsh dance,
+    // fish's `\'`) so no name survives as a raw `'`-terminated token — the marker
+    // that a name reached a pattern/spec unescaped.
+    const b = try bash.generate(std.testing.allocator, "advapp", &adv_name_commands, &global_options);
+    defer std.testing.allocator.free(b);
+    const z = try zsh.generate(std.testing.allocator, "advapp", &adv_name_commands, &global_options);
+    defer std.testing.allocator.free(z);
+    const f = try fish.generate(std.testing.allocator, "advapp", &adv_name_commands, &global_options);
+    defer std.testing.allocator.free(f);
+
+    // bash/zsh single-quote dance turns `g'p` into `g'\''p`; a raw `case`/spec
+    // interpolation would instead show the unescaped `'g'p` prefix.
+    try std.testing.expect(contains(b, "g'\\''p"));
+    try std.testing.expect(contains(z, "g'\\''p"));
+    // fish escapes the quote as `\'` (so `l'f` → `l\'f`).
+    try std.testing.expect(contains(f, "l\\'f"));
+
+    // The option name reached its spec/case escaped too (bash `$prev` case; zsh
+    // `_arguments` spec).
+    try std.testing.expect(contains(b, "o'\\''p"));
+    try std.testing.expect(contains(z, "o'\\''p"));
+    try std.testing.expect(contains(f, "o\\'p"));
+}
+
+test "shell syntax - generators accept adversarial NAMES (bash -n / zsh -n / fish)" {
+    const bash_sh = findShell("bash");
+    const zsh_sh = findShell("zsh");
+    const fish_sh = findShell("fish");
+    if (bash_sh == null and zsh_sh == null and fish_sh == null) return error.SkipZigTest;
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    if (fish_sh == null and ciRequiresFish(a)) return error.FishRequiredButMissing;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // The embedded quote breaks an unescaped quoted context → the parse fails.
+    if (bash_sh) |sh| {
+        const s = try bash.generate(a, "advapp", &adv_name_commands, &global_options);
+        const path = try writeTemp(a, tmp.dir, "adv_names.bash", s);
+        try std.testing.expectEqual(@as(u8, 0), runExit(a, &.{ sh, "-n", path }));
+    }
+    if (zsh_sh) |sh| {
+        const s = try zsh.generate(a, "advapp", &adv_name_commands, &global_options);
+        const path = try writeTemp(a, tmp.dir, "adv_names.zsh", s);
+        try std.testing.expectEqual(@as(u8, 0), runExit(a, &.{ sh, "-n", path }));
+    }
+    if (fish_sh) |sh| {
+        const s = try fish.generate(a, "advapp", &adv_name_commands, &global_options);
+        const path = try writeTemp(a, tmp.dir, "adv_names.fish", s);
+        try std.testing.expectEqual(@as(u8, 0), runExit(a, &.{ sh, "--no-execute", path }));
+    }
+}
+
+test "functional bash - adversarial command/option NAMES do NOT execute at TAB" {
+    const sh = findShell("bash") orelse return error.SkipZigTest;
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const script = try bash.generate(a, "advapp", &adv_name_commands, &global_options);
+    const script_path = try writeTemp(a, tmp.dir, "advapp_names.bash", script);
+    // Resolve the temp dir (via a throwaway file) so the harness can `cd` into it;
+    // any `$(touch PWNED_*)` that fires would drop its marker right here.
+    const anchor = try writeTemp(a, tmp.dir, "anchor", "");
+    const dir_path = std.fs.path.dirname(anchor).?;
+
+    // Drive the completion function at the two cursor positions that reach the
+    // `case` blocks carrying the adversarial names: a bare word (command +
+    // `$prev` value cases) and an option prefix (option-name case). Bash expands
+    // every pattern in a reached `case` regardless of whether it matches, so an
+    // unescaped name's `$(touch …)` would run now. (We never type the adversarial
+    // name — doing so would run its substitution in the harness itself.)
+    const harness = try std.fmt.allocPrint(a,
+        \\source "{s}"
+        \\cd "{s}"
+        \\drive() {{
+        \\    COMP_WORDS=("$@")
+        \\    COMP_CWORD=$(( ${{#COMP_WORDS[@]}} - 1 ))
+        \\    COMPREPLY=()
+        \\    _advapp_completions
+        \\}}
+        \\drive advapp ''
+        \\drive advapp -
+        \\echo DONE
+        \\
+    , .{ script_path, dir_path });
+    const harness_path = try writeTemp(a, tmp.dir, "advapp_names_harness.bash", harness);
+
+    const result = try std.process.run(a, io, .{ .argv = &.{ sh, harness_path } });
+    try std.testing.expect(advContains(result.stdout, "DONE"));
+
+    // Not a single marker may exist: every name stayed a literal single-quoted
+    // pattern, so no command substitution fired.
+    for ([_][]const u8{ "PWNED_grp", "PWNED_leaf", "PWNED_alias", "PWNED_opt" }) |marker| {
+        const present = if (tmp.dir.access(io, marker, .{})) |_| true else |_| false;
+        try std.testing.expect(!present);
+    }
 }

--- a/packages/core/src/plugin_completions_test.zig
+++ b/packages/core/src/plugin_completions_test.zig
@@ -277,17 +277,17 @@ test "bash gen - dynamic branch, .file positional + option compgen" {
     const script = try bash.generate(std.testing.allocator, "advapp", &i2_commands, &global_options);
     defer std.testing.allocator.free(script);
     try std.testing.expect(contains(script, "__complete")); // dynamic branch for the hook option
-    try std.testing.expect(contains(script, "\"deploy\")")); // .file positional static case
+    try std.testing.expect(contains(script, "'deploy')")); // .file positional static case
     try std.testing.expect(contains(script, "compgen -f")); // .file → files
-    try std.testing.expect(contains(script, "--out)")); // .file option $prev case
+    try std.testing.expect(contains(script, "'--out')")); // .file option $prev case
 }
 
 test "fish gen - option hook + .file option + .file positional" {
     const script = try fish.generate(std.testing.allocator, "advapp", &i2_commands, &global_options);
     defer std.testing.allocator.free(script);
     try std.testing.expect(contains(script, "function __advapp_zcli_complete"));
-    try std.testing.expect(contains(script, "-l host -x -a '(__advapp_zcli_complete)'")); // dynamic option
-    try std.testing.expect(contains(script, "-l out -rF")); // .file option forces files
+    try std.testing.expect(contains(script, "-l 'host' -x -a '(__advapp_zcli_complete)'")); // dynamic option
+    try std.testing.expect(contains(script, "-l 'out' -rF")); // .file option forces files
     // .file positional: force-files at the command's own path, no `-f` suppression.
     try std.testing.expect(contains(script, "complete -c advapp -F -n '__fish_advapp_using_command deploy'"));
 }

--- a/packages/core/src/plugins/zcli_completions/bash.zig
+++ b/packages/core/src/plugins/zcli_completions/bash.zig
@@ -147,7 +147,7 @@ fn writeOptionNames(arena: std.mem.Allocator, writer: anytype, options: []const 
 /// names are single-quoted (escape.bash'd) while `"$opts "` expands the accumulator.
 fn writeOptionCases(arena: std.mem.Allocator, writer: anytype, node: *const tree.CommandNode) !void {
     if (node.options.len > 0) {
-        try writer.print("            \"{s}\")\n", .{try joinPath(arena, node.path)});
+        try writer.print("            '{s}')\n", .{try escape.bash(arena, try joinPath(arena, node.path))});
         try writer.writeAll("                opts=\"$opts \"'");
         try writeOptionNames(arena, writer, node.options);
         try writer.writeAll("'\n");
@@ -161,7 +161,7 @@ fn writeOptionCases(arena: std.mem.Allocator, writer: anytype, node: *const tree
 /// escape.bash'd inside a single-quoted literal.
 fn writeCommandCases(arena: std.mem.Allocator, writer: anytype, node: *const tree.CommandNode) !void {
     if (node.children.len > 0) {
-        try writer.print("        \"{s}\")\n", .{try joinPath(arena, node.path)});
+        try writer.print("        '{s}')\n", .{try escape.bash(arena, try joinPath(arena, node.path))});
         try writer.writeAll("            completions='");
         for (node.children) |child| {
             try writer.print("{s} ", .{try escape.bash(arena, child.name)});
@@ -207,7 +207,7 @@ fn staticCompgenArgs(arena: std.mem.Allocator, enum_values: ?[]const []const u8,
 fn writePositionalCases(arena: std.mem.Allocator, writer: anytype, node: *const tree.CommandNode) !void {
     if (node.isLeaf() and node.args.len > 0) {
         if (try staticCompgenArgs(arena, node.args[0].enum_values, node.args[0].complete)) |gen| {
-            try writer.print("            \"{s}\")\n", .{try joinPath(arena, node.path)});
+            try writer.print("            '{s}')\n", .{try escape.bash(arena, try joinPath(arena, node.path))});
             try writer.print("                COMPREPLY=($(compgen {s} -- \"$cur\"))\n", .{gen});
             try writer.writeAll("                ;;\n");
         }
@@ -261,8 +261,8 @@ fn writeStaticOptionValueCasesRec(arena: std.mem.Allocator, writer: anytype, nod
 fn writeStaticOptionValueCasesFor(arena: std.mem.Allocator, writer: anytype, options: []const zcli.OptionInfo) !void {
     for (options) |opt| {
         const gen = (try staticCompgenArgs(arena, opt.enum_values, opt.complete)) orelse continue;
-        try writer.print("        --{s}", .{opt.name});
-        if (opt.short) |short| try writer.print("|-{c}", .{short});
+        try writer.print("        '--{s}'", .{try escape.bash(arena, opt.name)});
+        if (opt.short) |short| try writer.print("|'-{c}'", .{short});
         try writer.writeAll(")\n");
         try writer.print("            COMPREPLY=($(compgen {s} -- \"$cur\"))\n", .{gen});
         try writer.writeAll("            return 0\n");

--- a/packages/core/src/plugins/zcli_completions/fish.zig
+++ b/packages/core/src/plugins/zcli_completions/fish.zig
@@ -98,8 +98,9 @@ fn writeNode(
         try writeCondition(arena, writer, app_name, node.path);
         // A subcommand takes no value itself. Fish uses only the last `-a`, so
         // offer the name and any aliases as one space-separated argument list.
-        try writer.print(" -a '{s}", .{child.name});
-        for (child.aliases) |alias| try writer.print(" {s}", .{alias});
+        // escape.fish each so a name can't break out of the single-quoted list.
+        try writer.print(" -a '{s}", .{try escape.fish(arena, child.name)});
+        for (child.aliases) |alias| try writer.print(" {s}", .{try escape.fish(arena, alias)});
         try writer.writeAll("'");
         if (child.description) |d| {
             const esc = try escape.fish(arena, d);
@@ -205,7 +206,9 @@ fn writeOption(
     if (path) |p| try writeCondition(arena, writer, app_name, p);
 
     if (opt.short) |short| try writer.print(" -s {c}", .{short});
-    try writer.print(" -l {s}", .{opt.name});
+    // Single-quote + escape.fish the long name so an exotic identifier stays one
+    // literal token rather than shell syntax.
+    try writer.print(" -l '{s}'", .{try escape.fish(arena, opt.name)});
 
     if (opt.description) |desc| {
         const esc = try escape.fish(arena, desc);

--- a/packages/core/src/plugins/zcli_completions/zsh.zig
+++ b/packages/core/src/plugins/zcli_completions/zsh.zig
@@ -92,9 +92,10 @@ fn writeArgsDispatch(
     try writer.print("{s}case $line[{d}] in\n", .{ indent, depth });
 
     for (node.children) |child| {
-        // Match the child by name or any alias.
-        try writer.print("{s}    {s}", .{ indent, child.name });
-        for (child.aliases) |alias| try writer.print("|{s}", .{alias});
+        // Match the child by name or any alias. Single-quoted so a name with a
+        // glob/command-substitution metacharacter is a literal pattern, not code.
+        try writer.print("{s}    '{s}'", .{ indent, try danceSingleQuotes(arena, child.name) });
+        for (child.aliases) |alias| try writer.print("|'{s}'", .{try danceSingleQuotes(arena, alias)});
         try writer.writeAll(")\n");
 
         if (child.children.len > 0) {
@@ -171,8 +172,10 @@ fn writeLeafArguments(
     // Nothing declared → nothing to complete for this command.
     if (specs.items.len == 0) return;
 
-    // Namespace the context so option state doesn't leak between commands.
-    const ctx = try std.mem.join(arena, "-", node.path);
+    // Namespace the context so option state doesn't leak between commands. The
+    // path sits in a double-quoted string, so dq-escape it (a `$(…)`/backtick in
+    // a name must not run).
+    const ctx = try dquoteEscape(arena, try std.mem.join(arena, "-", node.path));
     try writer.print("{s}        curcontext=\"${{curcontext%:*:*}}:{s}:\"\n", .{ indent, ctx });
     try writer.print("{s}        _arguments -S \\\n", .{indent});
     const spec_indent = try std.mem.concat(arena, u8, &.{ indent, "            " });
@@ -206,6 +209,7 @@ fn appendOptionSpecs(
 ) !void {
     for (options) |opt| {
         const esc_desc = if (opt.description) |d| try escape.zsh(arena, d) else null;
+        const esc_name = try escape.zsh(arena, opt.name);
         const action = try optionAction(arena, app_name, opt);
 
         if (opt.short) |short| {
@@ -216,9 +220,9 @@ fn appendOptionSpecs(
             try specs.append(arena, spec);
         }
         const spec = if (esc_desc) |d|
-            try std.fmt.allocPrint(arena, "--{s}[{s}]{s}", .{ opt.name, d, action })
+            try std.fmt.allocPrint(arena, "--{s}[{s}]{s}", .{ esc_name, d, action })
         else
-            try std.fmt.allocPrint(arena, "--{s}{s}", .{ opt.name, action });
+            try std.fmt.allocPrint(arena, "--{s}{s}", .{ esc_name, action });
         try specs.append(arena, spec);
     }
 }
@@ -305,19 +309,22 @@ fn danceSingleQuotes(arena: std.mem.Allocator, s: []const u8) ![]const u8 {
 ///   ":name:_<app>_zcli_complete"  → dynamic hook (calls `__complete`)
 ///   ":name:_files"/":name:_files -/" → the `.file`/`.dir` builtin
 fn optionAction(arena: std.mem.Allocator, app_name: []const u8, opt: zcli.OptionInfo) ![]const u8 {
+    // The option name is the action's message; it lands inside the single-quoted
+    // spec the caller wraps, so escape.zsh it (single-quote dance + spec metachars).
+    const esc_name = try escape.zsh(arena, opt.name);
     if (opt.complete) |c| {
         switch (c) {
-            .hook => return std.fmt.allocPrint(arena, ":{s}:_{s}_zcli_complete", .{ opt.name, app_name }),
-            .file => return std.mem.concat(arena, u8, &.{ ":", opt.name, ":_files" }),
-            .dir => return std.mem.concat(arena, u8, &.{ ":", opt.name, ":_files -/" }),
+            .hook => return std.fmt.allocPrint(arena, ":{s}:_{s}_zcli_complete", .{ esc_name, app_name }),
+            .file => return std.mem.concat(arena, u8, &.{ ":", esc_name, ":_files" }),
+            .dir => return std.mem.concat(arena, u8, &.{ ":", esc_name, ":_files -/" }),
         }
     }
     if (opt.enum_values) |values| {
         const group = try enumActionGroup(arena, values);
-        return std.mem.concat(arena, u8, &.{ ":", opt.name, ":", group });
+        return std.mem.concat(arena, u8, &.{ ":", esc_name, ":", group });
     }
     if (opt.takes_value) {
-        return std.mem.concat(arena, u8, &.{ ":", opt.name, ":" });
+        return std.mem.concat(arena, u8, &.{ ":", esc_name, ":" });
     }
     return "";
 }
@@ -359,7 +366,9 @@ fn writeDescribeEntry(
     name: []const u8,
     description: ?[]const u8,
 ) !void {
-    try writer.print("{s}'{s}", .{ indent, name });
+    // The name heads a single-quoted `_describe` entry (`'name:desc'`), so
+    // escape.zsh it: the single-quote dance plus the `:` separator it splits on.
+    try writer.print("{s}'{s}", .{ indent, try escape.zsh(arena, name) });
     if (description) |d| {
         const esc = try escape.zsh(arena, d);
         try writer.print(":{s}", .{esc});


### PR DESCRIPTION
## Summary

Fixes shell-completion injection: command paths, option names, and aliases were interpolated **raw** into generated completion scripts, so a name containing shell metacharacters could break out of its context or execute at TAB.

- **bash** (`bash.zig`): `case "$key" in "<path>")` patterns and the `--<name>|-s)` `$prev` value cases were built via `joinPath`/`opt.name` unescaped. Bash performs command substitution inside `case` patterns, so a name like `foo$(id)` runs `id` on every TAB. Now single-quoted and routed through `escape.bash` (command substitution does not fire inside `'…'`).
- **zsh** (`zsh.zig`): `case $line[N]` command/alias alternations, `_arguments` option specs, the option-action message, and `_describe` entry names are now `escape.zsh`'d / single-quote-danced; the namespaced `curcontext` path is double-quote-escaped.
- **fish** (`fish.zig`): the `-a` subcommand/alias list and the `-l` long-option name are now `escape.fish`'d and single-quoted.
- **PowerShell** (`powershell.zig`): already escaped every identifier — the reference-correct implementation. **Left unchanged.**

Descriptions were already escaped (the earlier fish-apostrophe fix); names were the remaining gap, which is why this went uncaught.

## Tests

Adds a Layer-4 adversarial-**NAME** suite in `plugin_completions_test.zig` using command/option/alias names like `g'p$(touch PWNED_grp)`:
- structural: asserts the embedded quote is escaped (`'\''` dance / fish `\'`) in every generator's output;
- real-shell syntax: `bash -n` / `zsh -n` / `fish --no-execute` accept the adversarial scripts;
- functional bash: drives the completion function at the cursor positions that reach the adversarial `case` blocks and asserts **no `PWNED_*` marker is dropped** (proves no command substitution fired).

Confirmed empirically that unescaped double-quoted `case` patterns DO execute `$(…)` in bash, while the single-quoted fix and `compgen -W` from a variable are safe.

## Verification note

Local `zig build test` / `test-plugins` could not be completed to green in this environment — the machine is saturated (test binaries OOM-killed mid-run). CI is the authoritative gate for this change.

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)