### PR TITLE
Standard exit codes: 2 for CLI misuse, 3 for command not found

### DIFF
--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -13,6 +13,8 @@ Did you mean:
   --verbose
 ```
 
+The exit code follows the conventional CLI split: `0` success, `2` misuse (a bad/unknown/missing option or argument, or a constraint/validation failure), `3` an unknown (sub)command, and `1` a general failure a command reported itself via `context.fail()`. A closed downstream pipe (`myapp cmd | head`) exits `141` like any well-behaved unix program.
+
 Under the hood everything is a standard Zig error union — a structured `ZcliError` plus an optional `ZcliDiagnostic` carrying the field, position, and expected type. When you parse outside the framework (`zcli.parseCommandLine`, `parseArgs`, `parseOptions`), `formatDiagnostic` renders the same messages.
 
 For the full `ZcliError` set, diagnostic-driven messages, memory/cleanup rules, and a complete standalone parser, see **[zcli.sh/errors](https://zcli.sh/errors/)**.

--- a/err.txt
+++ b/err.txt
@@ -1,0 +1,2 @@
+error: the following build command terminated with signal KILL:
+.zig-cache/o/92a2676355f14361cd4f2319a7ccfd23/build /Users/ryanhair/.local/share/mise/installs/zig/0.16.0/zig /Users/ryanhair/.local/share/mise/installs/zig/0.16.0/lib /Users/ryanhair/Projects/zcli/.claude/worktrees/agent-a2fc2356dbc415c27 .zig-cache /Users/ryanhair/.cache/zig --seed 0x2538e015 -Za67764ea59cb5517 test

--- a/packages/core/src/registry/compiled.zig
+++ b/packages/core/src/registry/compiled.zig
@@ -83,6 +83,26 @@ fn isReportedCliError(err: anyerror) bool {
     };
 }
 
+/// Process exit status for a reported CLI error, following the conventional
+/// sysexits-flavoured split most CLIs use:
+///   2 — misuse: the argv itself is wrong (bad/unknown/missing options and
+///       arguments, constraint and validation failures). The user should fix
+///       the command line.
+///   3 — the named (sub)command doesn't exist at all.
+///   1 — a general failure the command itself reported via context.fail(): the
+///       command was well-formed, but the work couldn't be done.
+/// Caller must have already established `isReportedCliError(err)` is true.
+fn exitCodeForReportedError(err: anyerror) u8 {
+    return switch (err) {
+        error.CommandNotFound,
+        error.SubcommandNotFound,
+        => 3,
+        error.CommandFailed => 1,
+        // Everything else reported is CLI misuse (see isReportedCliError).
+        else => 2,
+    };
+}
+
 /// Conventional exit status for a process terminated by SIGPIPE (128 + 13).
 /// A zcli CLI whose stdout/stderr pipe is closed by a downstream reader (the
 /// classic `yourcli cmd | head` case) mimics that status so shell pipelines
@@ -122,6 +142,19 @@ test "isReportedCliError: context.fail's error exits cleanly, unexpected errors 
     try std.testing.expect(isReportedCliError(error.ArgumentValidationFailed));
     // An unexpected failure keeps its name + trace (propagated, not swallowed).
     try std.testing.expect(!isReportedCliError(error.OutOfMemory));
+}
+
+test "exitCodeForReportedError: misuse=2, not-found=3, general=1" {
+    // A missing/wrong command line is misuse.
+    try std.testing.expectEqual(@as(u8, 2), exitCodeForReportedError(error.OptionUnknown));
+    try std.testing.expectEqual(@as(u8, 2), exitCodeForReportedError(error.ArgumentMissingRequired));
+    try std.testing.expectEqual(@as(u8, 2), exitCodeForReportedError(error.OptionMutuallyExclusive));
+    try std.testing.expectEqual(@as(u8, 2), exitCodeForReportedError(error.ArgumentValidationFailed));
+    // A non-existent (sub)command gets its own status.
+    try std.testing.expectEqual(@as(u8, 3), exitCodeForReportedError(error.CommandNotFound));
+    try std.testing.expectEqual(@as(u8, 3), exitCodeForReportedError(error.SubcommandNotFound));
+    // A well-formed command that reported its own failure is a general error.
+    try std.testing.expectEqual(@as(u8, 1), exitCodeForReportedError(error.CommandFailed));
 }
 
 test "isBrokenPipe: only BrokenPipe counts as a broken pipe" {
@@ -712,14 +745,15 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
                 }
                 // CLI-entry semantics: some failures already showed the user a
                 // message — parse/routing diagnostics, a plugin, the framework
-                // fallback, or a command's own context.fail(). Exit(1) without
-                // letting a raw error trace follow that friendly message.
-                // Anything else is an unexpected failure; propagate it so the
-                // name and trace aid debugging. Library/test callers who want
-                // the error itself use execute() directly.
+                // fallback, or a command's own context.fail(). Exit non-zero
+                // with the conventional status (2 misuse / 3 command-not-found
+                // / 1 general) without letting a raw error trace follow that
+                // friendly message. Anything else is an unexpected failure;
+                // propagate it so the name and trace aid debugging. Library/test
+                // callers who want the error itself use execute() directly.
                 if (isReportedCliError(err)) {
                     console.restore();
-                    std.process.exit(1);
+                    std.process.exit(exitCodeForReportedError(err));
                 }
                 return err;
             };

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -483,14 +483,15 @@ test "add command outside a project fails clearly" {
     try testing.expect(std.mem.indexOf(u8, r.stderr, "error: NotInZcliProject") == null);
 }
 
-test "unknown option prints the diagnostic message, exits 1, no error trace" {
+test "unknown option prints the diagnostic message, exits 2 (misuse), no error trace" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
     try makeProjectDirs(tmp.dir);
 
     var r = try run(tmp.dir, &.{ zcli_exe, "tree", "--bogus" });
     defer r.deinit();
-    try testing.expect(r.exit_code == 1);
+    // CLI misuse (a bad option) exits 2 by convention.
+    try testing.expect(r.exit_code == 2);
     // The wired diagnostic names the exact flag...
     try expectContains(r.stderr, "Unknown option '--bogus'");
     // ...and the raw Zig error trace no longer follows the friendly message.


### PR DESCRIPTION
DESIGN.md documents the conventional exit-code table (0/1/2/3), but the entry point exited `1` for every reported CLI error alike. This implements the documented split.

## Exit-code mapping

All reported errors funnel through the single process-exit site in `run()` (`packages/core/src/registry/compiled.zig`), so the mapping lives in one small function, `exitCodeForReportedError`:

| Code | Meaning | Errors |
|------|---------|--------|
| `0` | Success | — |
| `1` | General error | `error.CommandFailed` (`context.fail()`) — the command line was fine, the work failed |
| `2` | Misuse | every reported parse/validation error: unknown/duplicate/missing options, bad values, missing/extra/invalid arguments, constraint (`exclusive`/`requires`) and `validate` failures, resource limits |
| `3` | Command not found | `error.CommandNotFound`, `error.SubcommandNotFound` |
| `141` | Broken pipe | unchanged (128+SIGPIPE) |

`context.exit(code)` remains fully user-driven, and unexpected errors still propagate with their name/trace instead of being mapped.

## Changes

- `packages/core/src/registry/compiled.zig`: new `exitCodeForReportedError()` + unit test; the `run()` exit site uses it instead of a hard-coded `exit(1)`.
- `projects/zcli/test/e2e.zig`: the unknown-option e2e now asserts exit `2`.
- `docs/ERROR_HANDLING.md`: one paragraph stating the exit-code convention. `docs/DESIGN.md:697-702` already documented this table and is now accurate as written.

## Verification

`zig build test` locally: all spawned package/example suites green (repostat, oauth-device, zcli, ghauth, tasks, ext-plugin, notes); the core unit-test compile could not finish locally due to machine saturation (concurrent agents, OOM-killed test binaries) — CI is the authoritative gate for this PR.

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4
