### PR TITLE
Fix dash-token classification: consolidate isNegativeNumber, bare '-' as value, short-option flag swallowing

### DIFF
--- a/packages/core/src/command_parser.zig
+++ b/packages/core/src/command_parser.zig
@@ -78,8 +78,10 @@ pub fn parseCommandLine(
             break;
         }
 
-        // Handle options (start with -, but not negative numbers)
-        if (std.mem.startsWith(u8, arg, "-") and !isNegativeNumber(arg)) {
+        // Handle options. `isOption` (options/utils.zig — the single source of
+        // truth) excludes negative numbers (`-.5`, `-inf`) and the bare `-`
+        // stdin/stdout sentinel, which are positionals, not flags.
+        if (option_utils.isOption(arg)) {
             option_args.append(allocator, arg) catch return ZcliError.SystemOutOfMemory;
 
             // Check if this option expects a value
@@ -96,9 +98,7 @@ pub fn parseCommandLine(
                     // another flag" condition, so split and parse agree.
                     const option_name = arg[2..]; // Remove "--"
                     const takes_value = option_utils.longOptionTakesValue(OptionsType, meta, option_name) orelse false;
-                    if (takes_value and i + 1 < args.len and
-                        (!std.mem.startsWith(u8, args[i + 1], "-") or isNegativeNumber(args[i + 1])))
-                    {
+                    if (takes_value and i + 1 < args.len and option_utils.isValueToken(args[i + 1])) {
                         i += 1;
                         option_args.append(allocator, args[i]) catch return ZcliError.SystemOutOfMemory;
                     }
@@ -110,7 +110,9 @@ pub fn parseCommandLine(
                     // Single short option, might need value
                     const option_char = option_chars[0];
                     const takes_value = option_utils.shortOptionTakesValue(OptionsType, meta, option_char) orelse false;
-                    if (takes_value and i + 1 < args.len) {
+                    // A following flag is not this short option's value — same
+                    // "next token is a value" rule the long path uses (#299).
+                    if (takes_value and i + 1 < args.len and option_utils.isValueToken(args[i + 1])) {
                         i += 1;
                         option_args.append(allocator, args[i]) catch return ZcliError.SystemOutOfMemory;
                     }
@@ -157,14 +159,6 @@ pub fn parseCommandLine(
             break :blk null;
         },
     };
-}
-
-/// Check if a string represents a negative number
-fn isNegativeNumber(arg: []const u8) bool {
-    if (arg.len < 2 or arg[0] != '-') return false;
-
-    // Check if the character after '-' is a digit
-    return std.ascii.isDigit(arg[1]);
 }
 
 /// Parse options from a list of option arguments, returning the parsed values
@@ -1059,6 +1053,103 @@ test "negative numbers classify as values and positionals, not flags" {
     defer result.deinit();
     try std.testing.expectEqual(@as(i32, -5), result.options.offset);
     try std.testing.expectEqual(@as(i32, -10), result.args.delta);
+}
+
+// #287 — the pre-split classifier used a local `-<digit>`-only isNegativeNumber
+// that diverged from the shared one, so `-.5`/`-inf` positionals were silently
+// routed to options and dropped. These parseCommandLine-level tests are the
+// layer the prior gap slipped through (lower-layer tests all passed).
+test "#287 non-integer negative positional reaches the args, not option_args" {
+    const allocator = std.testing.allocator;
+    const Args = struct { v: []const u8 };
+    const Options = struct { verbose: bool = false };
+
+    // Previously ArgumentMissingRequired: `-.5` vanished between split and parse.
+    for ([_][]const u8{ "-.5", "-inf", "-nan", "-1e5", "-1.5e-3" }) |tok| {
+        const result = try parseCommandLine(Args, Options, null, allocator, null, &.{tok}, null);
+        defer result.deinit();
+        try std.testing.expectEqualStrings(tok, result.args.v);
+    }
+}
+
+test "#287 varargs of non-integer negatives are all captured" {
+    const allocator = std.testing.allocator;
+    const Args = struct { values: [][]const u8 };
+    const Options = struct {};
+
+    // Previously received zero values.
+    const result = try parseCommandLine(Args, Options, null, allocator, null, &.{ "-.5", "-.25", "-inf" }, null);
+    defer result.deinit();
+    try std.testing.expectEqual(@as(usize, 3), result.args.values.len);
+    try std.testing.expectEqualStrings("-.5", result.args.values[0]);
+    try std.testing.expectEqualStrings("-.25", result.args.values[1]);
+    try std.testing.expectEqualStrings("-inf", result.args.values[2]);
+}
+
+test "#287 non-integer negative as an option value (both positions agree)" {
+    const allocator = std.testing.allocator;
+    const Options = struct { min: f64 = 0 };
+
+    const result = try parseCommandLine(struct {}, Options, null, allocator, null, &.{ "--min", "-.5" }, null);
+    defer result.deinit();
+    try std.testing.expectApproxEqAbs(@as(f64, -0.5), result.options.min, 0.0001);
+}
+
+test "#298 a bare '-' is a positional, not an unknown option" {
+    const allocator = std.testing.allocator;
+    const Args = struct { file: []const u8 };
+    const Options = struct { verbose: bool = false };
+
+    // Previously OptionUnknown; `-` is the stdin/stdout sentinel (`cat -`).
+    const result = try parseCommandLine(Args, Options, null, allocator, null, &.{"-"}, null);
+    defer result.deinit();
+    try std.testing.expectEqualStrings("-", result.args.file);
+    try std.testing.expect(!result.options.verbose);
+}
+
+test "#298 bare '-' among other args and after a flag" {
+    const allocator = std.testing.allocator;
+    const Args = struct { a: []const u8, b: []const u8 };
+    const Options = struct { verbose: bool = false };
+
+    const result = try parseCommandLine(Args, Options, null, allocator, null, &.{ "--verbose", "-", "out" }, null);
+    defer result.deinit();
+    try std.testing.expect(result.options.verbose);
+    try std.testing.expectEqualStrings("-", result.args.a);
+    try std.testing.expectEqualStrings("out", result.args.b);
+}
+
+test "#299 a short value-option does not swallow a following flag" {
+    const allocator = std.testing.allocator;
+    const Options = struct {
+        tag: ?[]const u8 = null,
+        verbose: bool = false,
+        pub const meta = .{ .options = .{ .tag = .{ .short = 't' } } };
+    };
+
+    // Previously tag="--verbose", verbose=false, no error. Must mirror the long
+    // path (`--tag --verbose` → OptionMissingValue).
+    var diag: ?ZcliDiagnostic = null;
+    const result = parseCommandLine(struct {}, Options, Options.meta, allocator, null, &.{ "-t", "--verbose" }, &diag);
+    try std.testing.expectError(ZcliError.OptionMissingValue, result);
+}
+
+test "#315 '-' is consistently an option value across --opt -, --opt=-, -o -" {
+    const allocator = std.testing.allocator;
+    const Options = struct {
+        out: ?[]const u8 = null,
+        pub const meta = .{ .options = .{ .out = .{ .short = 'o' } } };
+    };
+
+    inline for (.{
+        &.{ "--out", "-" },
+        &.{"--out=-"},
+        &.{ "-o", "-" },
+    }) |argv| {
+        const result = try parseCommandLine(struct {}, Options, Options.meta, allocator, null, argv, null);
+        defer result.deinit();
+        try std.testing.expectEqualStrings("-", result.options.out.?);
+    }
 }
 
 test "firstMissingRequiredOption: satisfied by CLI, env, or config; else reported" {

--- a/packages/core/src/options/array_utils.zig
+++ b/packages/core/src/options/array_utils.zig
@@ -101,6 +101,13 @@ pub fn appendToArrayListUnionShort(comptime ElementType: type, allocator: std.me
 /// An empty segment (`a,,b`, `,a`, `a,`) is rejected as an invalid value.
 /// Delegates to `appendToArrayListUnion` per segment, reusing its per-element
 /// parsing and diagnostics unchanged.
+///
+/// KNOWN LIMITATION (grade6 #316): the comma is an unconditional separator —
+/// there is no escape, so a single string-array element cannot contain a literal
+/// comma. `--label a,b` is always two elements (`a`, `b`), never the one element
+/// `a,b`. If an element must carry a comma, the CSV shorthand cannot express it;
+/// this is an accepted tradeoff of the `--opt a,b` sugar (ADR-0024). Repeated
+/// flags (`--label a --label b`) remain available and are unaffected.
 pub fn appendCsvToArrayListUnion(comptime ElementType: type, allocator: std.mem.Allocator, list_union: *ArrayListUnion, value: []const u8, option_name: []const u8) !void {
     var it = std.mem.splitScalar(u8, value, ',');
     while (it.next()) |segment| {

--- a/packages/core/src/options/parser.zig
+++ b/packages/core/src/options/parser.zig
@@ -214,14 +214,10 @@ pub fn parseOptionsWithMeta(
             break;
         }
 
-        // Not an option, skip to next argument (GNU-style parsing)
-        if (!std.mem.startsWith(u8, arg, "-")) {
-            arg_index += 1;
-            continue;
-        }
-
-        // Check if this is a negative number - if so, skip it (GNU-style parsing)
-        if (utils.isNegativeNumber(arg)) {
+        // Not an option — a bare word, a negative number (`-5`, `-.5`, `-inf`),
+        // or the bare `-` stdin/stdout sentinel: skip it (GNU-style parsing
+        // leaves positionals in place). `isOption` is the single source of truth.
+        if (!utils.isOption(arg)) {
             arg_index += 1;
             continue;
         }
@@ -549,7 +545,7 @@ fn parseLongOptions(
             const value = blk: {
                 if (option_value) |val| {
                     break :blk val;
-                } else if (arg_index + 1 < args.len and (!std.mem.startsWith(u8, args[arg_index + 1], "-") or utils.isNegativeNumber(args[arg_index + 1]))) {
+                } else if (arg_index + 1 < args.len and utils.isValueToken(args[arg_index + 1])) {
                     break :blk args[arg_index + 1];
                 } else {
                     if (diag) |d| d.* = .{ .OptionMissingValue = .{
@@ -709,8 +705,11 @@ fn parseShortOptionsWithMeta(
                         // Value attached: -ovalue
                         value = options_part[1..];
                     } else {
-                        // Value in next argument
-                        if (arg_index + 1 >= args.len) {
+                        // Value in the next argument — but only if that token is
+                        // a value, not another option (#299). A following flag
+                        // (`-t --verbose`) is a missing value, mirroring the long
+                        // path; the bare `-` and negative numbers count as values.
+                        if (arg_index + 1 >= args.len or !utils.isValueToken(args[arg_index + 1])) {
                             if (diag) |d| d.* = .{ .OptionMissingValue = .{
                                 .option_name = options_part[0..1],
                                 .is_short = true,
@@ -1468,8 +1467,8 @@ pub fn parseOptionsAndArgs(
     while (i < args.len) {
         const arg = args[i];
 
-        // Check if this is an option
-        if (std.mem.startsWith(u8, arg, "-") and !utils.isNegativeNumber(arg)) {
+        // Check if this is an option (not a negative number or bare `-`).
+        if (utils.isOption(arg)) {
             option_args.append(allocator, arg) catch {
                 return ZcliError.SystemOutOfMemory;
             };
@@ -1499,7 +1498,7 @@ pub fn parseOptionsAndArgs(
             // If option expects a value and next arg exists and isn't an option, consume it
             if (expects_value and i + 1 < args.len) {
                 const next_arg = args[i + 1];
-                if (!std.mem.startsWith(u8, next_arg, "-") or utils.isNegativeNumber(next_arg)) {
+                if (utils.isValueToken(next_arg)) {
                     option_args.append(allocator, next_arg) catch {
                         return ZcliError.SystemOutOfMemory;
                     };

--- a/packages/core/src/options/utils.zig
+++ b/packages/core/src/options/utils.zig
@@ -172,6 +172,27 @@ fn isValidInteger(s: []const u8) bool {
     return true;
 }
 
+/// Is `tok` a value token rather than a new option? A token that follows a
+/// value-taking option is that option's value unless the token is itself another
+/// option. A token is NOT a new option — so it serves as a value/positional —
+/// when it does not start with `-`, when it is a negative number (`-5`, `-.5`,
+/// `-inf`, `-1e9`), or when it is the bare `-` stdin/stdout sentinel
+/// (`cat -`, `sort -`). This is the single predicate every value lookahead and
+/// positional classifier shares, so the pre-split and the parser always agree.
+pub fn isValueToken(tok: []const u8) bool {
+    if (!std.mem.startsWith(u8, tok, "-")) return true;
+    if (std.mem.eql(u8, tok, "-")) return true;
+    return isNegativeNumber(tok);
+}
+
+/// Is `arg` an option flag (a `--long`, `-x`, or bundled `-xyz`)? The inverse of
+/// `isValueToken` for `-`-prefixed tokens: a leading `-` is an option unless the
+/// token is a negative number or the bare `-` sentinel. (`--` end-of-options is
+/// handled by callers before this.)
+pub fn isOption(arg: []const u8) bool {
+    return std.mem.startsWith(u8, arg, "-") and !isValueToken(arg);
+}
+
 /// Check if a type is boolean
 pub fn isBooleanType(comptime T: type) bool {
     return T == bool;
@@ -365,6 +386,37 @@ test "isNegativeNumber function - decimal edge cases" {
     try std.testing.expect(!isNegativeNumber("-.")); // Just dash-dot
     try std.testing.expect(!isNegativeNumber("-..5")); // Multiple dots
     try std.testing.expect(!isNegativeNumber("-1.2.3")); // Multiple dots
+}
+
+test "isValueToken: bare word, negative number, and bare '-' are values; flags are not" {
+    // Plain positionals / values.
+    try std.testing.expect(isValueToken("input.txt"));
+    try std.testing.expect(isValueToken(""));
+    // Negative numbers in every spelling the shared classifier accepts.
+    try std.testing.expect(isValueToken("-5"));
+    try std.testing.expect(isValueToken("-.5"));
+    try std.testing.expect(isValueToken("-1e9"));
+    try std.testing.expect(isValueToken("-inf"));
+    try std.testing.expect(isValueToken("-nan"));
+    // The bare '-' stdin/stdout sentinel is a value, never a flag.
+    try std.testing.expect(isValueToken("-"));
+    // Real options are not value tokens.
+    try std.testing.expect(!isValueToken("-t"));
+    try std.testing.expect(!isValueToken("--verbose"));
+    try std.testing.expect(!isValueToken("-xyz"));
+}
+
+test "isOption is the inverse of isValueToken for '-'-prefixed tokens" {
+    try std.testing.expect(isOption("--verbose"));
+    try std.testing.expect(isOption("-t"));
+    try std.testing.expect(isOption("-xyz"));
+    // Bare '-', negative numbers, and plain words are not options.
+    try std.testing.expect(!isOption("-"));
+    try std.testing.expect(!isOption("-5"));
+    try std.testing.expect(!isOption("-.5"));
+    try std.testing.expect(!isOption("-inf"));
+    try std.testing.expect(!isOption("input.txt"));
+    try std.testing.expect(!isOption(""));
 }
 
 test "parseFloat function - special values" {

--- a/packages/core/src/plugins/zcli_completions/resolve.zig
+++ b/packages/core/src/plugins/zcli_completions/resolve.zig
@@ -160,7 +160,7 @@ fn optionSpecFor(
 fn isOption(tok: []const u8) bool {
     if (tok.len < 2) return false;
     if (tok[0] != '-') return false;
-    if (isNegativeNumber(tok)) return false;
+    if (zcli.isNegativeNumber(tok)) return false;
     return true;
 }
 
@@ -252,11 +252,3 @@ fn argForSlot(args: []const zcli.ArgInfo, slot: usize) ?zcli.ArgInfo {
     return if (last.is_variadic) last else null;
 }
 
-/// A leading-`-` token that is actually a negative number, so not an option.
-fn isNegativeNumber(arg: []const u8) bool {
-    if (arg.len < 2 or arg[0] != '-') return false;
-    for (arg[1..]) |c| {
-        if (!std.ascii.isDigit(c) and c != '.') return false;
-    }
-    return true;
-}

--- a/packages/core/src/plugins/zcli_completions/resolve.zig
+++ b/packages/core/src/plugins/zcli_completions/resolve.zig
@@ -251,4 +251,3 @@ fn argForSlot(args: []const zcli.ArgInfo, slot: usize) ?zcli.ArgInfo {
     const last = args[args.len - 1];
     return if (last.is_variadic) last else null;
 }
-

--- a/packages/core/src/registry/compiled.zig
+++ b/packages/core/src/registry/compiled.zig
@@ -773,9 +773,7 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
                             if (global_opt.type != bool) {
                                 // Same next-token-is-a-value rule the command
                                 // parsers share (options/utils.zig).
-                                if (i + 1 < args.len and
-                                    (!std.mem.startsWith(u8, args[i + 1], "-") or option_utils.isNegativeNumber(args[i + 1])))
-                                {
+                                if (i + 1 < args.len and option_utils.isValueToken(args[i + 1])) {
                                     i += 1;
                                     value = args[i];
                                     try consumed.append(context.allocator, i);
@@ -805,9 +803,7 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
 
                             var value: []const u8 = "true";
                             if (global_opt.type != bool) {
-                                if (i + 1 < args.len and
-                                    (!std.mem.startsWith(u8, args[i + 1], "-") or option_utils.isNegativeNumber(args[i + 1])))
-                                {
+                                if (i + 1 < args.len and option_utils.isValueToken(args[i + 1])) {
                                     i += 1;
                                     value = args[i];
                                     try consumed.append(context.allocator, i);

--- a/packages/core/src/zcli.zig
+++ b/packages/core/src/zcli.zig
@@ -87,6 +87,13 @@ pub const custom_type = @import("custom_type.zig");
 /// `__complete` command runs a field's hook at `<TAB>`.
 pub const completion = @import("completion.zig");
 
+/// Is this `-`-prefixed token actually a negative number (`-5`, `-.5`, `-1e9`,
+/// `-inf`, `-nan`) rather than an option flag? The single source of truth shared
+/// with the argument parser — the `zcli_completions` cursor walk must count
+/// positional slots exactly as the parser does, so both read this one predicate
+/// instead of keeping divergent copies (grade6 #300).
+pub const isNegativeNumber = option_utils.isNegativeNumber;
+
 /// Option value-coercion surface for the zcli_config plugin. A config file
 /// stores scalars in a format-native shape (JSON/TOML/YAML); the plugin
 /// stringifies them and routes through *the same* parser the CLI and env use,


### PR DESCRIPTION
## Summary

All dash-prefixed token classification now flows through two shared predicates in `packages/core/src/options/utils.zig`:

- **`isValueToken(tok)`** — a token serves as an option value / positional when it doesn't start with `-`, is a negative number (`-5`, `-.5`, `-1e5`, `-inf`, `-nan`), or is the bare `-` stdin/stdout sentinel.
- **`isOption(arg)`** — its inverse for `-`-prefixed tokens.

Both are built on the single full `isNegativeNumber`, and every pre-split classifier and value lookahead (`command_parser.zig`, `options/parser.zig` long+short+`parseOptionsAndArgs`, `registry/compiled.zig` global options, `zcli_completions/resolve.zig`) now reads them, so split and parse can no longer disagree about the same token.

## Per-issue

- **#287 (P1 silent drop):** deleted the local `-<digit>`-only `isNegativeNumber` in `command_parser.zig` whose divergence from the shared classifier made positional `-.5`/`-inf`/`-1e5` vanish (routed to `option_args` by the local copy, then skipped as a negative number by the shared one). Added `parseCommandLine`-level differential tests — the layer the bug previously survived under — for non-integer negatives as positionals, varargs, and option values.
- **#298:** bare `-` is now a positional (`cat -` convention) instead of `OptionUnknown`, handled in the pre-split and the options parser's GNU-style skip via the shared predicate.
- **#299:** the short value-option path (pre-split + `parseShortOptionsWithMeta`) now applies the same "a following flag is not a value" rule the long path had: `-t --verbose` errors `OptionMissingValue` instead of silently setting `tag="--verbose"`.
- **#315:** with the above, `-` is consistently accepted as an option value across `--out -`, `--out=-`, and `-o -` (previously `--out -` errored). Test asserts all three spellings agree.
- **#300:** four `isNegativeNumber` implementations consolidated to one. `zcli_completions/resolve.zig` (whose digits-or-dot copy misclassified `-1e5`/`-inf`, drifting completion's positional-slot count from the parse) now uses a new `zcli.isNegativeNumber` re-export; the copies in `command_parser.zig` and `resolve.zig` are deleted. Differential coverage lives in the shared predicate's unit tests plus the new `parseCommandLine`-level tests.
- **#316:** documented as a known limitation on `appendCsvToArrayListUnion` (`options/array_utils.zig`): the CSV comma has no escape, a literal comma in a string-array element is inexpressible via the `--opt a,b` sugar; repeated flags remain the workaround (accepted ADR-0024 tradeoff). No escape mechanism added.

## Verification

Local verification was limited by machine saturation (multiple concurrent agent builds; test binaries OOM-killed): `zig ast-check` passes on all seven edited files, and the `zig test packages/core/src/command_parser.zig` binary (including all new tests) **compiled** cleanly but could not finish executing locally. **CI is authoritative for this PR.**

Closes #287
Closes #298
Closes #299
Closes #300
Closes #315
Closes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4