### PR TITLE
docs: fix ERROR_HANDLING.md API refs, document context.fail/exit

### DIFF
--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -15,6 +15,23 @@ Did you mean:
 
 The exit code follows the conventional CLI split: `0` success, `2` misuse (a bad/unknown/missing option or argument, or a constraint/validation failure), `3` an unknown (sub)command, and `1` a general failure a command reported itself via `context.fail()`. A closed downstream pipe (`myapp cmd | head`) exits `141` like any well-behaved unix program.
 
-Under the hood everything is a standard Zig error union — a structured `ZcliError` plus an optional `ZcliDiagnostic` carrying the field, position, and expected type. When you parse outside the framework (`zcli.parseCommandLine`, `parseArgs`, `parseOptions`), `formatDiagnostic` renders the same messages.
+Under the hood everything is a standard Zig error union — a structured `ZcliError` plus an optional `ZcliDiagnostic` carrying the field, position, and expected type. When you parse outside the framework with `zcli.parseCommandLine`, `formatDiagnostic` renders the same messages.
+
+## Reporting errors from a command
+
+Inside `execute()`, use `context.fail` and `context.exit` to report failures yourself:
+
+```zig
+pub fn execute(args: Args, options: Options, context: *zcli.Context) !void {
+    if (!std.mem.eql(u8, args.env, "prod") and !std.mem.eql(u8, args.env, "staging")) {
+        return context.fail("unknown environment '{s}'", .{args.env});
+    }
+    // ...
+}
+```
+
+`context.fail(comptime fmt, args)` prints the formatted message to stderr and returns `error.CommandFailed`, which the framework maps to exit code `1` (see the exit-code table above). It's the standard way for a command to report a general failure of its own without hand-rolling stderr writes and error values.
+
+`context.exit(code: u8) noreturn` flushes buffered stdout/stderr and calls `std.process.exit(code)` directly, for the rarer case where a command needs to terminate with a specific exit code immediately rather than propagating an error up through `execute()`.
 
 For the full `ZcliError` set, diagnostic-driven messages, memory/cleanup rules, and a complete standalone parser, see **[zcli.sh/errors](https://zcli.sh/errors/)**.


### PR DESCRIPTION
## Summary
- Removes references to `zcli.parseArgs` / `zcli.parseOptions` from `docs/ERROR_HANDLING.md` — neither is re-exported on the `zcli` namespace (verified against `packages/core/src/zcli.zig:363-370`); only `zcli.parseCommandLine` is public. `parseArgs`/`parseOptions` exist only as private imports in `args.zig` / `options/parser.zig`.
- Adds a "Reporting errors from a command" section documenting `context.fail(comptime fmt, args)` and `context.exit(code: u8) noreturn`, verified against `packages/core/src/context.zig:254-303`. Builds on the exit-code paragraph added by #356 rather than duplicating it.

Closes #312
Closes #341

## Premise check
Both issues' premises matched the code exactly — no mismatches found.

## Test plan
- [x] Docs-only change; no build required
- [x] Verified `parseCommandLine` is the only public re-export (`zcli.zig:370`)
- [x] Verified `context.fail` / `context.exit` signatures against `context.zig`
- [x] Verified exit-code mapping (`CommandFailed` -> 1) against `registry/compiled.zig`

🤖 Generated with [Claude Code](https://claude.com/claude-code)