### PR TITLE
docs: fix global-options fiction, ContextFor rename, hook order, main.zig, add generateDocs/addCommandTests

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -289,6 +289,104 @@ _ = zcli.addCommandTests(b, zcli_dep, .{
 See `examples/tasks` for a full, compiling example (the `store` module shared
 across its commands).
 
+## Command Unit Tests (`addCommandTests`)
+
+`zcli.addCommandTests` (`packages/core/src/build_utils/command_tests.zig`) is
+the build-time entry point behind the `zig build test` step that a scaffolded
+project ships with. It discovers every command file under `commands_dir` and
+compiles each as its own in-process test binary, so a command's `test` blocks
+(typically using `zcli-testing`'s `runCommand`) actually run — without pulling
+in the whole generated app.
+
+```zig
+pub fn addCommandTests(
+    b: *std.Build,
+    zcli_dep: *std.Build.Dependency,
+    config: zcli.CommandTestsConfig,
+) *std.Build.Step
+```
+
+`CommandTestsConfig`:
+
+```zig
+pub const CommandTestsConfig = struct {
+    commands_dir: []const u8,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    // Same list passed to `generate()`, so command imports resolve identically
+    // under test.
+    shared_modules: []const SharedModule = &.{},
+    // Same `plugins_dir` passed to `generate()`, so the stub Context includes
+    // the project's local plugins.
+    plugins_dir: ?[]const u8 = null,
+};
+```
+
+Each discovered command compiles against a *stub* `command_registry` module
+(`Context = zcli.TestContext(&.{...})`, built from the project's local plugins
+plus an in-memory `zcli_secrets` stand-in) rather than the real generated
+registry — a command's tests must not require the whole app to compile.
+
+```zig
+// build.zig
+_ = zcli.addCommandTests(b, zcli_dep, .{
+    .commands_dir = "src/commands",
+    .target = target,
+    .optimize = optimize,
+    .plugins_dir = "src/plugins",
+    .shared_modules = &shared_modules,
+});
+```
+
+Returns the created `test` step (registered as `zig build test`) so the caller
+can attach more tests to it. `zcli init` wires this automatically in every
+scaffolded project; see `projects/zcli/src/commands/init.zig` for the generated
+`build.zig` template. For the testing API itself (`runCommand`, VTerm
+assertions, integration/E2E tiers), see [TESTING.md](TESTING.md).
+
+## Documentation Generation (`generateDocs`)
+
+`zcli.generateDocs` (`packages/core/src/build_utils/main.zig`) wires a `zig
+build docs` step that renders command help (from the same `meta`/`Args`/
+`Options` data the registry uses) to files on disk. It is opt-in and kept off
+the default `install`/`test` steps, so an ordinary `zig build` produces no doc
+output.
+
+```zig
+pub fn generateDocs(
+    b: *std.Build,
+    registry_module: *std.Build.Module,
+    zcli_dep: *std.Build.Dependency,
+    config: zcli.DocsConfig,
+) void
+```
+
+`DocsConfig`:
+
+```zig
+pub const DocsConfig = struct {
+    // Formats to generate; each gets its own subdirectory under output_dir.
+    formats: []const []const u8 = &.{"markdown"},
+    output_dir: []const u8 = "docs",
+};
+```
+
+```zig
+// build.zig — after cmd_registry is created by generate()
+// Single format (default: markdown)
+zcli.generateDocs(b, cmd_registry, zcli_dep, .{});
+
+// Multiple formats — each gets its own subdirectory
+zcli.generateDocs(b, cmd_registry, zcli_dep, .{
+    .formats = &.{ "markdown", "man" },
+    .output_dir = "docs",
+});
+```
+
+Run it with `zig build docs`. Under the hood this builds and runs a small
+host-target `zcli-doc-gen` executable (`packages/core/src/doc_gen_main.zig`)
+against your `cmd_registry` module.
+
 ## Registry Generation Process
 
 ### 1. Plugin Registry Integration
@@ -354,8 +452,8 @@ inline for (plugins) |Plugin| {
 
 Each plugin's `ContextData` becomes a typed field on the generated `Context`,
 nested under `plugins` and named by the plugin's `plugin_id`. The field type and
-name are computed at compile time (see `ComputedContextType` in
-`packages/core/src/registry.zig`) — there is no `StringHashMap` or runtime key
+name are computed at compile time (see `ContextFor` in
+`packages/core/src/context.zig`) — there is no `StringHashMap` or runtime key
 lookup, so access is fully typed:
 
 ```zig

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -410,45 +410,53 @@ Plugins can provide global options. For example, the zcli_help plugin provides:
 **Naming Convention:**
 
 - CLI flags: underscores become dashes (`no_color` → `--no-color`)
-- Zig access: accessed through typed globals struct (`context.globals.no_color`)
+- Zig access: read the value back from the declaring plugin's `ContextData`
 
 **Context Access:**
 
-Global options are accessible to all commands through the strongly-typed `context.globals` struct:
+There is no generated `context.globals` struct. A global option is owned by
+the plugin that declares it: `handleGlobalOption` stashes the value on that
+plugin's own `ContextData` (see §12, "Type-Safe Context Extensions"), and any
+command or hook reads it back through `context.plugins.<plugin_id>`:
+
+```zig
+// In the declaring plugin:
+pub const plugin_id = "my_plugin";
+
+pub const ContextData = struct {
+    verbose: bool = false,
+    config: ?[]const u8 = null,
+};
+
+pub fn handleGlobalOption(context: anytype, option_name: []const u8, value: anytype) !void {
+    if (std.mem.eql(u8, option_name, "verbose")) {
+        context.plugins.my_plugin.verbose = value;
+    } else if (std.mem.eql(u8, option_name, "config")) {
+        context.plugins.my_plugin.config = value;
+    }
+}
+```
 
 ```zig
 // In any command file (e.g., commands/deploy.zig)
 pub fn execute(args: Args, options: Options, context: *Context) !void {
-    // Access global options with full type safety
-    if (context.globals.verbose) {
+    // Access global options through the plugin that owns them.
+    if (context.plugins.my_plugin.verbose) {
         try context.stdout().print("Verbose mode enabled\n", .{});
     }
 
     // Optional globals use Zig's optional syntax
-    if (context.globals.config) |config_path| {
+    if (context.plugins.my_plugin.config) |config_path| {
         try loadConfig(config_path);
     }
 }
 ```
 
-**Generated Globals Struct:**
-
-Based on the `global_options` definition in build.zig, zcli generates a strongly-typed `Globals` struct at build time:
-
-```zig
-// Generated from your global_options config
-pub const Globals = struct {
-    verbose: bool,           // .default = false
-    config: ?[]const u8,     // Optional type, no default
-    no_color: bool,          // .default = false
-};
-```
-
 **Global vs Command-Specific Options:**
 
-- **Global options**: Available to all commands via `context.globals`
+- **Global options**: Declared by a plugin, stored on that plugin's `ContextData`, and read via `context.plugins.<plugin_id>`
 - **Command-specific options**: Defined per-command in the `Options` struct
-- **Plugin-provided globals**: Handled by plugins (like `--help`) and typically don't need explicit access
+- **Plugin-provided globals**: Handled by plugins (like `--help`, owned by `zcli_help`'s `ContextData`) and typically don't need explicit access from your own commands
 
 ```zig
 // Command-specific options stay in the Options struct
@@ -458,8 +466,8 @@ pub const Options = struct {
 };
 
 pub fn execute(args: Args, options: Options, context: *Context) !void {
-    // Mix command-specific and global options naturally
-    if (context.globals.verbose or options.force) {
+    // Mix command-specific options with a plugin-owned global naturally
+    if (context.plugins.my_plugin.verbose or options.force) {
         try context.stdout().print("Executing with force\n", .{});
     }
 }
@@ -482,7 +490,7 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
    - Handles --help and --version automatically
    - Parses global options
    - Looks up command in static table
-   - Calls appropriate handler with parsed args and globals
+   - Calls appropriate handler with parsed args and options (plugins read their own globals off `context.plugins.<plugin_id>`)
 
 ## 6. Option Parsing Behavior
 
@@ -548,7 +556,7 @@ files: [][]const u8
 **Context System:**
 
 - Pass a context struct to all commands
-- Contains: stdout, stderr, stdin, globals, environment
+- Contains: stdout, stderr, stdin, environment, and per-plugin `ContextData` (via `context.plugins.<plugin_id>`)
 - Enables testing and different output modes
 
 **Progressive Enhancement:**
@@ -766,18 +774,14 @@ const registry = @import("command_registry");
 
 pub fn main(init: std.process.Init) !void {
     const args = try init.minimal.args.toSlice(init.arena.allocator());
-
     var app = registry.init();
-
-    app.run(init.gpa, init.io, init.environ_map, args) catch |err| switch (err) {
-        error.CommandNotFound => {
-            // Error was already handled by plugins or registry
-            std.process.exit(1);
-        },
-        else => return err,
-    };
+    try app.run(init.gpa, init.io, init.environ_map, args);
 }
 ```
+
+`run` already reports the error, dispatches `onError` hooks, and calls
+`std.process.exit` with the appropriate status (see "Exit Codes" above) —
+there is no error to catch in `main`.
 
 ## 11. Plugin System
 
@@ -843,12 +847,16 @@ const cmd_registry = try zcli.generate(b, exe, zcli_dep, .{
 **Plugin Execution Order:**
 
 1. Plugins are sorted by priority at compile time — a plugin may declare `pub const priority: i32` (default 50); higher values run first, and ties keep registration order
-2. All `handleGlobalOption` hooks called for each global option
-3. All `preExecute` hooks called before command execution
-4. All `applyConfigDefaults` hooks called after CLI/env parse — filling options no higher-precedence source set — then required/dependency/exclusive validation runs
-5. Command executes
-6. All `postExecute` hooks called after successful execution
-7. On error, `onError` hooks called until one handles the error
+2. All `preParse` hooks called, threading each plugin's rewritten argv into the next
+3. Global options are extracted from argv and dispatched to each declaring plugin's `handleGlobalOption`
+4. All `transformArgs` hooks called (each may rewrite argv or stop processing)
+5. Command resolution routes to the matched command, then all `postParse` hooks called, threading each plugin's replacement `ParsedArgs`
+6. All `preExecute` hooks called before command execution (a plugin may cancel execution by returning `null`)
+7. Argv is parsed into the command's `Args`/`Options`
+8. All `applyConfigDefaults` hooks called after CLI/env parse — filling options no higher-precedence source set — then required/dependency/exclusive/per-field validation runs
+9. Command executes
+10. All `postExecute` hooks called after execution (success or a handled failure)
+11. On error at any stage above, `onError` hooks called until one handles the error
 
 **Built-in Plugins:**
 
@@ -920,8 +928,8 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
 `ContextData` structs must be default-constructible; the generated `Context`
 initializes each plugin's field to `.{}`, then — for plugins that declare
 `initContextData` — the dispatcher calls that hook once per invocation (via
-`context.initPluginData()`) before any lifecycle hook. See `ComputedContextType`
-in `packages/core/src/registry.zig`.
+`context.initPluginData()`) before any lifecycle hook. See `ContextFor`
+in `packages/core/src/context.zig`.
 
 **Typing the `context` parameter:**
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -28,4 +28,10 @@ test "deploy command" {
 }
 ```
 
+Unit tests only run under `zig build test` if `build.zig` wires
+`zcli.addCommandTests(b, zcli_dep, .{ .commands_dir = "src/commands", ... })` —
+a scaffolded project (`zcli init`) already does this. See
+[BUILD.md](BUILD.md#command-unit-tests-addcommandtests) for the full config
+and how commands are compiled for testing.
+
 For the full VTerm assertion API, the integration/E2E tiers, snapshot testing, and the recommended per-command strategy, see **[zcli.sh/testing](https://zcli.sh/testing/)**.


### PR DESCRIPTION
## Summary

Docs-only accuracy fixes across DESIGN.md / BUILD.md / TESTING.md, verified against source (packages/core/src).

- **#289 (P1)**: DESIGN.md §4 documented `context.globals.*` and a generated `pub const Globals = struct {...}` — neither exists. `grep` for `globals`/`Globals` in `packages/core/src` (excluding tests/completions) confirms it. Rewrote the section around the real model: a plugin declares `global_options` + `handleGlobalOption`, stashes the value on its own `ContextData`, and any command reads it back via `context.plugins.<plugin_id>` (verified against `packages/core/src/plugins/zcli_help/plugin.zig`). Also fixed the two other stray `context.globals` mentions in §5 and §7.
- **#311**: `ComputedContextType` doesn't exist; the real symbol is `ContextFor` in `packages/core/src/context.zig` (re-exported as `zcli.ContextFor`). Fixed both DESIGN.md §12 and BUILD.md.
- **#319**: DESIGN.md §11's pipeline list jumped straight from priority-sort to `handleGlobalOption`/`preExecute`/`applyConfigDefaults`, skipping `preParse`, `transformArgs`, and `postParse`. Rewrote the full 11-step order by reading `executeWithStdio` and `executeResolvedCommand` in `packages/core/src/registry/compiled.zig`.
- **#339**: DESIGN.md's `main.zig` example wrapped `app.run(...)` in a `catch |err| switch` on `error.CommandNotFound` with a manual `std.process.exit(1)`. The real scaffolded entrypoint (`projects/zcli/src/main.zig`) is just `try app.run(...)` — `run()` already handles reported CLI errors and calls `std.process.exit` with the right status internally (verified in `compiled.zig`'s `run()`). Fixed the example and added a one-line explanation.
- **#340**: `zcli.generateDocs` and `zcli.addCommandTests` were real, exported, but essentially undocumented. Added a full "Command Unit Tests" section and a full "Documentation Generation" section to BUILD.md (signatures + `CommandTestsConfig`/`DocsConfig`, verified against `packages/core/src/build_utils/command_tests.zig` and `main.zig`), and pointed TESTING.md at the new BUILD.md section.

## Exit codes note

PR #356 already shipped the real 0/1/2/3 exit codes (`exitCodeForReportedError` in `compiled.zig`), and DESIGN.md's existing "Exit Codes" list already matched — no change needed there.

## Premise mismatches / notes

- None of the five issues' premises were wrong — all confirmed against source before editing.
- `addCommandTests` was actually already mentioned once in BUILD.md (in the "Sharing Code Between Commands" section) but only as a `shared_modules`-passthrough aside, not a real reference doc — treated as "undocumented" per #340 and gave it a proper standalone section.
- Did not touch any other drift outside these five issues' scope (docs-only PR, no scope creep).

## Test plan

- [x] Docs-only change; no build required per task instructions
- [x] Every API name/signature verified against source with grep/Read (`context.zig`, `zcli.zig`, `registry/compiled.zig`, `plugins/zcli_help/plugin.zig`, `build_utils/main.zig`, `build_utils/command_tests.zig`, `build_utils/types.zig`, `projects/zcli/src/main.zig`, `projects/zcli/src/commands/init.zig`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)