### PR TITLE
chore: document anytype convention, widen dev watch scope, drop dead defer

### DIFF
--- a/projects/zcli/src/commands/dev.zig
+++ b/projects/zcli/src/commands/dev.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const zcli = @import("zcli");
 const nightwatch = @import("nightwatch");
 
@@ -56,21 +57,31 @@ pub fn execute(args: Args, options: Options, context: anytype) !void {
     const cwd_len = try std.process.currentPath(io, &cwd_buf);
     const cwd = cwd_buf[0..cwd_len];
 
-    var state = WatchState{ .io = io };
+    var state = WatchState{ .io = io, .root_len = cwd.len };
     var watcher = try nightwatch.Default.init(io, gpa, &state.handler);
     defer watcher.deinit();
 
     // Watch src/ (the command tree) plus the build description itself: editing
     // build.zig or build.zig.zon (e.g. adding a shared module or dependency)
-    // needs a rebuild just as much as editing a command file does.
+    // needs a rebuild just as much as editing a command file does. Events are
+    // filtered down to those paths in the handler either way.
     var watched = std.ArrayList([]const u8).empty;
     defer {
         for (watched.items) |p| gpa.free(p);
         watched.deinit(gpa);
     }
-    try watchPath(&watcher, io, gpa, cwd, "src", &watched);
-    try watchPath(&watcher, io, gpa, cwd, "build.zig", &watched);
-    try watchPath(&watcher, io, gpa, cwd, "build.zig.zon", &watched);
+    if (builtin.os.tag == .windows) {
+        // ReadDirectoryChangesW only watches directories, so plain-file watches
+        // (build.zig) fail on Windows. One recursive watch on the project root
+        // is a single handle; the handler filter discards zig-out/.zig-cache
+        // noise. On POSIX this would be wasteful (kqueue opens an fd per
+        // directory), so only Windows takes this path.
+        try watcher.watch(cwd);
+    } else {
+        try watchPath(&watcher, io, gpa, cwd, "src", &watched);
+        try watchPath(&watcher, io, gpa, cwd, "build.zig", &watched);
+        try watchPath(&watcher, io, gpa, cwd, "build.zig.zon", &watched);
+    }
 
     try paint(status, theme, "zcli dev", .header);
     try status.writeAll(" — watching src/, build.zig, build.zig.zon (Ctrl-C to stop)\n");
@@ -125,10 +136,26 @@ const vtable = nightwatch.Default.Handler.VTable{ .change = onChange, .rename = 
 /// lets the loop block instead of spin.
 const WatchState = struct {
     io: std.Io,
+    /// Length of the absolute project-root path that prefixes every event.
+    root_len: usize = 0,
     mutex: std.Io.Mutex = .init,
     cond: std.Io.Condition = .init,
     dirty: bool = false,
     handler: nightwatch.Default.Handler = .{ .vtable = &vtable },
+
+    /// Whether an event path warrants a rebuild: anything under src/, or the
+    /// build files themselves. On Windows the watch covers the whole project
+    /// root (see execute), so this discards zig-out/ and .zig-cache/ churn —
+    /// including the very builds this command runs, which would otherwise
+    /// retrigger forever.
+    fn isInteresting(self: *const WatchState, path: []const u8) bool {
+        if (path.len <= self.root_len + 1) return false;
+        const rel = path[self.root_len + 1 ..];
+        if (std.mem.eql(u8, rel, "build.zig") or std.mem.eql(u8, rel, "build.zig.zon")) return true;
+        if (std.mem.startsWith(u8, rel, "src") and
+            (rel.len == 3 or rel[3] == '/' or rel[3] == '\\')) return true;
+        return false;
+    }
 
     fn mark(self: *WatchState) void {
         self.mutex.lockUncancelable(self.io);
@@ -164,19 +191,16 @@ const WatchState = struct {
 };
 
 fn onChange(h: *nightwatch.Default.Handler, path: []const u8, event: nightwatch.EventType, obj: nightwatch.ObjectType) error{HandlerFailed}!void {
-    _ = path;
     _ = event;
     _ = obj;
     const self: *WatchState = @fieldParentPtr("handler", h);
-    self.mark();
+    if (self.isInteresting(path)) self.mark();
 }
 
 fn onRename(h: *nightwatch.Default.Handler, src: []const u8, dst: []const u8, obj: nightwatch.ObjectType) error{HandlerFailed}!void {
-    _ = src;
-    _ = dst;
     _ = obj;
     const self: *WatchState = @fieldParentPtr("handler", h);
-    self.mark();
+    if (self.isInteresting(src) or self.isInteresting(dst)) self.mark();
 }
 
 // ============================================================================
@@ -374,6 +398,23 @@ test "appArgv with no command is just the binary" {
     const argv = try appArgv(arena_state.allocator(), "zig-out/bin/app", &.{});
     try testing.expectEqual(@as(usize, 1), argv.len);
     try testing.expectEqualStrings("zig-out/bin/app", argv[0]);
+}
+
+test "isInteresting filters events to src/ and the build files" {
+    const root = "/home/me/proj";
+    const s = WatchState{ .io = std.testing.io, .root_len = root.len };
+
+    try testing.expect(s.isInteresting(root ++ "/src"));
+    try testing.expect(s.isInteresting(root ++ "/src/commands/hello.zig"));
+    try testing.expect(s.isInteresting(root ++ "\\src\\commands\\hello.zig"));
+    try testing.expect(s.isInteresting(root ++ "/build.zig"));
+    try testing.expect(s.isInteresting(root ++ "/build.zig.zon"));
+
+    try testing.expect(!s.isInteresting(root ++ "/zig-out/bin/app"));
+    try testing.expect(!s.isInteresting(root ++ "/.zig-cache/o/abc/foo.o"));
+    try testing.expect(!s.isInteresting(root ++ "/srcs/other.zig")); // prefix, not src/
+    try testing.expect(!s.isInteresting(root ++ "/build.zig.bak"));
+    try testing.expect(!s.isInteresting(root)); // the root itself
 }
 
 test "WatchState coalesces and consumes the dirty signal" {

--- a/projects/zcli/src/commands/dev.zig
+++ b/projects/zcli/src/commands/dev.zig
@@ -6,7 +6,7 @@ const themed = zcli.theme.styled;
 const ThemeContext = zcli.theme.ThemeContext;
 
 pub const meta = .{
-    .description = "Watch src/ and rebuild on change (optionally run a command)",
+    .description = "Watch src/, build.zig, and build.zig.zon; rebuild on change (optionally run a command)",
     .examples = &.{
         "dev",
         "dev -- users create alice@example.com",
@@ -27,6 +27,9 @@ pub const Options = struct {};
 /// writes into a single rebuild.
 const debounce_ms = 80;
 
+// Convention: this command takes `context: anytype` (not `*Context`) so tests
+// can pass a lightweight stub instead of a full app registry; commands that
+// don't need that testability use `*Context` for the compile-time contract.
 pub fn execute(args: Args, options: Options, context: anytype) !void {
     _ = options;
 
@@ -51,37 +54,64 @@ pub fn execute(args: Args, options: Options, context: anytype) !void {
     // calls std.Io.Dir.cwd().realPath, which is broken on 0.16.0. currentPath works.
     var cwd_buf: [std.fs.max_path_bytes]u8 = undefined;
     const cwd_len = try std.process.currentPath(io, &cwd_buf);
-    const src_abs = try std.fmt.allocPrint(gpa, "{s}{c}src", .{ cwd_buf[0..cwd_len], std.fs.path.sep });
-    defer gpa.free(src_abs);
+    const cwd = cwd_buf[0..cwd_len];
 
     var state = WatchState{ .io = io };
     var watcher = try nightwatch.Default.init(io, gpa, &state.handler);
     defer watcher.deinit();
-    try watcher.watch(src_abs);
+
+    // Watch src/ (the command tree) plus the build description itself: editing
+    // build.zig or build.zig.zon (e.g. adding a shared module or dependency)
+    // needs a rebuild just as much as editing a command file does.
+    var watched = std.ArrayList([]const u8).empty;
+    defer {
+        for (watched.items) |p| gpa.free(p);
+        watched.deinit(gpa);
+    }
+    try watchPath(&watcher, io, gpa, cwd, "src", &watched);
+    try watchPath(&watcher, io, gpa, cwd, "build.zig", &watched);
+    try watchPath(&watcher, io, gpa, cwd, "build.zig.zon", &watched);
 
     try paint(status, theme, "zcli dev", .header);
-    try status.writeAll(" — watching src/ (Ctrl-C to stop)\n");
+    try status.writeAll(" — watching src/, build.zig, build.zig.zon (Ctrl-C to stop)\n");
     try status.flush();
 
     var cycle_arena = std.heap.ArenaAllocator.init(gpa);
     defer cycle_arena.deinit();
 
     // The app started by `-- <command>`, if any. Killed and restarted each cycle.
+    // The loop below never returns normally — Ctrl-C kills the whole process
+    // group (including this child) — so there's nothing to clean up here.
     var app_child: ?std.process.Child = null;
-    // The loop below only exits via error (Ctrl-C kills the whole process
-    // group) — don't leave the spawned app running past dev itself.
-    defer if (app_child) |*c| c.kill(io);
 
     // Build once up front, then rebuild on every change.
-    runCycle(io, &cycle_arena, status, theme, args.command, &app_child);
+    runCycle(io, &cycle_arena, status, theme, context.app_name, args.command, &app_child);
     while (true) {
         state.waitDirty();
         nap(io, debounce_ms); // let the burst settle
         state.clear(); // coalesce events that arrived during the settle window
         try paint(status, theme, "\n• change detected", .dim);
         try status.writeByte('\n');
-        runCycle(io, &cycle_arena, status, theme, args.command, &app_child);
+        runCycle(io, &cycle_arena, status, theme, context.app_name, args.command, &app_child);
     }
+}
+
+/// Watch `name` (relative to `cwd`) if it exists, recording the allocated
+/// absolute path in `watched` so it can be freed later. Missing files (e.g. a
+/// project without a build.zig.zon) are silently skipped.
+fn watchPath(
+    watcher: *nightwatch.Default,
+    io: std.Io,
+    gpa: std.mem.Allocator,
+    cwd: []const u8,
+    name: []const u8,
+    watched: *std.ArrayList([]const u8),
+) !void {
+    std.Io.Dir.cwd().access(io, name, .{}) catch return;
+    const abs = try std.fmt.allocPrint(gpa, "{s}{c}{s}", .{ cwd, std.fs.path.sep, name });
+    errdefer gpa.free(abs);
+    try watcher.watch(abs);
+    try watched.append(gpa, abs);
 }
 
 // ============================================================================
@@ -158,11 +188,12 @@ fn runCycle(
     cycle_arena: *std.heap.ArenaAllocator,
     status: *std.Io.Writer,
     theme: *const ThemeContext,
+    app_name: []const u8,
     command: []const []const u8,
     app_child: *?std.process.Child,
 ) void {
     _ = cycle_arena.reset(.retain_capacity);
-    doCycle(io, cycle_arena.allocator(), status, theme, command, app_child) catch |err| {
+    doCycle(io, cycle_arena.allocator(), status, theme, app_name, command, app_child) catch |err| {
         // Never let a transient failure tear down the watcher.
         status.print("dev: {s}\n", .{@errorName(err)}) catch {};
         status.flush() catch {};
@@ -174,6 +205,7 @@ fn doCycle(
     arena: std.mem.Allocator,
     status: *std.Io.Writer,
     theme: *const ThemeContext,
+    app_name: []const u8,
     command: []const []const u8,
     app_child: *?std.process.Child,
 ) !void {
@@ -191,7 +223,7 @@ fn doCycle(
     if (!try build(io, status, theme)) return; // build failed → don't run
 
     if (command.len > 0) {
-        app_child.* = try startApp(io, arena, status, theme, command);
+        app_child.* = try startApp(io, arena, status, theme, app_name, command);
     }
 }
 
@@ -226,9 +258,10 @@ fn startApp(
     arena: std.mem.Allocator,
     status: *std.Io.Writer,
     theme: *const ThemeContext,
+    app_name: []const u8,
     command: []const []const u8,
 ) !?std.process.Child {
-    const binary = (try findBinary(io, arena)) orelse {
+    const binary = (try findBinary(io, arena, status, theme, app_name)) orelse {
         try paint(status, theme, "  (no executable in zig-out/bin to run)", .dim);
         try status.writeByte('\n');
         try status.flush();
@@ -248,17 +281,45 @@ fn startApp(
     });
 }
 
-/// The first executable in zig-out/bin (a project produces one), or null.
-fn findBinary(io: std.Io, arena: std.mem.Allocator) !?[]const u8 {
+/// Picks the executable in zig-out/bin to run. A scaffolded project produces
+/// exactly one, so the common case is unambiguous; if a project's build
+/// produces several (multiple `b.addExecutable` calls), prefer the one whose
+/// name matches the app (`app_name`, e.g. from `.app_name` in `generate()`),
+/// falling back to the first entry (sorted for determinism) with a warning so
+/// the choice is visible rather than silent.
+fn findBinary(
+    io: std.Io,
+    arena: std.mem.Allocator,
+    status: *std.Io.Writer,
+    theme: *const ThemeContext,
+    app_name: []const u8,
+) !?[]const u8 {
     var dir = std.Io.Dir.cwd().openDir(io, "zig-out/bin", .{ .iterate = true }) catch return null;
     defer dir.close(io);
+
+    var names = std.ArrayList([]const u8).empty;
     var it = dir.iterate();
     while (try it.next(io)) |entry| {
-        if (entry.kind == .file) {
+        if (entry.kind != .file) continue;
+        if (std.mem.eql(u8, std.fs.path.stem(entry.name), app_name)) {
             return try std.fmt.allocPrint(arena, "zig-out{c}bin{c}{s}", .{ std.fs.path.sep, std.fs.path.sep, entry.name });
         }
+        try names.append(arena, try arena.dupe(u8, entry.name));
     }
-    return null;
+    if (names.items.len == 0) return null;
+
+    std.mem.sort([]const u8, names.items, {}, lessThanStr);
+    if (names.items.len > 1) {
+        try paint(status, theme, "  (multiple executables in zig-out/bin; running ", .dim);
+        try status.writeAll(names.items[0]);
+        try status.writeAll(" — pass a distinct app_name or clean zig-out/bin to disambiguate)\n");
+        try status.flush();
+    }
+    return try std.fmt.allocPrint(arena, "zig-out{c}bin{c}{s}", .{ std.fs.path.sep, std.fs.path.sep, names.items[0] });
+}
+
+fn lessThanStr(_: void, a: []const u8, b: []const u8) bool {
+    return std.mem.lessThan(u8, a, b);
 }
 
 /// `<binary> <command...>`.

--- a/projects/zcli/src/commands/dev.zig
+++ b/projects/zcli/src/commands/dev.zig
@@ -6,8 +6,19 @@ const nightwatch = @import("nightwatch");
 const themed = zcli.theme.styled;
 const ThemeContext = zcli.theme.ThemeContext;
 
+/// Whether build.zig/build.zig.zon are watched alongside src/. Windows can't:
+/// nightwatch's backend (ReadDirectoryChangesW) only watches directories, and
+/// the only directory containing the build files is the project root — which
+/// the backend rescans recursively on every create/rename, racing zig's own
+/// package extraction under zig-pkg/ and corrupting builds. So Windows watches
+/// src/ only; build-file edits there need a dev restart.
+const watch_build_files = builtin.os.tag != .windows;
+
 pub const meta = .{
-    .description = "Watch src/, build.zig, and build.zig.zon; rebuild on change (optionally run a command)",
+    .description = if (watch_build_files)
+        "Watch src/, build.zig, and build.zig.zon; rebuild on change (optionally run a command)"
+    else
+        "Watch src/ and rebuild on change (optionally run a command)",
     .examples = &.{
         "dev",
         "dev -- users create alice@example.com",
@@ -57,34 +68,30 @@ pub fn execute(args: Args, options: Options, context: anytype) !void {
     const cwd_len = try std.process.currentPath(io, &cwd_buf);
     const cwd = cwd_buf[0..cwd_len];
 
-    var state = WatchState{ .io = io, .root_len = cwd.len };
+    var state = WatchState{ .io = io };
     var watcher = try nightwatch.Default.init(io, gpa, &state.handler);
     defer watcher.deinit();
 
-    // Watch src/ (the command tree) plus the build description itself: editing
-    // build.zig or build.zig.zon (e.g. adding a shared module or dependency)
-    // needs a rebuild just as much as editing a command file does. Events are
-    // filtered down to those paths in the handler either way.
+    // Watch src/ (the command tree) plus — where the platform allows it, see
+    // watch_build_files — the build description itself: editing build.zig or
+    // build.zig.zon (e.g. adding a shared module or dependency) needs a
+    // rebuild just as much as editing a command file does.
     var watched = std.ArrayList([]const u8).empty;
     defer {
         for (watched.items) |p| gpa.free(p);
         watched.deinit(gpa);
     }
-    if (builtin.os.tag == .windows) {
-        // ReadDirectoryChangesW only watches directories, so plain-file watches
-        // (build.zig) fail on Windows. One recursive watch on the project root
-        // is a single handle; the handler filter discards zig-out/.zig-cache
-        // noise. On POSIX this would be wasteful (kqueue opens an fd per
-        // directory), so only Windows takes this path.
-        try watcher.watch(cwd);
-    } else {
-        try watchPath(&watcher, io, gpa, cwd, "src", &watched);
+    try watchPath(&watcher, io, gpa, cwd, "src", &watched);
+    if (watch_build_files) {
         try watchPath(&watcher, io, gpa, cwd, "build.zig", &watched);
         try watchPath(&watcher, io, gpa, cwd, "build.zig.zon", &watched);
     }
 
     try paint(status, theme, "zcli dev", .header);
-    try status.writeAll(" — watching src/, build.zig, build.zig.zon (Ctrl-C to stop)\n");
+    try status.writeAll(if (watch_build_files)
+        " — watching src/, build.zig, build.zig.zon (Ctrl-C to stop)\n"
+    else
+        " — watching src/; build.zig changes need a restart (Ctrl-C to stop)\n");
     try status.flush();
 
     var cycle_arena = std.heap.ArenaAllocator.init(gpa);
@@ -136,26 +143,10 @@ const vtable = nightwatch.Default.Handler.VTable{ .change = onChange, .rename = 
 /// lets the loop block instead of spin.
 const WatchState = struct {
     io: std.Io,
-    /// Length of the absolute project-root path that prefixes every event.
-    root_len: usize = 0,
     mutex: std.Io.Mutex = .init,
     cond: std.Io.Condition = .init,
     dirty: bool = false,
     handler: nightwatch.Default.Handler = .{ .vtable = &vtable },
-
-    /// Whether an event path warrants a rebuild: anything under src/, or the
-    /// build files themselves. On Windows the watch covers the whole project
-    /// root (see execute), so this discards zig-out/ and .zig-cache/ churn —
-    /// including the very builds this command runs, which would otherwise
-    /// retrigger forever.
-    fn isInteresting(self: *const WatchState, path: []const u8) bool {
-        if (path.len <= self.root_len + 1) return false;
-        const rel = path[self.root_len + 1 ..];
-        if (std.mem.eql(u8, rel, "build.zig") or std.mem.eql(u8, rel, "build.zig.zon")) return true;
-        if (std.mem.startsWith(u8, rel, "src") and
-            (rel.len == 3 or rel[3] == '/' or rel[3] == '\\')) return true;
-        return false;
-    }
 
     fn mark(self: *WatchState) void {
         self.mutex.lockUncancelable(self.io);
@@ -191,16 +182,19 @@ const WatchState = struct {
 };
 
 fn onChange(h: *nightwatch.Default.Handler, path: []const u8, event: nightwatch.EventType, obj: nightwatch.ObjectType) error{HandlerFailed}!void {
+    _ = path;
     _ = event;
     _ = obj;
     const self: *WatchState = @fieldParentPtr("handler", h);
-    if (self.isInteresting(path)) self.mark();
+    self.mark();
 }
 
 fn onRename(h: *nightwatch.Default.Handler, src: []const u8, dst: []const u8, obj: nightwatch.ObjectType) error{HandlerFailed}!void {
+    _ = src;
+    _ = dst;
     _ = obj;
     const self: *WatchState = @fieldParentPtr("handler", h);
-    if (self.isInteresting(src) or self.isInteresting(dst)) self.mark();
+    self.mark();
 }
 
 // ============================================================================
@@ -398,23 +392,6 @@ test "appArgv with no command is just the binary" {
     const argv = try appArgv(arena_state.allocator(), "zig-out/bin/app", &.{});
     try testing.expectEqual(@as(usize, 1), argv.len);
     try testing.expectEqualStrings("zig-out/bin/app", argv[0]);
-}
-
-test "isInteresting filters events to src/ and the build files" {
-    const root = "/home/me/proj";
-    const s = WatchState{ .io = std.testing.io, .root_len = root.len };
-
-    try testing.expect(s.isInteresting(root ++ "/src"));
-    try testing.expect(s.isInteresting(root ++ "/src/commands/hello.zig"));
-    try testing.expect(s.isInteresting(root ++ "\\src\\commands\\hello.zig"));
-    try testing.expect(s.isInteresting(root ++ "/build.zig"));
-    try testing.expect(s.isInteresting(root ++ "/build.zig.zon"));
-
-    try testing.expect(!s.isInteresting(root ++ "/zig-out/bin/app"));
-    try testing.expect(!s.isInteresting(root ++ "/.zig-cache/o/abc/foo.o"));
-    try testing.expect(!s.isInteresting(root ++ "/srcs/other.zig")); // prefix, not src/
-    try testing.expect(!s.isInteresting(root ++ "/build.zig.bak"));
-    try testing.expect(!s.isInteresting(root)); // the root itself
 }
 
 test "WatchState coalesces and consumes the dirty signal" {

--- a/projects/zcli/src/commands/gh/add/workflow/release.zig
+++ b/projects/zcli/src/commands/gh/add/workflow/release.zig
@@ -12,6 +12,9 @@ pub const Args = struct {};
 
 pub const Options = struct {};
 
+// Convention: this command takes `context: anytype` (not `*Context`) so tests
+// can pass a lightweight stub instead of a full app registry; commands that
+// don't need that testability use `*Context` for the compile-time contract.
 pub fn execute(_: Args, _: Options, context: anytype) !void {
     var stdout = context.stdout();
     var stderr = context.stderr();

--- a/projects/zcli/src/commands/release.zig
+++ b/projects/zcli/src/commands/release.zig
@@ -84,6 +84,9 @@ const Version = struct {
     }
 };
 
+// Convention: this command takes `context: anytype` (not `*Context`) so tests
+// can pass a lightweight stub instead of a full app registry; commands that
+// don't need that testability use `*Context` for the compile-time contract.
 pub fn execute(args: Args, options: Options, context: anytype) !void {
     const allocator = context.allocator;
     var stdout = context.stdout();

--- a/projects/zcli/src/commands/tree.zig
+++ b/projects/zcli/src/commands/tree.zig
@@ -31,6 +31,9 @@ pub const Options = struct {
 /// Maximum bytes read from any single command source file.
 const max_source_bytes = 1024 * 1024;
 
+// Convention: this command takes `context: anytype` (not `*Context`) so tests
+// can pass a lightweight stub instead of a full app registry; commands that
+// don't need that testability use `*Context` for the compile-time contract.
 pub fn execute(args: Args, options: Options, context: anytype) !void {
     _ = args;
 


### PR DESCRIPTION
## Summary
- Closes #330: added a one-line convention comment above `execute` in each meta-CLI command that takes `context: anytype` (`dev.zig`, `tree.zig`, `release.zig`, `gh/add/workflow/release.zig`), explaining that `anytype` trades the compile-time `*Context` contract for stub-testability — so the split reads as a decision, not drift.
- Closes #331: `zcli dev` now watches `build.zig` and `build.zig.zon` (in addition to `src/`) on POSIX — editing either triggers a rebuild. **Windows exception**: nightwatch's `ReadDirectoryChangesW` backend can only watch directories, and watching the project root recursively makes its rescans race zig's own package extraction under `zig-pkg/` (corrupting builds — caught by the Windows e2e leg). So on Windows the scope stays `src/` only, and both the command's meta description and the startup status line document it (`build.zig changes need a restart`), per the issue's "watch build files or document the scope". `findBinary` is now explicit: it prefers the executable in `zig-out/bin` whose stem matches `context.app_name`, and if multiple executables exist and none match, it picks the first (sorted, for determinism) and prints a warning to stderr instead of silently guessing.
- Closes #332: removed the `defer if (app_child) |*c| c.kill(io)` in `execute` — the watch loop never returns normally (Ctrl-C kills the whole process group, including the spawned app), so the defer never ran. Replaced the misleading comment with one that states this directly.

## Verification
- `zig ast-check` passes clean on all edited files.
- Local `mise x -- zig build test` could not be completed: the machine had ~26 concurrent `zig build` processes from other agent worktrees contending for the shared zig cache; every attempt hung for the full timeout with no output. Environmental, not a diff failure. **CI is authoritative.**
- Windows e2e history on this PR: first run failed because file-watching `build.zig` crashes on Windows (`ReadDirectoryChangesW` is directory-only); second run failed because the replacement recursive project-root watch raced zig's package fetch under `zig-pkg/`. Current approach (Windows watches `src/` only, documented) removes both failure modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)