### PR TITLE
security: harden editor temp file, secrets error-path zeroing, config cwd guidance

### DIFF
--- a/examples/tasks/src/commands/edit.zig
+++ b/examples/tasks/src/commands/edit.zig
@@ -66,6 +66,7 @@ pub fn execute(args: Args, _: Options, context: *Context) !void {
             .io = context.io,
             .default = initial,
             .extension = ".md",
+            .environ = context.environ,
         }) catch |err| switch (err) {
             error.EndOfStream => return context.fail("edit requires an interactive terminal (stdin closed).", .{}),
             else => return err,

--- a/packages/core/src/plugins/zcli_config/plugin.zig
+++ b/packages/core/src/plugins/zcli_config/plugin.zig
@@ -32,6 +32,19 @@ const zcli = @import("zcli");
 /// arrays/multi-value (from a config list). Config stays lenient: a value that
 /// won't parse (bad format, out of range, unknown enum variant) is skipped with
 /// a warning, never injected — see docs/DESIGN.md.
+///
+/// Consumer note — cwd-controlled defaults: case 2 above means anyone who can
+/// get a victim to run the CLI inside a directory they control (a cloned repo,
+/// an extracted archive, a shared build dir) can set the *default* for any
+/// Option this plugin covers, for that one invocation. This is bounded — every
+/// value still flows through the normal typed parser (no code execution),
+/// content is capped at 1 MB, and a CLI flag or env var always overrides it —
+/// but it is still an attacker-influenced default. Consequently: do not model
+/// security-sensitive behavior (e.g. "skip verification", "disable a safety
+/// check", a trusted path/URL/repo) as a plain config-overridable Option field.
+/// Either keep it out of Options entirely (comptime/build-time config, as the
+/// upgrade plugin does for its repo and signing key), or gate it so config
+/// alone cannot flip it.
 pub const plugin_id = "zcli_config";
 
 pub const Format = enum { json, toml, yaml };

--- a/packages/core/src/plugins/zcli_secrets/subprocess.zig
+++ b/packages/core/src/plugins/zcli_secrets/subprocess.zig
@@ -62,6 +62,7 @@ const Drainer = struct {
 /// the stdin write.
 fn drain(d: Drainer) void {
     var buf: [4096]u8 = undefined;
+    defer std.crypto.secureZero(u8, &buf);
     var reader = d.file.reader(d.io, &buf);
     if (reader.interface.allocRemaining(d.allocator, .limited(1 << 20))) |bytes| {
         d.out.* = bytes;
@@ -116,6 +117,7 @@ pub fn run(
 
     if (stdin_bytes) |bytes| {
         var in_buf: [4096]u8 = undefined;
+        defer std.crypto.secureZero(u8, &in_buf);
         var in = child.stdin.?.writer(io, &in_buf);
         // A write failure here just means the child closed stdin early; the exit
         // status read below is the authoritative signal, so it is ignored.
@@ -134,8 +136,18 @@ pub fn run(
     const drain_err: ?anyerror = out_err orelse err_err;
     if (drain_err) |e| {
         child.kill(io);
-        if (out_bytes) |b| allocator.free(b);
-        if (err_bytes) |b| allocator.free(b);
+        // stdout may hold a decrypted secret (a `pass show` / `secret-tool
+        // lookup` reads the stored value back on stdout) even when the
+        // *other* stream is what failed to drain, so wipe both before
+        // freeing — mirrors `Output.deinit`.
+        if (out_bytes) |b| {
+            std.crypto.secureZero(u8, b);
+            allocator.free(b);
+        }
+        if (err_bytes) |b| {
+            std.crypto.secureZero(u8, b);
+            allocator.free(b);
+        }
         return e;
     }
 

--- a/packages/prompts/examples/editor.zig
+++ b/packages/prompts/examples/editor.zig
@@ -32,6 +32,7 @@ pub fn main(init: std.process.Init) !void {
         .extension = ".md",
         .editor_cmd = editor_cmd,
         .io = init.io,
+        .environ = init.environ_map,
     }) catch |err| {
         try t.w().print("\n({s})\n", .{@errorName(err)});
         return;

--- a/packages/prompts/src/editor.zig
+++ b/packages/prompts/src/editor.zig
@@ -17,6 +17,10 @@ pub const EditorConfig = struct {
     prefix: []const u8 = "? ",
     editor_cmd: []const u8 = "vi",
     io: std.Io,
+    /// Threaded environ, used to honor `$TMPDIR` when placing the scratch
+    /// file. Falls back to `/tmp` when unset (or when `environ` itself is
+    /// null, e.g. in tests that don't exercise the temp-file path).
+    environ: ?*const std.process.Environ.Map = null,
 };
 
 /// Launch the user's editor for multiline input. Returns owned string, or
@@ -81,16 +85,27 @@ pub fn editor(p: Prompts, config: EditorConfig) ![]u8 {
     raw.disable();
     Prompts.flushWriter(writer);
 
-    // Create temp file and write default content
-    const tmp_name = try std.fmt.allocPrint(allocator, "/tmp/prompts_edit{s}", .{config.extension});
+    // Create temp file and write default content. The name is randomized (a
+    // local attacker who knows a fixed name could pre-plant a symlink at it,
+    // CWE-59) and created with `.exclusive = true` (refuses to follow an
+    // existing path) and mode 0600 (the content — potentially a secret being
+    // edited — isn't left world-readable while the editor is open).
+    const tmp_dir = if (config.environ) |e| (e.get("TMPDIR") orelse "/tmp") else "/tmp";
+    var name_buf: [scratch_name_len]u8 = undefined;
+    const scratch_name = randomScratchName(config.io, &name_buf);
+    const tmp_name = try std.fmt.allocPrint(allocator, "{s}/{s}{s}", .{ tmp_dir, scratch_name, config.extension });
     defer allocator.free(tmp_name);
 
     const cwd = std.Io.Dir.cwd();
-    var tmp_file = try cwd.createFile(config.io, tmp_name, .{});
+    var tmp_file = try cwd.createFile(config.io, tmp_name, .{
+        .exclusive = true,
+        .permissions = @enumFromInt(0o600),
+    });
     if (config.default) |def| {
         try tmp_file.writeStreamingAll(config.io, def);
     }
     tmp_file.close(config.io);
+    defer cwd.deleteFile(config.io, tmp_name) catch {};
 
     // Spawn editor
     var child = try std.process.spawn(config.io, .{
@@ -153,6 +168,29 @@ test "non-TTY: reads piped multiline input" {
     defer allocator.free(result);
 
     try std.testing.expectEqualStrings("line one\nline two", result);
+}
+
+/// Length of a scratch file name: the ".prompts_edit-" prefix plus 16 hex chars.
+const scratch_name_len = ".prompts_edit-".len + 16;
+
+/// A random, unpredictable name for the scratch file, so a local attacker
+/// cannot pre-plant anything (e.g. a symlink) at the edit path.
+fn randomScratchName(io: std.Io, buf: *[scratch_name_len]u8) []const u8 {
+    var random_bytes: [8]u8 = undefined;
+    io.random(&random_bytes);
+    const hex = std.fmt.bytesToHex(&random_bytes, .lower);
+    return std.fmt.bufPrint(buf, ".prompts_edit-{s}", .{hex}) catch unreachable;
+}
+
+test "randomScratchName - hidden, fixed-length, unpredictable" {
+    var buf_a: [scratch_name_len]u8 = undefined;
+    var buf_b: [scratch_name_len]u8 = undefined;
+    const a = randomScratchName(std.testing.io, &buf_a);
+    const b = randomScratchName(std.testing.io, &buf_b);
+
+    try std.testing.expect(std.mem.startsWith(u8, a, ".prompts_edit-"));
+    try std.testing.expectEqual(scratch_name_len, a.len);
+    try std.testing.expect(!std.mem.eql(u8, a, b));
 }
 
 fn renderFrame(app: *ui.App, ctx: Prompts.ThemeContext, config: EditorConfig) !void {


### PR DESCRIPTION
Local-hardening fixes for the three grade6 security issues.

## #291 — editor prompt temp file (packages/prompts/src/editor.zig)

The multiline-editor prompt wrote to a fixed, predictable `/tmp/prompts_edit<ext>` via a non-exclusive, default-mode `createFile` (symlink-followable, world-readable). Now:

- **Random name**: `.prompts_edit-<16 hex chars>` from `io.random`, mirroring the upgrade plugin's `randomScratchName` (unit test included).
- **`.exclusive = true`**: the create refuses to follow a pre-planted path (CWE-59).
- **Mode `0o600`**: content being edited is not world-readable while the editor is open (CWE-377).
- **`$TMPDIR` honored**: `EditorConfig` gains an optional `environ: ?*const std.process.Environ.Map` (threaded, no C getenv); falls back to `/tmp` when unset.
- Drive-by: the scratch file is now deleted after the read-back (previously it was left behind).

Callers updated: `packages/prompts/examples/editor.zig` and `examples/tasks/src/commands/edit.zig` now pass the environ.

## #294 — secrets memory hygiene (packages/core/src/plugins/zcli_secrets/subprocess.zig)

- The drain-error branch now `std.crypto.secureZero`s both captured streams before `allocator.free`, mirroring `Output.deinit` (stdout can hold a decrypted `pass show` value).
- The 4096-byte stdin-writer and drainer stack buffers get `defer secureZero` so secret fragments do not persist in the dead frame.

## #295 — cwd config guidance (packages/core/src/plugins/zcli_config/plugin.zig)

Per the issue's "keep as-is, but document" resolution: the runtime `note:` when a project-local config is applied from cwd already shipped (commit 9fb1d64); this PR adds the missing consumer-facing doc — a "Consumer note — cwd-controlled defaults" section in the module doc explaining the bounded threat (typed parser, 1 MB cap, CLI/env always win) and that security-sensitive behavior must not be modeled as a plain config-overridable Option (use comptime/build-time config as the upgrade plugin does, or gate it).

## Verification

`zig ast-check` passes on all five changed files. **Local `zig build test` could not complete**: the full-repo build timed out twice at the 10-minute cap in this fresh worktree (cold cache plus concurrent builds from sibling sessions contending on the zig cache), and a package-scoped run hit the same contention. Per protocol, CI is authoritative for this PR.

Closes #291
Closes #294
Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4