### PR TITLE
Unit-test terminal backend mode-transition logic without a TTY

### DIFF
--- a/packages/terminal/src/backend.zig
+++ b/packages/terminal/src/backend.zig
@@ -60,3 +60,27 @@ pub const InputWait = impl.InputWait;
 /// Result of `ResizeWatcher.waitTimeout`: input ready, a resize, or the
 /// caller's deadline elapsed with neither.
 pub const WaitResult = impl.WaitResult;
+
+test {
+    // Pull in the active platform backend's unit tests (the impl is imported
+    // via a comptime branch, so nothing else references its file for tests).
+    _ = impl;
+}
+
+test "re-exported surface resolves on this platform" {
+    // Referencing each re-export forces the (lazily analyzed) platform impl
+    // to provide the full surface with the expected shape.
+    try std.testing.expect(@hasDecl(RawMode, "disable"));
+    try std.testing.expect(@typeInfo(@TypeOf(enableRawMode)) == .@"fn");
+    try std.testing.expect(@typeInfo(@TypeOf(setEcho)) == .@"fn");
+    try std.testing.expect(@typeInfo(@TypeOf(getWindowSize)) == .@"fn");
+    try std.testing.expect(@typeInfo(@TypeOf(isTty)) == .@"fn");
+    try std.testing.expect(@typeInfo(@TypeOf(waitReadable)) == .@"fn");
+    try std.testing.expect(@hasDecl(ResizeWatcher, "init"));
+    try std.testing.expect(@hasDecl(ResizeWatcher, "deinit"));
+    try std.testing.expect(@hasDecl(ResizeWatcher, "wait"));
+    try std.testing.expect(@hasDecl(ResizeWatcher, "waitTimeout"));
+    // Both watcher result enums cover the same cases on every platform.
+    try std.testing.expect(@hasField(InputWait, "input") and @hasField(InputWait, "resize"));
+    try std.testing.expect(@hasField(WaitResult, "input") and @hasField(WaitResult, "resize") and @hasField(WaitResult, "timeout"));
+}

--- a/packages/terminal/src/backend_posix.zig
+++ b/packages/terminal/src/backend_posix.zig
@@ -21,11 +21,11 @@ pub const RawMode = struct {
     }
 };
 
-pub fn enableRawMode(fd: Handle) TerminalError!RawMode {
-    const original = posix.tcgetattr(fd) catch return error.NotATerminal;
-
-    // cfmakeraw() equivalent: clear the flags that cook input/output so bytes
-    // arrive unmodified, one at a time, with no echo or signal handling.
+/// cfmakeraw() equivalent: given the terminal's current mode, compute the
+/// termios to install for raw mode — clears the flags that cook input/output
+/// so bytes arrive unmodified, one at a time, with no echo or signal handling.
+/// Pure (no syscalls), so it's testable without a TTY.
+fn rawTermios(original: posix.termios) posix.termios {
     var raw = original;
     raw.iflag.BRKINT = false;
     raw.iflag.ICRNL = false;
@@ -41,15 +41,28 @@ pub fn enableRawMode(fd: Handle) TerminalError!RawMode {
     raw.cflag.CSIZE = .CS8;
     raw.cc[@intFromEnum(posix.V.MIN)] = 1;
     raw.cc[@intFromEnum(posix.V.TIME)] = 0;
+    return raw;
+}
 
+/// Given the terminal's current mode, compute the termios with echo set to
+/// `enabled` and everything else untouched. Pure — testable without a TTY.
+fn echoTermios(termios: posix.termios, enabled: bool) posix.termios {
+    var t = termios;
+    t.lflag.ECHO = enabled;
+    return t;
+}
+
+pub fn enableRawMode(fd: Handle) TerminalError!RawMode {
+    const original = posix.tcgetattr(fd) catch return error.NotATerminal;
+    const raw = rawTermios(original);
     posix.tcsetattr(fd, .FLUSH, raw) catch return error.TerminalSettingsError;
     return .{ .fd = fd, .original = original };
 }
 
 pub fn setEcho(fd: Handle, enabled: bool) TerminalError!void {
-    var termios = posix.tcgetattr(fd) catch return error.NotATerminal;
-    termios.lflag.ECHO = enabled;
-    posix.tcsetattr(fd, .FLUSH, termios) catch return error.TerminalSettingsError;
+    const termios = posix.tcgetattr(fd) catch return error.NotATerminal;
+    const updated = echoTermios(termios, enabled);
+    posix.tcsetattr(fd, .FLUSH, updated) catch return error.TerminalSettingsError;
 }
 
 pub fn getWindowSize(fd: Handle) !Winsize {
@@ -167,3 +180,57 @@ pub const ResizeWatcher = struct {
         }
     }
 };
+
+test "rawTermios clears cooked-mode flags and sets CS8 + VMIN/VTIME" {
+    var original = std.mem.zeroes(posix.termios);
+    original.iflag.BRKINT = true;
+    original.iflag.ICRNL = true;
+    original.iflag.INPCK = true;
+    original.iflag.ISTRIP = true;
+    original.iflag.IXON = true;
+    original.oflag.OPOST = true;
+    original.lflag.ECHO = true;
+    original.lflag.ICANON = true;
+    original.lflag.IEXTEN = true;
+    original.lflag.ISIG = true;
+    original.cflag.PARENB = true;
+
+    const raw = rawTermios(original);
+
+    try std.testing.expect(!raw.iflag.BRKINT);
+    try std.testing.expect(!raw.iflag.ICRNL);
+    try std.testing.expect(!raw.iflag.INPCK);
+    try std.testing.expect(!raw.iflag.ISTRIP);
+    try std.testing.expect(!raw.iflag.IXON);
+    try std.testing.expect(!raw.oflag.OPOST);
+    try std.testing.expect(!raw.lflag.ECHO);
+    try std.testing.expect(!raw.lflag.ICANON);
+    try std.testing.expect(!raw.lflag.IEXTEN);
+    try std.testing.expect(!raw.lflag.ISIG);
+    try std.testing.expect(!raw.cflag.PARENB);
+    try std.testing.expectEqual(posix.CSIZE.CS8, raw.cflag.CSIZE);
+    try std.testing.expectEqual(@as(posix.cc_t, 1), raw.cc[@intFromEnum(posix.V.MIN)]);
+    try std.testing.expectEqual(@as(posix.cc_t, 0), raw.cc[@intFromEnum(posix.V.TIME)]);
+}
+
+test "rawTermios leaves untouched flags alone" {
+    var original = std.mem.zeroes(posix.termios);
+    original.iflag.IXOFF = true; // not part of the raw-mode transform
+
+    const raw = rawTermios(original);
+
+    try std.testing.expect(raw.iflag.IXOFF);
+}
+
+test "echoTermios toggles ECHO without touching other flags" {
+    var termios = std.mem.zeroes(posix.termios);
+    termios.lflag.ICANON = true;
+
+    const disabled = echoTermios(termios, false);
+    try std.testing.expect(!disabled.lflag.ECHO);
+    try std.testing.expect(disabled.lflag.ICANON);
+
+    const enabled = echoTermios(termios, true);
+    try std.testing.expect(enabled.lflag.ECHO);
+    try std.testing.expect(enabled.lflag.ICANON);
+}

--- a/packages/terminal/src/backend_windows.zig
+++ b/packages/terminal/src/backend_windows.zig
@@ -73,6 +73,30 @@ pub const RawMode = struct {
     }
 };
 
+/// Given the input console's current mode, compute the raw-mode input flags
+/// to install: line buffering/echo/processed-input off, VT input on so
+/// `key.zig`'s escape-sequence parsing sees the same bytes as a POSIX tty.
+/// Pure (no syscalls) — testable without a console.
+fn rawInputMode(in_mode: DWORD) DWORD {
+    var raw_in = in_mode;
+    raw_in &= ~(ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_PROCESSED_INPUT);
+    raw_in |= ENABLE_VIRTUAL_TERMINAL_INPUT;
+    return raw_in;
+}
+
+/// Given the output console's current mode, compute the mode with VT
+/// processing enabled so the package's ANSI (cursor, color) sequences render.
+/// Pure.
+fn vtOutputMode(out_mode: DWORD) DWORD {
+    return out_mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING | ENABLE_PROCESSED_OUTPUT;
+}
+
+/// Given the console's current mode, compute the mode with echo set to
+/// `enabled` and everything else untouched. Pure.
+fn echoMode(mode: DWORD, enabled: bool) DWORD {
+    return if (enabled) mode | ENABLE_ECHO_INPUT else mode & ~ENABLE_ECHO_INPUT;
+}
+
 pub fn enableRawMode(in: Handle) TerminalError!RawMode {
     var in_mode: DWORD = 0;
     if (GetConsoleMode(in, &in_mode) == 0) return error.NotATerminal;
@@ -83,13 +107,10 @@ pub fn enableRawMode(in: Handle) TerminalError!RawMode {
     var out_mode: DWORD = 0;
     const out_is_console = GetConsoleMode(out, &out_mode) != 0;
 
-    var raw_in = in_mode;
-    raw_in &= ~(ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_PROCESSED_INPUT);
-    raw_in |= ENABLE_VIRTUAL_TERMINAL_INPUT;
-    if (SetConsoleMode(in, raw_in) == 0) return error.TerminalSettingsError;
+    if (SetConsoleMode(in, rawInputMode(in_mode)) == 0) return error.TerminalSettingsError;
 
     if (out_is_console) {
-        _ = SetConsoleMode(out, out_mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING | ENABLE_PROCESSED_OUTPUT);
+        _ = SetConsoleMode(out, vtOutputMode(out_mode));
     }
 
     return .{
@@ -104,12 +125,7 @@ pub fn enableRawMode(in: Handle) TerminalError!RawMode {
 pub fn setEcho(handle: Handle, enabled: bool) TerminalError!void {
     var mode: DWORD = 0;
     if (GetConsoleMode(handle, &mode) == 0) return error.NotATerminal;
-    if (enabled) {
-        mode |= ENABLE_ECHO_INPUT;
-    } else {
-        mode &= ~ENABLE_ECHO_INPUT;
-    }
-    if (SetConsoleMode(handle, mode) == 0) return error.TerminalSettingsError;
+    if (SetConsoleMode(handle, echoMode(mode, enabled)) == 0) return error.TerminalSettingsError;
 }
 
 pub fn getWindowSize(handle: Handle) !Winsize {
@@ -196,3 +212,37 @@ pub const ResizeWatcher = struct {
         }
     }
 };
+
+test "rawInputMode clears line/echo/processed-input and sets VT input" {
+    const cooked: DWORD = ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_PROCESSED_INPUT;
+    const raw = rawInputMode(cooked);
+
+    try std.testing.expect(raw & ENABLE_LINE_INPUT == 0);
+    try std.testing.expect(raw & ENABLE_ECHO_INPUT == 0);
+    try std.testing.expect(raw & ENABLE_PROCESSED_INPUT == 0);
+    try std.testing.expect(raw & ENABLE_VIRTUAL_TERMINAL_INPUT != 0);
+}
+
+test "rawInputMode preserves bits it doesn't touch" {
+    const extra_bit: DWORD = 0x0100;
+    const raw = rawInputMode(extra_bit);
+    try std.testing.expect(raw & extra_bit != 0);
+}
+
+test "vtOutputMode sets VT processing and processed output" {
+    const mode = vtOutputMode(0);
+    try std.testing.expect(mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING != 0);
+    try std.testing.expect(mode & ENABLE_PROCESSED_OUTPUT != 0);
+}
+
+test "echoMode toggles ENABLE_ECHO_INPUT without touching other bits" {
+    const base: DWORD = ENABLE_LINE_INPUT;
+
+    const disabled = echoMode(base | ENABLE_ECHO_INPUT, false);
+    try std.testing.expect(disabled & ENABLE_ECHO_INPUT == 0);
+    try std.testing.expect(disabled & ENABLE_LINE_INPUT != 0);
+
+    const enabled = echoMode(base, true);
+    try std.testing.expect(enabled & ENABLE_ECHO_INPUT != 0);
+    try std.testing.expect(enabled & ENABLE_LINE_INPUT != 0);
+}

--- a/packages/terminal/src/terminal.zig
+++ b/packages/terminal/src/terminal.zig
@@ -196,4 +196,7 @@ test "symbols provide correct fallbacks" {
 
 test {
     std.testing.refAllDecls(@This());
+    // `backend` is a private import, so refAllDecls doesn't reach it; reference
+    // it explicitly so the backend (and its platform impl's) tests run.
+    _ = backend;
 }


### PR DESCRIPTION
Closes #302

The terminal package's raw-mode backends had zero inline test coverage — the crash-restore-critical paths were only exercised transitively by the e2e SIGTERM-restore test, which degrades to a skip when no PTY is available.

## What this does

Minimal, behavior-preserving refactor: the pure mode computations are extracted from the syscall wrappers so they're testable without a TTY, and the wrappers now call them.

**`backend_posix.zig`**
- `rawTermios()` — the cfmakeraw-equivalent transform, extracted from `enableRawMode`. Tests assert every flag the transform clears (BRKINT/ICRNL/INPCK/ISTRIP/IXON, OPOST, ECHO/ICANON/IEXTEN/ISIG, PARENB), `CSIZE = CS8`, `VMIN=1`/`VTIME=0`, and that flags outside the transform (e.g. IXOFF) survive — which is what guarantees `RawMode.original` is a faithful restore target.
- `echoTermios()` — extracted from `setEcho`; tests both directions and that other lflag bits are untouched.

**`backend_windows.zig`**
- `rawInputMode()` — clears `ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_PROCESSED_INPUT`, sets `ENABLE_VIRTUAL_TERMINAL_INPUT`; tests cover set/clear and preservation of unrelated bits.
- `vtOutputMode()` and `echoMode()` — same treatment.
- These tests compile and run natively on the `windows-latest` unit-test CI leg (the existing 3-OS matrix), which is how cross-platform tests are wired in this repo — no cross-target scaffolding exists or is needed.

**`backend.zig`**
- A verify-surface test: the platform impl provides the full re-exported surface (`RawMode.disable`, the fn re-exports, `ResizeWatcher.init/deinit/wait/waitTimeout`, and both watcher result enums with matching cases on every platform).
- `test { _ = impl; }` so the active backend's tests are collected.

**`terminal.zig`** — one-line test wiring: the root test block now references the private `backend` import (`refAllDecls` only reaches pub decls, so without this none of the new tests would run).

`guard.zig` already had unit tests covering the arm/disarm/restore transitions, so it's untouched.

## Verification

Local verification was limited: this machine cannot run concurrent `zig build` invocations (maintainer instruction after repeated 10-minute build timeouts from cache contention), so the local gate was `zig fmt --check` + `zig ast-check` on every edited file (all pass). **CI is the authoritative gate** — the unit-test matrix (ubuntu/macos/windows) runs `zig build test`, which includes the terminal package and exercises both the POSIX and Windows backend tests natively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4