### PR TITLE
scaffold: fix dead CommandNotFound branch, silent fetch failure, wrong lib tag

### DIFF
--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -200,8 +200,9 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
     try stdout.print("  Creating build.zig.zon...\n", .{});
     // Pin the generated project to the same zcli release as this CLI.
     // `context.app_version` is read from build.zig.zon at build time, so it
-    // tracks releases automatically (the framework and this CLI are tagged in
-    // lockstep as `zcli-v<version>`).
+    // tracks releases automatically. Releases are dual-tagged: `zcli-v<version>`
+    // for the CLI binary, `v<version>` for the library — build.zig.zon deps must
+    // reference the library tag (see README's dual-tag contract).
     const zcli_version = context.app_version;
     // Package fingerprint: high 32 bits are a checksum of the package name, low
     // 32 bits a random id. Zig rejects a zero fingerprint at build time.
@@ -332,15 +333,17 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
     try stdout.print("  Creating src/main.zig...\n", .{});
     const main_content =
         \\const std = @import("std");
+        \\const zcli = @import("zcli");
         \\const registry = @import("command_registry");
+        \\
+        \\/// Prompts (`add`, `init`) and progress bars hide the cursor and drive raw
+        \\/// mode, so a panic mid-prompt must restore the terminal.
+        \\pub const panic = zcli.ui.panic;
         \\
         \\pub fn main(init: std.process.Init) !void {
         \\    const args = try init.minimal.args.toSlice(init.arena.allocator());
         \\    var app = registry.init();
-        \\    app.run(init.gpa, init.io, init.environ_map, args) catch |err| switch (err) {
-        \\        error.CommandNotFound => std.process.exit(1),
-        \\        else => return err,
-        \\    };
+        \\    try app.run(init.gpa, init.io, init.environ_map, args);
         \\}
         \\
     ;
@@ -411,37 +414,50 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
 
     // Fetch the zcli dependency. `zig fetch --save` computes the real hash and
     // writes the dependency into build.zig.zon; without it the generated project
-    // won't build, so warn with the exact command if it doesn't run.
-    {
-        try stdout.print("  Fetching dependencies (this may take a moment)...\n", .{});
-        const zcli_url = try std.fmt.allocPrint(allocator, "https://github.com/ryanhair/zcli/archive/refs/tags/zcli-v{s}.tar.gz", .{zcli_version});
-        defer allocator.free(zcli_url);
+    // won't build, so warn with the exact command if it doesn't run, and reflect
+    // the failure in the final success/next-steps messaging below.
+    const zcli_url = try std.fmt.allocPrint(allocator, "https://github.com/ryanhair/zcli/archive/refs/tags/v{s}.tar.gz", .{zcli_version});
+    defer allocator.free(zcli_url);
 
-        const ok = ok: {
-            var fetch_child = std.process.spawn(io, .{
-                .argv = &.{ "zig", "fetch", "--save", zcli_url },
-                .cwd = .{ .dir = project_dir },
-                .stdout = .ignore,
-                .stderr = .inherit,
-            }) catch break :ok false;
-            const term = fetch_child.wait(io) catch break :ok false;
-            break :ok term == .exited and term.exited == 0;
-        };
-        if (!ok) {
-            try stderr.print("  Warning: could not add the zcli dependency automatically.\n", .{});
-            try stderr.print("  Run this inside the project to finish setup:\n    zig fetch --save {s}\n", .{zcli_url});
+    try stdout.print("  Fetching dependencies (this may take a moment)...\n", .{});
+    const fetch_ok = ok: {
+        var fetch_child = std.process.spawn(io, .{
+            .argv = &.{ "zig", "fetch", "--save", zcli_url },
+            .cwd = .{ .dir = project_dir },
+            .stdout = .ignore,
+            .stderr = .inherit,
+        }) catch break :ok false;
+        const term = fetch_child.wait(io) catch break :ok false;
+        break :ok term == .exited and term.exited == 0;
+    };
+    if (!fetch_ok) {
+        try stderr.print("  Warning: could not add the zcli dependency automatically.\n", .{});
+        try stderr.print("  Run this inside the project to finish setup:\n    zig fetch --save {s}\n", .{zcli_url});
+    }
+
+    // Success message. When the fetch failed, `zig build` would only fail with
+    // a missing-dependency error the user never asked for — don't claim success
+    // or suggest a next step that can't work yet.
+    if (fetch_ok) {
+        try stdout.print("\n✓ Project '{s}' created successfully!\n\n", .{project_name});
+        try stdout.print("Next steps:\n", .{});
+        if (!use_current_dir) {
+            try stdout.print("  cd {s}\n", .{args.name});
         }
+        try stdout.print("  zig build\n", .{});
+        try stdout.print("  ./zig-out/bin/{s} hello World\n", .{project_name});
+        try stdout.print("  ./zig-out/bin/{s} --help\n", .{project_name});
+    } else {
+        try stdout.print("\n⚠ Project '{s}' created, but the zcli dependency was not fetched.\n\n", .{project_name});
+        try stdout.print("Next steps:\n", .{});
+        if (!use_current_dir) {
+            try stdout.print("  cd {s}\n", .{args.name});
+        }
+        try stdout.print("  zig fetch --save {s}\n", .{zcli_url});
+        try stdout.print("  zig build\n", .{});
+        try stdout.print("  ./zig-out/bin/{s} hello World\n", .{project_name});
+        try stdout.print("  ./zig-out/bin/{s} --help\n", .{project_name});
     }
-
-    // Success message
-    try stdout.print("\n✓ Project '{s}' created successfully!\n\n", .{project_name});
-    try stdout.print("Next steps:\n", .{});
-    if (!use_current_dir) {
-        try stdout.print("  cd {s}\n", .{args.name});
-    }
-    try stdout.print("  zig build\n", .{});
-    try stdout.print("  ./zig-out/bin/{s} hello World\n", .{project_name});
-    try stdout.print("  ./zig-out/bin/{s} --help\n", .{project_name});
 }
 
 // ---------------------------------------------------------------------------

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -1335,11 +1335,11 @@ test "root zcli_theme declaration themes help output" {
 
     // Declare a custom theme in the app root — the std_options-style hook.
     // Command names in help should render in this color (tomato, 255;99;71).
+    // The scaffolded main.zig already imports zcli (for the panic hook).
     try replaceInFile(proj, a, "src/main.zig",
         \\const registry = @import("command_registry");
     ,
         \\const registry = @import("command_registry");
-        \\const zcli = @import("zcli");
         \\
         \\pub const zcli_theme: zcli.Theme = .{
         \\    .palette = .{ .command = .{ .foreground = .{ .rgb = .{ .r = 255, .g = 99, .b = 71 } } } },


### PR DESCRIPTION
## Summary

All changes are to the generated scaffold templates in `projects/zcli/src/commands/init.zig`.

- **#327**: the generated `main.zig` template caught `error.CommandNotFound` after `app.run(...)` and called `std.process.exit(1)`, but `CommandNotFound` is a reported CLI error that `run()` already exits the process on internally — it never returns that error. The branch was dead code. Scaffold now emits the minimal `try app.run(...)`, matching zcli's own `projects/zcli/src/main.zig`.
- **#328**: `zcli init` printed a warning when `zig fetch --save` failed, but still printed "✓ Project created successfully!" and a `zig build` next-step that would immediately fail with a missing-dependency error. `init` now tracks the fetch result and, on failure, prints a distinct "created, but the dependency was not fetched" message with `zig fetch --save <url>` as the first next-step (ahead of `zig build`).
- **#352**: `zcli init` scaffolded the dependency in `build.zig.zon` pointed at the `zcli-v*` tag (the CLI-binary release), but README/CHANGELOG document `v*` as the tag for `build.zig.zon` (the library release). Both tags point at the same tree today, so nothing was actually broken, but the scaffold now references the `v*` tag to match the documented dual-tag contract.
- **Extra (part of #288)**: the scaffolded `main.zig` now also sets `pub const panic = zcli.ui.panic;`, so scaffolded apps get terminal restoration on a panic mid-prompt — the same pattern zcli's own `main.zig` already uses. The framework side of #288 already shipped in #353; this is the matching scaffold-side change.

## Verification

- `mise x -- zig ast-check projects/zcli/src/commands/init.zig` — passes.
- Full `zig build test` / `zig build e2e` runs could not be completed locally: this machine is running many concurrent worktree-agent zig builds right now and full builds were hanging/getting killed under that contention (unrelated to this diff, confirmed via `ps aux` showing many other agents' `zig build` processes). Per the coordinator's guidance, local verification here is capped at `ast-check`; **CI is the authoritative gate** for this PR.

Closes #327
Closes #328
Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)