### PR TITLE
Route progress to stderr; gate prompts on interactive TTY (#324, #325)

### DIFF
--- a/packages/core/src/context.zig
+++ b/packages/core/src/context.zig
@@ -186,12 +186,14 @@ pub fn ContextFor(comptime plugins: []const type) type {
         }
 
         /// A `Progress` instance pre-wired to this command's environment:
-        /// stdout, the framework `io`, the arena-per-command allocator, and the
-        /// app theme. Call `.spinner(...)`, `.progressBar(...)`, or
+        /// stderr, the framework `io`, the arena-per-command allocator, and the
+        /// app theme. Progress renders to stderr (not stdout) by convention, so
+        /// it survives `myapp | tee` / stdout redirection while keeping piped
+        /// stdout clean. Call `.spinner(...)`, `.progressBar(...)`, or
         /// `.multiBar(...)` on the result.
         pub fn progress(self: *Self) zcli.Progress {
             return .{
-                .writer = self.stdout(),
+                .writer = self.stderr(),
                 .io = self.io,
                 .allocator = self.allocator,
                 .theme = self.theme,

--- a/packages/progress/src/Progress.zig
+++ b/packages/progress/src/Progress.zig
@@ -38,7 +38,9 @@
 //! ```
 //!
 //! In a zcli command, `context.progress()` returns an instance pre-wired to the
-//! command's stdout, `io`, arena allocator, and theme.
+//! command's stderr, `io`, arena allocator, and theme. Progress goes to stderr
+//! by convention so it survives stdout redirection (`myapp | tee`) while keeping
+//! piped stdout clean; interactivity keys on whether stderr is a TTY.
 
 writer: *std.Io.Writer,
 /// The framework's `std.Io` — powers each indicator's `ui.App` (animation
@@ -175,7 +177,7 @@ pub const Spinner = struct {
             .app = try ui.App.init(allocator, writer, .{
                 .capability = theme.capability(),
                 .unicode = config.unicode,
-                .interactive = terminal.isStdoutTty(),
+                .interactive = terminal.isStderrTty(),
             }),
         };
     }
@@ -368,7 +370,7 @@ pub const ProgressBar = struct {
             .app = try ui.App.init(allocator, writer, .{
                 .capability = theme.capability(),
                 .unicode = config.unicode,
-                .interactive = terminal.isStdoutTty(),
+                .interactive = terminal.isStderrTty(),
             }),
             .start_time = nowMsIo(io),
         };
@@ -544,7 +546,7 @@ pub const MultiBar = struct {
             .app = try ui.App.init(allocator, writer, .{
                 .capability = theme.capability(),
                 .unicode = config.unicode,
-                .interactive = terminal.isStdoutTty(),
+                .interactive = terminal.isStderrTty(),
             }),
         };
     }

--- a/packages/prompts/src/confirm.zig
+++ b/packages/prompts/src/confirm.zig
@@ -24,7 +24,7 @@ pub const ConfirmConfig = struct {
 pub fn confirm(p: Prompts, config: ConfirmConfig) !bool {
     const writer = p.writer;
     const reader = p.reader;
-    const is_tty = terminal.isStdinTty();
+    const is_tty = terminal.isInteractiveTty();
 
     const hint = if (config.default) "(Y/n)" else "(y/N)";
 

--- a/packages/prompts/src/editor.zig
+++ b/packages/prompts/src/editor.zig
@@ -25,7 +25,7 @@ pub fn editor(p: Prompts, config: EditorConfig) ![]u8 {
     const writer = p.writer;
     const reader = p.reader;
     const allocator = p.allocator;
-    const is_tty = terminal.isStdinTty();
+    const is_tty = terminal.isInteractiveTty();
 
     if (!is_tty) {
         try writer.print("{s}{s}", .{ config.prefix, config.message });

--- a/packages/prompts/src/multi_select.zig
+++ b/packages/prompts/src/multi_select.zig
@@ -25,7 +25,7 @@ pub fn multiSelect(p: Prompts, config: MultiSelectConfig) ![]usize {
     const reader = p.reader;
     const allocator = p.allocator;
     if (config.choices.len == 0) return error.NoChoices;
-    const is_tty = terminal.isStdinTty();
+    const is_tty = terminal.isInteractiveTty();
 
     if (!is_tty) {
         // Non-TTY: numbered list, accept comma-separated numbers

--- a/packages/prompts/src/number.zig
+++ b/packages/prompts/src/number.zig
@@ -28,7 +28,7 @@ pub const NumberConfig = struct {
 pub fn number(p: Prompts, config: NumberConfig) !i64 {
     const writer = p.writer;
     const reader = p.reader;
-    const is_tty = terminal.isStdinTty();
+    const is_tty = terminal.isInteractiveTty();
 
     if (is_tty) return numberTty(p, config);
 

--- a/packages/prompts/src/password.zig
+++ b/packages/prompts/src/password.zig
@@ -22,7 +22,7 @@ pub fn password(p: Prompts, config: PasswordConfig) ![]u8 {
     const writer = p.writer;
     const reader = p.reader;
     const allocator = p.allocator;
-    const is_tty = terminal.isStdinTty();
+    const is_tty = terminal.isInteractiveTty();
 
     if (!is_tty) {
         // Non-TTY: read line (no masking possible)

--- a/packages/prompts/src/search.zig
+++ b/packages/prompts/src/search.zig
@@ -24,7 +24,7 @@ pub fn search(p: Prompts, config: SearchConfig) !usize {
     const reader = p.reader;
     const allocator = p.allocator;
     if (config.choices.len == 0) return error.NoChoices;
-    const is_tty = terminal.isStdinTty();
+    const is_tty = terminal.isInteractiveTty();
 
     if (!is_tty) {
         // Non-TTY: same as select — numbered list

--- a/packages/prompts/src/select.zig
+++ b/packages/prompts/src/select.zig
@@ -29,7 +29,7 @@ pub fn select(p: Prompts, config: SelectConfig) !usize {
     const writer = p.writer;
     const reader = p.reader;
     if (config.choices.len == 0) return error.NoChoices;
-    const is_tty = terminal.isStdinTty();
+    const is_tty = terminal.isInteractiveTty();
 
     if (!is_tty) {
         // Non-TTY: numbered list

--- a/packages/prompts/src/text.zig
+++ b/packages/prompts/src/text.zig
@@ -39,7 +39,7 @@ pub fn text(p: Prompts, config: TextConfig) ![]u8 {
     const writer = p.writer;
     const reader = p.reader;
     const allocator = p.allocator;
-    const is_tty = terminal.isStdinTty();
+    const is_tty = terminal.isInteractiveTty();
 
     if (!is_tty) {
         // Non-TTY: prompt inline, read a line byte by byte

--- a/packages/terminal/src/terminal.zig
+++ b/packages/terminal/src/terminal.zig
@@ -76,6 +76,18 @@ pub fn isStdoutTty() bool {
     return isTty(std.Io.File.stdout().handle);
 }
 
+pub fn isStderrTty() bool {
+    return isTty(std.Io.File.stderr().handle);
+}
+
+/// Whether the process can drive an interactive full-frame prompt: it needs
+/// stdin as a TTY to read keystrokes in raw mode *and* stdout as a TTY so the
+/// rendered frame escapes land on the terminal rather than a redirected file.
+/// If either end is redirected, callers must fall back to the plain line path.
+pub fn isInteractiveTty() bool {
+    return isStdinTty() and isStdoutTty();
+}
+
 // ============================================================================
 // Unicode detection
 // ============================================================================


### PR DESCRIPTION
## Summary

Fixes two stdio-routing inconsistencies surfaced in the grade6 audit.

### #324 — Progress indicators write to stdout instead of stderr
`context.progress()` was wired to the command's stdout, and each indicator keyed `interactive` on `isStdoutTty()`. Piping stdout (`myapp | tee`) therefore made the App non-interactive and hid progress entirely, instead of keeping it on the terminal.

- `context.progress()` now returns an instance wired to **stderr**.
- The three indicator init sites (Spinner / ProgressBar / MultiBar) now key `interactive` on `terminal.isStderrTty()`.

Result: progress renders on the terminal even when stdout is redirected, and piped stdout stays clean.

### #325 — Prompts render to stdout even when only stdin is a TTY
Interactive prompts gated on `terminal.isStdinTty()` alone. With a TTY stdin but a redirected stdout, the ui-engine frame escapes were written into the redirected stdout file.

- Added `terminal.isInteractiveTty()` = `isStdinTty() and isStdoutTty()` (raw-mode rendering needs stdin to read keys AND stdout so frames land on the terminal).
- Applied it across all eight interactive prompts: text, editor, number, search, select, password, multi_select, confirm. When either end is redirected they now fall back to the plain line path.

Builds on PR #353 (guard arming) — only the TTY-gate line in `text.zig` changed; raw-mode guard registration is untouched.

## Behavior change
- Progress output moves from stdout to stderr (maintainer-approved).
- Interactive prompts now require **both** stdin and stdout to be TTYs; a redirected stdout drops them to the non-interactive line path instead of leaking escapes.

## Verification
Not built locally (per maintainer policy — machine can't run `zig build`). Every edited file passes `zig ast-check` (0.16.0). CI is the authoritative gate: 3-OS unit tests + build-examples + 3-OS e2e.

Closes #324
Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)