### PR TITLE
Add community-health files (SECURITY.md, CODE_OF_CONDUCT.md, issue/PR templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,57 @@
+name: Bug report
+description: Something in zcli isn't working as expected
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, and what you expected instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction
+      description: >
+        Minimal steps to reproduce — ideally a snippet of `Args`/`Options`/`meta`
+        or a `build.zig` config that triggers it. Paste the exact command and
+        output if it's a runtime behavior.
+      render: shell
+    validations:
+      required: true
+
+  - type: input
+    id: zig-version
+    attributes:
+      label: Zig version
+      placeholder: "0.16.0"
+    validations:
+      required: true
+
+  - type: input
+    id: zcli-version
+    attributes:
+      label: zcli version / commit
+      description: The `vX.Y.Z` tag, `zcli-vX.Y.Z` tag, or commit hash you're on.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: OS
+      multiple: true
+      options:
+        - macOS
+        - Linux
+        - Windows
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Logs, stack traces, or context that might help.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,31 @@
+name: Feature request
+description: Propose a new capability or improvement for zcli
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: What are you trying to do that zcli doesn't support well today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: >
+        What would the API/CLI/build-time config look like? A short code sketch
+        (a `meta`/`Args`/`Options` block, a `build.zig` snippet, a plugin hook)
+        is more useful than prose.
+      render: zig
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches, workarounds, or how other CLI frameworks handle this.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## What & why
+
+<!-- One or two sentences: what changed, and why. Keep the PR to one logical change. -->
+
+## Testing
+
+- [ ] `zig build test` passes
+- [ ] If this touches the build system, `zig build build-examples` still passes (examples are drift detectors — update them in the same PR if they break)
+- [ ] If this changes prompt/render/help behavior, `zig build e2e` passes
+- [ ] Added or updated tests covering the change
+
+## Docs
+
+- [ ] Updated relevant docs under `docs/` (or the scaffolding templates in `projects/zcli/src/commands/init.zig`) if user-facing behavior changed
+- [ ] Added an ADR under `docs/adr/` if this is a significant design decision

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces (issues, pull
+requests, discussions), and also applies when an individual is officially
+representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainer, [@ryanhair](https://github.com/ryanhair), via
+GitHub (a private message, or a [private security
+advisory](https://github.com/ryanhair/zcli/security) if the report needs to
+stay confidential). All complaints will be reviewed and investigated promptly
+and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,66 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Please **do not** open a public issue for security vulnerabilities. Instead, use
+GitHub's private reporting flow:
+
+1. Go to the [Security tab](https://github.com/ryanhair/zcli/security) of this repo.
+2. Click **Report a vulnerability** to open a private security advisory.
+
+This reaches the maintainer directly without disclosing details publicly while a
+fix is worked out. If that's not available to you for some reason, you can
+instead contact the maintainer ([@ryanhair](https://github.com/ryanhair)) through
+their GitHub profile.
+
+Please include:
+
+- The version/tag (or commit) affected.
+- A minimal reproduction if possible.
+- The impact you believe it has (e.g. arbitrary code execution during upgrade,
+  bypassed signature verification, path traversal in generated code, etc.).
+
+There is no fixed SLA — this is a single-maintainer project — but reports will be
+acknowledged and triaged as soon as possible, and a fix or mitigation will ship
+before any public disclosure.
+
+## Supported versions
+
+zcli is pre-1.0 and ships from `main`. Security fixes land on the latest release
+only; there is no long-term-support branch to backport to.
+
+## Release signing and verification model
+
+CLI releases (the `zcli-vX.Y.Z` tags, which carry the prebuilt meta-CLI binaries)
+are signed with [minisign](https://jedisct1.github.io/minisign/) (Ed25519):
+
+- `checksums.txt` lists a SHA-256 for every release binary, and `checksums.txt`
+  itself is signed — `checksums.txt.minisig` ships as a release asset.
+- The **secret** signing key is generated and kept offline (password-manager
+  custody); it never touches CI. The release workflow only publishes a
+  **draft** release; the maintainer signs `checksums.txt` locally with
+  `scripts/sign-release.sh` and then publishes it. This means a compromised
+  GitHub account or CI workflow can swap binaries and rewrite checksums, but
+  cannot forge a valid signature.
+- The **public** key is pinned in the clients: `install.sh` requires `minisign`
+  and verifies the signature before installing anything (fail closed — it does
+  not fall back to checksum-only verification if `minisign` is missing), and
+  `zcli upgrade` verifies it natively in pure Zig (no external tool, no libc
+  dependency) before trusting any checksum.
+- Apps built with zcli's `zcli_github_upgrade` plugin must explicitly choose a
+  verification mode — `.{ .minisign = "<public key>" }` or the explicit opt-out
+  `.checksum_only` — there is no silent default that skips verification.
+
+The full trust model, threat model, and the key rotation/compromise procedure
+are documented in [docs/RELEASE-SIGNING.md](docs/RELEASE-SIGNING.md),
+[ADR-0023](docs/adr/0023-release-signing-minisign.md), and
+[ADR-0009](docs/adr/0009-release-integrity-trust-model.md).
+
+**Scope note**: this signing scheme covers zcli's own `zcli-v*` CLI releases.
+It does not automatically extend to apps built *with* zcli — those apps must
+configure `zcli_github_upgrade`'s `verification` option (and run their own
+signing ceremony) to get the same guarantee for their own releases.
+
+The library releases (the `vX.Y.Z` tags consumed via `build.zig.zon`) are not
+signed with minisign — `zig fetch`'s content-hash pinning is the integrity
+mechanism there, verified against the hash recorded in your `build.zig.zon`.


### PR DESCRIPTION
## Summary
- `SECURITY.md`: private vulnerability reporting via GitHub security advisories, plus an accurate description of the existing minisign release-signing model (offline key custody, draft-then-sign release flow, fail-closed `install.sh`/`zcli upgrade` verification) — verified against ADR-0023, `docs/RELEASE-SIGNING.md`, `packages/core/src/plugins/zcli_github_upgrade/minisign.zig`, and `.github/workflows/release.yml`.
- `CODE_OF_CONDUCT.md`: Contributor Covenant v2.1, contact routed to the maintainer's GitHub / security advisories.
- `.github/ISSUE_TEMPLATE/bug_report.yml` + `feature_request.yml`: YAML issue forms.
- `.github/pull_request_template.md`: short checklist aligned with CONTRIBUTING.md conventions (`zig build test`, examples as drift detectors, one logical change per PR).

Closes #350

## Test plan
- [x] Verified the signing-key/verification claims against ADR-0023, `docs/RELEASE-SIGNING.md`, `projects/zcli/build.zig` (key is pinned and active — not still pending a keygen ceremony), `install.sh`, and `.github/workflows/release.yml`
- [x] No code changes — docs/config only, no build required

🤖 Generated with [Claude Code](https://claude.com/claude-code)