### PR TITLE
ci: per-target zig cache key + document coverage/examples-test decisions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,15 @@ jobs:
           fi
           echo "No raw.githubusercontent.com install URLs — all install commands use the branded zcli.sh host"
 
+  # Coverage instrumentation (kcov / llvm-cov) was considered here (#335) and
+  # deliberately deferred rather than wired in: Zig 0.16 has no stable,
+  # first-party coverage story, and every third-party route (kcov's DWARF
+  # unwinding against Zig's codegen, llvm-cov needing a matching profile
+  # runtime bundled with this Zig's LLVM) is fragile enough on a moving Zig
+  # release to be its own maintenance burden — exactly what this repo's CI
+  # philosophy (concrete assertions over qualitative feel, see the
+  # output-contract check above) tries to avoid shipping half-working.
+  # Revisit if Zig grows a built-in `-fcoverage`-equivalent.
   test:
     name: unit tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -227,10 +236,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
+      # mlugg/setup-zig already caches the global Zig cache dir (~/.cache/zig
+      # on Linux; local caches are redirected into it) between runs by
+      # default — no separate actions/cache step is needed here or on any
+      # other job in this file. Its cache key includes the runner OS
+      # automatically, but NOT matrix variables, and this is the one job in
+      # this workflow whose matrix axis (zig_target) doesn't vary by OS: both
+      # legs run on ubuntu-latest but cross-compile genuinely different
+      # targets (x86_64 vs aarch64 musl). Without an explicit cache-key the
+      # two legs would thrash a single shared cache entry. (test/secrets/e2e
+      # matrix only on `os`, which is already disambiguated for free.)
       - name: Setup Zig
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.16.0
+          cache-key: ${{ matrix.zig_target }}
 
       # Byte-for-byte the release build command (release.yml → build job → Build
       # zcli). No test suite re-run — the `test` job already covers that; this
@@ -361,6 +381,15 @@ jobs:
       # (ADR-0004): compiling them here means a framework change that breaks the
       # documented idioms fails CI, rather than silently rotting the examples
       # (and the AI context sourced from them).
+      #
+      # This job only compiles (install-target) the examples — it deliberately
+      # does NOT run their `zig build test` (#345's premise). That's not a gap:
+      # the root `test_projects` loop in build.zig already runs `zig build
+      # test` as a subprocess in every example directory (exercising each
+      # command's `addCommandTests` blocks), and that loop feeds the root
+      # `test` step, which is exactly what the `test` job below runs via
+      # `zig build test` on all three OSes. Adding a second `zig build test`
+      # here would just re-run the same work a second time on a fourth OS.
       - name: Build all example CLIs
         run: zig build build-examples
 


### PR DESCRIPTION
## Summary

Investigates and closes #335 and #345. Both issues' literal asks turned out to already be substantially handled by existing code — this PR makes the remaining real gap explicit and documents the rest so the confusion doesn't recur.

### #335 — build-cache caching + coverage

- `mlugg/setup-zig@v2` (already in use on every job) caches the global Zig cache dir (`~/.cache/zig`) between runs **by default**, and redirects all local caches into it — so no separate `actions/cache` step was missing.
- Its cache key includes the runner OS automatically but not matrix variables. The one job where that matters is `linux-musl-release-build`: its matrix axis is `zig_target` (`x86_64-linux-musl` / `aarch64-linux-musl`), not `os` — both legs run on `ubuntu-latest` and would otherwise thrash a single shared cache entry between two genuinely different cross-compiles. Added `cache-key: ${{ matrix.zig_target }}` there. Every other matrixed job (`test`, `secrets`, `e2e`) varies only by `os`, which is already disambiguated for free.
- Coverage (kcov/llvm-cov): deliberately **not** wired in. Zig 0.16 has no stable first-party coverage story, and every third-party route is fragile against a moving Zig/LLVM pairing — exactly the kind of half-working tooling this repo avoids. Documented the deferral with a comment above the `test` job; revisit if Zig grows built-in coverage support.

### #345 — example unit tests "never executed in CI"

Premise mismatch: the root `build.zig`'s `test_projects` loop already runs `zig build test` as a subprocess in every example directory (`examples/tasks`, `repostat`, `ghauth`, `oauth-device`, `notes`, `ext-plugin`), exercising each command's `addCommandTests` blocks — and that loop feeds the root `test` step, which is exactly what the CI `test` job runs via `zig build test` on all three OSes.

Confirmed with a real CI run's logs (run 29371813255, all three `test` legs):
```
==> Running tests for tasks (examples/tasks)
    ✓ tasks tests passed
```

So the example test blocks already run in CI, just via the `test` job rather than the `examples` job the issue pointed at (which is intentionally build-only, per ADR-0004's drift-detector rationale). No functional change needed; added a comment on the `examples` job explaining this so a future reader doesn't reintroduce a redundant `zig build test` step there.

## Verification

Per this repo's CI-change policy, `zig build` was **not** run locally. Validated with `actionlint` — no new findings (the two pre-existing shellcheck notices on the `secrets` job's inline scripts are untouched by this diff). The PR's own CI run is the real test.

Closes #335
Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)