### PR TITLE
feat(core): @file response-file argument expansion (#347)

### DIFF
--- a/packages/core/src/registry/compiled.zig
+++ b/packages/core/src/registry/compiled.zig
@@ -5,6 +5,7 @@ const plugin_types = @import("../plugin_types.zig");
 const zcli = @import("../zcli.zig");
 
 const console_utf8 = @import("../console_utf8.zig");
+const response_file = @import("../response_file.zig");
 const paths = @import("paths.zig");
 const builder = @import("builder.zig");
 const comptimeJoinPath = paths.comptimeJoinPath;
@@ -78,6 +79,9 @@ fn isReportedCliError(err: anyerror) bool {
         // A command that failed via context.fail() already printed its own
         // user-facing message; exit non-zero without the name/trace.
         error.CommandFailed,
+        // A `@file` response file that couldn't be read is CLI misuse: the
+        // message (naming the file) was already printed at the parse front.
+        error.ResponseFileUnreadable,
         => true,
         else => false,
     };
@@ -664,8 +668,29 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
             // execution and runs any deinit hooks already owed.
             try context.initPluginData();
 
+            // 0.5 Response-file (@file) expansion, once, at the very front of
+            // parsing — before global options, transforms, and command routing
+            // — so a @file may contribute the command name, options, and
+            // positionals alike. See response_file.zig for the full semantics
+            // (single-level, `--` stops it). Allocations land in the arena.
+            var rf_diag: ?response_file.Diagnostic = null;
+            const expanded_args = response_file.expandArgs(context.allocator, io, std.Io.Dir.cwd(), args, &rf_diag) catch |err| {
+                // A missing/unreadable response file is reported CLI misuse:
+                // print the offending path (sanitized — it comes from argv) and
+                // a usage pointer, then let run() map it to exit code 2.
+                if (rf_diag) |d| {
+                    var stderr = context.stderr();
+                    try stderr.print("Error: cannot read response file '", .{});
+                    try zcli.writeSanitized(stderr, d.path);
+                    try stderr.print("'\n", .{});
+                    try stderr.print("Run '{s} --help' for usage.\n", .{context.app_name});
+                    try stderr.flush();
+                }
+                return err;
+            };
+
             // 1. Run preParse hooks
-            var current_args = args;
+            var current_args = expanded_args;
             inline for (sorted_plugins) |Plugin| {
                 if (@hasDecl(Plugin, "preParse")) {
                     current_args = try Plugin.preParse(&context, current_args);

--- a/packages/core/src/registry/compiled.zig
+++ b/packages/core/src/registry/compiled.zig
@@ -672,7 +672,11 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
             // parsing — before global options, transforms, and command routing
             // — so a @file may contribute the command name, options, and
             // positionals alike. See response_file.zig for the full semantics
-            // (single-level, `--` stops it). Allocations land in the arena.
+            // (single-level, `--` stops it). With no @file present this is the
+            // caller's argv untouched — pass-through arguments always keep
+            // their original lifetime (plugins and diagnostics may hold argv
+            // slices past this call); only file-derived arguments and the
+            // rebuilt outer slice land in the arena.
             var rf_diag: ?response_file.Diagnostic = null;
             const expanded_args = response_file.expandArgs(context.allocator, io, std.Io.Dir.cwd(), args, &rf_diag) catch |err| {
                 // A missing/unreadable response file is reported CLI misuse:

--- a/packages/core/src/response_file.zig
+++ b/packages/core/src/response_file.zig
@@ -1,0 +1,257 @@
+//! `@file` response-file argument expansion.
+//!
+//! Many CLIs (Cobra, clap-rs, GCC/clang, .NET) let you replace a long or
+//! awkward argument list with `myapp @args.txt`, where the `@file` token is
+//! substituted by arguments read from a file. This is handy for very long
+//! invocations and for working around OS `argv` length limits.
+//!
+//! Expansion happens exactly once, at the very front of parsing (before global
+//! options, arg transforms, and command routing), so a response file may
+//! contribute the command name, options, and positionals alike.
+//!
+//! Semantics (see `expandArgs`):
+//!   * A token `@PATH` (leading `@`, length > 1) is replaced by the arguments
+//!     read from the file at PATH: one argument per line. Blank lines and lines
+//!     whose first non-blank character is `#` are skipped; leading/trailing
+//!     whitespace is trimmed. A line's remaining text is one argument verbatim —
+//!     internal spaces stay part of that single argument.
+//!   * Expansion is **single-level by construction**: arguments pulled from a
+//!     response file are never rescanned for `@file`, so a `@`-prefixed line is
+//!     a literal argument (e.g. an `@scope/pkg` name or an `@handle`) and
+//!     recursion is impossible. This is the guard against runaway/nested
+//!     expansion — there is nothing to depth-limit because the second level
+//!     never exists.
+//!   * `--` stops expansion: the `--` token and everything after it are copied
+//!     through verbatim, so a literal `@value` argument can still be passed
+//!     after `--`.
+//!   * A bare `@` (no path) is a literal argument.
+//!
+//! A missing or unreadable response file is a reported CLI misuse error
+//! (`error.ResponseFileUnreadable`, exit code 2 at the registry front).
+
+const std = @import("std");
+
+/// Errors specific to response-file expansion. `error.ResponseFileUnreadable`
+/// is treated as a reported CLI misuse error by the registry entry point.
+pub const Error = error{ResponseFileUnreadable};
+
+/// Upper bound on the bytes read from a single response file. Generous enough
+/// for any realistic argument list while bounding memory from a pathological or
+/// hostile path.
+pub const max_file_bytes: usize = 1 << 20; // 1 MiB
+
+/// Filled on failure so the caller can name the offending file in its message.
+pub const Diagnostic = struct {
+    /// The response-file path that could not be read (the token after `@`).
+    path: []const u8,
+};
+
+/// Expand `@file` response-file tokens in `argv`, returning a freshly allocated
+/// argument list. When `argv` contains no expandable tokens the result is a
+/// straight (owned) copy, so the caller frees the returned slice (and its
+/// elements) uniformly. `dir` is the directory `@PATH` is resolved against
+/// (normally `std.Io.Dir.cwd()`); `io` threads file I/O.
+///
+/// On a missing/unreadable file, sets `diag` and returns
+/// `error.ResponseFileUnreadable`.
+pub fn expandArgs(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    dir: std.Io.Dir,
+    argv: []const []const u8,
+    diag: *?Diagnostic,
+) ![]const []const u8 {
+    var out: std.ArrayList([]const u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    var passthrough = false;
+    for (argv) |arg| {
+        // Everything from `--` onward is literal — including a `@value` a
+        // command legitimately wants to receive.
+        if (passthrough) {
+            try out.append(allocator, try allocator.dupe(u8, arg));
+            continue;
+        }
+        if (std.mem.eql(u8, arg, "--")) {
+            passthrough = true;
+            try out.append(allocator, try allocator.dupe(u8, arg));
+            continue;
+        }
+
+        if (arg.len > 1 and arg[0] == '@') {
+            const path = arg[1..];
+            const content = dir.readFileAlloc(io, path, allocator, .limited(max_file_bytes)) catch {
+                diag.* = .{ .path = path };
+                return Error.ResponseFileUnreadable;
+            };
+            defer allocator.free(content);
+            try appendFileArgs(allocator, &out, content);
+            continue;
+        }
+
+        // A plain argument, or a bare `@`: passed through verbatim.
+        try out.append(allocator, try allocator.dupe(u8, arg));
+    }
+
+    return out.toOwnedSlice(allocator);
+}
+
+/// Parse one response file's `content` into arguments and append them to `out`.
+/// One argument per line; blank lines and `#` comment lines skipped; each line
+/// trimmed. Lines are taken verbatim (never rescanned for `@file`).
+fn appendFileArgs(allocator: std.mem.Allocator, out: *std.ArrayList([]const u8), content: []const u8) !void {
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |raw_line| {
+        // Tolerate CRLF line endings.
+        const unterminated = if (raw_line.len > 0 and raw_line[raw_line.len - 1] == '\r')
+            raw_line[0 .. raw_line.len - 1]
+        else
+            raw_line;
+        const line = std.mem.trim(u8, unterminated, " \t");
+        if (line.len == 0) continue; // blank line
+        if (line[0] == '#') continue; // comment
+        try out.append(allocator, try allocator.dupe(u8, line));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const testing = std.testing;
+
+/// Free a slice returned by `expandArgs` (each element plus the slice itself).
+fn freeExpanded(allocator: std.mem.Allocator, args: []const []const u8) void {
+    for (args) |a| allocator.free(a);
+    allocator.free(args);
+}
+
+test "expandArgs: no @file tokens returns an owned copy unchanged" {
+    const allocator = testing.allocator;
+    var diag: ?Diagnostic = null;
+    const argv = [_][]const u8{ "users", "list", "--json" };
+    const out = try expandArgs(allocator, testing.io, std.Io.Dir.cwd(), &argv, &diag);
+    defer freeExpanded(allocator, out);
+
+    try testing.expectEqual(@as(usize, 3), out.len);
+    try testing.expectEqualStrings("users", out[0]);
+    try testing.expectEqualStrings("list", out[1]);
+    try testing.expectEqualStrings("--json", out[2]);
+    try testing.expect(diag == null);
+}
+
+test "expandArgs: reads args from a file (one per line, comments and blanks skipped)" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "args.txt", .data =
+        \\# a comment
+        \\--name
+        \\Ada Lovelace
+        \\
+        \\--count
+        \\3
+        \\
+    });
+
+    var diag: ?Diagnostic = null;
+    const argv = [_][]const u8{ "create", "@args.txt", "trailing" };
+    const out = try expandArgs(allocator, testing.io, tmp.dir, &argv, &diag);
+    defer freeExpanded(allocator, out);
+
+    // "create", then the four file args, then "trailing".
+    try testing.expectEqual(@as(usize, 6), out.len);
+    try testing.expectEqualStrings("create", out[0]);
+    try testing.expectEqualStrings("--name", out[1]);
+    // A whole line is one argument — internal spaces preserved.
+    try testing.expectEqualStrings("Ada Lovelace", out[2]);
+    try testing.expectEqualStrings("--count", out[3]);
+    try testing.expectEqualStrings("3", out[4]);
+    try testing.expectEqualStrings("trailing", out[5]);
+}
+
+test "expandArgs: -- stops expansion and passes a literal @value through" {
+    const allocator = testing.allocator;
+    var diag: ?Diagnostic = null;
+    const argv = [_][]const u8{ "run", "--", "@notafile", "plain" };
+    const out = try expandArgs(allocator, testing.io, std.Io.Dir.cwd(), &argv, &diag);
+    defer freeExpanded(allocator, out);
+
+    try testing.expectEqual(@as(usize, 4), out.len);
+    try testing.expectEqualStrings("run", out[0]);
+    try testing.expectEqualStrings("--", out[1]);
+    try testing.expectEqualStrings("@notafile", out[2]);
+    try testing.expectEqualStrings("plain", out[3]);
+    try testing.expect(diag == null);
+}
+
+test "expandArgs: expansion is single-level (a @ line in a file is literal, not recursed)" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // The referenced file names another file — which must NOT be expanded.
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "inner.txt", .data = "should-not-be-read\n" });
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "outer.txt", .data = "@inner.txt\n@scope/pkg\n" });
+
+    var diag: ?Diagnostic = null;
+    const argv = [_][]const u8{"@outer.txt"};
+    const out = try expandArgs(allocator, testing.io, tmp.dir, &argv, &diag);
+    defer freeExpanded(allocator, out);
+
+    try testing.expectEqual(@as(usize, 2), out.len);
+    // Both @-prefixed lines are literal arguments, never treated as @file refs.
+    try testing.expectEqualStrings("@inner.txt", out[0]);
+    try testing.expectEqualStrings("@scope/pkg", out[1]);
+    try testing.expect(diag == null);
+}
+
+test "expandArgs: a bare @ is a literal argument" {
+    const allocator = testing.allocator;
+    var diag: ?Diagnostic = null;
+    const argv = [_][]const u8{ "cmd", "@" };
+    const out = try expandArgs(allocator, testing.io, std.Io.Dir.cwd(), &argv, &diag);
+    defer freeExpanded(allocator, out);
+
+    try testing.expectEqual(@as(usize, 2), out.len);
+    try testing.expectEqualStrings("@", out[1]);
+}
+
+test "expandArgs: a missing response file is a reported error naming the path" {
+    const allocator = testing.allocator;
+    var diag: ?Diagnostic = null;
+    const argv = [_][]const u8{ "cmd", "@does-not-exist.txt" };
+    try testing.expectError(Error.ResponseFileUnreadable, expandArgs(allocator, testing.io, std.Io.Dir.cwd(), &argv, &diag));
+    try testing.expect(diag != null);
+    try testing.expectEqualStrings("does-not-exist.txt", diag.?.path);
+}
+
+test "expandArgs into parseCommandLine: file-supplied options and positionals parse" {
+    const command_parser = @import("command_parser.zig");
+    const allocator = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "run.txt", .data =
+        \\--verbose
+        \\--count
+        \\7
+        \\input.txt
+        \\
+    });
+
+    var diag: ?Diagnostic = null;
+    const argv = [_][]const u8{"@run.txt"};
+    const expanded = try expandArgs(allocator, testing.io, tmp.dir, &argv, &diag);
+    defer freeExpanded(allocator, expanded);
+
+    const Args = struct { file: []const u8 };
+    const Options = struct { verbose: bool = false, count: u32 = 1 };
+
+    var parse_diag: ?command_parser.ZcliDiagnostic = null;
+    const result = try command_parser.parseCommandLine(Args, Options, null, allocator, null, expanded, &parse_diag);
+    defer result.deinit();
+
+    try testing.expectEqualStrings("input.txt", result.args.file);
+    try testing.expect(result.options.verbose);
+    try testing.expectEqual(@as(u32, 7), result.options.count);
+}

--- a/packages/core/src/response_file.zig
+++ b/packages/core/src/response_file.zig
@@ -46,14 +46,22 @@ pub const Diagnostic = struct {
     path: []const u8,
 };
 
-/// Expand `@file` response-file tokens in `argv`, returning a freshly allocated
-/// argument list. When `argv` contains no expandable tokens the result is a
-/// straight (owned) copy, so the caller frees the returned slice (and its
-/// elements) uniformly. `dir` is the directory `@PATH` is resolved against
-/// (normally `std.Io.Dir.cwd()`); `io` threads file I/O.
+/// Expand `@file` response-file tokens in `argv`.
 ///
-/// On a missing/unreadable file, sets `diag` and returns
-/// `error.ResponseFileUnreadable`.
+/// When `argv` contains no expandable token this returns `argv` itself — no
+/// allocation, and every argument keeps its original (caller-owned) lifetime.
+/// This matters: plugins and diagnostics may hold argv slices beyond the parse,
+/// so pass-through tokens must never be moved into shorter-lived memory.
+///
+/// When expansion does occur, the returned outer slice and the file-derived
+/// argument strings are allocated from `allocator`; pass-through tokens are
+/// still borrowed from `argv` unchanged. The mixed ownership is intended for
+/// an arena (the registry's per-command arena) — free by discarding the arena,
+/// not element-by-element.
+///
+/// `dir` is the directory `@PATH` is resolved against (normally
+/// `std.Io.Dir.cwd()`); `io` threads file I/O. On a missing/unreadable file,
+/// sets `diag` and returns `error.ResponseFileUnreadable`.
 pub fn expandArgs(
     allocator: std.mem.Allocator,
     io: std.Io,
@@ -61,44 +69,59 @@ pub fn expandArgs(
     argv: []const []const u8,
     diag: *?Diagnostic,
 ) ![]const []const u8 {
+    // Fast path: leave argv untouched when there is nothing to expand.
+    if (!hasExpandableToken(argv)) return argv;
+
     var out: std.ArrayList([]const u8) = .empty;
     errdefer out.deinit(allocator);
 
     var passthrough = false;
     for (argv) |arg| {
-        // Everything from `--` onward is literal — including a `@value` a
-        // command legitimately wants to receive.
-        if (passthrough) {
-            try out.append(allocator, try allocator.dupe(u8, arg));
-            continue;
+        if (!passthrough) {
+            // Everything from `--` onward is literal — including a `@value`
+            // a command legitimately wants to receive.
+            if (std.mem.eql(u8, arg, "--")) {
+                passthrough = true;
+            } else if (isResponseToken(arg)) {
+                const path = arg[1..];
+                const content = dir.readFileAlloc(io, path, allocator, .limited(max_file_bytes)) catch {
+                    diag.* = .{ .path = path };
+                    return Error.ResponseFileUnreadable;
+                };
+                // Not freed: the file-derived argument slices point into it
+                // (arena-owned, reclaimed with everything else).
+                try appendFileArgs(allocator, &out, content);
+                continue;
+            }
         }
-        if (std.mem.eql(u8, arg, "--")) {
-            passthrough = true;
-            try out.append(allocator, try allocator.dupe(u8, arg));
-            continue;
-        }
-
-        if (arg.len > 1 and arg[0] == '@') {
-            const path = arg[1..];
-            const content = dir.readFileAlloc(io, path, allocator, .limited(max_file_bytes)) catch {
-                diag.* = .{ .path = path };
-                return Error.ResponseFileUnreadable;
-            };
-            defer allocator.free(content);
-            try appendFileArgs(allocator, &out, content);
-            continue;
-        }
-
-        // A plain argument, or a bare `@`: passed through verbatim.
-        try out.append(allocator, try allocator.dupe(u8, arg));
+        // A plain argument (or a bare `@`, or anything after `--`): borrowed
+        // from argv verbatim, keeping its original lifetime.
+        try out.append(allocator, arg);
     }
 
     return out.toOwnedSlice(allocator);
 }
 
+/// Whether `arg` is a `@PATH` response-file reference (leading `@`, non-empty
+/// path). A bare `@` is a literal argument.
+fn isResponseToken(arg: []const u8) bool {
+    return arg.len > 1 and arg[0] == '@';
+}
+
+/// Whether any token before a `--` terminator is a `@PATH` reference — i.e.
+/// whether `expandArgs` has any work to do.
+fn hasExpandableToken(argv: []const []const u8) bool {
+    for (argv) |arg| {
+        if (std.mem.eql(u8, arg, "--")) return false;
+        if (isResponseToken(arg)) return true;
+    }
+    return false;
+}
+
 /// Parse one response file's `content` into arguments and append them to `out`.
 /// One argument per line; blank lines and `#` comment lines skipped; each line
-/// trimmed. Lines are taken verbatim (never rescanned for `@file`).
+/// trimmed. Lines are taken verbatim (never rescanned for `@file`) and the
+/// appended slices point into `content`.
 fn appendFileArgs(allocator: std.mem.Allocator, out: *std.ArrayList([]const u8), content: []const u8) !void {
     var lines = std.mem.splitScalar(u8, content, '\n');
     while (lines.next()) |raw_line| {
@@ -110,38 +133,32 @@ fn appendFileArgs(allocator: std.mem.Allocator, out: *std.ArrayList([]const u8),
         const line = std.mem.trim(u8, unterminated, " \t");
         if (line.len == 0) continue; // blank line
         if (line[0] == '#') continue; // comment
-        try out.append(allocator, try allocator.dupe(u8, line));
+        try out.append(allocator, line);
     }
 }
 
 // ---------------------------------------------------------------------------
 // Tests
+//
+// expandArgs allocates arena-style (mixed borrowed/owned elements), so each
+// test that can expand wraps testing.allocator in an ArenaAllocator.
 // ---------------------------------------------------------------------------
 
 const testing = std.testing;
 
-/// Free a slice returned by `expandArgs` (each element plus the slice itself).
-fn freeExpanded(allocator: std.mem.Allocator, args: []const []const u8) void {
-    for (args) |a| allocator.free(a);
-    allocator.free(args);
-}
-
-test "expandArgs: no @file tokens returns an owned copy unchanged" {
-    const allocator = testing.allocator;
+test "expandArgs: no @file tokens returns argv itself, untouched" {
     var diag: ?Diagnostic = null;
     const argv = [_][]const u8{ "users", "list", "--json" };
-    const out = try expandArgs(allocator, testing.io, std.Io.Dir.cwd(), &argv, &diag);
-    defer freeExpanded(allocator, out);
-
-    try testing.expectEqual(@as(usize, 3), out.len);
-    try testing.expectEqualStrings("users", out[0]);
-    try testing.expectEqualStrings("list", out[1]);
-    try testing.expectEqualStrings("--json", out[2]);
+    const out = try expandArgs(testing.allocator, testing.io, std.Io.Dir.cwd(), &argv, &diag);
+    // The fast path: the very same slice, no allocation, original lifetimes.
+    try testing.expectEqual(@as([]const []const u8, &argv), out);
     try testing.expect(diag == null);
 }
 
 test "expandArgs: reads args from a file (one per line, comments and blanks skipped)" {
-    const allocator = testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
     try tmp.dir.writeFile(testing.io, .{ .sub_path = "args.txt", .data =
@@ -156,8 +173,7 @@ test "expandArgs: reads args from a file (one per line, comments and blanks skip
 
     var diag: ?Diagnostic = null;
     const argv = [_][]const u8{ "create", "@args.txt", "trailing" };
-    const out = try expandArgs(allocator, testing.io, tmp.dir, &argv, &diag);
-    defer freeExpanded(allocator, out);
+    const out = try expandArgs(arena.allocator(), testing.io, tmp.dir, &argv, &diag);
 
     // "create", then the four file args, then "trailing".
     try testing.expectEqual(@as(usize, 6), out.len);
@@ -168,25 +184,44 @@ test "expandArgs: reads args from a file (one per line, comments and blanks skip
     try testing.expectEqualStrings("--count", out[3]);
     try testing.expectEqualStrings("3", out[4]);
     try testing.expectEqualStrings("trailing", out[5]);
+    // Pass-through tokens are borrowed from argv (original lifetime kept).
+    try testing.expectEqual(argv[0].ptr, out[0].ptr);
+    try testing.expectEqual(argv[2].ptr, out[5].ptr);
 }
 
 test "expandArgs: -- stops expansion and passes a literal @value through" {
-    const allocator = testing.allocator;
     var diag: ?Diagnostic = null;
     const argv = [_][]const u8{ "run", "--", "@notafile", "plain" };
-    const out = try expandArgs(allocator, testing.io, std.Io.Dir.cwd(), &argv, &diag);
-    defer freeExpanded(allocator, out);
+    const out = try expandArgs(testing.allocator, testing.io, std.Io.Dir.cwd(), &argv, &diag);
 
-    try testing.expectEqual(@as(usize, 4), out.len);
-    try testing.expectEqualStrings("run", out[0]);
-    try testing.expectEqualStrings("--", out[1]);
-    try testing.expectEqualStrings("@notafile", out[2]);
-    try testing.expectEqualStrings("plain", out[3]);
+    // Nothing expandable before `--` → argv itself, verbatim.
+    try testing.expectEqual(@as([]const []const u8, &argv), out);
     try testing.expect(diag == null);
 }
 
+test "expandArgs: -- stops expansion even when a @file was expanded before it" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "pre.txt", .data = "--verbose\n" });
+
+    var diag: ?Diagnostic = null;
+    const argv = [_][]const u8{ "run", "@pre.txt", "--", "@notafile" };
+    const out = try expandArgs(arena.allocator(), testing.io, tmp.dir, &argv, &diag);
+
+    try testing.expectEqual(@as(usize, 4), out.len);
+    try testing.expectEqualStrings("run", out[0]);
+    try testing.expectEqualStrings("--verbose", out[1]);
+    try testing.expectEqualStrings("--", out[2]);
+    try testing.expectEqualStrings("@notafile", out[3]);
+}
+
 test "expandArgs: expansion is single-level (a @ line in a file is literal, not recursed)" {
-    const allocator = testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
     // The referenced file names another file — which must NOT be expanded.
@@ -195,8 +230,7 @@ test "expandArgs: expansion is single-level (a @ line in a file is literal, not 
 
     var diag: ?Diagnostic = null;
     const argv = [_][]const u8{"@outer.txt"};
-    const out = try expandArgs(allocator, testing.io, tmp.dir, &argv, &diag);
-    defer freeExpanded(allocator, out);
+    const out = try expandArgs(arena.allocator(), testing.io, tmp.dir, &argv, &diag);
 
     try testing.expectEqual(@as(usize, 2), out.len);
     // Both @-prefixed lines are literal arguments, never treated as @file refs.
@@ -206,28 +240,26 @@ test "expandArgs: expansion is single-level (a @ line in a file is literal, not 
 }
 
 test "expandArgs: a bare @ is a literal argument" {
-    const allocator = testing.allocator;
     var diag: ?Diagnostic = null;
     const argv = [_][]const u8{ "cmd", "@" };
-    const out = try expandArgs(allocator, testing.io, std.Io.Dir.cwd(), &argv, &diag);
-    defer freeExpanded(allocator, out);
-
-    try testing.expectEqual(@as(usize, 2), out.len);
-    try testing.expectEqualStrings("@", out[1]);
+    const out = try expandArgs(testing.allocator, testing.io, std.Io.Dir.cwd(), &argv, &diag);
+    // Not expandable → the fast path returns argv itself.
+    try testing.expectEqual(@as([]const []const u8, &argv), out);
 }
 
 test "expandArgs: a missing response file is a reported error naming the path" {
-    const allocator = testing.allocator;
     var diag: ?Diagnostic = null;
     const argv = [_][]const u8{ "cmd", "@does-not-exist.txt" };
-    try testing.expectError(Error.ResponseFileUnreadable, expandArgs(allocator, testing.io, std.Io.Dir.cwd(), &argv, &diag));
+    try testing.expectError(Error.ResponseFileUnreadable, expandArgs(testing.allocator, testing.io, std.Io.Dir.cwd(), &argv, &diag));
     try testing.expect(diag != null);
     try testing.expectEqualStrings("does-not-exist.txt", diag.?.path);
 }
 
 test "expandArgs into parseCommandLine: file-supplied options and positionals parse" {
     const command_parser = @import("command_parser.zig");
-    const allocator = testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
 
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -242,7 +274,6 @@ test "expandArgs into parseCommandLine: file-supplied options and positionals pa
     var diag: ?Diagnostic = null;
     const argv = [_][]const u8{"@run.txt"};
     const expanded = try expandArgs(allocator, testing.io, tmp.dir, &argv, &diag);
-    defer freeExpanded(allocator, expanded);
 
     const Args = struct { file: []const u8 };
     const Options = struct { verbose: bool = false, count: u32 = 1 };

--- a/packages/core/src/zcli.zig
+++ b/packages/core/src/zcli.zig
@@ -139,6 +139,10 @@ pub const writeSanitized = diagnostic_errors.writeSanitized;
 /// suggestions), so both draw "did you mean" hints from one implementation.
 pub const levenshtein = @import("levenshtein.zig");
 
+/// `@file` response-file argument expansion, applied once at the registry's
+/// parse front (see registry/compiled.zig).
+pub const response_file = @import("response_file.zig");
+
 // Re-export plugin types for user convenience
 
 // Re-export new plugin system types


### PR DESCRIPTION
## What

Implements `@file` response-file argument expansion (issue #347). `myapp @args.txt` replaces the `@file` token in argv with arguments read from the file — matching Cobra/clap-rs/GCC and useful for very long invocations and OS `argv` length limits.

Expansion runs **once at the registry's parse front** (`CompiledRegistry.executeWithStdio`, before global options, arg transforms, and command routing), so a response file can contribute the command name, options, and positionals alike. The read threads `io` via `std.Io.Dir.cwd()` — no C shortcuts.

## Semantics (`packages/core/src/response_file.zig`)

- `@PATH` (leading `@`, length > 1) → one argument per line; blank lines and `#` comment lines skipped; each line trimmed, taken verbatim (internal spaces stay part of the one argument). CRLF tolerated.
- **Single-level by construction**: file contents are never rescanned for `@file`, so a `@`-prefixed line is a literal argument (e.g. `@scope/pkg`, `@handle`) and recursion is impossible. This is the guard against nested/runaway expansion — there is no second level to depth-limit, and legitimate `@`-prefixed values are never falsely rejected.
- `--` stops expansion: the `--` token and everything after pass through verbatim, so a literal `@value` can still be passed after `--`.
- A bare `@` (no path) is a literal argument.
- A missing/unreadable file is **reported CLI misuse** — `error.ResponseFileUnreadable`, exit code 2 — with the offending path printed (sanitized) to stderr plus a usage pointer.

## Tests

Unit tests at the expansion function (no-op copy, file read + comments/blanks, `--` passthrough, single-level guard, bare `@`, missing file) plus a `parseCommandLine`-level test showing file-supplied options/positionals parse. Tests live in the source file and run via `refAllDecls` (a `pub const response_file` re-export was added to `zcli.zig`).

## Premise notes

- The issue named "`run()` / `parseCommandLine` front" as the wiring point. `parseCommandLine` runs per-resolved-command (after routing), which is too late for a `@file` that supplies the command name — so expansion is wired at the single front-of-pipeline choke point in `executeWithStdio`, which both `execute()` and `run()` flow through.
- The issue offered "forbid nested @file with a clear error **or** depth-limit". I chose single-level-by-construction instead: it is the cleanest (no recursion path exists) and, unlike an error, never mis-rejects a legitimate `@scope/pkg` value inside a response file. Documented in the module header.

## Verification

Per maintainer policy, not built locally: each edited file passes `zig ast-check` (0.16.0). CI is the authoritative gate.

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)