### PR TITLE
Add example coverage: secrets kitchen sink, option/prompt features, testing harness, self-upgrade

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -109,6 +109,11 @@ pub fn build(b: *std.Build) void {
         .{ .name = "oauth-device", .path = "examples/oauth-device" },
         .{ .name = "notes", .path = "examples/notes" },
         .{ .name = "ext-plugin", .path = "examples/ext-plugin" },
+        .{ .name = "vault", .path = "examples/vault" },
+        .{ .name = "options-features", .path = "examples/options-features" },
+        .{ .name = "prompts-features", .path = "examples/prompts-features" },
+        .{ .name = "testing-demo", .path = "examples/testing-demo" },
+        .{ .name = "upgrade-demo", .path = "examples/upgrade-demo" },
     };
 
     // Add tests for each project that has them
@@ -151,6 +156,11 @@ pub fn build(b: *std.Build) void {
         .{ .name = "oauth-device", .path = "examples/oauth-device" },
         .{ .name = "notes", .path = "examples/notes" },
         .{ .name = "ext-plugin", .path = "examples/ext-plugin" },
+        .{ .name = "vault", .path = "examples/vault" },
+        .{ .name = "options-features", .path = "examples/options-features" },
+        .{ .name = "prompts-features", .path = "examples/prompts-features" },
+        .{ .name = "testing-demo", .path = "examples/testing-demo" },
+        .{ .name = "upgrade-demo", .path = "examples/upgrade-demo" },
         .{ .name = "vterm_example", .path = "packages/vterm/example" },
     };
 

--- a/examples/options-features/README.md
+++ b/examples/options-features/README.md
@@ -1,0 +1,25 @@
+# options-features
+
+A small `deployctl` CLI whose only job is to exercise option-parsing features
+that had no example anywhere in the repo:
+
+- **`deploy`** — a required option (`--region`, satisfiable by `--region`,
+  `$DEPLOY_REGION`, or config), a multi-value/array option (`--tag`,
+  repeatable), a per-field `validate` hook (`--replicas`, range-checked), and a
+  custom `parse` type (`--timeout`, `"30s"`/`"5m"`/`"1h"`).
+- **`export`** — `meta.exclusive` (`--json`/`--yaml` are mutually exclusive)
+  and a directional `meta.options.<field>.requires` (`--format` only makes
+  sense alongside `--output`).
+
+```
+deployctl deploy api --region us-east-1 --tag env=prod --replicas 5 --timeout 2m
+deployctl export --json
+deployctl export --output state.txt --format text
+```
+
+## Build
+
+```
+zig build
+./zig-out/bin/deployctl --help
+```

--- a/examples/options-features/build.zig
+++ b/examples/options-features/build.zig
@@ -1,0 +1,49 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) !void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const zcli_dep = b.dependency("zcli", .{ .target = target, .optimize = optimize });
+    const zcli_module = zcli_dep.module("zcli");
+
+    const exe = b.addExecutable(.{
+        .name = "deployctl",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    exe.root_module.addImport("zcli", zcli_module);
+
+    const zcli = @import("zcli");
+
+    const cmd_registry = try zcli.generate(b, exe, zcli_dep, .{
+        .commands_dir = "src/commands",
+        .plugins = &.{
+            zcli.builtin(.help, .{}),
+            zcli.builtin(.version, .{}),
+            zcli.builtin(.not_found, .{}),
+        },
+        .app_name = "deployctl",
+        .app_description = "Option-parsing features: required options, validate/parse hooks, exclusive/requires constraints, array options",
+    });
+    exe.root_module.addImport("command_registry", cmd_registry);
+
+    b.installArtifact(exe);
+
+    const run_cmd = b.addRunArtifact(exe);
+    run_cmd.step.dependOn(b.getInstallStep());
+    if (b.args) |args| run_cmd.addArgs(args);
+    const run_step = b.step("run", "Run the application");
+    run_step.dependOn(&run_cmd.step);
+
+    // Per-command unit tests (the scaffolded-project idiom): compiles each
+    // command file as its own test root so its `test` blocks run.
+    _ = zcli.addCommandTests(b, zcli_dep, .{
+        .commands_dir = "src/commands",
+        .target = target,
+        .optimize = optimize,
+    });
+}

--- a/examples/options-features/build.zig.zon
+++ b/examples/options-features/build.zig.zon
@@ -1,0 +1,18 @@
+.{
+    .name = .@"options-features",
+    .version = "0.1.0",
+    .fingerprint = 0x29c583816e9d7c3b,
+    .minimum_zig_version = "0.16.0",
+    .dependencies = .{
+        // Local path because this example lives in-repo (so CI compiles it
+        // against unreleased changes as a drift-detector). Your own project
+        // doesn't hand-write this — `zcli init` fetches a released zcli:
+        //   .zcli = .{ .url = "git+https://github.com/ryanhair/zcli#<tag>", .hash = "..." },
+        .zcli = .{ .path = "../.." },
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}

--- a/examples/options-features/build.zig.zon
+++ b/examples/options-features/build.zig.zon
@@ -1,7 +1,7 @@
 .{
-    .name = .@"options-features",
+    .name = .options_features,
     .version = "0.1.0",
-    .fingerprint = 0x29c583816e9d7c3b,
+    .fingerprint = 0x15fa6aadeb2cb013,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         // Local path because this example lives in-repo (so CI compiles it

--- a/examples/options-features/src/commands/deploy.zig
+++ b/examples/options-features/src/commands/deploy.zig
@@ -1,0 +1,98 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
+
+pub const meta = .{
+    .description = "Deploy a service (demonstrates required options, array options, a validate hook, and a custom parse type)",
+    .examples = &.{
+        "deploy api --region us-east-1",
+        "deploy api --region us-east-1 --tag env=prod --tag team=payments --replicas 5 --timeout 2m",
+    },
+    .args = .{ .name = "Service to deploy" },
+    .options = .{
+        // `env`: a source between struct default and CLI — reading
+        // $DEPLOY_REGION satisfies the required check exactly like passing
+        // `--region` would.
+        .region = .{ .short = 'r', .description = "Target region", .env = "DEPLOY_REGION" },
+        .tag = .{ .short = 't', .description = "key=value tag (repeatable)" },
+        .replicas = .{ .description = "Number of replicas", .validate = validateReplicas },
+        .timeout = .{ .description = "Deploy timeout, e.g. 30s / 5m / 1h" },
+    },
+};
+
+pub const Args = struct { name: []const u8 };
+
+pub const Options = struct {
+    // No default: a required option. Help marks it `(required)`, and the
+    // command never runs until it's supplied by a CLI flag, `.env`, or config.
+    region: []const u8,
+
+    // Multi-value/array option: []const []const u8 — each `--tag value` on the
+    // command line appends to this slice, so `--tag a --tag b` yields
+    // &.{ "a", "b" }.
+    tag: []const []const u8 = &.{},
+
+    replicas: u32 = 1,
+
+    timeout: Duration = .{ .seconds = 30 },
+};
+
+/// Per-field `validate` hook: runs after the value is resolved from every
+/// source. Returning null means valid; a returned string is the reason shown
+/// to the user (a misuse — exit code 2).
+fn validateReplicas(n: u32) ?[]const u8 {
+    if (n == 0) return "must be at least 1";
+    if (n > 100) return "must be at most 100";
+    return null;
+}
+
+/// A custom `parse` type: any struct/union declaring `pub fn parse(s: []const
+/// u8) !@This()` can be used as an option (or arg) field type, and the CLI,
+/// env, and config sources all funnel through the same parser.
+pub const Duration = struct {
+    seconds: u32,
+
+    pub fn parse(s: []const u8) !Duration {
+        if (s.len < 2) return error.InvalidDuration;
+        const unit = s[s.len - 1];
+        const digits = s[0 .. s.len - 1];
+        const n = try std.fmt.parseInt(u32, digits, 10);
+        const multiplier: u32 = switch (unit) {
+            's' => 1,
+            'm' => 60,
+            'h' => 3600,
+            else => return error.InvalidDuration,
+        };
+        return .{ .seconds = n * multiplier };
+    }
+};
+
+pub fn execute(args: Args, options: Options, context: *Context) !void {
+    const stdout = context.stdout();
+    try stdout.print("Deploying '{s}' to {s} ({d} replicas, timeout {d}s)\n", .{
+        args.name,
+        options.region,
+        options.replicas,
+        options.timeout.seconds,
+    });
+    for (options.tag) |tag| {
+        try stdout.print("  tag: {s}\n", .{tag});
+    }
+}
+
+test "Duration.parse: seconds, minutes, hours" {
+    try std.testing.expectEqual(@as(u32, 30), (try Duration.parse("30s")).seconds);
+    try std.testing.expectEqual(@as(u32, 120), (try Duration.parse("2m")).seconds);
+    try std.testing.expectEqual(@as(u32, 3600), (try Duration.parse("1h")).seconds);
+}
+
+test "Duration.parse: rejects an unknown unit" {
+    try std.testing.expectError(error.InvalidDuration, Duration.parse("30x"));
+}
+
+test "validateReplicas: rejects zero and anything over 100" {
+    try std.testing.expect(validateReplicas(0) != null);
+    try std.testing.expect(validateReplicas(101) != null);
+    try std.testing.expect(validateReplicas(1) == null);
+    try std.testing.expect(validateReplicas(100) == null);
+}

--- a/examples/options-features/src/commands/export.zig
+++ b/examples/options-features/src/commands/export.zig
@@ -1,0 +1,46 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
+
+pub const meta = .{
+    .description = "Export deployment state (demonstrates meta.exclusive and a directional meta.options.requires)",
+    .examples = &.{
+        "export",
+        "export --json",
+        "export --output state.txt --format text",
+    },
+    .options = .{
+        .json = .{ .description = "Print as JSON" },
+        .yaml = .{ .description = "Print as YAML" },
+        .output = .{ .short = 'o', .description = "Write to a file instead of stdout" },
+        // `requires`: `--format` only makes sense once `--output` names a
+        // file to write (stdout output is always plain text) — supplying
+        // `format` without `output` is a reported misuse (exit code 2).
+        .format = .{ .description = "File format when writing to a file", .requires = .{.output} },
+    },
+    // At most one of `json`/`yaml` may be supplied — supplying both is a
+    // reported misuse (exit code 2), checked at comptime for typos/self-
+    // reference and at runtime for the actual conflict.
+    .exclusive = .{.{ .json, .yaml }},
+};
+
+pub const Args = struct {};
+
+pub const Options = struct {
+    json: bool = false,
+    yaml: bool = false,
+    output: ?[]const u8 = null,
+    format: ?[]const u8 = null,
+};
+
+pub fn execute(_: Args, options: Options, context: *Context) !void {
+    const stdout = context.stdout();
+
+    const style: []const u8 = if (options.json) "json" else if (options.yaml) "yaml" else "text";
+
+    if (options.output) |path| {
+        try stdout.print("Wrote {s} state to {s} (format: {s})\n", .{ style, path, options.format orelse "default" });
+    } else {
+        try stdout.print("state: ok ({s})\n", .{style});
+    }
+}

--- a/examples/options-features/src/main.zig
+++ b/examples/options-features/src/main.zig
@@ -1,0 +1,9 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const registry = @import("command_registry");
+
+pub fn main(init: std.process.Init) !void {
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
+    var app = registry.init();
+    try app.run(init.gpa, init.io, init.environ_map, args);
+}

--- a/examples/prompts-features/README.md
+++ b/examples/prompts-features/README.md
@@ -1,0 +1,18 @@
+# prompts-features
+
+A one-command `signup-cli` whose only job is to exercise the two prompt types
+that had no example anywhere in the repo: `password` (masked input) and
+`multi_select` (toggle-selection with space, confirm with enter). The other
+prompt types — `text`, `select`, `number`, `confirm` — already have worked
+examples in `examples/tasks`.
+
+```
+signup-cli signup
+```
+
+## Build
+
+```
+zig build
+./zig-out/bin/signup-cli signup
+```

--- a/examples/prompts-features/build.zig
+++ b/examples/prompts-features/build.zig
@@ -1,0 +1,49 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) !void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const zcli_dep = b.dependency("zcli", .{ .target = target, .optimize = optimize });
+    const zcli_module = zcli_dep.module("zcli");
+
+    const exe = b.addExecutable(.{
+        .name = "signup-cli",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    exe.root_module.addImport("zcli", zcli_module);
+
+    const zcli = @import("zcli");
+
+    const cmd_registry = try zcli.generate(b, exe, zcli_dep, .{
+        .commands_dir = "src/commands",
+        .plugins = &.{
+            zcli.builtin(.help, .{}),
+            zcli.builtin(.version, .{}),
+            zcli.builtin(.not_found, .{}),
+        },
+        .app_name = "signup-cli",
+        .app_description = "Prompt features with no other example: password and multi_select",
+    });
+    exe.root_module.addImport("command_registry", cmd_registry);
+
+    b.installArtifact(exe);
+
+    const run_cmd = b.addRunArtifact(exe);
+    run_cmd.step.dependOn(b.getInstallStep());
+    if (b.args) |args| run_cmd.addArgs(args);
+    const run_step = b.step("run", "Run the application");
+    run_step.dependOn(&run_cmd.step);
+
+    // Per-command unit tests (the scaffolded-project idiom): compiles each
+    // command file as its own test root so its `test` blocks run.
+    _ = zcli.addCommandTests(b, zcli_dep, .{
+        .commands_dir = "src/commands",
+        .target = target,
+        .optimize = optimize,
+    });
+}

--- a/examples/prompts-features/build.zig.zon
+++ b/examples/prompts-features/build.zig.zon
@@ -1,7 +1,7 @@
 .{
-    .name = .@"prompts-features",
+    .name = .prompts_features,
     .version = "0.1.0",
-    .fingerprint = 0xeb870eebef93db43,
+    .fingerprint = 0x0e57014d30c1bd8b,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         // Local path because this example lives in-repo (so CI compiles it

--- a/examples/prompts-features/build.zig.zon
+++ b/examples/prompts-features/build.zig.zon
@@ -1,0 +1,18 @@
+.{
+    .name = .@"prompts-features",
+    .version = "0.1.0",
+    .fingerprint = 0xeb870eebef93db43,
+    .minimum_zig_version = "0.16.0",
+    .dependencies = .{
+        // Local path because this example lives in-repo (so CI compiles it
+        // against unreleased changes as a drift-detector). Your own project
+        // doesn't hand-write this — `zcli init` fetches a released zcli:
+        //   .zcli = .{ .url = "git+https://github.com/ryanhair/zcli#<tag>", .hash = "..." },
+        .zcli = .{ .path = "../.." },
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}

--- a/examples/prompts-features/src/commands/signup.zig
+++ b/examples/prompts-features/src/commands/signup.zig
@@ -1,0 +1,63 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
+
+pub const meta = .{
+    .description = "Create an account (demonstrates the password and multi_select prompts)",
+    .examples = &.{"signup"},
+};
+
+pub const Args = struct {};
+pub const Options = struct {};
+
+const interests = [_][]const u8{ "Announcements", "Product updates", "Security bulletins", "Community events" };
+
+pub fn execute(_: Args, _: Options, context: *Context) !void {
+    const allocator = context.allocator;
+    const stdout = context.stdout();
+    const p = context.prompts();
+
+    const username = p.text(.{
+        .message = "Username:",
+    }) catch |err| switch (err) {
+        error.EndOfStream => return context.fail("signup requires an interactive terminal (stdin closed).", .{}),
+        else => return err,
+    };
+    defer allocator.free(username);
+
+    // Masked input: typed characters render as `*` and the value never
+    // echoes to the terminal.
+    const password = p.password(.{
+        .message = "Password:",
+    }) catch |err| switch (err) {
+        error.EndOfStream => return context.fail("signup requires an interactive terminal (stdin closed).", .{}),
+        else => return err,
+    };
+    defer allocator.free(password);
+
+    if (password.len < 8) {
+        return context.fail("password must be at least 8 characters.", .{});
+    }
+
+    // Toggle-selection with space, confirm with enter; returns the chosen
+    // indices into `choices`.
+    const selected = p.multiSelect(.{
+        .message = "Subscribe to:",
+        .choices = &interests,
+        .defaults = &.{ true, false, true, false },
+    }) catch |err| switch (err) {
+        error.EndOfStream => return context.fail("signup requires an interactive terminal (stdin closed).", .{}),
+        else => return err,
+    };
+    defer allocator.free(selected);
+
+    try stdout.print("Account created for {s}.\n", .{username});
+    if (selected.len == 0) {
+        try stdout.writeAll("Subscribed to: nothing\n");
+    } else {
+        try stdout.writeAll("Subscribed to:\n");
+        for (selected) |idx| {
+            try stdout.print("  - {s}\n", .{interests[idx]});
+        }
+    }
+}

--- a/examples/prompts-features/src/main.zig
+++ b/examples/prompts-features/src/main.zig
@@ -1,0 +1,14 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const registry = @import("command_registry");
+
+/// The `password` and `multi_select` prompts drive raw mode and hide the
+/// cursor, so a panic mid-prompt must restore the terminal instead of
+/// stranding it.
+pub const panic = zcli.ui.panic;
+
+pub fn main(init: std.process.Init) !void {
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
+    var app = registry.init();
+    try app.run(init.gpa, init.io, init.environ_map, args);
+}

--- a/examples/testing-demo/.gitattributes
+++ b/examples/testing-demo/.gitattributes
@@ -1,0 +1,5 @@
+# Snapshot goldens are compared byte-for-byte against subprocess stdout, so
+# they must survive checkout unmodified on every OS. Without this, the default
+# core.autocrlf=true on Windows runners rewrites them to CRLF at checkout and
+# the LF output of the binary no longer matches (an invisible diff).
+tests/snapshots/** -text

--- a/examples/testing-demo/README.md
+++ b/examples/testing-demo/README.md
@@ -1,0 +1,24 @@
+# testing-demo
+
+A minimal `greeter` CLI whose entire purpose is to show the `zcli-testing`
+harness used directly inside a real example app, not just wired in silently by
+the scaffolding:
+
+- `src/commands/greet.zig` has `test` blocks that call the **unit tier**
+  (`testing.runCommand`) explicitly — the same idiom `zcli init` scaffolds,
+  written out so it's visible.
+- `src/integration_test.zig` is a dedicated integration test file (this
+  project's counterpart to `packages/core/src/build_integration_test.zig`)
+  using the **subprocess/snapshot tier** (`testing.runSubprocess` +
+  `testing.expectSnapshot`) against the actual compiled `./zig-out/bin/greeter`
+  binary — the full stack, not just `execute()` in isolation.
+
+```
+zig build test
+```
+
+runs both tiers (`build.zig` wires the integration test's `Run` step to depend
+on the install step, so the binary exists before it's driven).
+
+See [`packages/testing/README.md`](../../packages/testing/README.md) and its
+`examples/` for the complete tour of all three testing tiers in isolation.

--- a/examples/testing-demo/build.zig
+++ b/examples/testing-demo/build.zig
@@ -1,0 +1,67 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) !void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const zcli_dep = b.dependency("zcli", .{ .target = target, .optimize = optimize });
+    const zcli_module = zcli_dep.module("zcli");
+
+    const exe = b.addExecutable(.{
+        .name = "greeter",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    exe.root_module.addImport("zcli", zcli_module);
+
+    const zcli = @import("zcli");
+
+    const cmd_registry = try zcli.generate(b, exe, zcli_dep, .{
+        .commands_dir = "src/commands",
+        .plugins = &.{
+            zcli.builtin(.help, .{}),
+            zcli.builtin(.version, .{}),
+            zcli.builtin(.not_found, .{}),
+        },
+        .app_name = "greeter",
+        .app_description = "A minimal CLI whose tests exercise the zcli-testing harness directly",
+    });
+    exe.root_module.addImport("command_registry", cmd_registry);
+
+    b.installArtifact(exe);
+
+    const run_cmd = b.addRunArtifact(exe);
+    run_cmd.step.dependOn(b.getInstallStep());
+    if (b.args) |args| run_cmd.addArgs(args);
+    const run_step = b.step("run", "Run the application");
+    run_step.dependOn(&run_cmd.step);
+
+    // Per-command unit tests (the scaffolded-project idiom): compiles each
+    // command file as its own test root, with `zcli-testing` (the unit tier,
+    // `runCommand`) wired in — see `src/commands/greet.zig`'s own `test`
+    // blocks. Returns the `test` step so more tiers can attach to it below.
+    const test_step = zcli.addCommandTests(b, zcli_dep, .{
+        .commands_dir = "src/commands",
+        .target = target,
+        .optimize = optimize,
+    });
+
+    // Integration/snapshot tier (`zcli_testing`'s `runSubprocess` +
+    // `expectSnapshot`), against the actual compiled binary — see
+    // `src/integration_test.zig`. Its Run step depends on the install step so
+    // `./zig-out/bin/greeter` exists before any test in it runs.
+    const integration_test_mod = b.createModule(.{
+        .root_source_file = b.path("src/integration_test.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    integration_test_mod.addImport("zcli-testing", zcli_dep.module("zcli_testing"));
+
+    const integration_tests = b.addTest(.{ .root_module = integration_test_mod });
+    const run_integration_tests = b.addRunArtifact(integration_tests);
+    run_integration_tests.step.dependOn(b.getInstallStep());
+    test_step.dependOn(&run_integration_tests.step);
+}

--- a/examples/testing-demo/build.zig.zon
+++ b/examples/testing-demo/build.zig.zon
@@ -14,5 +14,6 @@
         "build.zig",
         "build.zig.zon",
         "src",
+        "tests",
     },
 }

--- a/examples/testing-demo/build.zig.zon
+++ b/examples/testing-demo/build.zig.zon
@@ -1,7 +1,7 @@
 .{
-    .name = .@"testing-demo",
+    .name = .testing_demo,
     .version = "0.1.0",
-    .fingerprint = 0xd1169655a19aaf07,
+    .fingerprint = 0x81b201b0704e6d4e,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         // Local path because this example lives in-repo (so CI compiles it

--- a/examples/testing-demo/build.zig.zon
+++ b/examples/testing-demo/build.zig.zon
@@ -1,0 +1,18 @@
+.{
+    .name = .@"testing-demo",
+    .version = "0.1.0",
+    .fingerprint = 0xd1169655a19aaf07,
+    .minimum_zig_version = "0.16.0",
+    .dependencies = .{
+        // Local path because this example lives in-repo (so CI compiles it
+        // against unreleased changes as a drift-detector). Your own project
+        // doesn't hand-write this — `zcli init` fetches a released zcli:
+        //   .zcli = .{ .url = "git+https://github.com/ryanhair/zcli#<tag>", .hash = "..." },
+        .zcli = .{ .path = "../.." },
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}

--- a/examples/testing-demo/src/commands/greet.zig
+++ b/examples/testing-demo/src/commands/greet.zig
@@ -1,0 +1,52 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
+
+pub const meta = .{
+    .description = "Print a greeting",
+    .examples = &.{ "greet world", "greet world --loud" },
+    .args = .{ .name = "Who to greet" },
+    .options = .{
+        .loud = .{ .description = "Shout the greeting" },
+    },
+};
+
+pub const Args = struct { name: []const u8 };
+pub const Options = struct { loud: bool = false };
+
+pub fn execute(args: Args, options: Options, context: *Context) !void {
+    if (options.loud) {
+        const upper = try std.ascii.allocUpperString(context.allocator, args.name);
+        try context.stdout().print("HELLO, {s}!\n", .{upper});
+    } else {
+        try context.stdout().print("Hello, {s}!\n", .{args.name});
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tier (`zcli-testing`'s `runCommand`): the exact idiom `addCommandTests`
+// wires up for every command file — `@This()` is `greet` itself, and
+// `runCommand` derives the right `TestContext` from `execute`'s signature.
+// ---------------------------------------------------------------------------
+
+test "greet prints a friendly hello" {
+    const testing = @import("zcli-testing");
+
+    var result = try testing.runCommand(@This(), .{ .args = .{ .name = "world" } });
+    defer result.deinit();
+
+    try std.testing.expect(result.success);
+    try std.testing.expectEqualStrings("Hello, world!\n", result.stdout);
+}
+
+test "greet --loud shouts" {
+    const testing = @import("zcli-testing");
+
+    var result = try testing.runCommand(@This(), .{
+        .args = .{ .name = "world" },
+        .options = .{ .loud = true },
+    });
+    defer result.deinit();
+
+    try std.testing.expectEqualStrings("HELLO, WORLD!\n", result.stdout);
+}

--- a/examples/testing-demo/src/integration_test.zig
+++ b/examples/testing-demo/src/integration_test.zig
@@ -1,0 +1,64 @@
+//! Integration/snapshot tier (`zcli_testing`'s `runSubprocess` + `expectSnapshot`)
+//! run against the actual compiled `greeter` binary — the full stack: parsing,
+//! routing, and exit codes, not just `execute()` in isolation (see
+//! `src/commands/greet.zig`'s unit-tier tests for that). `build.zig` wires this
+//! file as its own test module (see the comment there) and makes its `Run`
+//! step depend on the install step, so `./zig-out/bin/greeter` exists before
+//! any test here runs.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const testing = @import("zcli-testing");
+
+const exe_path = if (builtin.os.tag == .windows) "./zig-out/bin/greeter.exe" else "./zig-out/bin/greeter";
+
+test "greet world prints a greeting and exits 0" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    var result = try testing.runSubprocess(allocator, io, exe_path, &.{"world"});
+    defer result.deinit();
+
+    try testing.expectExitCode(result, 0);
+    try testing.expectContains(result.stdout, "Hello, world!");
+    try testing.expectStderrEmpty(result);
+}
+
+test "greet --loud shouts" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    var result = try testing.runSubprocess(allocator, io, exe_path, &.{ "world", "--loud" });
+    defer result.deinit();
+
+    try testing.expectExitCode(result, 0);
+    try testing.expectContains(result.stdout, "HELLO, WORLD!");
+}
+
+test "an unrecognized flag is reported misuse (exit code 2)" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    var result = try testing.runSubprocess(allocator, io, exe_path, &.{ "world", "--bogus" });
+    defer result.deinit();
+
+    // See DESIGN.md's exit-code table: 2 is reserved for CLI misuse (unknown
+    // options, bad values, missing arguments), distinct from 1 (a command's own
+    // `context.fail()`) and 3 (command not found).
+    try testing.expectExitCode(result, 2);
+}
+
+test "greet output matches a golden snapshot" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    var result = try testing.runSubprocess(allocator, io, exe_path, &.{"snapshot-friend"});
+    defer result.deinit();
+
+    // Compares against the golden checked in at
+    // `tests/snapshots/integration_test/greet-output.txt`. If `greet`'s output
+    // ever changes on purpose, regenerate it with `.update = true` (typically
+    // threaded from a build option, e.g. `zig build test -Dupdate-snapshots`)
+    // and review the diff like any other file.
+    try testing.expectSnapshot(allocator, io, std.Io.Dir.cwd(), result.stdout, @src(), "greet-output", .{});
+}

--- a/examples/testing-demo/src/integration_test.zig
+++ b/examples/testing-demo/src/integration_test.zig
@@ -16,7 +16,9 @@ test "greet world prints a greeting and exits 0" {
     const allocator = std.testing.allocator;
     const io = std.testing.io;
 
-    var result = try testing.runSubprocess(allocator, io, exe_path, &.{"world"});
+    // The first arg is the command name — `greeter greet world`, exactly as a
+    // user would type it (runSubprocess supplies the binary as argv[0]).
+    var result = try testing.runSubprocess(allocator, io, exe_path, &.{ "greet", "world" });
     defer result.deinit();
 
     try testing.expectExitCode(result, 0);
@@ -28,7 +30,7 @@ test "greet --loud shouts" {
     const allocator = std.testing.allocator;
     const io = std.testing.io;
 
-    var result = try testing.runSubprocess(allocator, io, exe_path, &.{ "world", "--loud" });
+    var result = try testing.runSubprocess(allocator, io, exe_path, &.{ "greet", "world", "--loud" });
     defer result.deinit();
 
     try testing.expectExitCode(result, 0);
@@ -39,7 +41,7 @@ test "an unrecognized flag is reported misuse (exit code 2)" {
     const allocator = std.testing.allocator;
     const io = std.testing.io;
 
-    var result = try testing.runSubprocess(allocator, io, exe_path, &.{ "world", "--bogus" });
+    var result = try testing.runSubprocess(allocator, io, exe_path, &.{ "greet", "world", "--bogus" });
     defer result.deinit();
 
     // See DESIGN.md's exit-code table: 2 is reserved for CLI misuse (unknown
@@ -52,7 +54,7 @@ test "greet output matches a golden snapshot" {
     const allocator = std.testing.allocator;
     const io = std.testing.io;
 
-    var result = try testing.runSubprocess(allocator, io, exe_path, &.{"snapshot-friend"});
+    var result = try testing.runSubprocess(allocator, io, exe_path, &.{ "greet", "snapshot-friend" });
     defer result.deinit();
 
     // Compares against the golden checked in at

--- a/examples/testing-demo/src/main.zig
+++ b/examples/testing-demo/src/main.zig
@@ -1,0 +1,9 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const registry = @import("command_registry");
+
+pub fn main(init: std.process.Init) !void {
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
+    var app = registry.init();
+    try app.run(init.gpa, init.io, init.environ_map, args);
+}

--- a/examples/testing-demo/tests/snapshots/integration_test/greet-output.txt
+++ b/examples/testing-demo/tests/snapshots/integration_test/greet-output.txt
@@ -1,0 +1,1 @@
+Hello, snapshot-friend!

--- a/examples/upgrade-demo/README.md
+++ b/examples/upgrade-demo/README.md
@@ -1,0 +1,31 @@
+# upgrade-demo
+
+A minimal CLI wiring the `github_upgrade` plugin (previously only used by
+zcli's own meta-CLI — no `examples/` app demonstrated it). `build.zig` shows
+the whole shape:
+
+```zig
+zcli.builtin(.github_upgrade, .{
+    .repo = "your-org/your-cli",       // placeholder — point at your own repo
+    .command_name = "upgrade",
+    .verification = .checksum_only,    // demo-only; see the comment in build.zig
+}),
+```
+
+adding an `upgrade` command that checks GitHub Releases for `{repo}`'s latest
+`upgrade-demo-v*` tag, downloads the matching release asset, verifies it, and
+replaces the running binary.
+
+`repo` is a placeholder pointing nowhere real — running `upgrade-demo upgrade`
+against it will simply fail to find a release. `.verification` has no
+default; this example opts explicitly into `.checksum_only` (with a comment
+explaining the real option) rather than fabricate a minisign key, since a real
+release pipeline should sign `checksums.txt` and pin the public key instead
+(see `docs/RELEASE-SIGNING.md`, and `projects/zcli/build.zig` for the real
+thing zcli upgrades itself with).
+
+```
+zig build
+./zig-out/bin/upgrade-demo status
+./zig-out/bin/upgrade-demo upgrade --help
+```

--- a/examples/upgrade-demo/build.zig
+++ b/examples/upgrade-demo/build.zig
@@ -1,0 +1,71 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) !void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const zcli_dep = b.dependency("zcli", .{ .target = target, .optimize = optimize });
+    const zcli_module = zcli_dep.module("zcli");
+
+    const exe = b.addExecutable(.{
+        .name = "upgrade-demo",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    exe.root_module.addImport("zcli", zcli_module);
+
+    const zcli = @import("zcli");
+
+    const cmd_registry = try zcli.generate(b, exe, zcli_dep, .{
+        .commands_dir = "src/commands",
+        .plugins = &.{
+            zcli.builtin(.help, .{}),
+            zcli.builtin(.version, .{}),
+            zcli.builtin(.not_found, .{}),
+            // Self-upgrade (ADR-0023): adds an `upgrade` command that checks
+            // GitHub Releases for `{repo}`'s latest `upgrade-demo-v*` tag,
+            // downloads the matching release asset, verifies it, and replaces
+            // the running binary.
+            //
+            // `repo` is a placeholder — point it at your own GitHub repo
+            // publishing releases named `{cli_name}-v{version}` (see
+            // `projects/zcli/build.zig` for the real thing zcli upgrades
+            // itself with, including a pinned minisign key).
+            zcli.builtin(.github_upgrade, .{
+                .repo = "your-org/your-cli",
+                .command_name = "upgrade",
+                // A real release pipeline should sign checksums.txt with
+                // minisign and pin the public key here instead:
+                //   .verification = .{ .minisign = "<base64 public key>" },
+                // (docs/RELEASE-SIGNING.md documents key generation and
+                // rotation.) This example has no real release to sign, so it
+                // opts explicitly into checksum-only trust — the plugin prints
+                // a one-line warning on every upgrade run when this variant is
+                // selected, precisely so it's never silently insecure.
+                .verification = .checksum_only,
+            }),
+        },
+        .app_name = "upgrade-demo",
+        .app_description = "A minimal CLI wiring the github_upgrade plugin's self-upgrade flow",
+    });
+    exe.root_module.addImport("command_registry", cmd_registry);
+
+    b.installArtifact(exe);
+
+    const run_cmd = b.addRunArtifact(exe);
+    run_cmd.step.dependOn(b.getInstallStep());
+    if (b.args) |args| run_cmd.addArgs(args);
+    const run_step = b.step("run", "Run the application");
+    run_step.dependOn(&run_cmd.step);
+
+    // Per-command unit tests (the scaffolded-project idiom): compiles each
+    // command file as its own test root so its `test` blocks run.
+    _ = zcli.addCommandTests(b, zcli_dep, .{
+        .commands_dir = "src/commands",
+        .target = target,
+        .optimize = optimize,
+    });
+}

--- a/examples/upgrade-demo/build.zig.zon
+++ b/examples/upgrade-demo/build.zig.zon
@@ -1,0 +1,18 @@
+.{
+    .name = .@"upgrade-demo",
+    .version = "0.1.0",
+    .fingerprint = 0x9120c4b3536f022c,
+    .minimum_zig_version = "0.16.0",
+    .dependencies = .{
+        // Local path because this example lives in-repo (so CI compiles it
+        // against unreleased changes as a drift-detector). Your own project
+        // doesn't hand-write this — `zcli init` fetches a released zcli:
+        //   .zcli = .{ .url = "git+https://github.com/ryanhair/zcli#<tag>", .hash = "..." },
+        .zcli = .{ .path = "../.." },
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}

--- a/examples/upgrade-demo/build.zig.zon
+++ b/examples/upgrade-demo/build.zig.zon
@@ -1,7 +1,7 @@
 .{
-    .name = .@"upgrade-demo",
+    .name = .upgrade_demo,
     .version = "0.1.0",
-    .fingerprint = 0x9120c4b3536f022c,
+    .fingerprint = 0xa2b498be657328b2,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         // Local path because this example lives in-repo (so CI compiles it

--- a/examples/upgrade-demo/src/commands/status.zig
+++ b/examples/upgrade-demo/src/commands/status.zig
@@ -1,0 +1,18 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
+
+pub const meta = .{
+    .description = "Print the running version",
+    .examples = &.{"status"},
+};
+
+pub const Args = struct {};
+pub const Options = struct {};
+
+pub fn execute(_: Args, _: Options, context: *Context) !void {
+    try context.stdout().print("{s} {s} — run `upgrade-demo upgrade` to self-update\n", .{
+        context.app_name,
+        context.app_version,
+    });
+}

--- a/examples/upgrade-demo/src/main.zig
+++ b/examples/upgrade-demo/src/main.zig
@@ -1,0 +1,9 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const registry = @import("command_registry");
+
+pub fn main(init: std.process.Init) !void {
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
+    var app = registry.init();
+    try app.run(init.gpa, init.io, init.environ_map, args);
+}

--- a/examples/vault/.vault.config.json
+++ b/examples/vault/.vault.config.json
@@ -1,0 +1,5 @@
+{
+  "list": {
+    "verbose": true
+  }
+}

--- a/examples/vault/README.md
+++ b/examples/vault/README.md
@@ -1,0 +1,32 @@
+# vault
+
+A secrets-backed CLI that stitches together the four features a realistic
+"secrets + prompts" app needs, which previously only existed split across
+separate examples:
+
+- **`zcli_secrets`** — `set`/`get`/`remove` store and retrieve values in the OS
+  keychain / Credential Manager / Secret Service (never a plaintext file).
+- **`zcli_config`** — `list --verbose` defaults from `.vault.config.json`.
+- **`zcli_completions`** — static shell completion, plus a dynamic `.complete`
+  hook on `get`/`remove`'s `<name>` argument that offers the names actually
+  stored.
+- **prompts** — `set` reads the secret value from a hidden `password` prompt
+  and confirms before overwriting/deleting.
+
+Secret *values* never touch disk — only a small JSON index of *names*
+(`.vault-index.json`) is kept alongside, so `list` and the dynamic completion
+have something to enumerate.
+
+```
+vault set github-token   # prompts for the value (hidden input)
+vault get github-token
+vault list
+vault remove github-token
+```
+
+## Build
+
+```
+zig build
+./zig-out/bin/vault --help
+```

--- a/examples/vault/build.zig
+++ b/examples/vault/build.zig
@@ -1,0 +1,75 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) !void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const zcli_dep = b.dependency("zcli", .{ .target = target, .optimize = optimize });
+    const zcli_module = zcli_dep.module("zcli");
+
+    // The name-index kept alongside the OS-keychain-backed secrets (see
+    // src/store.zig): the secrets plugin can set/get/delete an opaque value by
+    // name, but has no "list all names" operation, so the index is what makes
+    // `vault list` and the `<name>` completion possible.
+    const store_module = b.createModule(.{
+        .root_source_file = b.path("src/store.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const exe = b.addExecutable(.{
+        .name = "vault",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    exe.root_module.addImport("zcli", zcli_module);
+    exe.root_module.addImport("store", store_module);
+
+    const zcli = @import("zcli");
+
+    const cmd_registry = try zcli.generate(b, exe, zcli_dep, .{
+        .commands_dir = "src/commands",
+        .plugins = &.{
+            zcli.builtin(.help, .{}),
+            zcli.builtin(.version, .{}),
+            zcli.builtin(.not_found, .{}),
+            // Static shell completion (bash/zsh/fish) for command/flag names,
+            // plus the substrate the per-arg `.complete` hooks in
+            // src/commands/get.zig and remove.zig plug into (ADR-0026).
+            zcli.builtin(.completions, .{}),
+            // Transparent config-file defaults — see .vault.config.json.
+            zcli.builtin(.config, .{}),
+            // Opt in to OS-keychain-backed credential storage (ADR-0003):
+            // makes `context.plugins.zcli_secrets` available.
+            zcli.builtin(.secrets, .{}),
+        },
+        .shared_modules = &[_]zcli.SharedModule{
+            .{ .name = "store", .module = store_module },
+        },
+        .app_name = "vault",
+        .app_description = "A secrets-backed CLI combining config, completions, and prompts",
+    });
+    exe.root_module.addImport("command_registry", cmd_registry);
+
+    b.installArtifact(exe);
+
+    const run_cmd = b.addRunArtifact(exe);
+    run_cmd.step.dependOn(b.getInstallStep());
+    if (b.args) |args| run_cmd.addArgs(args);
+    const run_step = b.step("run", "Run the application");
+    run_step.dependOn(&run_cmd.step);
+
+    // Per-command unit tests (the scaffolded-project idiom): compiles each
+    // command file as its own test root so its `test` blocks run.
+    _ = zcli.addCommandTests(b, zcli_dep, .{
+        .commands_dir = "src/commands",
+        .target = target,
+        .optimize = optimize,
+        .shared_modules = &[_]zcli.SharedModule{
+            .{ .name = "store", .module = store_module },
+        },
+    });
+}

--- a/examples/vault/build.zig.zon
+++ b/examples/vault/build.zig.zon
@@ -1,0 +1,18 @@
+.{
+    .name = .vault,
+    .version = "0.1.0",
+    .fingerprint = 0x75efe8a622c7056f,
+    .minimum_zig_version = "0.16.0",
+    .dependencies = .{
+        // Local path because this example lives in-repo (so CI compiles it
+        // against unreleased changes as a drift-detector). Your own project
+        // doesn't hand-write this — `zcli init` fetches a released zcli:
+        //   .zcli = .{ .url = "git+https://github.com/ryanhair/zcli#<tag>", .hash = "..." },
+        .zcli = .{ .path = "../.." },
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}

--- a/examples/vault/build.zig.zon
+++ b/examples/vault/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .vault,
     .version = "0.1.0",
-    .fingerprint = 0x75efe8a622c7056f,
+    .fingerprint = 0xff304921bee8feb8,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         // Local path because this example lives in-repo (so CI compiles it

--- a/examples/vault/src/commands/get.zig
+++ b/examples/vault/src/commands/get.zig
@@ -1,0 +1,34 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
+const store = @import("store");
+
+pub const meta = .{
+    .description = "Print a stored secret's value",
+    .examples = &.{"get github-token"},
+    .args = .{ .name = .{ .description = "Name the secret was stored under", .complete = completeName } },
+};
+
+pub const Args = struct { name: []const u8 };
+pub const Options = struct {};
+
+/// Dynamic completion (ADR-0026): offer the known names from the index, so
+/// `vault get <TAB>` lists what's actually stored instead of nothing.
+fn completeName(req: *zcli.completion.Request) !zcli.completion.Result {
+    var loaded = try store.load(req.allocator, req.io);
+    defer loaded.deinit();
+
+    var out: std.ArrayList(zcli.completion.Candidate) = .empty;
+    for (loaded.value.names) |name| {
+        if (!std.mem.startsWith(u8, name, req.partial)) continue;
+        try out.append(req.allocator, .{ .value = try req.allocator.dupe(u8, name) });
+    }
+    return .{ .candidates = try out.toOwnedSlice(req.allocator) };
+}
+
+pub fn execute(args: Args, _: Options, context: *Context) !void {
+    const value = (try context.plugins.zcli_secrets.get(args.name)) orelse {
+        return context.fail("no secret stored under '{s}'. Run `vault set {s}` first.", .{ args.name, args.name });
+    };
+    try context.stdout().print("{s}\n", .{value});
+}

--- a/examples/vault/src/commands/list.zig
+++ b/examples/vault/src/commands/list.zig
@@ -1,0 +1,43 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
+const store = @import("store");
+
+pub const meta = .{
+    .description = "List the names of stored secrets",
+    .examples = &.{"list"},
+    .options = .{
+        .verbose = .{ .description = "Also print how many secrets are stored" },
+    },
+};
+
+pub const Args = struct {};
+pub const Options = struct {
+    // Left unset on the CLI, this is filled from `.vault.config.json`'s
+    // `"list": { "verbose": true }` — the zcli_config plugin (wired in
+    // build.zig) applies command-scoped config as a default, beaten only by an
+    // explicit `--verbose`/`--no-verbose` flag or env var.
+    verbose: bool = false,
+};
+
+pub fn execute(_: Args, options: Options, context: *Context) !void {
+    const allocator = context.allocator;
+    var loaded = try store.load(allocator, context.io);
+    defer loaded.deinit();
+
+    if (loaded.value.names.len == 0) {
+        try context.stdout().writeAll("No secrets stored. Run `vault set <name>` to add one.\n");
+        return;
+    }
+
+    for (loaded.value.names) |name| {
+        try context.stdout().print("{s}\n", .{name});
+    }
+
+    if (options.verbose) {
+        try context.stdout().print("({d} secret{s} stored)\n", .{
+            loaded.value.names.len,
+            if (loaded.value.names.len == 1) "" else "s",
+        });
+    }
+}

--- a/examples/vault/src/commands/remove.zig
+++ b/examples/vault/src/commands/remove.zig
@@ -1,0 +1,52 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
+const store = @import("store");
+
+pub const meta = .{
+    .description = "Delete a stored secret",
+    .examples = &.{"remove github-token"},
+    .args = .{ .name = .{ .description = "Name the secret was stored under", .complete = completeName } },
+    .aliases = &.{"rm"},
+};
+
+pub const Args = struct { name: []const u8 };
+pub const Options = struct {};
+
+fn completeName(req: *zcli.completion.Request) !zcli.completion.Result {
+    var loaded = try store.load(req.allocator, req.io);
+    defer loaded.deinit();
+
+    var out: std.ArrayList(zcli.completion.Candidate) = .empty;
+    for (loaded.value.names) |name| {
+        if (!std.mem.startsWith(u8, name, req.partial)) continue;
+        try out.append(req.allocator, .{ .value = try req.allocator.dupe(u8, name) });
+    }
+    return .{ .candidates = try out.toOwnedSlice(req.allocator) };
+}
+
+pub fn execute(args: Args, _: Options, context: *Context) !void {
+    const allocator = context.allocator;
+    var loaded = try store.load(allocator, context.io);
+    defer loaded.deinit();
+
+    if (!store.contains(loaded.value.names, args.name)) {
+        return context.fail("no secret stored under '{s}'.", .{args.name});
+    }
+
+    const p = context.prompts();
+    const msg = try std.fmt.allocPrint(allocator, "Delete secret '{s}'?", .{args.name});
+    const confirmed = p.confirm(.{ .message = msg, .default = false }) catch true; // non-interactive: default to yes
+
+    if (!confirmed) {
+        try context.stdout().writeAll("Cancelled.\n");
+        return;
+    }
+
+    try context.plugins.zcli_secrets.delete(args.name);
+
+    const updated_names = try store.withRemoved(allocator, loaded.value.names, args.name);
+    try store.save(allocator, context.io, .{ .names = updated_names });
+
+    try context.stdout().print("Deleted secret '{s}'.\n", .{args.name});
+}

--- a/examples/vault/src/commands/set.zig
+++ b/examples/vault/src/commands/set.zig
@@ -1,0 +1,57 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
+const store = @import("store");
+
+pub const meta = .{
+    .description = "Store a secret under a name (value is read from a hidden prompt)",
+    .examples = &.{"set github-token"},
+    .args = .{ .name = "Name to store the secret under" },
+};
+
+pub const Args = struct { name: []const u8 };
+pub const Options = struct {};
+
+pub fn execute(args: Args, _: Options, context: *Context) !void {
+    const allocator = context.allocator;
+    var loaded = try store.load(allocator, context.io);
+    defer loaded.deinit();
+
+    const p = context.prompts();
+
+    if (store.contains(loaded.value.names, args.name)) {
+        const msg = try std.fmt.allocPrint(allocator, "'{s}' already exists. Overwrite?", .{args.name});
+        const overwrite = p.confirm(.{ .message = msg, .default = false }) catch |err| switch (err) {
+            error.EndOfStream => return context.fail("set requires an interactive terminal (stdin closed).", .{}),
+            else => return err,
+        };
+        if (!overwrite) {
+            try context.stdout().writeAll("Cancelled.\n");
+            return;
+        }
+    }
+
+    // Masked input: the value never echoes to the terminal or lands in shell
+    // history the way an `--value` flag would.
+    const value = p.password(.{
+        .message = "Secret value:",
+    }) catch |err| switch (err) {
+        error.EndOfStream => return context.fail("set requires an interactive terminal (stdin closed).", .{}),
+        else => return err,
+    };
+    defer allocator.free(value);
+
+    if (value.len == 0) {
+        return context.fail("secret value cannot be empty.", .{});
+    }
+
+    // The keychain/Secret Service backend stores only the opaque bytes; the
+    // name index (JSON, plaintext) tracks nothing sensitive — just which names
+    // exist, so `list`/`get`/`remove` have something to enumerate and complete.
+    try context.plugins.zcli_secrets.set(args.name, value);
+
+    const updated_names = try store.withAdded(allocator, loaded.value.names, args.name);
+    try store.save(allocator, context.io, .{ .names = updated_names });
+
+    try context.stdout().print("Saved secret '{s}'.\n", .{args.name});
+}

--- a/examples/vault/src/main.zig
+++ b/examples/vault/src/main.zig
@@ -1,0 +1,14 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const registry = @import("command_registry");
+
+/// The `set`/`remove` confirmation prompt and the masked `password` prompt
+/// drive raw mode and hide the cursor, so a panic mid-prompt must restore the
+/// terminal instead of stranding it.
+pub const panic = zcli.ui.panic;
+
+pub fn main(init: std.process.Init) !void {
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
+    var app = registry.init();
+    try app.run(init.gpa, init.io, init.environ_map, args);
+}

--- a/examples/vault/src/store.zig
+++ b/examples/vault/src/store.zig
@@ -1,0 +1,92 @@
+//! The name index for stored secrets.
+//!
+//! `zcli_secrets` (OS keychain / Credential Manager / Secret Service) stores
+//! an opaque value by name, but it has no "list all names" operation — so this
+//! tiny JSON file alongside it tracks *which names exist*, without ever
+//! touching a secret value itself. `vault list` reads it to enumerate entries,
+//! and `get`/`remove`'s dynamic completion (ADR-0026) reads it to offer known
+//! names on <TAB>.
+
+const std = @import("std");
+
+pub const IndexData = struct {
+    names: [][]const u8 = &.{},
+};
+
+const FILENAME = ".vault-index.json";
+
+pub const LoadResult = struct {
+    value: IndexData,
+    _parsed: ?std.json.Parsed(IndexData),
+
+    pub fn deinit(self: *LoadResult) void {
+        if (self._parsed) |*p| p.deinit();
+    }
+};
+
+pub fn load(allocator: std.mem.Allocator, io: std.Io) !LoadResult {
+    const cwd = std.Io.Dir.cwd();
+    const content = cwd.readFileAlloc(io, FILENAME, allocator, .limited(1024 * 1024)) catch {
+        return .{ .value = .{}, ._parsed = null };
+    };
+    defer allocator.free(content);
+    if (content.len == 0) return .{ .value = .{}, ._parsed = null };
+    const parsed = std.json.parseFromSlice(IndexData, allocator, content, .{
+        .allocate = .alloc_always,
+    }) catch return .{ .value = .{}, ._parsed = null };
+    return .{ .value = parsed.value, ._parsed = parsed };
+}
+
+pub fn save(_: std.mem.Allocator, io: std.Io, data: IndexData) !void {
+    const cwd = std.Io.Dir.cwd();
+    const file = try cwd.createFile(io, FILENAME, .{});
+    defer file.close(io);
+    var buf: [4096]u8 = undefined;
+    var fw = file.writer(io, &buf);
+    try fw.interface.print("{f}", .{std.json.fmt(data, .{ .whitespace = .indent_2 })});
+    try fw.interface.flush();
+}
+
+pub fn contains(names: []const []const u8, name: []const u8) bool {
+    for (names) |n| {
+        if (std.mem.eql(u8, n, name)) return true;
+    }
+    return false;
+}
+
+/// Returns a new owned slice with `name` appended, unless already present (in
+/// which case the input slice is returned unchanged — no-op re-add).
+pub fn withAdded(allocator: std.mem.Allocator, names: []const []const u8, name: []const u8) ![][]const u8 {
+    if (contains(names, name)) return allocator.dupe([]const u8, names);
+    const grown = try allocator.alloc([]const u8, names.len + 1);
+    @memcpy(grown[0..names.len], names);
+    grown[names.len] = name;
+    return grown;
+}
+
+/// Returns a new owned slice with every entry equal to `name` removed.
+pub fn withRemoved(allocator: std.mem.Allocator, names: []const []const u8, name: []const u8) ![][]const u8 {
+    var remaining: std.ArrayList([]const u8) = .empty;
+    defer remaining.deinit(allocator);
+    for (names) |n| {
+        if (!std.mem.eql(u8, n, name)) try remaining.append(allocator, n);
+    }
+    return remaining.toOwnedSlice(allocator);
+}
+
+test "withAdded: skips a duplicate name" {
+    const allocator = std.testing.allocator;
+    const names = [_][]const u8{"github"};
+    const result = try withAdded(allocator, &names, "github");
+    defer allocator.free(result);
+    try std.testing.expectEqual(@as(usize, 1), result.len);
+}
+
+test "withRemoved: drops the matching entry" {
+    const allocator = std.testing.allocator;
+    const names = [_][]const u8{ "github", "npm" };
+    const result = try withRemoved(allocator, &names, "github");
+    defer allocator.free(result);
+    try std.testing.expectEqual(@as(usize, 1), result.len);
+    try std.testing.expectEqualStrings("npm", result[0]);
+}


### PR DESCRIPTION
## Summary

Five new canonical examples (additive only — nothing existing touched besides wiring them into `build.zig`'s `test_projects`/`example_projects` lists, which drive both `zig build test` and CI's authoritative `zig build build-examples` compile gate):

- **`examples/vault`** (#342) — a secrets-backed CLI combining the four features that previously only existed split across separate examples: `zcli_secrets` (`set`/`get`/`remove`, OS keychain-backed), `zcli_config` (`.vault.config.json` defaults `list --verbose`), `zcli_completions` (static shell completion + a dynamic `.complete` hook on `get`/`remove`'s `<name>` arg, backed by a small JSON name-index since the secrets plugin has no "list all names" op), and prompts (`password` for the hidden secret value, `confirm` before overwrite/delete).
- **`examples/options-features`** (#343) — a `deployctl` CLI: `deploy` demonstrates a required option (`--region`, satisfiable by CLI/`$DEPLOY_REGION`/config), an array/multi-value option (`--tag`, repeatable), a per-field `validate` hook (`--replicas`, range-checked), and a custom `parse` type (`--timeout`, `"30s"`/`"5m"`/`"1h"`); `export` demonstrates `meta.exclusive` (`--json`/`--yaml`) and a directional `meta.options.<field>.requires` (`--format` requires `--output`).
- **`examples/prompts-features`** (#343) — a one-command `signup-cli` exercising `password` and `multi_select`, the two prompt types with no prior example (the rest — `text`/`select`/`number`/`confirm` — already appear in `examples/tasks`).
- **`examples/testing-demo`** (#343) — a minimal `greeter` CLI whose `src/commands/greet.zig` has explicit unit-tier (`testing.runCommand`) test blocks, plus a dedicated `src/integration_test.zig` (this project's counterpart to `packages/core/src/build_integration_test.zig`) exercising the subprocess/snapshot tier (`runSubprocess` + `expectSnapshot`) against the actual compiled `./zig-out/bin/greeter` — a checked-in golden lives at `tests/snapshots/integration_test/greet-output.txt`.
- **`examples/upgrade-demo`** (#344) — wires `zcli.builtin(.github_upgrade, .{ .repo = "your-org/your-cli", .verification = .checksum_only })` (placeholder repo, documented verification choice — a real pipeline should sign `checksums.txt` with minisign per `docs/RELEASE-SIGNING.md` instead, as `projects/zcli/build.zig` itself does).

All `main.zig` files use the current post-#356 entry-point idiom (`try app.run(...)`; reported errors — including `CommandNotFound` — now exit with the documented exit code from inside `run()` itself, so the old `catch |err| switch (err) { error.CommandNotFound => std.process.exit(1), ... }` pattern in some pre-existing examples is stale and was **not** copied here).

## Premise mismatches / notes

- None of #358 (plugin ABI namespace) or #361 (widget contract) landed on `main` as checked out here, so no `plugin_abi` touches were needed and no `ui` widgets were used, per instructions.
- `examples/testing-demo`'s integration test compares against a **checked-in golden** rather than always running with `.update = true`, since an always-update snapshot test never actually asserts anything — this is closer to how a real project would use `expectSnapshot`.

## Test plan

- [x] `mise x -- zig ast-check <file>` on every new `.zig` file (all clean) — **do not run `zig build`** per the verification policy; CI's `zig build build-examples` / `zig build test` are the authoritative gate.
- [ ] CI green on `build-examples` and `test` for all five new example projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)