### PR TITLE
security: gate site/installer deploys behind a protected environment

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -21,6 +21,11 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # Every deploy republishes install.sh/install.ps1 — the curl|sh trust root —
+    # so the job is gated behind a protected environment with required reviewers
+    # (grade6 #293). Inert until the "docs-deploy" environment is created in
+    # repo settings; create it with at least one required reviewer.
+    environment: docs-deploy
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1


### PR DESCRIPTION
Closes #293

Every docs deploy republishes `install.sh`/`install.ps1` — the `curl|sh` trust root — to zcli.sh on any main push, with no review gate. This adds `environment: docs-deploy` to the deploy job, mirroring the `environment: release` pattern from #376.

**Inert until configured:** create the `docs-deploy` environment in repo settings with at least one required reviewer for it to have teeth (same one-time setup as the `release` environment).

actionlint passes with no new findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)