### PR TITLE
e2e: init scaffold test tolerates the release-staging unpublished tag

### DIFF
--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -228,8 +228,19 @@ test "init scaffolds a project with the expected files and wiring" {
 
     const zon = try readFile(proj, a, "build.zig.zon");
     try expectContains(zon, ".name = .myapp");
-    try expectContains(zon, ".zcli = .{");
-    try expectContains(zon, "github.com/ryanhair/zcli");
+
+    // The zcli dependency comes from a real `zig fetch` of the release tag
+    // pinned to this build's version. During a release run that tag does not
+    // exist yet — tests gate the tag creation (#301), so the staged version's
+    // `zig fetch` fails by design and init reports it (#328). Assert whichever
+    // outcome init declared; both verify the v* tag wiring (#352).
+    if (std.mem.indexOf(u8, r.stdout, "was not fetched") == null) {
+        try expectContains(zon, ".zcli = .{");
+        try expectContains(zon, "github.com/ryanhair/zcli");
+    } else {
+        try testing.expect(std.mem.indexOf(u8, zon, ".zcli = .{") == null);
+        try expectContains(r.stdout, "zig fetch --save https://github.com/ryanhair/zcli/archive/refs/tags/v");
+    }
 
     const build_zig = try readFile(proj, a, "build.zig");
     try expectContains(build_zig, "zcli.generate(");


### PR DESCRIPTION
Found by the first release dry run (run 29387523305): the macOS test gate failed on `init scaffolds a project with the expected files and wiring`.

**Chicken-and-egg introduced by #376's (correct) test-before-tag ordering:** the dispatch stages the version bump, so `zcli init` inside the e2e fetches `v0.20.0` — a tag that only comes into existence in `finalize`, *after* tests pass. `zig fetch` fails, init correctly reports it (#328) and leaves `.dependencies` empty, and the test's unconditional `.zcli = .{` assertion fails.

The test now branches on the outcome init declared:
- fetch succeeded → assert the dependency + URL landed in `build.zig.zon` (unchanged, this is what normal CI exercises)
- fetch failed → assert the dep is **absent** and the next-steps print the correct `v*` tag fetch command — still verifying the #352 tag-scheme wiring

Verified locally: full `zig build e2e` green on the success path, and a temporary 0.99.9 version bump reproduces the release condition and passes the failure-path assertions.

After this merges, re-dispatch the release dry run — the test gate should clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)