### PR TITLE
docs: finish the 0.20.0 release (CHANGELOG retitle + stale callouts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to zcli are documented here.
 
 **Versioning policy:** zcli follows [semver](https://semver.org). Until 1.0, breaking changes may land in minor versions and are called out below; patch versions are always safe to take. Releases target **stable Zig** — moving to a new Zig version is at least a minor bump and is stated in the entry. Each release is tagged twice in lockstep: `vX.Y.Z` is the framework library (the tag for your `build.zig.zon`), `zcli-vX.Y.Z` carries the prebuilt meta-CLI binaries.
 
-## Unreleased
+## v0.20.0 — 2026-07-15
 
-The terminal-native layout engine (ADR-0013), the migration of the interactive packages onto it, and its growth into a full-screen TUI toolkit (ADRs 0015–0020).
+The terminal-native layout engine (ADR-0013), the migration of the interactive packages onto it, and its growth into a full-screen TUI toolkit (ADRs 0015–0020). Requires Zig 0.16.0.
 
 ### Added
 - **Required options** — a non-`bool`, non-optional, non-array `Options` field with no default (e.g. `region: []const u8`) is now a **required option**: the type says a value must be provided. "Required" means absent after *every* source — the CLI flag, a declared `.env` variable, and `zcli_config`'s config file all satisfy it; only if none did does the command fail with `Missing required option '--region'.` plus a usage hint. Help marks these `(required)`, shows them in the usage line (`app cmd --region <value> [OPTIONS]`), and lists enum choices for both options and positional args (`one of: dev, staging, prod`). (This shape was previously a compile error — see the breaking note below.) The `zcli add option <cmd> <name> --type T` scaffolder (and the interactive wizard) create a required option when no `--default`/`--nullable` is given.

--- a/README.md
+++ b/README.md
@@ -231,13 +231,6 @@ Nine spinner styles, plus stacked multi-bars for parallel work; animations auto-
 
 ## The CLI/TUI hybrid
 
-> **Unreleased.** `zcli.ui`, full-screen mode, and the focusable widget catalog
-> described below are on `main` and slated for the upcoming **0.20** release
-> (see [CHANGELOG.md](CHANGELOG.md#unreleased) and
-> [ROADMAP.md](ROADMAP.md)) — they aren't in v0.19.0, the version the manual-setup
-> snippet above pins. Track `main` if you want them today; pin a tagged release
-> once 0.20 ships.
-
 Prompts and progress render on `zcli.ui` — a terminal-native layout engine, and it's yours to use directly. Output splits into a static stream that flows into scrollback and a live region that repaints in place just above it — a full layout, from a single line up to the whole viewport, not a fixed bottom strip. Unlike a full-screen TUI it never takes the terminal over, so your scrollback stays intact. This is the shape of modern agent-style CLIs: a component is just a function returning a node, and frames are diffed, so an animation repaints one cell, not the screen.
 
 ```zig

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,12 +10,12 @@ whether to adopt today or wait.
 
 It is a statement of *intent*, not a delivery contract. **There is no 1.0 date.**
 The freeze list below is the ratified plan for what 1.0 will promise when it
-happens; the next concrete milestone is 0.20 (§3), and 1.0 ships when the
-maintainer judges the frozen surfaces have settled — not before.
+happens; 0.20 (the last known breaking block) shipped 2026-07-15, and 1.0 ships
+when the maintainer judges the frozen surfaces have settled — not before.
 
 ## 1. Where zcli is today
 
-Current release: **v0.19.0** (Zig 0.16.0, Linux/macOS/Windows).
+Current release: **v0.20.0** (Zig 0.16.0, Linux/macOS/Windows).
 
 zcli is past the experimental stage. The parts an app is actually built *on* have
 been stable across several releases and are exercised by the framework's own
@@ -114,17 +114,18 @@ these are final.
 
 1.0 is a *stability* declaration, not a feature gate, so the bar for an item here
 is "shipping this after 1.0 would be a breaking change or an integrity gap we'd
-regret freezing around." **1.0 is deliberately not scheduled.** The next
-milestone is 0.20; the freeze happens some releases after that, once the
-surfaces in §2 have stopped moving on their own.
+regret freezing around." **1.0 is deliberately not scheduled.** 0.20 — the
+release that carried the last known breaking block — shipped 2026-07-15; the
+freeze happens some releases after it, once the surfaces in §2 have stopped
+moving on their own.
 
 **Blockers (in order):**
 
-- **0.20: release the current `Unreleased` block and let it settle.** The
-  progress/prompts instance-API rebuild (ADR-0014) and the `zcli.ui` engine are
-  the last *known* breaking changes to the surfaces §2 freezes. They ship as
-  0.20, get adopted by the examples and the meta-CLI, and get at least one
-  released minor of real use before any freeze.
+- **Let 0.20 settle.** ~~Release the `Unreleased` block~~ — done: 0.20.0 shipped
+  2026-07-15 with the progress/prompts instance-API rebuild (ADR-0014) and the
+  `zcli.ui` engine, the last *known* breaking changes to the surfaces §2
+  freezes. What remains is the settling: at least one released minor of real
+  use before any freeze.
 - **A final API sweep of the freeze list in §2.** One pass to rename/remove
   anything awkward *while it's still free* — the project's stated preference is
   "never prioritize backwards compatibility pre-1.0; make the cleanest choice."
@@ -199,7 +200,7 @@ the remaining churn is scoped (§3). To insulate yourself pre-1.0:
 - **Pin a release tag** with its immutable hash — never track `main` in a project
   you ship:
   ```bash
-  zig fetch --save https://github.com/ryanhair/zcli/archive/refs/tags/v0.19.0.tar.gz
+  zig fetch --save https://github.com/ryanhair/zcli/archive/refs/tags/v0.20.0.tar.gz
   ```
   (`main`'s hash changes every commit; that's for trying the development branch,
   not depending on it.)
@@ -209,8 +210,8 @@ the remaining churn is scoped (§3). To insulate yourself pre-1.0:
 - **Expected migration effort per minor, pre-1.0:** small and mechanical. The
   recent breaks are representative — a package rename (search-and-replace), an
   instance-API shift (`context.progress()` instead of a free function), a renamed
-  method (`setText` → `setMessage`). The pending 0.20 block (§3) is the same
-  character. None have been architectural rewrites of your command files; the
+  method (`setText` → `setMessage`). The 0.20 breaks were the same character.
+  None have been architectural rewrites of your command files; the
   `meta`/`Args`/`Options`/`execute` shape has held throughout.
 - **The meta-CLI helps you migrate.** `zcli guide` is version-matched to your
   pinned release, and `zcli dev`/`tree` surface breakage fast on upgrade.


### PR DESCRIPTION
The release dispatch published v0.20.0 for real (the `release` environment had no required-reviewers rule, so nothing paused). Per maintainer decision the release is accepted — this PR syncs the docs that still called it unreleased:

- **CHANGELOG**: `## Unreleased` → `## v0.20.0 — 2026-07-15`, with the "Requires Zig 0.16.0" note matching prior entries.
- **README**: the "Unreleased / not in v0.19.0" TUI callout is removed — the manual-setup snippet (auto-bumped by the release) now pins v0.20.0, which contains everything the section describes.
- **ROADMAP**: current release is 0.20.0; the "release the Unreleased block" blocker is marked shipped (what remains is the settling period); fetch snippet bumped.

Remaining release loose ends (outside this PR): sign `checksums.txt` and publish the `zcli-v0.20.0` draft; add required reviewers to the `release` and `docs-deploy` environments so the gates actually gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)