### PR TITLE
Route mistyped-subcommand CommandNotFound through onError hooks (#384)

### DIFF
--- a/packages/core/src/plugin_pipeline_test.zig
+++ b/packages/core/src/plugin_pipeline_test.zig
@@ -986,6 +986,23 @@ test "not_found: nothing close offers no suggestions but still lists commands" {
     try testing.expect(contains(cap.stderr, "search"));
 }
 
+test "not_found: mistyped subcommand of a no-Args command renders suggestions (#384)" {
+    const App = zcli.Registry.init(test_config)
+        .register("init", Init)
+        .registerPlugin(NotFound)
+        .build();
+
+    // "init" declares no positionals, so a stray non-option token is a
+    // mistyped subcommand. It must route through onError (rendering the
+    // not-found block with the stray token in the attempted path), not
+    // silently exit with no output.
+    const cap = try runCapture(App, &.{ "init", "foo" });
+    defer cap.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(?anyerror, error.CommandNotFound), cap.err);
+    try testing.expect(contains(cap.stderr, "Unknown command 'init foo'"));
+}
+
 test "not_found (self-contained): a bare command group lists its subcommands, no double output" {
     const App = zcli.Registry.init(test_config)
         .registerPlugin(NotFound)

--- a/packages/core/src/registry/compiled.zig
+++ b/packages/core/src/registry/compiled.zig
@@ -1158,9 +1158,19 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
             // A regular command that declares no positionals but got a
             // non-option argument was almost certainly invoked with a
             // mistyped subcommand — CommandNotFound, not a parse error.
+            // Record the attempted path (base command + stray token) and
+            // dispatch onError like every other not-found site, so the
+            // not-found plugin renders suggestions instead of a silent
+            // exit (#384).
             if (kind == .regular and std.meta.fields(ArgsType).len == 0 and
                 remaining_args.len > 0 and !std.mem.startsWith(u8, remaining_args[0], "-"))
             {
+                const attempted = try context.allocator.alloc([]const u8, command_parts.len + 1);
+                defer context.allocator.free(attempted);
+                @memcpy(attempted[0..command_parts.len], command_parts);
+                attempted[command_parts.len] = remaining_args[0];
+                try setCommandPath(context, attempted);
+                if (try runOnErrorHooks(context, error.CommandNotFound)) return;
                 return error.CommandNotFound;
             }
 


### PR DESCRIPTION
Fixes #384.

`executeResolvedCommand`'s stray-argument guard (regular command, no declared positionals, non-option token present) returned raw `error.CommandNotFound` without running `runOnErrorHooks` — the only not-found site that skipped them. Result: `myapp version foo` exited 3 with **no output at all**, and `zcli_not_found` never rendered suggestions.

Also fixes the secondary defect from the issue: `context.command_path` was still the resolved command (`["version"]`), so even a handling plugin would have mislabeled the real command as unknown. The guard now sets the attempted path to base command + stray token (`["version", "foo"]`) before dispatching onError, then propagates if unhandled — identical shape to the other three not-found sites.

New pipeline test asserts `init foo` (no-Args command + stray token) produces `Unknown command 'init foo'` on stderr and propagates `error.CommandNotFound`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4