### PR TITLE
Keep the original error when an onError hook itself fails (#390)

### DIFF
--- a/packages/core/src/plugin_pipeline_test.zig
+++ b/packages/core/src/plugin_pipeline_test.zig
@@ -442,6 +442,44 @@ const NotFoundPlugin = struct {
     }
 };
 
+const ThrowingOnError = struct {
+    pub const priority = 200; // runs before any handler
+    pub fn onError(_: anytype, _: anyerror) !bool {
+        return error.HookBoom;
+    }
+};
+
+test "pipeline: a failing onError hook does not swallow the original error (#390)" {
+    const App = zcli.Registry.init(test_config)
+        .register("fail", Fail)
+        .registerPlugin(ThrowingOnError)
+        .build();
+
+    const cap = try runCapture(App, &.{"fail"});
+    defer cap.deinit(testing.allocator);
+
+    // The command's own error propagates — not the hook's.
+    try testing.expectEqual(@as(?anyerror, error.Boom), cap.err);
+    // The hook's failure is surfaced, not silently dropped.
+    try testing.expect(contains(cap.stderr, "onError hook failed with HookBoom"));
+}
+
+test "pipeline: a failing onError hook falls through to the next handler (#390)" {
+    const App = zcli.Registry.init(test_config)
+        .register("fail", Fail)
+        .registerPlugin(ThrowingOnError)
+        .registerPlugin(SuppressErrPlugin)
+        .build();
+
+    SuppressErrPlugin.seen = null;
+    const cap = try runCapture(App, &.{"fail"});
+    defer cap.deinit(testing.allocator);
+
+    // The lower-priority handler still sees and suppresses the original error.
+    try testing.expectEqual(@as(?anyerror, null), cap.err);
+    try testing.expectEqual(@as(?anyerror, error.Boom), SuppressErrPlugin.seen);
+}
+
 test "pipeline: onError returning true suppresses CommandNotFound" {
     const App = zcli.Registry.init(test_config)
         .register("greet", Greet)

--- a/packages/core/src/registry/compiled.zig
+++ b/packages/core/src/registry/compiled.zig
@@ -950,10 +950,21 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
 
         /// Dispatch `err` to the plugins' onError hooks, first handler wins.
         /// Returns whether a plugin handled (and thereby suppressed) the error.
+        /// A hook that itself errors must not replace the original error (whose
+        /// diagnostic would then never be reported) — the hook's failure is
+        /// noted on stderr and dispatch continues to the next hook (#390).
         fn runOnErrorHooks(context: *Context, err: anyerror) !bool {
             inline for (sorted_plugins) |Plugin| {
                 if (@hasDecl(Plugin, "onError")) {
-                    if (try Plugin.onError(context, err)) return true;
+                    const plugin_name = comptime if (@hasDecl(Plugin, "plugin_id")) Plugin.plugin_id else @typeName(Plugin);
+                    const handled = Plugin.onError(context, err) catch |hook_err| blk: {
+                        context.stderr().print(
+                            "Warning: {s} onError hook failed with {s} while handling {s}\n",
+                            .{ plugin_name, @errorName(hook_err), @errorName(err) },
+                        ) catch {};
+                        break :blk false;
+                    };
+                    if (handled) return true;
                 }
             }
             return false;


### PR DESCRIPTION
Fixes #390.

`runOnErrorHooks` dispatched with `try Plugin.onError(context, err)` — a hook that itself errored replaced the *original* error (and orphaned its stored diagnostic), making the exit code and trace reflect the hook's failure instead of the command's.

Hook errors are now caught per-plugin: a one-line stderr warning names the plugin (its `plugin_id` when declared, type name otherwise), the hook's error, and the error being handled; dispatch continues to the next hook, and if none handles it the **original** error propagates to default reporting.

Two pipeline tests: a throwing hook (original error propagates + warning printed), and a throwing hook stacked above a real handler (handler still sees and suppresses the original error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4