### PR TITLE
Run postExecute hooks when a command fails with an unhandled error (#389)

### DIFF
--- a/packages/core/src/plugin_pipeline_test.zig
+++ b/packages/core/src/plugin_pipeline_test.zig
@@ -410,9 +410,13 @@ test "pipeline: onError returning true suppresses a command-execution error" {
 
 const PassThroughErrPlugin = struct {
     var seen: ?anyerror = null;
+    var post_success: ?bool = null;
     pub fn onError(_: anytype, err: anyerror) !bool {
         seen = err;
         return false; // observe only -> error still propagates
+    }
+    pub fn postExecute(_: anytype, success: bool) !void {
+        post_success = success;
     }
 };
 
@@ -423,8 +427,12 @@ test "pipeline: onError returning false lets a command error propagate" {
         .build();
 
     PassThroughErrPlugin.seen = null;
+    PassThroughErrPlugin.post_success = null;
     try testing.expectError(error.Boom, run(App, &.{"fail"}));
     try testing.expectEqual(@as(?anyerror, error.Boom), PassThroughErrPlugin.seen);
+    // postExecute still runs on the unhandled-error path (#389) — plugin
+    // teardown must not depend on the command succeeding.
+    try testing.expectEqual(@as(?bool, false), PassThroughErrPlugin.post_success);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/registry/compiled.zig
+++ b/packages/core/src/registry/compiled.zig
@@ -1260,13 +1260,23 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
             }
 
             // Execute. A handled error (onError returns true) is suppressed
-            // and falls through to postExecute with success = false.
+            // and falls through to postExecute with success = false. An
+            // unhandled error still runs postExecute (plugin teardown must
+            // not depend on the command succeeding, #389) before propagating.
             var success = true;
             Module.execute(args_instance, options_instance, context) catch |err| {
                 success = false;
-                if (!try runOnErrorHooks(context, err)) return err;
+                if (!try runOnErrorHooks(context, err)) {
+                    try runPostExecuteHooks(context, false);
+                    return err;
+                }
             };
 
+            try runPostExecuteHooks(context, success);
+        }
+
+        /// Run every plugin's postExecute hook with the command's outcome.
+        fn runPostExecuteHooks(context: *Context, success: bool) !void {
             inline for (sorted_plugins) |Plugin| {
                 if (@hasDecl(Plugin, "postExecute")) {
                     try Plugin.postExecute(context, success);


### PR DESCRIPTION
Fixes #389.

`executeResolvedCommand` returned an unhandled command error before the postExecute loop — hooks ran on success and on *handled* failures, but not on the common unhandled one, so plugin-side teardown leaked.

The unhandled path now runs every `postExecute(context, success=false)` before propagating the error, matching the documented lifecycle contract. The hook loop is extracted into `runPostExecuteHooks`, shared by both paths.

Extended the existing pass-through pipeline test to assert `postExecute` fires with `success=false` while the error still propagates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4