### PR TITLE
CI backstop: assert release/docs-deploy environment protection exists (#397)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -27,6 +27,21 @@ jobs:
     # repo settings; create it with at least one required reviewer.
     environment: docs-deploy
     steps:
+      # Environment gating is a repo-settings fact this YAML cannot see: if
+      # the environment loses its required-reviewers rule, the gate is
+      # silently inert (#397). An unprotected environment starts this job
+      # immediately — and this step then refuses to deploy. Fail-closed.
+      - name: Assert the docs-deploy environment is protected
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          rules=$(gh api "repos/$GITHUB_REPOSITORY/environments/docs-deploy" --jq '[.protection_rules[].type]') || {
+            echo "::error::cannot read the 'docs-deploy' environment — it must exist with a required-reviewers rule (Settings → Environments)"; exit 1; }
+          echo "protection rules: $rules"
+          echo "$rules" | grep -q required_reviewers || {
+            echo "::error::the 'docs-deploy' environment has NO required-reviewers rule — the approval gate is inert (#397); refusing to deploy"; exit 1; }
+
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -288,6 +288,23 @@ jobs:
     permissions:
       contents: write
     steps:
+      # Environment gating is a repo-settings fact this YAML cannot see: if
+      # the `release` environment loses its required-reviewers rule, the
+      # gate is silently inert (the 0.20.0 release proved it, #397). This
+      # runs first in every environment-gated job — an unprotected
+      # environment starts the job immediately, and this step then refuses
+      # to proceed. Fail-closed: an unreadable environment also fails.
+      - name: Assert the release environment is protected
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          rules=$(gh api "repos/$GITHUB_REPOSITORY/environments/release" --jq '[.protection_rules[].type]') || {
+            echo "::error::cannot read the 'release' environment — it must exist with a required-reviewers rule (Settings → Environments)"; exit 1; }
+          echo "protection rules: $rules"
+          echo "$rules" | grep -q required_reviewers || {
+            echo "::error::the 'release' environment has NO required-reviewers rule — the approval gate is inert (#397); refusing to publish"; exit 1; }
+
       - name: Checkout staged commit
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -325,6 +342,19 @@ jobs:
       contents: write
 
     steps:
+      # See the identical step in `finalize` — the tag-push path skips
+      # finalize, so every environment-gated job carries the check (#397).
+      - name: Assert the release environment is protected
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          rules=$(gh api "repos/$GITHUB_REPOSITORY/environments/release" --jq '[.protection_rules[].type]') || {
+            echo "::error::cannot read the 'release' environment — it must exist with a required-reviewers rule (Settings → Environments)"; exit 1; }
+          echo "protection rules: $rules"
+          echo "$rules" | grep -q required_reviewers || {
+            echo "::error::the 'release' environment has NO required-reviewers rule — the approval gate is inert (#397); refusing to publish"; exit 1; }
+
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -383,6 +413,19 @@ jobs:
       contents: write
 
     steps:
+      # See the identical step in `finalize` — the tag-push path skips
+      # finalize, so every environment-gated job carries the check (#397).
+      - name: Assert the release environment is protected
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          rules=$(gh api "repos/$GITHUB_REPOSITORY/environments/release" --jq '[.protection_rules[].type]') || {
+            echo "::error::cannot read the 'release' environment — it must exist with a required-reviewers rule (Settings → Environments)"; exit 1; }
+          echo "protection rules: $rules"
+          echo "$rules" | grep -q required_reviewers || {
+            echo "::error::the 'release' environment has NO required-reviewers rule — the approval gate is inert (#397); refusing to publish"; exit 1; }
+
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:


### PR DESCRIPTION
Fixes #397.

`environment: release` / `environment: docs-deploy` are inert unless the GitHub Environments carry protection rules — a settings-side fact the workflows can't enforce, and the 0.20.0 release proved the failure mode.

**In-repo backstop (this PR):** each environment-gated job (`finalize`, `release`, `library-release`, docs `deploy`) begins with a step that queries `GET /repos/{repo}/environments/{name}` with the workflow token and fails unless a `required_reviewers` protection rule is present. The logic: an *unprotected* environment starts the job with no approval — and the first step then refuses to publish/deploy. An unreadable environment also fails (fail-closed).

**Operational half:** already done — both environments now carry a required-reviewers rule (verified via the API before writing this PR).

Not included: the two informational nits from the issue (`cli_tag` via `env:` hygiene, `install.sh` latest-version robustness) — happy to follow up separately if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4