### PR TITLE
Scaffold templates follow the unused-parameter style rule (#399)

### DIFF
--- a/projects/zcli/src/commands/add/_generate.zig
+++ b/projects/zcli/src/commands/add/_generate.zig
@@ -95,14 +95,12 @@ pub fn generateSource(
         try w.writeAll("};\n\n");
     }
 
-    // execute. `args`/`options` are discarded until the user implements the
-    // body (Zig rejects unused parameters); the hint comment names the fields.
-    try w.writeAll("pub fn execute(args: Args, options: Options, context: *Context) !void {\n");
-    try w.writeAll("    _ = args;\n    _ = options;\n");
-    if (args_list.len == 0 and opts_list.len == 0) {
-        try w.writeAll("\n");
-    } else {
-        try w.writeAll("    // TODO: implement. Available:");
+    // execute. Unused parameters are `_` in the signature (the project style —
+    // Zig rejects unused named parameters); the hint comment tells the user to
+    // rename them as the body starts using the fields.
+    try w.writeAll("pub fn execute(_: Args, _: Options, context: *Context) !void {\n");
+    if (args_list.len != 0 or opts_list.len != 0) {
+        try w.writeAll("    // TODO: implement. Rename `_: Args`/`_: Options` to `args`/`options` to use:");
         var first = true;
         for (args_list) |a| {
             try w.writeAll(if (first) " " else ", ");
@@ -238,7 +236,8 @@ test "generateSource: empty command is the minimal skeleton" {
 
     try expectContains(src, "pub const Args = struct {};");
     try expectContains(src, "pub const Options = struct {};");
-    try expectContains(src, "_ = args;");
+    // Unused params live in the signature per the project style (#399).
+    try expectContains(src, "pub fn execute(_: Args, _: Options, context: *Context) !void {");
     try expectContains(src, "\"ping\"");
     try expectContains(src, "TODO: Implement ping");
     try testing.expect(std.mem.indexOf(u8, src, ".args = .{") == null);

--- a/projects/zcli/src/commands/add/group.zig
+++ b/projects/zcli/src/commands/add/group.zig
@@ -109,10 +109,7 @@ fn generateIndex(arena: std.mem.Allocator, parts: []const []const u8, descriptio
             \\
             \\pub const Options = struct {};
             \\
-            \\pub fn execute(args: Args, options: Options, context: *Context) !void {
-            \\    _ = args;
-            \\    _ = options;
-            \\
+            \\pub fn execute(_: Args, _: Options, context: *Context) !void {
             \\    const stdout = context.stdout();
             \\    try stdout.print("TODO: Implement
         );
@@ -181,7 +178,7 @@ test "generateIndex: with-landing adds an empty-Args execute" {
 
     const src = try generateIndex(a, &.{ "gh", "pr" }, "Pull requests", true);
     try testing.expect(std.mem.indexOf(u8, src, "pub const Args = struct {};") != null); // no positionals
-    try testing.expect(std.mem.indexOf(u8, src, "pub fn execute(args: Args, options: Options") != null);
+    try testing.expect(std.mem.indexOf(u8, src, "pub fn execute(_: Args, _: Options") != null);
     try testing.expect(std.mem.indexOf(u8, src, "TODO: Implement gh pr") != null);
     try expectParses(a, src);
 }

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -443,7 +443,7 @@ test "add group scaffolds meta-only and landing index files" {
     }
     const landing = try readFile(tmp.dir, a, "src/commands/gh/pr/index.zig");
     try expectContains(landing, "pub const Args = struct {};"); // no positionals
-    try expectContains(landing, "pub fn execute(args: Args, options: Options");
+    try expectContains(landing, "pub fn execute(_: Args, _: Options");
     try expectContains(landing, "TODO: Implement gh pr");
 }
 


### PR DESCRIPTION
Fixes #399.

`zcli add command` (and `zcli add group --with-landing`) scaffolded `pub fn execute(args: Args, options: Options, …)` with `_ = args; _ = options;` in the body — the exact anti-pattern the repo's own style guide forbids. The generator now emits `_: Args, _: Options` inline in the signature, and the TODO hint comment tells the user to rename `_` back to `args`/`options` as the body starts using the fields.

Checked `zcli init`'s hello template per the issue — it uses both parameters, so no change there. Unit + e2e assertions updated; full `zig build test` and `zig build e2e` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4