### PR TITLE
ADR-0007/0008: current package names with editorial notes (#400)

### DIFF
--- a/docs/adr/0007-tree-read-back-format.md
+++ b/docs/adr/0007-tree-read-back-format.md
@@ -2,7 +2,7 @@
 
 Status: accepted
 
-The AI's "observe" step (read-back) is served by enriching the existing `tree --show-options`, not by adding a separate format or `--json`. The default `tree` stays compact and pretty for humans; `--show-options` becomes the complete, machine-legible read-back (ANSI-free when non-TTY via the existing ztheme `no_color` path). The guiding principle is **read/write symmetry**: the read-back surfaces exactly the spec fields the AI writes via `add option`/`add arg`, so it can reconcile current shape against intent and round-trip.
+The AI's "observe" step (read-back) is served by enriching the existing `tree --show-options`, not by adding a separate format or `--json`. The default `tree` stays compact and pretty for humans; `--show-options` becomes the complete, machine-legible read-back (ANSI-free when non-TTY via the existing theme package's `no_color` path — named `ztheme` when this ADR was written, renamed in PR #158). The guiding principle is **read/write symmetry**: the read-back surfaces exactly the spec fields the AI writes via `add option`/`add arg`, so it can reconcile current shape against intent and round-trip.
 
 To achieve that, args and options share **one notation** where every glyph maps to one spec field:
 

--- a/docs/adr/0008-agents-md-three-layer-context.md
+++ b/docs/adr/0008-agents-md-three-layer-context.md
@@ -17,7 +17,7 @@ Curation rule: an invariant belongs here only if it is **(a) high-leverage again
 1. Never call `free`/`deinit` on what you allocate in `execute()` — the allocator is a per-command arena, reclaimed automatically (ADR-0001).
 2. Change structure with `zcli add`/`rm`/`mv`, not by hand; write freeform code only in `execute()` bodies.
 3. Output via `context.stdout()`/`context.stderr()` — never `std.debug.print` or direct stdout.
-4. Don't hand-roll terminal I/O — use `zinput` (input), `zprogress` (progress), `ztheme` (color).
+4. Don't hand-roll terminal I/O — use `prompts` (input), `progress` (progress), `theme` (color). *(Named `zinput`/`zprogress`/`ztheme` when this ADR was written; renamed in PR #158.)*
 5. Verify with `zig build` + tests; run `zcli guide` for version-matched API detail and examples.
 6. File path = command path (`src/commands/foo/bar.zig` → `app foo bar`; `index.zig` = group landing; plugins in `src/plugins/`).
 


### PR DESCRIPTION
Fixes #400.

Both ADRs are `Status: accepted` — live guidance, not historical snapshots — yet still prescribed the pre-rename names. Updated:
- ADR-0007: "the existing ztheme `no_color` path" → the theme package, with a parenthetical noting the original name and the rename PR.
- ADR-0008: the prescriptive "use `zinput`/`zprogress`/`ztheme`" list → `prompts`/`progress`/`theme`, with an italic editorial note preserving historicity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4