### PR TITLE
Required options: explicit config-applied bitset replaces the value diff (#388)

### DIFF
--- a/packages/core/src/command_parser.zig
+++ b/packages/core/src/command_parser.zig
@@ -7,6 +7,11 @@ const diagnostic_errors = @import("diagnostic_errors.zig");
 pub const ZcliError = diagnostic_errors.ZcliError;
 pub const ZcliDiagnostic = diagnostic_errors.ZcliDiagnostic;
 
+/// One flag per Options field (field-declaration order) — the size of the
+/// `options_provided`/`config_applied` bitsets the registry threads through
+/// the required/constraint checks.
+pub const optionFieldCount = options_parser.optionFieldCount;
+
 /// Result of parsing a complete command line with mixed arguments and options
 pub fn CommandParseResult(comptime ArgsType: type, comptime OptionsType: type) type {
     return struct {
@@ -188,23 +193,22 @@ pub const MissingRequiredOption = struct {
 ///
 /// A required option — see `option_utils.isRequiredOption` — has no meaning when
 /// absent, so exactly one of these must hold for it: env or CLI set it
-/// (`provided[i]`), or config set it (its value changed between `before_config`
-/// and `after_config`). `std.meta.eql` compares strings by pointer+len, so a
-/// config-supplied string differs from the zero-initialized placeholder even
-/// when both are empty. Called by the registry after the config pass.
+/// (`provided[i]`), or the config pass filled it (`config_applied[i]`, reported
+/// by the config plugin's applyConfigDefaults). Explicit bitsets, not a value
+/// diff — a config value equal to the required-option placeholder (0, the first
+/// enum variant) is still supplied (#388). Called by the registry after the
+/// config pass.
 pub fn firstMissingRequiredOption(
     comptime OptionsType: type,
     comptime meta: anytype,
-    before_config: OptionsType,
-    after_config: OptionsType,
     provided: [options_parser.optionFieldCount(OptionsType)]bool,
+    config_applied: [options_parser.optionFieldCount(OptionsType)]bool,
 ) ?MissingRequiredOption {
     const info = @typeInfo(OptionsType);
     if (info != .@"struct") return null;
     inline for (info.@"struct".fields, 0..) |field, i| {
         if (comptime option_utils.isRequiredOption(field)) {
-            const config_set = !std.meta.eql(@field(before_config, field.name), @field(after_config, field.name));
-            if (!provided[i] and !config_set) {
+            if (!provided[i] and !config_applied[i]) {
                 return .{
                     .name = comptime option_utils.effectiveLongName(meta, field.name),
                     .expected_type = diagnostic_errors.expectedTypeName(field.type),
@@ -213,22 +217,6 @@ pub fn firstMissingRequiredOption(
         }
     }
     return null;
-}
-
-/// Was this option supplied by *some* source — CLI/env (`provided[index]`) or
-/// config (its value changed between the before/after snapshot)? The same
-/// "provided" notion `firstMissingRequiredOption` uses, shared by the exclusive
-/// and requires constraint walks so all three agree on what "supplied" means.
-fn optionSupplied(
-    comptime OptionsType: type,
-    comptime field_name: []const u8,
-    comptime index: usize,
-    before_config: OptionsType,
-    after_config: OptionsType,
-    provided: [options_parser.optionFieldCount(OptionsType)]bool,
-) bool {
-    if (provided[index]) return true;
-    return !std.meta.eql(@field(before_config, field_name), @field(after_config, field_name));
 }
 
 /// The field index of `name` in `OptionsType` (comptime). Constraint names are
@@ -252,22 +240,22 @@ pub const MissingDependency = struct {
 /// order), or null. A field's dependencies are enforced only when the field
 /// itself was supplied; each dependency must then be supplied by some source.
 /// Runs beside `firstMissingRequiredOption`, over the same `options_provided`
-/// bitset and config snapshot.
+/// and `config_applied` bitsets ("supplied" = either flag; the same explicit
+/// notion `firstMissingRequiredOption` uses).
 pub fn firstMissingDependency(
     comptime OptionsType: type,
     comptime meta: anytype,
-    before_config: OptionsType,
-    after_config: OptionsType,
     provided: [options_parser.optionFieldCount(OptionsType)]bool,
+    config_applied: [options_parser.optionFieldCount(OptionsType)]bool,
 ) ?MissingDependency {
     const info = @typeInfo(OptionsType);
     if (info != .@"struct") return null;
     inline for (info.@"struct".fields, 0..) |field, i| {
         if (comptime option_utils.requiresFor(meta, field.name)) |req_list| {
-            if (optionSupplied(OptionsType, field.name, i, before_config, after_config, provided)) {
+            if (provided[i] or config_applied[i]) {
                 inline for (req_list) |dep| {
                     const dep_i = comptime fieldIndex(OptionsType, dep);
-                    if (!optionSupplied(OptionsType, dep, dep_i, before_config, after_config, provided)) {
+                    if (!(provided[dep_i] or config_applied[dep_i])) {
                         return .{
                             .option_name = comptime option_utils.effectiveLongName(meta, field.name),
                             .required_name = comptime option_utils.effectiveLongName(meta, dep),
@@ -290,20 +278,19 @@ pub const MutuallyExclusive = struct {
 /// The first `meta.exclusive` set with two or more supplied members (reporting
 /// the first two in declaration order), or null. Runs beside
 /// `firstMissingRequiredOption`, after `requires`, over the same
-/// `options_provided` bitset and config snapshot.
+/// `options_provided` and `config_applied` bitsets.
 pub fn firstExclusiveViolation(
     comptime OptionsType: type,
     comptime meta: anytype,
-    before_config: OptionsType,
-    after_config: OptionsType,
     provided: [options_parser.optionFieldCount(OptionsType)]bool,
+    config_applied: [options_parser.optionFieldCount(OptionsType)]bool,
 ) ?MutuallyExclusive {
     const sets = comptime option_utils.exclusiveSets(meta);
     inline for (sets) |set| {
         var first_name: ?[]const u8 = null;
         inline for (set) |member| {
             const idx = comptime fieldIndex(OptionsType, member);
-            if (optionSupplied(OptionsType, member, idx, before_config, after_config, provided)) {
+            if (provided[idx] or config_applied[idx]) {
                 const eff = comptime option_utils.effectiveLongName(meta, member);
                 if (first_name) |f| return .{ .first = f, .second = eff };
                 first_name = eff;
@@ -1158,45 +1145,41 @@ test "firstMissingRequiredOption: satisfied by CLI, env, or config; else reporte
         verbose: bool = false,
     };
 
-    // Nothing set it and config left it unchanged → missing.
+    const none = [_]bool{ false, false };
+
+    // Nothing set it and config didn't fill it → missing.
     {
-        const before = Options{ .region = "", .verbose = false };
-        const provided = [_]bool{ false, false };
-        const miss = firstMissingRequiredOption(Options, null, before, before, provided);
+        const miss = firstMissingRequiredOption(Options, null, none, none);
         try std.testing.expect(miss != null);
         try std.testing.expectEqualStrings("region", miss.?.name);
         try std.testing.expectEqualStrings("[]const u8", miss.?.expected_type);
     }
     // env or CLI set it (provided[0] = true) → satisfied.
     {
-        const opts = Options{ .region = "us", .verbose = false };
         const provided = [_]bool{ true, false };
-        try std.testing.expect(firstMissingRequiredOption(Options, null, opts, opts, provided) == null);
+        try std.testing.expect(firstMissingRequiredOption(Options, null, provided, none) == null);
     }
-    // Config set it (value changed between the before/after snapshot) → satisfied.
+    // Config filled it (config_applied[0] = true) → satisfied, even if the
+    // value it wrote equals the required-option placeholder (#388).
     {
-        const before = Options{ .region = "", .verbose = false };
-        const after = Options{ .region = "from-config", .verbose = false };
-        const provided = [_]bool{ false, false };
-        try std.testing.expect(firstMissingRequiredOption(Options, null, before, after, provided) == null);
+        const config_applied = [_]bool{ true, false };
+        try std.testing.expect(firstMissingRequiredOption(Options, null, none, config_applied) == null);
     }
 }
 
 test "firstMissingRequiredOption: reports the effective (custom) flag name" {
     const Options = struct { output_file: []const u8 };
     const meta = .{ .options = .{ .output_file = .{ .name = "out" } } };
-    const before = Options{ .output_file = "" };
-    const provided = [_]bool{false};
-    const miss = firstMissingRequiredOption(Options, meta, before, before, provided);
+    const none = [_]bool{false};
+    const miss = firstMissingRequiredOption(Options, meta, none, none);
     try std.testing.expect(miss != null);
     try std.testing.expectEqualStrings("out", miss.?.name);
 }
 
 test "firstMissingRequiredOption: no required fields is never missing" {
     const Options = struct { verbose: bool = false, name: ?[]const u8 = null };
-    const before = Options{};
-    const provided = [_]bool{ false, false };
-    try std.testing.expect(firstMissingRequiredOption(Options, null, before, before, provided) == null);
+    const none = [_]bool{ false, false };
+    try std.testing.expect(firstMissingRequiredOption(Options, null, none, none) == null);
 }
 
 test "firstMissingDependency: enforced only when the dependent option is supplied" {
@@ -1205,12 +1188,12 @@ test "firstMissingDependency: enforced only when the dependent option is supplie
         output_format: ?enum { pretty, compact } = null,
     };
     const meta = .{ .options = .{ .output_format = .{ .requires = .{.output} } } };
-    const before = Options{};
+    const none = [_]bool{ false, false };
 
     // output_format supplied, output not → violation.
     {
         const provided = [_]bool{ false, true };
-        const miss = firstMissingDependency(Options, meta, before, before, provided);
+        const miss = firstMissingDependency(Options, meta, provided, none);
         try std.testing.expect(miss != null);
         try std.testing.expectEqualStrings("output-format", miss.?.option_name);
         try std.testing.expectEqualStrings("output", miss.?.required_name);
@@ -1218,18 +1201,18 @@ test "firstMissingDependency: enforced only when the dependent option is supplie
     // Both supplied → satisfied.
     {
         const provided = [_]bool{ true, true };
-        try std.testing.expect(firstMissingDependency(Options, meta, before, before, provided) == null);
+        try std.testing.expect(firstMissingDependency(Options, meta, provided, none) == null);
     }
     // Dependent option absent → dependency not enforced.
     {
         const provided = [_]bool{ true, false };
-        try std.testing.expect(firstMissingDependency(Options, meta, before, before, provided) == null);
+        try std.testing.expect(firstMissingDependency(Options, meta, provided, none) == null);
     }
-    // Dependency satisfied by config (value changed between snapshots).
+    // Dependency satisfied by config (config_applied flag).
     {
-        const after = Options{ .output = "out.txt" };
         const provided = [_]bool{ false, true };
-        try std.testing.expect(firstMissingDependency(Options, meta, before, after, provided) == null);
+        const config_applied = [_]bool{ true, false };
+        try std.testing.expect(firstMissingDependency(Options, meta, provided, config_applied) == null);
     }
 }
 
@@ -1242,9 +1225,9 @@ test "firstMissingDependency: reports effective (custom/dashed) flag names" {
         .out = .{ .name = "output" },
         .fmt = .{ .requires = .{.out} },
     } };
-    const before = Options{};
+    const none = [_]bool{ false, false };
     const provided = [_]bool{ false, true };
-    const miss = firstMissingDependency(Options, meta, before, before, provided);
+    const miss = firstMissingDependency(Options, meta, provided, none);
     try std.testing.expect(miss != null);
     try std.testing.expectEqualStrings("fmt", miss.?.option_name);
     // The dependency reports its custom flag name, not the field name.
@@ -1258,12 +1241,12 @@ test "firstExclusiveViolation: at most one member of a set may be supplied" {
         xml: bool = false,
     };
     const meta = .{ .exclusive = .{.{ .json, .yaml, .xml }} };
-    const opts = Options{};
+    const none = [_]bool{ false, false, false };
 
     // Two members supplied → violation, reporting them in declaration order.
     {
         const provided = [_]bool{ true, false, true }; // json + xml
-        const ex = firstExclusiveViolation(Options, meta, opts, opts, provided);
+        const ex = firstExclusiveViolation(Options, meta, provided, none);
         try std.testing.expect(ex != null);
         try std.testing.expectEqualStrings("json", ex.?.first);
         try std.testing.expectEqualStrings("xml", ex.?.second);
@@ -1271,12 +1254,11 @@ test "firstExclusiveViolation: at most one member of a set may be supplied" {
     // Exactly one supplied → fine.
     {
         const provided = [_]bool{ false, true, false };
-        try std.testing.expect(firstExclusiveViolation(Options, meta, opts, opts, provided) == null);
+        try std.testing.expect(firstExclusiveViolation(Options, meta, provided, none) == null);
     }
     // None supplied → fine.
     {
-        const provided = [_]bool{ false, false, false };
-        try std.testing.expect(firstExclusiveViolation(Options, meta, opts, opts, provided) == null);
+        try std.testing.expect(firstExclusiveViolation(Options, meta, none, none) == null);
     }
 }
 
@@ -1288,17 +1270,17 @@ test "firstExclusiveViolation: overlapping sets are checked independently" {
         c: bool = false,
     };
     const meta = .{ .exclusive = .{ .{ .a, .b }, .{ .b, .c } } };
-    const opts = Options{};
+    const none = [_]bool{ false, false, false };
 
     // a + c: neither set has two supplied members → legal.
     {
         const provided = [_]bool{ true, false, true };
-        try std.testing.expect(firstExclusiveViolation(Options, meta, opts, opts, provided) == null);
+        try std.testing.expect(firstExclusiveViolation(Options, meta, provided, none) == null);
     }
     // b + c: violates the second set.
     {
         const provided = [_]bool{ false, true, true };
-        const ex = firstExclusiveViolation(Options, meta, opts, opts, provided);
+        const ex = firstExclusiveViolation(Options, meta, provided, none);
         try std.testing.expect(ex != null);
         try std.testing.expectEqualStrings("b", ex.?.first);
         try std.testing.expectEqualStrings("c", ex.?.second);

--- a/packages/core/src/plugin_config_integration_test.zig
+++ b/packages/core/src/plugin_config_integration_test.zig
@@ -84,7 +84,8 @@ test "integration: --config path drives coercion for every type through the real
     };
     var opts = Opts{};
     const provided = [_]bool{false} ** 6;
-    config.applyConfigDefaults(&ctx, Opts, &opts, &provided);
+    var applied = [_]bool{false} ** @typeInfo(Opts).@"struct".fields.len;
+    config.applyConfigDefaults(&ctx, Opts, &opts, &provided, &applied);
 
     try testing.expect(opts.flag);
     try testing.expectEqualStrings("hi", opts.name);
@@ -127,7 +128,8 @@ test "integration: cwd discovery finds .{app}.config.toml (via chdir into tmp)" 
     const Opts = struct { count: u32 = 0 };
     var opts = Opts{};
     const provided = [_]bool{false};
-    config.applyConfigDefaults(&ctx, Opts, &opts, &provided);
+    var applied = [_]bool{false} ** @typeInfo(Opts).@"struct".fields.len;
+    config.applyConfigDefaults(&ctx, Opts, &opts, &provided, &applied);
     try testing.expectEqual(@as(u32, 42), opts.count);
 
     config.deinitContextData(&ctx.plugins.zcli_config, alloc);
@@ -160,13 +162,52 @@ test "integration: required option satisfied by config (through parseCommandLine
     try testing.expect(!result.options_provided[0]); // no source yet
 
     var opts = result.options;
-    const before = opts;
-    config.applyConfigDefaults(&ctx, Opts, &opts, &result.options_provided);
+    var applied = [_]bool{false} ** @typeInfo(Opts).@"struct".fields.len;
+    config.applyConfigDefaults(&ctx, Opts, &opts, &result.options_provided, &applied);
 
-    // Config filled it — the value differs from the pre-config snapshot, which
-    // is exactly what the registry's required-option check treats as "supplied".
+    // Config filled it and reported so in `applied` — exactly what the
+    // registry's required-option check treats as "supplied".
     try testing.expectEqualStrings("secret123", opts.token);
-    try testing.expect(!std.mem.eql(u8, before.token, opts.token));
+    try testing.expect(applied[0]);
+
+    config.deinitContextData(&ctx.plugins.zcli_config, alloc);
+}
+
+test "integration: required option satisfied by a placeholder-equal config value (#388)" {
+    var a = arena();
+    defer a.deinit();
+    const alloc = a.allocator();
+    const io = testing.io;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // 0 for the u32 and the FIRST enum variant — both equal the required-option
+    // placeholder, the exact values the old value-diff check misread as missing.
+    try tmp.dir.writeFile(io, .{ .sub_path = "myapp.json", .data = "{\"offset\": 0, \"format\": \"json\"}" });
+    const abs = try tmp.dir.realPathFileAlloc(io, "myapp.json", alloc);
+
+    var environ = std.process.Environ.Map.init(alloc);
+    const cmd_path = [_][]const u8{};
+    var ctx = makeCtx(alloc, &environ, &cmd_path, &discard.writer);
+    ctx.plugins.zcli_config.custom_path = abs;
+    const args = zcli.ParsedArgs.init(alloc);
+    _ = try config.preExecute(&ctx, args);
+
+    const Opts = struct { offset: u32, format: enum { json, yaml } };
+    const result = try zcli.parseCommandLine(struct {}, Opts, null, alloc, &environ, &.{}, null);
+    defer result.deinit();
+
+    var opts = result.options;
+    var applied = [_]bool{false} ** @typeInfo(Opts).@"struct".fields.len;
+    config.applyConfigDefaults(&ctx, Opts, &opts, &result.options_provided, &applied);
+
+    try testing.expectEqual(@as(u32, 0), opts.offset);
+    try testing.expect(opts.format == .json);
+    // The registry's required-option check reads exactly these flags
+    // (firstMissingRequiredOption is bitset-driven — unit-tested in
+    // command_parser.zig), so both fields count as supplied.
+    try testing.expect(applied[0]);
+    try testing.expect(applied[1]);
 
     config.deinitContextData(&ctx.plugins.zcli_config, alloc);
 }
@@ -197,7 +238,8 @@ test "integration: CLI-provided value beats config (equal-to-default regression)
     try testing.expect(result.options_provided[0]);
 
     var opts = result.options;
-    config.applyConfigDefaults(&ctx, Opts, &opts, &result.options_provided);
+    var applied = [_]bool{false} ** @typeInfo(Opts).@"struct".fields.len;
+    config.applyConfigDefaults(&ctx, Opts, &opts, &result.options_provided, &applied);
     try testing.expectEqual(@as(u32, 5), opts.count); // config's 10 did NOT win
 
     config.deinitContextData(&ctx.plugins.zcli_config, alloc);
@@ -231,7 +273,8 @@ test "integration: env-provided value beats config" {
     try testing.expect(result.options_provided[0]); // env supplied it
 
     var opts = result.options;
-    config.applyConfigDefaults(&ctx, Opts, &opts, &result.options_provided);
+    var applied = [_]bool{false} ** @typeInfo(Opts).@"struct".fields.len;
+    config.applyConfigDefaults(&ctx, Opts, &opts, &result.options_provided, &applied);
     try testing.expectEqual(@as(u32, 99), opts.count); // env wins over config
 
     config.deinitContextData(&ctx.plugins.zcli_config, alloc);

--- a/packages/core/src/plugin_types.zig
+++ b/packages/core/src/plugin_types.zig
@@ -204,15 +204,20 @@ pub fn getPriority(comptime T: type) i32 {
 ///   onError(context, err: anyerror) !bool
 ///
 ///   applyConfigDefaults(context, comptime OptionsType: type,
-///                       options: *OptionsType, provided: []const bool) void
+///                       options: *OptionsType, provided: []const bool,
+///                       applied: []bool) void
 ///     Fills option fields from a lower-precedence source (e.g. a config file)
 ///     after CLI + env parsing but before required/dependency/exclusive
 ///     validation. `provided` has one flag per Options field, in field-
 ///     declaration order, true when the CLI or the field's env fallback already
 ///     set it. The precedence obligation: the hook MUST skip any field whose
 ///     `provided` flag is true — this single check is what makes
-///     CLI > env > hook hold. `options` is mutated in place; `provided` is a
-///     read-only view. The hook does not return an error union — a malformed or
+///     CLI > env > hook hold. `applied` (same keying, caller-zeroed) is the
+///     hook's report back: it MUST mark every field it fills — the registry's
+///     required-option and constraint checks treat `provided[i] or applied[i]`
+///     as "supplied", with no value diffing (#388). `options` is mutated in
+///     place; `provided` is a read-only view. The hook does not return an
+///     error union — a malformed or
 ///     unreadable source is a warning-and-skip, never a hard failure (a config
 ///     typo must not brick every command). Any values it writes into `options`
 ///     (e.g. coerced strings/arrays) must outlive the command's execution;
@@ -399,10 +404,11 @@ test "editDistance flags an applyConfigDefaults typo" {
 test "validatePlugin accepts a well-formed applyConfigDefaults hook" {
     const Plugin = struct {
         pub const plugin_id = "cfg_plugin";
-        pub fn applyConfigDefaults(context: anytype, comptime OptionsType: type, options: *OptionsType, provided: []const bool) void {
+        pub fn applyConfigDefaults(context: anytype, comptime OptionsType: type, options: *OptionsType, provided: []const bool, applied: []bool) void {
             _ = context;
             _ = options;
             _ = provided;
+            _ = applied;
         }
     };
     comptime validatePlugin(Plugin);

--- a/packages/core/src/plugins/zcli_config/plugin.zig
+++ b/packages/core/src/plugins/zcli_config/plugin.zig
@@ -130,6 +130,15 @@ pub fn preExecute(context: anytype, args: zcli.ParsedArgs) !?zcli.ParsedArgs {
 /// option's env fallback set it; config only fills fields it left false, so
 /// CLI > env > config falls out of a single check.
 ///
+/// `applied` (same keying, caller-zeroed) is the hook's report back: every
+/// field this pass fills is marked, and the registry's required-option and
+/// constraint checks read it directly — an explicit signal, not a value diff,
+/// so a config value equal to a field's placeholder still counts as supplied
+/// (#388). It doubles as config's own two-tier precedence tracker: the
+/// command-scope pass runs first and marks fields it fills; the global pass
+/// then skips them (without this, the second pass would overwrite a more
+/// specific value).
+///
 /// Applies config values scoped to the current command, plus global values,
 /// identically for JSON, TOML, and YAML. Top-level keys are global (apply to
 /// every command); keys nested under the command path are command-scoped and
@@ -138,7 +147,7 @@ pub fn preExecute(context: anytype, args: zcli.ParsedArgs) !?zcli.ParsedArgs {
 ///     "list": { "all": true } }    // scoped — applies only to "list" command
 /// and the equivalent TOML `[list]` table / YAML `list:` mapping.
 /// Precedence: CLI flag > env > command-scoped config > global config > struct default.
-pub fn applyConfigDefaults(context: anytype, comptime OptionsType: type, options: *OptionsType, provided: []const bool) void {
+pub fn applyConfigDefaults(context: anytype, comptime OptionsType: type, options: *OptionsType, provided: []const bool, applied: []bool) void {
     const data = &context.plugins.zcli_config;
     const content = data.raw_content orelse return;
     const format = data.format orelse return;
@@ -153,18 +162,10 @@ pub fn applyConfigDefaults(context: anytype, comptime OptionsType: type, options
     // command-scoped section within the config tree.
     const cmd_path = context.command_path;
 
-    // Config's own two-tier precedence (command-scoped > global) is tracked here:
-    // the command-scope pass runs first and marks fields it fills; the global
-    // pass then skips them. Without this, the second pass would overwrite a more
-    // specific value. Sized per Options field, in declaration order — same
-    // keying as `provided`.
-    const field_count = @typeInfo(OptionsType).@"struct".fields.len;
-    var applied = [_]bool{false} ** field_count;
-
     switch (format) {
-        .json => applyFromJsonScoped(OptionsType, options, content, ctx, data, cmd_path, provided, &applied),
-        .toml => applyFromTomlScoped(OptionsType, options, content, ctx, data, cmd_path, provided, &applied),
-        .yaml => applyFromYamlScoped(OptionsType, options, content, ctx, data, cmd_path, provided, &applied),
+        .json => applyFromJsonScoped(OptionsType, options, content, ctx, data, cmd_path, provided, applied),
+        .toml => applyFromTomlScoped(OptionsType, options, content, ctx, data, cmd_path, provided, applied),
+        .yaml => applyFromYamlScoped(OptionsType, options, content, ctx, data, cmd_path, provided, applied),
     }
 }
 

--- a/packages/core/src/registry/compiled.zig
+++ b/packages/core/src/registry/compiled.zig
@@ -1176,18 +1176,17 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
             const args_instance = parse_result.args;
             var options_instance = parse_result.options;
 
-            // Snapshot the post-parse options (a value copy) so the required
-            // check below can see which fields the config pass filled in.
-            const before_config = options_instance;
-
             // Config defaults fill only options no higher source set. The
             // provided bitset (CLI + env, keyed by Options field order) is the
             // single mechanism enforcing CLI > env > config: config skips any
-            // field whose flag is true. Passed by value copy — the plugin reads,
-            // never mutates it.
+            // field whose flag is true. The plugin marks every field it fills
+            // in `config_applied` — an explicit report, not a value diff, so a
+            // config value equal to a field's placeholder still counts as
+            // supplied (#388).
+            var config_applied = [_]bool{false} ** command_parser.optionFieldCount(OptionsType);
             inline for (sorted_plugins) |Plugin| {
                 if (@hasDecl(Plugin, "applyConfigDefaults")) {
-                    Plugin.applyConfigDefaults(context, OptionsType, &options_instance, &parse_result.options_provided);
+                    Plugin.applyConfigDefaults(context, OptionsType, &options_instance, &parse_result.options_provided, &config_applied);
                 }
             }
 
@@ -1195,7 +1194,7 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
             // Options field must be supplied by SOME source — CLI, env, or config.
             // Checked here, after every source has been applied, and reported like
             // any other parse error (humane message + usage hint).
-            if (command_parser.firstMissingRequiredOption(OptionsType, cmd_meta, before_config, options_instance, parse_result.options_provided)) |missing| {
+            if (command_parser.firstMissingRequiredOption(OptionsType, cmd_meta, parse_result.options_provided, config_applied)) |missing| {
                 const diag: zcli.ZcliDiagnostic = .{ .OptionMissingRequired = .{
                     .option_name = missing.name,
                     .expected_type = missing.expected_type,
@@ -1207,9 +1206,9 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
             }
 
             // Cross-field constraints (ADR-0022), checked over the same
-            // provided-set + config snapshot. Order per ADR: requires, then
+            // provided + config_applied bitsets. Order per ADR: requires, then
             // exclusive (missing-required above ran first).
-            if (command_parser.firstMissingDependency(OptionsType, cmd_meta, before_config, options_instance, parse_result.options_provided)) |dep| {
+            if (command_parser.firstMissingDependency(OptionsType, cmd_meta, parse_result.options_provided, config_applied)) |dep| {
                 const diag: zcli.ZcliDiagnostic = .{ .OptionMissingDependency = .{
                     .option_name = dep.option_name,
                     .required_name = dep.required_name,
@@ -1220,7 +1219,7 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
                 return error.OptionMissingDependency;
             }
 
-            if (command_parser.firstExclusiveViolation(OptionsType, cmd_meta, before_config, options_instance, parse_result.options_provided)) |ex| {
+            if (command_parser.firstExclusiveViolation(OptionsType, cmd_meta, parse_result.options_provided, config_applied)) |ex| {
                 const diag: zcli.ZcliDiagnostic = .{ .OptionMutuallyExclusive = .{
                     .first = ex.first,
                     .second = ex.second,


### PR DESCRIPTION
Fixes #388.

**Bug:** the registry inferred "config supplied this option" by `std.meta.eql`-diffing the options struct around the config pass. Required options pre-initialize to `requiredPlaceholder(T)` (0 for ints/floats, first variant for enums), so a config value *equal* to the placeholder diffed empty → falsely reported missing (`required u32 offset` + config `0`; `enum{json,yaml}` + config `json`). The same diff silently mis-evaluated `requires`/`exclusive` members.

**Fix (the issue's suggested shape):**
- `applyConfigDefaults` gains an `applied: []bool` out-parameter — the plugin was already computing exactly this internally for its command-scope>global precedence; it now writes into the caller's bitset instead of a local.
- `firstMissingRequiredOption` / `firstMissingDependency` / `firstExclusiveViolation` take `(provided, config_applied)` bitsets; "supplied" = either flag, no value comparison. The `before_config` snapshot and the string pointer-identity workaround are retired.
- Hook contract doc (`plugin_types.zig`) and `validatePlugin` test updated; this is a breaking signature change for third-party `applyConfigDefaults` implementations (pre-1.0 policy: cleanest choice).

**Tests:** command_parser unit tests rewritten against the bitsets; new integration test drives the real plugin through a JSON config with `offset: 0` + `format: "json"` (both placeholder-equal) and asserts both are reported applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4