### PR TITLE
--version on a known command group beats group help (#403)

### DIFF
--- a/packages/core/src/plugin_pipeline_test.zig
+++ b/packages/core/src/plugin_pipeline_test.zig
@@ -851,6 +851,27 @@ test "version: --version on a bogus command shows the version via onError (regre
     try testing.expect(!contains(cap.stderr, "Unknown command"));
 }
 
+test "version: --version on a known command group beats group help (#403)" {
+    const Help = @import("plugins/zcli_help/plugin.zig");
+    // A PURE group ("users" has subcommands but no module of its own) routes
+    // through the raw not-found path, where help's onError renders group help
+    // at priority 100 — `--version users` used to lose that race and be
+    // silently ignored. Help now defers to the pending version request.
+    const App = zcli.Registry.init(test_config)
+        .register("users list", Greet)
+        .register("users create", Checkout)
+        .registerPlugin(Help)
+        .registerPlugin(Version)
+        .build();
+
+    const cap = try runCapture(App, &.{ "--version", "users" });
+    defer cap.deinit(testing.allocator);
+
+    try testing.expect(cap.err == null);
+    try testing.expect(contains(cap.stdout, "test v1.0.0"));
+    try testing.expect(!contains(cap.stderr, "list")); // no group help rendered
+}
+
 test "version: declares priority 90 so a higher-priority plugin's preExecute wins" {
     // The priority mechanism orders EVERY dispatched hook highest-first (see the
     // "descending priority order" test above). Version sits at 90 so that when

--- a/packages/core/src/plugins/zcli_help/plugin.zig
+++ b/packages/core/src/plugins/zcli_help/plugin.zig
@@ -111,6 +111,14 @@ pub fn onError(
     err: anyerror,
 ) !bool {
     if (err == error.CommandNotFound) {
+        // A pending --version belongs to the version plugin, which runs at a
+        // lower priority and would otherwise lose this CommandNotFound to the
+        // group-help rendering below — `myapp --version <group>` must print
+        // the version, exactly like `myapp --version <unknown>` does (#403).
+        // Comptime-guarded: apps without the version plugin skip this.
+        if (comptime @hasField(@TypeOf(context.plugins), "zcli_version")) {
+            if (context.plugins.zcli_version.version_requested) return false;
+        }
         // If no command was provided at all, show app help. This is an error
         // reaction (CommandNotFound), so it goes to stderr.
         if (context.command_path.len == 0) {


### PR DESCRIPTION
Fixes #403.

`myapp --version <group>` (a pure group — subcommands, no module) routed through the not-found path, where help's `onError` (priority 100) rendered group help before the version plugin (90) was consulted — the version request was silently ignored, inconsistently with `myapp --version <unknown>`, which prints the version.

Fix: help's `onError` returns false for `CommandNotFound` when a version request is pending, deferring to the version plugin's own `onError`. The check is comptime-guarded on `@hasField(context.plugins, "zcli_version")`, so apps without the version plugin are untouched. `--help --version` still resolves to help (that happens in `preExecute`, before any of this).

Pipeline test registers the real Help + Version plugins with a pure group and asserts `--version users` prints the version line with no group help; verified the test fails without the plugin change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4