### PR TITLE
Targeted coverage: progress flush contract + ConPTY smoke/quoting tests (#404)

### DIFF
--- a/packages/progress/src/flush_test.zig
+++ b/packages/progress/src/flush_test.zig
@@ -1,0 +1,90 @@
+//! Flush-contract tests: an indicator's output must reach the underlying
+//! file as it happens, not sit in the writer's buffer until process exit.
+//! This package's prior form is exactly this bug (the no-flush spinner,
+//! PR #136) — these tests drive each indicator over a genuinely *buffered*
+//! file writer and read the file back mid-flight, so a dropped flush in the
+//! ui engine or the indicators fails here instead of in a user's terminal.
+
+const std = @import("std");
+const progress = @import("Progress.zig");
+
+const testing = std.testing;
+
+fn readBack(io: std.Io, dir: std.Io.Dir, alloc: std.mem.Allocator) ![]u8 {
+    return dir.readFileAlloc(io, "out.txt", alloc, .limited(1 << 16));
+}
+
+test "non-interactive spinner flushes each status line as it is set" {
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var file = try tmp.dir.createFile(io, "out.txt", .{ .read = true });
+    defer file.close(io);
+    var buf: [4096]u8 = undefined; // large enough that nothing auto-drains
+    var fw = file.writer(io, &buf);
+
+    var spinner = try progress.Spinner.init(testing.allocator, &fw.interface, io, .fallback, .{});
+    defer spinner.deinit();
+    spinner.app.options.interactive = false;
+
+    spinner.start("Working on it");
+    {
+        const content = try readBack(io, tmp.dir, testing.allocator);
+        defer testing.allocator.free(content);
+        try testing.expect(std.mem.indexOf(u8, content, "Working on it") != null);
+    }
+
+    spinner.succeed("Done");
+    const content = try readBack(io, tmp.dir, testing.allocator);
+    defer testing.allocator.free(content);
+    try testing.expect(std.mem.indexOf(u8, content, "Done") != null);
+}
+
+test "piped progress bar flushes its single finish line at finish" {
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var file = try tmp.dir.createFile(io, "out.txt", .{ .read = true });
+    defer file.close(io);
+    var buf: [4096]u8 = undefined;
+    var fw = file.writer(io, &buf);
+
+    var bar = try progress.ProgressBar.init(testing.allocator, &fw.interface, io, .fallback, .{ .total = 10 });
+    defer bar.deinit();
+    bar.app.options.interactive = false;
+
+    bar.update(10, null);
+    bar.finish();
+
+    // The finish summary must be on disk before deinit/process exit.
+    const content = try readBack(io, tmp.dir, testing.allocator);
+    defer testing.allocator.free(content);
+    try testing.expect(content.len > 0);
+}
+
+test "piped multi bar is fully silent (documented degradation)" {
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var file = try tmp.dir.createFile(io, "out.txt", .{ .read = true });
+    defer file.close(io);
+    var buf: [4096]u8 = undefined;
+    var fw = file.writer(io, &buf);
+
+    var mb = try progress.MultiBar.init(testing.allocator, &fw.interface, io, .fallback, .{});
+    defer mb.deinit();
+    mb.app.options.interactive = false;
+
+    const item = try mb.add("download", 100);
+    mb.set(item, 100);
+    mb.finish();
+
+    // Unlike the single bar (one finish line), a piped multi bar emits
+    // nothing at all — no stray frames or partial escapes in the pipe.
+    const content = try readBack(io, tmp.dir, testing.allocator);
+    defer testing.allocator.free(content);
+    try testing.expectEqual(@as(usize, 0), content.len);
+}

--- a/packages/progress/src/test.zig
+++ b/packages/progress/src/test.zig
@@ -5,4 +5,5 @@
 test {
     _ = @import("Progress.zig");
     _ = @import("vterm_test.zig");
+    _ = @import("flush_test.zig");
 }

--- a/packages/testing/src/conpty.zig
+++ b/packages/testing/src/conpty.zig
@@ -332,7 +332,57 @@ fn buildEnvBlockW(alloc: std.mem.Allocator, env: *const std.process.Environ.Map)
     return block;
 }
 
-test "command-line quoting round-trips argv" {
-    // Compile-guard: this module is Windows-only.
+test "command-line quoting follows the CommandLineToArgvW rules" {
+    // appendQuotedArg is pure (no Windows API), so this runs on every host.
+    const alloc = std.testing.allocator;
+    const cases = [_]struct { arg: []const u8, expected: []const u8 }{
+        .{ .arg = "plain", .expected = "plain" },
+        .{ .arg = "", .expected = "\"\"" },
+        .{ .arg = "has space", .expected = "\"has space\"" },
+        .{ .arg = "tab\there", .expected = "\"tab\there\"" },
+        // A quote is escaped; backslashes are only special before a quote.
+        .{ .arg = "say \"hi\"", .expected = "\"say \\\"hi\\\"\"" },
+        .{ .arg = "C:\\Program Files\\x", .expected = "\"C:\\Program Files\\x\"" },
+        // Trailing backslashes before the closing quote double.
+        .{ .arg = "trail\\ ", .expected = "\"trail\\ \"" },
+        .{ .arg = "end\\\"", .expected = "\"end\\\\\\\"\"" },
+    };
+    for (cases) |case| {
+        var out: std.ArrayList(u8) = .empty;
+        defer out.deinit(alloc);
+        try appendQuotedArg(alloc, &out, case.arg);
+        try std.testing.expectEqualStrings(case.expected, out.items);
+    }
+}
+
+test "buildCommandLineW joins argv with spaces and NUL-terminates" {
+    const alloc = std.testing.allocator;
+    const cmdline = try buildCommandLineW(alloc, &.{ "cmd.exe", "/c", "echo hi" });
+    defer alloc.free(cmdline);
+    const expected = try std.unicode.utf8ToUtf16LeAlloc(alloc, "cmd.exe /c \"echo hi\"");
+    defer alloc.free(expected);
+    try std.testing.expectEqualSlices(u16, expected, cmdline[0..cmdline.len]);
+    try std.testing.expectEqual(@as(u16, 0), cmdline[cmdline.len]);
+}
+
+test "ConPTY smoke: spawn, read output, clean exit (#404)" {
+    // The only coverage ConPTY gets outside the full interactive e2e tier —
+    // bugs here previously surfaced only in CI, never on a dev box.
     if (builtin.os.tag != .windows) return;
+    const alloc = std.testing.allocator;
+
+    var session = try ConPtySession.spawn(alloc, &.{ "cmd.exe", "/c", "echo conpty-smoke" }, null, null, 24, 80);
+    defer session.deinit(alloc);
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+    var buf: [1024]u8 = undefined;
+    var attempts: usize = 0;
+    while (attempts < 100) : (attempts += 1) {
+        const n = session.pollRead(&buf, 100);
+        if (n > 0) try out.appendSlice(alloc, buf[0..n]);
+        if (std.mem.indexOf(u8, out.items, "conpty-smoke") != null) break;
+    }
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "conpty-smoke") != null);
+    try std.testing.expectEqual(@as(?u8, 0), session.waitExit(5000));
 }


### PR DESCRIPTION
Closes #404.

**packages/progress** (the flush/timing class the issue called out, with prior form in the no-flush spinner PR #136): new `flush_test.zig` drives each indicator over a *genuinely buffered* `std.Io.File.Writer` and reads the file back mid-flight:
- non-interactive spinner status lines are flushed as they're set (before any finish),
- the piped progress bar's single finish line reaches disk at `finish()`,
- the piped multi bar emits nothing at all (locks its documented degradation).

**packages/testing**:
- `conpty.zig`'s previous only test was an empty platform-guard stub. It's now a real `CommandLineToArgvW` quoting table (pure functions — runs on every host: backslash-before-quote doubling, trailing-backslash doubling, empty/space/tab args) + a `buildCommandLineW` join/NUL-termination test + a **Windows-only ConPTY smoke test** (spawn `cmd.exe /c echo`, poll the marker back, assert exit 0) so ConPTY breakage shows up in `zig build test` on Windows CI, not only the interactive e2e tier.

Deliberately not covered: `build_utils.zig` is 20 lines of `*std.Build` graph wiring — there's no way to unit-test it without a live Build instance, and it's exercised by every consumer's `update-snapshots` step; `runner.zig` is subprocess plumbing already exercised end-to-end by the e2e suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4