### PR TITLE
zcli_help: unify command-group help on the single command renderer

### DIFF
--- a/packages/core/src/plugins/zcli_help/app_help.zig
+++ b/packages/core/src/plugins/zcli_help/app_help.zig
@@ -1,14 +1,14 @@
 //! App-level help rendering for the zcli_help plugin.
 //!
-//! Covers the three "navigate to a command" scenarios:
+//! Covers the two "navigate to a command" scenarios:
 //!   - `showApp`   — general application help (`myapp --help`, bare `help`),
 //!   - `showRoot`  — root-command help (app help plus the root command's own
-//!                   args/options/examples),
-//!   - `showGroup` — command-group help (a bare group; its subcommand list).
+//!                   args/options/examples).
 //!
-//! Command-*specific* help (a single leaf command's synopsis) lives in
-//! `command_help.zig`. The per-field tables and the ARGUMENTS/EXAMPLES/GLOBAL
-//! OPTIONS sections these share with command help come from `format.zig`.
+//! Command-group help (a bare group or `myapp group --help`) shares the single
+//! command renderer in `command_help.zig` — a group is just a command that has
+//! subcommands. The per-field tables and the ARGUMENTS/EXAMPLES/GLOBAL OPTIONS
+//! sections these share with command help come from `format.zig`.
 
 const std = @import("std");
 const zcli = @import("zcli");
@@ -41,7 +41,7 @@ pub fn showApp(context: anytype, to_stdout: bool) !void {
     try fmt.write("    <command>{s}</command> [GLOBAL OPTIONS] <COMMAND> [ARGS]\n\n", .{app_name});
 
     // Commands (navigation to children)
-    try showCommandList(context, &fmt, .top_level);
+    try showCommandList(context, &fmt);
 
     // Global options
     try format.writeGlobalOptionsSection(writer, &fmt, context);
@@ -94,7 +94,7 @@ pub fn showRoot(context: anytype, to_stdout: bool) !void {
     }
 
     // Commands (navigation to children)
-    try showCommandList(context, &fmt, .top_level);
+    try showCommandList(context, &fmt);
 
     // Global options
     try format.writeGlobalOptionsSection(writer, &fmt, context);
@@ -107,44 +107,14 @@ pub fn showRoot(context: anytype, to_stdout: bool) !void {
     try fmt.write("Run '<command>{s}</command> <command><COMMAND></command> <flag>--help</flag>' for more information on a command.\n", .{app_name});
 }
 
-/// Show help for a command group: its subcommand list. Reached both explicitly
-/// (`myapp group --help`) and as an error reaction (a bare group), so the caller
-/// selects the stream via `to_stdout`.
-pub fn showGroup(context: anytype, group_name: []const u8, to_stdout: bool) !void {
-    var writer = if (to_stdout) context.stdout() else context.stderr();
-    var fmt = md.formatterWithPalette(writer, context.theme.capability(), app_palette);
-    const app_name = context.app_name;
-
-    // Header
-    try fmt.write("'<command>{s}</command>' is a command group. Available subcommands:\n\n", .{group_name});
-
-    // Usage
-    try fmt.write("<header>USAGE:</header>\n", .{});
-    try fmt.write("    <command>{s}</command> <command>{s}</command> <subcommand>\n\n", .{ app_name, group_name });
-
-    // Subcommand list
-    try showCommandList(context, &fmt, .{ .subcommands_of = group_name });
-
-    // Footer
-    try writer.writeAll("\n");
-    try fmt.write("Run '<command>{s}</command> <command>{s}</command> <subcommand> <flag>--help</flag>' for more information on a specific subcommand.\n", .{ app_name, group_name });
-    try fmt.write("Run '<command>{s}</command> <flag>--help</flag>' for general help.\n", .{app_name});
-}
-
 // ============================================================================
-// Command-list rendering (top-level commands + a group's subcommands)
+// Command-list rendering (top-level commands)
 // ============================================================================
 
 /// Helper struct for command display info with aliases
 const CommandDisplayInfo = struct {
     description: ?[]const u8,
     aliases: []const []const u8,
-};
-
-/// List type for showCommandList
-const CommandListType = union(enum) {
-    top_level, // Show top-level commands
-    subcommands_of: []const u8, // Show subcommands of a specific command
 };
 
 /// Sort comparator: order command names alphabetically for display.
@@ -160,13 +130,11 @@ pub fn isAlias(name: []const u8, aliases: []const []const u8) bool {
     return false;
 }
 
-/// Show a list of commands (used by app, root, and group help)
-fn showCommandList(context: anytype, fmt: anytype, list_type: CommandListType) !void {
-    if (list_type == .top_level) {
-        try fmt.write("<header>COMMANDS:</header>\n", .{});
-    } else {
-        try fmt.write("<header>SUBCOMMANDS:</header>\n", .{});
-    }
+/// Show the top-level command list (used by app and root help). A command
+/// group's subcommand list is rendered by the command renderer in
+/// `command_help.zig` instead.
+fn showCommandList(context: anytype, fmt: anytype) !void {
+    try fmt.write("<header>COMMANDS:</header>\n", .{});
 
     const command_infos = context.getAvailableCommandInfo();
     var displayed_names: std.ArrayList([]const u8) = .empty;
@@ -181,55 +149,13 @@ fn showCommandList(context: anytype, fmt: anytype, list_type: CommandListType) !
         // Skip hidden commands
         if (cmd_info.hidden) continue;
 
-        var should_process = false;
-        var display_name: []const u8 = undefined;
-        var is_exact_match = false;
+        if (cmd_info.path.len < 1) continue;
+        const display_name = cmd_info.path[0];
+        // Exact match if this is a top-level command (path.len == 1); a nested
+        // command contributes its top-level name but no description.
+        const is_exact_match = (cmd_info.path.len == 1);
 
-        switch (list_type) {
-            .top_level => {
-                if (cmd_info.path.len >= 1) {
-                    should_process = true;
-                    display_name = cmd_info.path[0];
-                    // Exact match if this is a top-level command (path.len == 1)
-                    is_exact_match = (cmd_info.path.len == 1);
-                }
-            },
-            .subcommands_of => |parent| {
-                // Split parent by spaces to get the full parent path
-                var parent_parts: std.ArrayList([]const u8) = .empty;
-                defer parent_parts.deinit(context.allocator);
-
-                var iter = std.mem.splitScalar(u8, parent, ' ');
-                while (iter.next()) |part| {
-                    if (part.len > 0) {
-                        try parent_parts.append(context.allocator, part);
-                    }
-                }
-
-                const parent_depth = parent_parts.items.len;
-
-                // Check if this command is a subcommand of the parent
-                if (cmd_info.path.len > parent_depth) {
-                    // Check if all parent parts match
-                    var matches = true;
-                    for (parent_parts.items, 0..) |part, i| {
-                        if (!std.mem.eql(u8, cmd_info.path[i], part)) {
-                            matches = false;
-                            break;
-                        }
-                    }
-
-                    if (matches) {
-                        should_process = true;
-                        display_name = cmd_info.path[parent_depth];
-                        // Exact match if the path length is exactly parent_depth + 1
-                        is_exact_match = (cmd_info.path.len == parent_depth + 1);
-                    }
-                }
-            },
-        }
-
-        if (should_process) {
+        {
             // Skip alias entries - the display_name is in the aliases list
             // This means this entry is an alias, not the primary command
             if (isAlias(display_name, cmd_info.aliases)) continue;
@@ -270,8 +196,8 @@ fn showCommandList(context: anytype, fmt: anytype, list_type: CommandListType) !
     var it = command_map.iterator();
     while (it.next()) |entry| {
         const display_name = entry.key_ptr.*;
-        // Skip help command for top-level (we'll add it manually)
-        if (list_type == .top_level and std.mem.eql(u8, display_name, "help")) continue;
+        // Skip the help command (we append it manually last).
+        if (std.mem.eql(u8, display_name, "help")) continue;
         try displayed_names.append(context.allocator, display_name);
     }
     std.mem.sort([]const u8, displayed_names.items, {}, lessByNameStr);
@@ -297,10 +223,8 @@ fn showCommandList(context: anytype, fmt: anytype, list_type: CommandListType) !
         }
     }
 
-    // Always show help command last for top-level
-    if (list_type == .top_level) {
-        try fmt.write("    <command>{s:<16}</command> Show help for commands\n\n", .{"help"});
-    }
+    // Always show the help command last.
+    try fmt.write("    <command>{s:<16}</command> Show help for commands\n\n", .{"help"});
 }
 
 // ============================================================================
@@ -346,40 +270,6 @@ test "showApp renders header, usage, the command list, and the command hint foot
     try std.testing.expect(std.mem.endsWith(u8, out, "for more information on a command.\n"));
 }
 
-test "showGroup renders the group header, subcommand list, and group footer" {
-    const allocator = std.testing.allocator;
-
-    const Ctx = zcli.TestContext(&.{});
-    var stdio: zcli.Stdio = undefined;
-    stdio.init(std.testing.io);
-    var aw: std.Io.Writer.Allocating = .init(allocator);
-    defer aw.deinit();
-    stdio.stdout_override = &aw.writer;
-
-    const environ = std.process.Environ.Map.init(allocator);
-    var ctx = Ctx.init(allocator, std.testing.io, &stdio, &environ);
-    defer ctx.deinit();
-    ctx.theme.caps = .{ .capability = .no_color, .is_tty = false, .color_enabled = false };
-
-    ctx.app_name = "myapp";
-    // `remote add` / `remote remove` under the `remote` group.
-    ctx.plugin_command_info = &.{
-        .{ .path = &.{ "remote", "add" }, .description = "Add a remote" },
-        .{ .path = &.{ "remote", "remove" }, .description = "Remove a remote" },
-    };
-
-    try showGroup(&ctx, "remote", true);
-    try ctx.stdout().flush();
-    const out = aw.written();
-
-    try std.testing.expect(std.mem.indexOf(u8, out, "'remote' is a command group") != null);
-    try std.testing.expect(std.mem.indexOf(u8, out, "USAGE:") != null);
-    try std.testing.expect(std.mem.indexOf(u8, out, "SUBCOMMANDS:") != null);
-    try std.testing.expect(std.mem.indexOf(u8, out, "add") != null);
-    try std.testing.expect(std.mem.indexOf(u8, out, "remove") != null);
-    try std.testing.expect(std.mem.endsWith(u8, out, "for general help.\n"));
-}
-
 test "showCommandList: dedups, sorts alphabetically, and renders aliases" {
     const allocator = std.testing.allocator;
 
@@ -406,7 +296,7 @@ test "showCommandList: dedups, sorts alphabetically, and renders aliases" {
     };
 
     var fmt = md.formatterWithPalette(ctx.stdout(), ctx.theme.capability(), app_palette);
-    try showCommandList(&ctx, &fmt, .top_level);
+    try showCommandList(&ctx, &fmt);
     try ctx.stdout().flush();
 
     const out = aw.written();

--- a/packages/core/src/plugins/zcli_help/app_help.zig
+++ b/packages/core/src/plugins/zcli_help/app_help.zig
@@ -155,39 +155,37 @@ fn showCommandList(context: anytype, fmt: anytype) !void {
         // command contributes its top-level name but no description.
         const is_exact_match = (cmd_info.path.len == 1);
 
-        {
-            // Skip alias entries - the display_name is in the aliases list
-            // This means this entry is an alias, not the primary command
-            if (isAlias(display_name, cmd_info.aliases)) continue;
+        // Skip alias entries - the display_name is in the aliases list
+        // This means this entry is an alias, not the primary command
+        if (isAlias(display_name, cmd_info.aliases)) continue;
 
-            const existing = command_map.get(display_name);
+        const existing = command_map.get(display_name);
 
-            // Add or update the command in the map
-            // Only use descriptions from exact matches (commands at the correct depth)
-            if (existing == null) {
-                // First time seeing this command
-                // Only add description if it's an exact match
-                if (is_exact_match) {
-                    try command_map.put(display_name, .{
-                        .description = cmd_info.description,
-                        .aliases = cmd_info.aliases,
-                    });
-                } else {
-                    // Not an exact match, add with no description
-                    try command_map.put(display_name, .{
-                        .description = null,
-                        .aliases = &.{},
-                    });
-                }
-            } else if (is_exact_match and cmd_info.description != null) {
-                // We have an exact match with a description, prefer it over previous entries
+        // Add or update the command in the map
+        // Only use descriptions from exact matches (commands at the correct depth)
+        if (existing == null) {
+            // First time seeing this command
+            // Only add description if it's an exact match
+            if (is_exact_match) {
                 try command_map.put(display_name, .{
                     .description = cmd_info.description,
                     .aliases = cmd_info.aliases,
                 });
+            } else {
+                // Not an exact match, add with no description
+                try command_map.put(display_name, .{
+                    .description = null,
+                    .aliases = &.{},
+                });
             }
-            // Otherwise keep existing entry
+        } else if (is_exact_match and cmd_info.description != null) {
+            // We have an exact match with a description, prefer it over previous entries
+            try command_map.put(display_name, .{
+                .description = cmd_info.description,
+                .aliases = cmd_info.aliases,
+            });
         }
+        // Otherwise keep existing entry
     }
 
     // Second pass: display commands in alphabetical order. The dedup map above

--- a/packages/core/src/plugins/zcli_help/plugin.zig
+++ b/packages/core/src/plugins/zcli_help/plugin.zig
@@ -159,11 +159,16 @@ pub fn onError(
                 }
 
                 // If we found subcommands at this depth, show help for this group
+                // using the same renderer as `<group> --help` (command_help). A
+                // pure group is unregistered, so its CommandNotFound carries the
+                // full unmatched argv (e.g. `app foo baz`); narrow command_path to
+                // the matched group prefix so the command renderer describes the
+                // group, not the phantom deeper command. The prefix is a subslice
+                // of the already-owned command_path, so no allocation is needed.
                 if (has_subcommands) {
-                    const group_name = try std.mem.join(context.allocator, " ", prefix);
-                    defer context.allocator.free(group_name);
+                    context.command_path = prefix;
                     // Reached from an error (a bare command group) → stderr.
-                    try app_help.showGroup(context, group_name, false);
+                    try command_help.showCommand(context, false);
                     return true; // Error handled, don't let it propagate
                 }
             }

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -1103,15 +1103,15 @@ test "scaffolded project builds, runs, and round-trips add command" {
     }
     {
         // Bare group invocation. A pure group's CommandNotFound is handled by the
-        // help plugin (shows help, doesn't propagate), so the process exits 0 —
-        // but the rendered group help (header + USAGE + subcommand list) is
-        // error-triggered, so it goes to STDERR (#236 convention), keeping a
-        // piped stdout clean.
+        // help plugin, which renders the group with the same command help renderer
+        // as `cfg --help` (USAGE + COMMANDS list). It doesn't propagate, so the
+        // process exits 0 — but the help is error-triggered, so it goes to STDERR
+        // (#236 convention), keeping a piped stdout clean.
         var r = try run(proj, &.{ demo_bin, "cfg" });
         defer r.deinit();
         try expectOk(r);
-        try expectContains(r.stderr, "is a command group");
-        try expectContains(r.stderr, "SUBCOMMANDS:");
+        try expectContains(r.stderr, "USAGE:");
+        try expectContains(r.stderr, "COMMANDS:");
         try expectContains(r.stderr, "show"); // the subcommand under cfg
         // Group help is an error reaction → stderr only. stdout stays empty.
         try testing.expect(r.stdout.len == 0);


### PR DESCRIPTION
## Problem

Command-group help had **two renderers reached by two different hooks**, producing divergent output for the same thing:

- `myapp group -h` / `--help` → `preExecute` → `command_help.showCommand` (description, `USAGE ... COMMAND`, `OPTIONS`, `COMMANDS:`)
- bare `myapp group` → `error.CommandNotFound` → `onError` → `app_help.showGroup` (`'group' is a command group. Available subcommands:`, `USAGE ... <subcommand>`, `SUBCOMMANDS:`, a different footer)

Reported via the `tasks` example: `tasks sprint` and `tasks sprint -h` rendered differently.

## Fix

Route the error path through `showCommand` too — a group is just a command that has subcommands — and delete `showGroup`.

`onError` narrows `context.command_path` to the matched group prefix before delegating. This is the one subtlety that made a naive call-site swap unsafe: **pure groups (a subcommand directory with no `index.zig`) are unregistered** (`code_generation.zig` — "Pure groups are not registered, just recurse"), so their `CommandNotFound` carries the *full unmatched argv* (e.g. `app foo baz`). Without narrowing, `showCommand` would describe a phantom `foo baz` command. The prefix is a subslice of the already-owned `command_path`, so no allocation.

Deleting `showGroup` left `showCommandList`'s `.subcommands_of` branch (and the `CommandListType` union) dead — its only caller was `showGroup` — so `showCommandList` is simplified to top-level-only.

Stream convention is preserved: bare group → stderr (error reaction), `-h` → stdout (explicit request).

## Files

- `packages/core/src/plugins/zcli_help/plugin.zig` — `onError` narrows `command_path`, calls `showCommand`
- `packages/core/src/plugins/zcli_help/app_help.zig` — delete `showGroup` + test; simplify `showCommandList`
- `projects/zcli/test/e2e.zig` — update bare pure-group (`cfg`) assertions to the command-renderer output

Left untouched: the `zcli_not_found` plugin's own minimal group renderer, which only runs as a fallback for apps that don't register `zcli_help` — a separate path, not part of this divergence.

## Verification

- `zig build test` — green (all packages + examples)
- `zig build e2e` — green (covers the bare pure-group `cfg` case)
- Live repro on `examples/tasks`: `tasks sprint` and `tasks sprint -h` now render identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)