### PR TITLE
Fix bundled short options with separated value mis-parsing (`-vf out.txt`)

### DIFF
--- a/packages/core/src/command_parser.zig
+++ b/packages/core/src/command_parser.zig
@@ -109,20 +109,31 @@ pub fn parseCommandLine(
                     }
                 }
             } else {
-                // Short option -x or -xyz
+                // Short option `-x` or bundle `-xyz`. Walk the chars mirroring
+                // the options parser's mixed-bundle handling
+                // (parseShortOptionsWithMeta): skip leading boolean chars; the
+                // first value-taking char either carries the rest of the token
+                // as its attached value (no next-token lookahead) or — when it
+                // is the last char — consumes the next token as its value under
+                // the shared `isValueToken` rule (#299). Reusing the shared
+                // `shortOptionTakesValue`/`isValueToken` classifiers keeps this
+                // split and the parser in agreement so a bundle like
+                // `-vf out.txt` no longer strands its value (#427).
                 const option_chars = arg[1..];
-                if (option_chars.len == 1) {
-                    // Single short option, might need value
-                    const option_char = option_chars[0];
-                    const takes_value = option_utils.shortOptionTakesValue(OptionsType, meta, option_char) orelse false;
-                    // A following flag is not this short option's value — same
-                    // "next token is a value" rule the long path uses (#299).
-                    if (takes_value and i + 1 < args.len and option_utils.isValueToken(args[i + 1])) {
+                var ci: usize = 0;
+                while (ci < option_chars.len) : (ci += 1) {
+                    const takes_value = option_utils.shortOptionTakesValue(OptionsType, meta, option_chars[ci]) orelse false;
+                    // Boolean (or unknown) leading char: keep walking.
+                    if (!takes_value) continue;
+                    // First value-taking char. If it is not the last char, the
+                    // rest of the token is its attached value — no lookahead. If
+                    // it is the last char, the next token may be its value.
+                    if (ci + 1 == option_chars.len and i + 1 < args.len and option_utils.isValueToken(args[i + 1])) {
                         i += 1;
                         option_args.append(allocator, args[i]) catch return ZcliError.SystemOutOfMemory;
                     }
+                    break;
                 }
-                // For bundled short options (-xyz), assume they're all boolean
             }
         } else {
             // Positional argument
@@ -1080,6 +1091,75 @@ test "#287 non-integer negative as an option value (both positions agree)" {
     const result = try parseCommandLine(struct {}, Options, null, allocator, null, &.{ "--min", "-.5" }, null);
     defer result.deinit();
     try std.testing.expectApproxEqAbs(@as(f64, -0.5), result.options.min, 0.0001);
+}
+
+// #427 — the pre-split only did value-lookahead for single-char short tokens, so
+// a bundle like `-vf out.txt` (a leading boolean then a value-taker) fell through
+// as "all boolean" and routed the value to the positionals; the parser then saw
+// `-vf` alone and reported a spurious OptionMissingValue. These parseCommandLine
+// -level tests go through the pre-split (the misleading parseOptions-direct test
+// in options/parser.zig bypasses it).
+test "#427 bundled short with value-taker last consumes the separated value" {
+    const allocator = std.testing.allocator;
+    const Options = struct { verbose: bool = false, file: []const u8 = "" };
+    const meta = .{ .options = .{ .file = .{ .short = 'f' } } };
+
+    const result = try parseCommandLine(struct {}, Options, meta, allocator, null, &.{ "-vf", "out.txt" }, null);
+    defer result.deinit();
+    try std.testing.expect(result.options.verbose);
+    try std.testing.expectEqualStrings("out.txt", result.options.file);
+}
+
+test "#427 bundled short with attached value" {
+    const allocator = std.testing.allocator;
+    const Options = struct { verbose: bool = false, file: []const u8 = "" };
+    const meta = .{ .options = .{ .file = .{ .short = 'f' } } };
+
+    const result = try parseCommandLine(struct {}, Options, meta, allocator, null, &.{"-vfout.txt"}, null);
+    defer result.deinit();
+    try std.testing.expect(result.options.verbose);
+    try std.testing.expectEqualStrings("out.txt", result.options.file);
+}
+
+test "#427 unbundled short value-taker still works" {
+    const allocator = std.testing.allocator;
+    const Options = struct { verbose: bool = false, file: []const u8 = "" };
+    const meta = .{ .options = .{ .file = .{ .short = 'f' } } };
+
+    const result = try parseCommandLine(struct {}, Options, meta, allocator, null, &.{ "-v", "-f", "out.txt" }, null);
+    defer result.deinit();
+    try std.testing.expect(result.options.verbose);
+    try std.testing.expectEqualStrings("out.txt", result.options.file);
+}
+
+test "#427 all-boolean bundle keeps a following word as a positional" {
+    const allocator = std.testing.allocator;
+    const Args = struct { path: []const u8 };
+    const Options = struct { verbose: bool = false, debug: bool = false };
+    const meta = .{ .options = .{ .debug = .{ .short = 'd' } } };
+
+    const result = try parseCommandLine(Args, Options, meta, allocator, null, &.{ "-vd", "input.txt" }, null);
+    defer result.deinit();
+    try std.testing.expect(result.options.verbose);
+    try std.testing.expect(result.options.debug);
+    try std.testing.expectEqualStrings("input.txt", result.args.path);
+}
+
+test "#427 value-taker mid-bundle takes the rest as attached value, next word stays positional" {
+    const allocator = std.testing.allocator;
+    const Args = struct { path: []const u8 };
+    const Options = struct { verbose: bool = false, file: []const u8 = "", debug: bool = false };
+    const meta = .{ .options = .{ .file = .{ .short = 'f' }, .debug = .{ .short = 'd' } } };
+
+    // `-vfd`: v is boolean, f is the first value-taker and is not the last char,
+    // so the remaining `d` is f's attached value (NOT a boolean flag). The
+    // following word remains a positional.
+    const result = try parseCommandLine(Args, Options, meta, allocator, null, &.{ "-vfd", "input.txt" }, null);
+    defer result.deinit();
+    try std.testing.expect(result.options.verbose);
+    try std.testing.expectEqualStrings("d", result.options.file);
+    try std.testing.expect(!result.options.debug);
+    try std.testing.expectEqualStrings("input.txt", result.args.path);
 }
 
 test "#298 a bare '-' is a positional, not an unknown option" {


### PR DESCRIPTION
## Problem

The argv pre-split in `packages/core/src/command_parser.zig` only performed value-lookahead when a short token had exactly one option char. A bundle like `-vf out.txt` (a leading boolean flag `verbose` then a value-taker `file` with short `'f'`) fell through the old branch that assumed bundled shorts are "all boolean", so `out.txt` was routed to the positionals. The options parser then received `-vf` alone, set `verbose=true`, saw `f` needs a value, found none, and returned a spurious `error.OptionMissingValue` — even though the user supplied the value.

The attached form `-vfout.txt` and unbundled `-v -f out.txt` both already worked, which is why this survived. A test in `options/parser.zig:1390` asserts the bundled-with-value form works but calls `parseOptions` directly, bypassing the pre-split that breaks it.

## Fix

The bundle branch now walks the chars mirroring `parseShortOptionsWithMeta`:

- skip leading boolean chars;
- on the first value-taking char, if it is **not** the last char the rest of the token is its attached value (no next-token lookahead);
- if it **is** the last char, consume the next token under the shared `isValueToken` rule (#299).

Classification reuses the shared `shortOptionTakesValue` and `isValueToken` from `options/utils.zig` so the pre-split and the options parser stay in agreement — no duplicated classification logic.

## Tests

Adds `parseCommandLine`-level regression tests (which go through the pre-split) alongside the existing `#287` suite: value-taker last with separated value, attached value, unbundled, all-boolean bundle followed by a positional, and value-taker mid-bundle. `zig build test` passes from repo root.

Fixes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4