### PR TITLE
Wire onStartup lifecycle hook so it actually dispatches (#428)

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -147,12 +147,13 @@ pub fn deinitContextData(data: *ContextData, allocator: std.mem.Allocator) void 
 
 Plugins can implement any of these lifecycle hooks:
 
-1. **`preParse`** - Called before argument parsing
-2. **`postParse`** - Called after parsing, before command execution  
-3. **`preExecute`** - Called right before command execution (can cancel)
-4. **`postExecute`** - Called after command execution
-5. **`onError`** - Called when an error occurs
-6. **`handleGlobalOption`** - Called when global options are processed
+1. **`onStartup`** - Called once per invocation, after plugin data is captured but before argument parsing/routing (for one-time work like update checks)
+2. **`preParse`** - Called before argument parsing
+3. **`postParse`** - Called after parsing, before command execution  
+4. **`preExecute`** - Called right before command execution (can cancel)
+5. **`postExecute`** - Called after command execution
+6. **`onError`** - Called when an error occurs
+7. **`handleGlobalOption`** - Called when global options are processed
 
 ### Plugin Integration
 

--- a/packages/core/src/plugin_pipeline_test.zig
+++ b/packages/core/src/plugin_pipeline_test.zig
@@ -319,6 +319,62 @@ test "pipeline: preExecute returning null cancels the command" {
 }
 
 // ---------------------------------------------------------------------------
+// 5b. onStartup fires once, before the command executes (#428)
+// ---------------------------------------------------------------------------
+
+// A command that records into the trace so we can assert onStartup ran first.
+const TracingGreet = struct {
+    pub const meta = .{ .description = "greet" };
+    pub const Args = struct {};
+    pub const Options = struct {};
+    pub fn execute(_: Args, _: Options, _: anytype) !void {
+        Trace.record("execute");
+    }
+};
+
+const StartupPlugin = struct {
+    pub fn onStartup(_: anytype) !void {
+        Trace.record("onStartup");
+    }
+};
+
+test "pipeline: onStartup fires before the command executes (#428)" {
+    const App = zcli.Registry.init(test_config)
+        .register("greet", TracingGreet)
+        .registerPlugin(StartupPlugin)
+        .build();
+
+    Trace.reset();
+    try run(App, &.{"greet"});
+
+    // onStartup must run, and it must run before the command body.
+    try Trace.expectOrder(&.{ "onStartup", "execute" });
+}
+
+// An onStartup that fails aborts the invocation before routing — matching how
+// the other pre-command hooks (preParse/transformArgs) propagate errors with a
+// bare `try`. The command must never run.
+const StartupFailPlugin = struct {
+    pub fn onStartup(_: anytype) !void {
+        return error.StartupBoom;
+    }
+};
+
+test "pipeline: an error from onStartup propagates and skips the command (#428)" {
+    const App = zcli.Registry.init(test_config)
+        .register("greet", Greet)
+        .registerPlugin(StartupFailPlugin)
+        .build();
+
+    Greet.executed = false;
+    const result = runCapture(App, &.{"greet"}) catch unreachable;
+    defer result.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(?anyerror, error.StartupBoom), result.err);
+    try testing.expect(!Greet.executed);
+}
+
+// ---------------------------------------------------------------------------
 // 6. Global options are parsed and dispatched with the right typed value
 // ---------------------------------------------------------------------------
 

--- a/packages/core/src/plugin_types.zig
+++ b/packages/core/src/plugin_types.zig
@@ -169,6 +169,12 @@ pub fn hasOnError(comptime T: type) bool {
     return @hasDecl(T, "onError");
 }
 
+/// Check if a type has an onStartup hook. Runs once per invocation after plugin
+/// data is captured and before argument parsing/routing.
+pub fn hasOnStartup(comptime T: type) bool {
+    return @hasDecl(T, "onStartup");
+}
+
 /// Check if a type has an applyConfigDefaults hook. See `hook_names` below for
 /// the full contract.
 pub fn hasApplyConfigDefaults(comptime T: type) bool {
@@ -231,6 +237,7 @@ const hook_names = [_][]const u8{
     "preExecute",
     "postExecute",
     "onError",
+    "onStartup",
     "applyConfigDefaults",
 };
 

--- a/packages/core/src/registry/compiled.zig
+++ b/packages/core/src/registry/compiled.zig
@@ -668,6 +668,18 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
             // execution and runs any deinit hooks already owed.
             try context.initPluginData();
 
+            // 0.25 Run onStartup hooks once per invocation, after plugin data
+            // is captured but before any argument parsing or routing. A startup
+            // hook does one-time work (e.g. a rate-limited "new version
+            // available" probe); an error here propagates like any other
+            // pre-command hook (preParse/transformArgs use a bare `try`),
+            // aborting before the command runs.
+            inline for (sorted_plugins) |Plugin| {
+                if (@hasDecl(Plugin, "onStartup")) {
+                    try Plugin.onStartup(&context);
+                }
+            }
+
             // 0.5 Response-file (@file) expansion, once, at the very front of
             // parsing — before global options, transforms, and command routing
             // — so a @file may contribute the command name, options, and


### PR DESCRIPTION
## Problem

The upgrade plugin's `inform_out_of_date` banner is implemented as `onStartup(context)` in `packages/core/src/plugins/zcli_github_upgrade/plugin.zig`, but the hook was **never dispatched**. `"onStartup"` was absent from `hook_names`/`contract_names` in `plugin_types.zig`, there was no `hasOnStartup` predicate, and neither `registry/compiled.zig` nor the generated registry called it. Apps enabling `inform_out_of_date` silently got nothing, and because it wasn't in `hook_names`, the near-miss typo guard couldn't catch misspellings of it either.

## Fix (wire the hook — feature kept)

- **`plugin_types.zig`**: add `"onStartup"` to `hook_names` (this also flows into `contract_names` and lets the edit-distance typo guard catch misspellings); add a `hasOnStartup` predicate following the existing `has*` pattern.
- **`registry/compiled.zig`**: dispatch `onStartup` once at the top of `executeWithStdio`, after `initPluginData` and before response-file expansion / routing, via the standard `inline for (sorted_plugins)` + `@hasDecl` pattern.
- **`plugin_pipeline_test.zig`**: two tests — one proving a plugin's `onStartup` runs and runs *before* the command body, one proving an error from `onStartup` propagates and skips the command.
- **`docs/BUILD.md`**: add `onStartup` to the lifecycle-hook list. This also addresses the `onStartup` line of the doc gap tracked in #451.

## Error semantics

`onStartup` runs as a pre-command hook and its errors propagate with a bare `try`, exactly matching `preParse` and `transformArgs` (the other pre-routing hooks). A failing `onStartup` aborts the invocation before the command runs, rather than being swallowed. The shipped upgrade-plugin `onStartup` already swallows its own network/cache failures internally (passive probe), so this strictness only surfaces genuine programming errors from a hook.

## Verification

- `zig build test` from repo root: all packages green.
- `cd projects/zcli && zig build`: meta-CLI (which consumes the generated registry / these APIs) builds clean.
- Confirmed the new ordering test actually executes by temporarily swapping the expected order and observing the failure.

Fixes #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4