### PR TITLE
Fix editor prompt leaving terminal in raw mode on error

### DIFF
--- a/packages/prompts/src/editor.zig
+++ b/packages/prompts/src/editor.zig
@@ -53,6 +53,8 @@ pub fn editor(p: Prompts, config: EditorConfig) ![]u8 {
         try writer.print("{s}{s}\n", .{ config.prefix, config.message });
         return try allocator.dupe(u8, config.default orelse "");
     };
+    var raw_active = true;
+    errdefer if (raw_active) raw.disable();
     var app = try ui.App.init(p.allocator, writer, .{
         .capability = p.theme.capability(),
         .hybrid_raw = raw,
@@ -70,6 +72,7 @@ pub fn editor(p: Prompts, config: EditorConfig) ![]u8 {
                     try app.emit("{s}{s}", .{ config.prefix, config.message });
                     app.deinit();
                     raw.disable();
+                    raw_active = false;
                     Prompts.flushWriter(writer);
                     return error.UserAborted;
                 }
@@ -83,6 +86,7 @@ pub fn editor(p: Prompts, config: EditorConfig) ![]u8 {
     try app.emit("{s}{s}", .{ config.prefix, config.message });
     app.deinit();
     raw.disable();
+    raw_active = false;
     Prompts.flushWriter(writer);
 
     // Create temp file and write default content. The name is randomized (a


### PR DESCRIPTION
Fixes #429

## Summary

`packages/prompts/src/editor.zig` enabled raw mode with no `defer`/`errdefer` protecting it. Any error between enabling raw mode and one of the two existing manual `raw.disable()` calls (Ctrl-C branch, happy-path before spawning `$EDITOR`) escaped with the terminal left in raw mode — most practically `error.EndOfStream` from `terminal.readKey` on Ctrl-D or a closed stdin at the "press Enter to open editor" prompt. `App.deinit` deliberately doesn't restore caller-owned raw mode (out of scope here, per the issue), so nothing else caught this.

Fix: added `var raw_active = true; errdefer if (raw_active) raw.disable();` right after raw mode is enabled, and set `raw_active = false` at both existing manual disable points (Ctrl-C abort branch, and the pre-`$EDITOR`-spawn happy path). Scoped to `editor.zig` only, per the issue.

## Test plan

- Investigated whether a unit test can force this path: `terminal.isInteractiveTty()` (`packages/terminal/src/terminal.zig`) does a real `isatty` syscall on the process's actual stdin/stdout with no injection seam, and all prompts (`editor.zig` included) gate the raw-mode/`ui.App` branch behind it. Existing `packages/prompts` unit tests only exercise the non-TTY branch via `std.Io.Reader.fixed`/`std.Io.Writer.fixed` for this reason — this is true of every prompt in the package, not just `editor.zig`. The raw-mode branch is only reachable through `packages/testing`'s PTY-based e2e harness (`e2e.runInteractive`, real compiled binary under a pseudo-terminal), and no e2e coverage of `editor.zig`'s TTY branch exists yet either way. Given that, I did not force a unit test for this specific path — the fix is a small, mechanically-verifiable errdefer/flag pattern already used elsewhere in the codebase for the same problem.
- [x] `zig build test` passes (all packages, including `test-prompts`)
- [x] `zig build e2e` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4