### PR TITLE
terminal: fix CSI desync on modified arrows and Insert swallowing keys

### DIFF
--- a/packages/terminal/src/key.zig
+++ b/packages/terminal/src/key.zig
@@ -234,14 +234,30 @@ fn parseEscapeSequence(reader: anytype, esc_handle: ?backend.Handle, paste: ?Pas
                 break :blk keyIn(.escape);
             },
             '2' => blk: {
-                // ESC [ 200 ~ = bracketed-paste start (DECSET 2004). Only that
-                // exact prefix; any other ESC[2… is an unhandled CSI.
-                var m: [3]u8 = undefined;
-                for (&m) |*c| c.* = readByteFn(reader) catch break :blk keyIn(.escape);
-                if (std.mem.eql(u8, &m, "00~")) break :blk readPasteBody(reader, paste);
+                // ESC [ 2 ~ = Insert; ESC [ 200 ~ = bracketed-paste start
+                // (DECSET 2004). Match the "00~" suffix incrementally
+                // (byte-at-a-time) rather than with a fixed 3-byte read, so
+                // Insert's lone '~' terminates the sequence immediately
+                // instead of blocking for two more bytes that will never
+                // arrive (and eating the next two real keystrokes).
+                for ("00~") |want| {
+                    const got = readByteFn(reader) catch break :blk keyIn(.escape);
+                    if (got != want) {
+                        skipCsiTail(reader, got);
+                        break :blk keyIn(.escape);
+                    }
+                }
+                break :blk readPasteBody(reader, paste);
+            },
+            else => blk: {
+                // Unrecognized CSI (e.g. a modified arrow/Home/End such as
+                // `ESC[1;5C`, Ctrl-Right): `code` is the sequence's first
+                // parameter byte, not a final byte. Consume the rest of the
+                // sequence so trailing parameter/intermediate bytes aren't
+                // misparsed as separate keys, then report it as unhandled.
+                skipCsiTail(reader, code);
                 break :blk keyIn(.escape);
             },
-            else => keyIn(.escape),
         };
     } else if (next == 'O') {
         // SS3 sequence: ESC O ...
@@ -254,6 +270,20 @@ fn parseEscapeSequence(reader: anytype, esc_handle: ?backend.Handle, paste: ?Pas
     }
 
     return keyIn(.escape);
+}
+
+/// Consume the remainder of an unrecognized CSI sequence so the byte stream
+/// stays in sync. `first` is the byte already read as the CSI's first byte
+/// after `ESC [` (which may itself already be the sequence's final byte).
+/// Per the CSI grammar, parameter bytes are 0x30-0x3F, intermediate bytes are
+/// 0x20-0x2F, and the sequence ends at a single final byte in 0x40-0x7E — so
+/// this reads bytes while they're in the parameter/intermediate range and
+/// stops once a final byte is seen (or the stream ends).
+fn skipCsiTail(reader: anytype, first: u8) void {
+    var b = first;
+    while (b >= 0x20 and b <= 0x3f) {
+        b = readByteFn(reader) catch return;
+    }
 }
 
 /// Parse the tail of an SGR mouse report (`ESC [ <` already consumed):
@@ -602,6 +632,43 @@ test "readInput still parses keys" {
 
 test "malformed mouse sequence degrades to escape, not a desync" {
     try std.testing.expectEqual(Key.escape, (try parseInput("\x1b[<0;xM")).key);
+}
+
+test "modified arrow key does not desync the stream" {
+    // Ctrl-Right = ESC[1;5C. The unrecognized CSI must consume the whole
+    // sequence (not just '1'), leaving the following real key intact.
+    var buf = "\x1b[1;5Ca".*;
+    var reader: std.Io.Reader = .fixed(&buf);
+    try std.testing.expectEqual(Key.escape, try readKey(&reader));
+    try std.testing.expectEqual(Key{ .char = 'a' }, try readKey(&reader));
+    try std.testing.expectError(error.EndOfStream, readKey(&reader));
+}
+
+test "modified Home/End does not desync the stream" {
+    // Shift-Home = ESC[1;2H, Shift-End = ESC[1;2F.
+    var buf = "\x1b[1;2H\x1b[1;2F".*;
+    var reader: std.Io.Reader = .fixed(&buf);
+    try std.testing.expectEqual(Key.escape, try readKey(&reader));
+    try std.testing.expectEqual(Key.escape, try readKey(&reader));
+    try std.testing.expectError(error.EndOfStream, readKey(&reader));
+}
+
+test "Insert does not swallow subsequent keystrokes" {
+    // ESC[2~ = Insert. The '2' arm must not block hunting for a 3-byte
+    // "00~" bracketed-paste suffix that will never arrive.
+    var buf = "\x1b[2~ab".*;
+    var reader: std.Io.Reader = .fixed(&buf);
+    try std.testing.expectEqual(Key.escape, try readKey(&reader));
+    try std.testing.expectEqual(Key{ .char = 'a' }, try readKey(&reader));
+    try std.testing.expectEqual(Key{ .char = 'b' }, try readKey(&reader));
+    try std.testing.expectError(error.EndOfStream, readKey(&reader));
+}
+
+test "bracketed paste still recognized after Insert fix" {
+    const i = try parseInput("\x1b[200~hi\x1b[201~");
+    // No sink provided, so the paste is discarded but the sequence is fully
+    // consumed (not misparsed as an Insert or desynced).
+    try std.testing.expectEqual(Key.escape, i.key);
 }
 
 test "readInput parses bracketed paste content" {


### PR DESCRIPTION
## Summary
- Fixes #431: two bugs in `packages/terminal/src/key.zig`'s `parseEscapeSequence`.
- Modified arrows/Home/End (e.g. Ctrl-Right = `ESC[1;5C`) previously hit the `else => keyIn(.escape)` arm without consuming the trailing parameter bytes (`;5C`), leaving them to be reparsed as three spurious `.char` keys injected into whatever text input was focused.
- Insert (`ESC[2~`) previously hit a fixed 3-byte read hunting for the bracketed-paste `"00~"` suffix, so it blocked and ate the user's next two real keystrokes.
- Fix: a new `skipCsiTail` helper consumes CSI parameter/intermediate bytes (0x20-0x3F) until a final byte (0x40-0x7E) is seen, keeping the stream in sync. Used by the generic `else` arm (unrecognized CSI) and by the `'2'` arm, which now matches the `"00~"` bracketed-paste suffix incrementally with early exit instead of a blind fixed-length read.
- Sibling arms (`'3'`/delete, `'5'`/pageup, `'6'`/pagedown) read exactly one more byte matching their actual sequence length, so they weren't affected and were left alone (minimal scope).

## Test plan
- [x] Added unit tests in `packages/terminal/src/key.zig`: modified arrow (`ESC[1;5C`) doesn't desync, modified Home/End don't desync, Insert (`ESC[2~ab`) doesn't swallow following keys, bracketed paste (`ESC[200~...ESC[201~`) still works correctly.
- [x] `zig build test` — all packages pass (65/65 in `packages/terminal`).
- [x] `zig build e2e` — passes (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4