### PR TITLE
codegen: escape plugin config string values in generated Zig source (#432)

### DIFF
--- a/packages/core/src/build_utils/types.zig
+++ b/packages/core/src/build_utils/types.zig
@@ -270,7 +270,10 @@ fn renderConfigValue(comptime value: anytype) []const u8 {
                 else => false,
             };
             if (!is_string) @compileError("Unsupported pointer type in plugin config: " ++ @typeName(T));
-            break :blk std.fmt.comptimePrint("\"{s}\"", .{value});
+            // Escape the value so quotes, backslashes (e.g. Windows paths), and
+            // newlines don't break out of — or inject code after — the generated
+            // string literal. Mirrors escapeStringLiteral on the app-metadata path.
+            break :blk std.fmt.comptimePrint("\"{f}\"", .{std.zig.fmtString(@as([]const u8, value))});
         },
         .bool => std.fmt.comptimePrint("{}", .{value}),
         .int, .comptime_int => std.fmt.comptimePrint("{d}", .{value}),
@@ -328,6 +331,20 @@ test "builtin() renders a bare enum-literal config field (e.g. .checksum_only)" 
     });
     try std.testing.expectEqualStrings(
         ".init(.{.repo = \"owner/app\", .verification = .checksum_only})",
+        cfg.init.?,
+    );
+}
+
+test "builtin() escapes string config values (backslash, quote, newline)" {
+    // A raw `"{s}"` splice would emit an illegal Zig escape (`\U`) for a Windows
+    // path, or break out of the literal on an embedded quote. The value must be
+    // escaped the same way app metadata is.
+    const cfg = builtin(.github_upgrade, .{
+        .key_path = "C:\\Users\\me",
+        .note = "he said \"hi\"\n",
+    });
+    try std.testing.expectEqualStrings(
+        ".init(.{.key_path = \"C:\\\\Users\\\\me\", .note = \"he said \\\"hi\\\"\\n\"})",
         cfg.init.?,
     );
 }


### PR DESCRIPTION
## Problem
`renderConfigValue` (`packages/core/src/build_utils/types.zig`) spliced string plugin-config values into the generated `.init(.{...})` literal with a raw `std.fmt.comptimePrint("\"{s}\"", .{value})` — no escaping. Any developer-supplied config value containing:

- a `"` → breaks out of / injects into the literal
- a backslash, e.g. a Windows path `.{ .key_path = "C:\\Users\\me" }` → `\U` is an illegal Zig escape
- a newline

produced an opaque compile error inside the generated `zcli_generated.zig`. This was inconsistent with the sibling app-metadata path, which correctly escapes via `escapeStringLiteral` → `std.zig.stringEscape`.

## Fix
Escape the value in `renderConfigValue` using `std.zig.fmtString` (the comptime-friendly `{f}` formatter that wraps `stringEscape`), mirroring the app-metadata path:

```zig
break :blk std.fmt.comptimePrint("\"{f}\"", .{std.zig.fmtString(@as([]const u8, value))});
```

Scope is strictly the codegen path — the separate scaffolding escaper (#434) is untouched.

## Testing
- Added unit test `builtin() escapes string config values (backslash, quote, newline)` in `types.zig` asserting the escaped `.init(...)` output. Fails before / passes after.
- `zig build test` at repo root: all tests pass, no errors.

Fixes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4