### PR TITLE
core: restore Windows console code pages in context.exit (#438)

### DIFF
--- a/packages/core/src/console_utf8.zig
+++ b/packages/core/src/console_utf8.zig
@@ -14,7 +14,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
-const UINT = std.os.windows.UINT;
+pub const UINT = std.os.windows.UINT;
 
 /// Code page identifier for UTF-8 (see the Win32 "Code Page Identifiers" list).
 const CP_UTF8: UINT = 65001;

--- a/packages/core/src/context.zig
+++ b/packages/core/src/context.zig
@@ -11,6 +11,7 @@
 
 const std = @import("std");
 const zcli = @import("zcli.zig");
+const console_utf8 = @import("console_utf8.zig");
 
 /// Field name in `context.plugins` for a plugin's ContextData: its `plugin_id`
 /// verbatim. `plugin_id` is required to be a valid Zig identifier — enforced at
@@ -100,6 +101,14 @@ pub fn ContextFor(comptime plugins: []const type) type {
 
         // Type-safe plugin data - each plugin's ContextData is a field
         plugins: PluginDataType(plugins) = .{},
+
+        /// Console code pages captured by the registry's `run()` when it
+        /// switched the Windows console to UTF-8 for this invocation. `exit()`
+        /// restores them before `std.process.exit` — which skips the deferred
+        /// restore `run()` relies on — so a command that exits early doesn't
+        /// leak CP_UTF8 into the parent shell. Zero-valued (a no-op restore)
+        /// for direct `execute()`/`executeWithStdio` callers and on POSIX.
+        console: console_utf8.State = .{},
 
         const Self = @This();
 
@@ -287,6 +296,11 @@ pub fn ContextFor(comptime plugins: []const type) type {
         /// just before the call.
         pub fn exit(self: *Self, code: u8) noreturn {
             self.stdio.flush();
+            // Restore the Windows console code pages `run()` switched to UTF-8;
+            // std.process.exit skips run()'s deferred restore, so without this
+            // an early exit leaks CP_UTF8 into the parent shell. No-op on POSIX
+            // and for callers that never enabled it.
+            self.console.restore();
             std.process.exit(code);
         }
 
@@ -312,6 +326,40 @@ test "context accessors type-check" {
     // signature (e.g. a stale bundle field) at build time rather than only when
     // an example happens to use it.
     std.testing.refAllDecls(ContextFor(&.{}));
+}
+
+test "Context carries the console State so exit() can restore code pages" {
+    // Regression for #438: context.exit must restore the Windows console code
+    // pages run() switched to UTF-8. exit() is `noreturn` and restore() is a
+    // no-op off Windows, so the leak itself can't be observed in-process here;
+    // this instead locks in the wiring — that Context has a `console` field the
+    // registry threads through and exit() reads — so the restore call can't be
+    // silently dropped again. The behavioral Windows path is exercised by CI.
+    const Ctx = ContextFor(&.{});
+    var stdio: zcli.Stdio = undefined;
+    stdio.init(std.testing.io);
+    const env = std.process.Environ.Map.init(std.testing.allocator);
+
+    // A Context built with captured code pages must retain them verbatim.
+    const ctx = Ctx{
+        .allocator = std.testing.allocator,
+        .io = std.testing.io,
+        .stdio = &stdio,
+        .environ = &env,
+        .console = .{ .prev_in = 437, .prev_out = 437 },
+    };
+    try std.testing.expectEqual(@as(console_utf8.UINT, 437), ctx.console.prev_in);
+    try std.testing.expectEqual(@as(console_utf8.UINT, 437), ctx.console.prev_out);
+
+    // The default (no run(), or POSIX) is an empty, safe-to-restore State.
+    var plain = Ctx{
+        .allocator = std.testing.allocator,
+        .io = std.testing.io,
+        .stdio = &stdio,
+        .environ = &env,
+    };
+    try std.testing.expectEqual(@as(console_utf8.UINT, 0), plain.console.prev_in);
+    plain.console.restore(); // no-op, must not crash
 }
 
 test "initPluginData runs declared init hook and mutates ContextData" {

--- a/packages/core/src/registry/compiled.zig
+++ b/packages/core/src/registry/compiled.zig
@@ -307,6 +307,13 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
     return struct {
         const Self = @This();
 
+        /// Windows console code pages captured by `run()` when it switched the
+        /// console to UTF-8 for the current invocation, handed to each Context
+        /// so `context.exit` can restore them before `std.process.exit` (which
+        /// skips run()'s deferred restore). Zero-valued (no-op) until run()
+        /// enables it, and for direct execute()/executeWithStdio callers.
+        console: console_utf8.State = .{},
+
         // Export the computed Context type for this registry
         pub const Context = zcli.ContextFor(new_plugins);
 
@@ -660,6 +667,7 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
                 .command_path = &.{},
                 .plugin_command_info = plugin_command_info_list,
                 .global_options = global_options_list,
+                .console = self.console,
             };
             defer context.deinit();
 
@@ -764,6 +772,10 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
             // so the reported-error path below restores explicitly.
             const console = console_utf8.enable();
             defer console.restore();
+            // Hand the captured code pages to each Context built for this run so
+            // context.exit() can restore them before std.process.exit skips the
+            // deferred restore above (issue #438).
+            self.console = console;
 
             // Own the Stdio here (rather than letting execute() create it) so
             // that after a failure we can inspect the writer state to tell a


### PR DESCRIPTION
## Problem

`console_utf8.enable()` switches the Windows console code pages to `CP_UTF8` for a run, and `run()` restores them via a `defer` plus explicit `console.restore()` calls before every `std.process.exit`. But `Context.exit` did `stdio.flush(); std.process.exit(code)` with no restore — and `std.process.exit` skips deferred restores. On a real Windows console the parent shell was left in `CP_UTF8`, mojibaking later non-UTF-8 programs (legacy conhost).

Reachable today: upgrade `--check` calls `context.exit(0)`; `guide.zig` calls `context.exit(1)`.

## Fix

Give the Context an owned restore hook (issue's first suggested sketch):

- `console_utf8.State` gains a `pub UINT` alias (test use).
- The registry struct gets a `console: console_utf8.State = .{}` field. `run()` stores the code pages it captured there; `executeWithStdio` threads `self.console` into each `Context`.
- New `Context.console` field; `Context.exit` calls `self.console.restore()` before `std.process.exit`.

No-op on POSIX and for direct `execute()`/`executeWithStdio` callers (tests, library users) — they never enable it, so the field stays zero-valued and restore does nothing.

## Testing

- `zig build test` (repo root, all packages + examples) — PASS.
- `cd projects/zcli && zig build -Dtarget=x86_64-windows` — PASS (compiles the Windows-gated `State.restore` path and the kernel32 externs).
- Added a regression unit test in `context.zig` locking in the wiring (Context retains the captured `State`; default is empty/safe-to-restore). The behavioral leak itself can't be observed in-process on macOS/Linux — `restore()` is a Windows-only mutation and `exit()` is `noreturn` — so the actual code-page restore is exercised by Windows CI.

Fixes #438

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4