### PR TITLE
scaffold: atomically replace command source in add/rm edits (#435)

### DIFF
--- a/projects/zcli/src/commands/add/arg.zig
+++ b/projects/zcli/src/commands/add/arg.zig
@@ -114,9 +114,7 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         },
     };
 
-    var file = try std.Io.Dir.cwd().createFile(io, file_path, .{});
-    defer file.close(io);
-    try file.writeStreamingAll(io, updated);
+    try scaffold.fs.writeFileAtomic(std.Io.Dir.cwd(), io, arena, file_path, updated);
 
     try finish(context.stdout(), &context.theme, file_path, arg);
 }

--- a/projects/zcli/src/commands/add/option.zig
+++ b/projects/zcli/src/commands/add/option.zig
@@ -101,9 +101,7 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         },
     };
 
-    var file = try std.Io.Dir.cwd().createFile(io, file_path, .{});
-    defer file.close(io);
-    try file.writeStreamingAll(io, updated);
+    try scaffold.fs.writeFileAtomic(std.Io.Dir.cwd(), io, arena, file_path, updated);
 
     try finish(context.stdout(), &context.theme, file_path, opt);
 }

--- a/projects/zcli/src/commands/rm/arg.zig
+++ b/projects/zcli/src/commands/rm/arg.zig
@@ -81,9 +81,7 @@ pub fn execute(args: Args, _: Options, context: *Context) !void {
         source = try arena.dupeZ(u8, updated);
     }
 
-    var file = try std.Io.Dir.cwd().createFile(io, file_path, .{});
-    defer file.close(io);
-    try file.writeStreamingAll(io, source);
+    try scaffold.fs.writeFileAtomic(std.Io.Dir.cwd(), io, arena, file_path, source);
 
     try finish(context.stdout(), &context.theme, file_path, names.len);
 }

--- a/projects/zcli/src/commands/rm/option.zig
+++ b/projects/zcli/src/commands/rm/option.zig
@@ -80,9 +80,7 @@ pub fn execute(args: Args, _: Options, context: *Context) !void {
         source = try arena.dupeZ(u8, updated);
     }
 
-    var file = try std.Io.Dir.cwd().createFile(io, file_path, .{});
-    defer file.close(io);
-    try file.writeStreamingAll(io, source);
+    try scaffold.fs.writeFileAtomic(std.Io.Dir.cwd(), io, arena, file_path, source);
 
     try finish(context.stdout(), &context.theme, file_path, names.len);
 }

--- a/projects/zcli/src/scaffold/fs.zig
+++ b/projects/zcli/src/scaffold/fs.zig
@@ -32,6 +32,20 @@ pub fn groupPath(arena: std.mem.Allocator, segments: []const []const u8) ![]cons
     return buf.items;
 }
 
+/// Atomically replace the file at `path` with `data`: write to a sibling
+/// `<path>.tmp`, then `rename` it over the target. A write failure or crash
+/// mid-stream leaves the original file untouched (only the throwaway temp is
+/// affected) instead of a truncated/corrupt command source.
+pub fn writeFileAtomic(base: std.Io.Dir, io: std.Io, arena: std.mem.Allocator, path: []const u8, data: []const u8) !void {
+    const tmp_path = try std.fmt.allocPrint(arena, "{s}.tmp", .{path});
+    {
+        var file = try base.createFile(io, tmp_path, .{});
+        defer file.close(io);
+        try file.writeStreamingAll(io, data);
+    }
+    try base.rename(tmp_path, base, path, io);
+}
+
 fn isEmptyDir(base: std.Io.Dir, io: std.Io, path: []const u8) bool {
     var dir = base.openDir(io, path, .{ .iterate = true }) catch return false;
     defer dir.close(io);
@@ -77,6 +91,29 @@ test "removeEmptyParents cascades up but stops at a non-empty group" {
     try testing.expect(!dirExists(tmp.dir, io, "src/commands/a/b"));
     try testing.expect(dirExists(tmp.dir, io, "src/commands/a"));
     try testing.expect(dirExists(tmp.dir, io, "src/commands/a/kept"));
+}
+
+test "writeFileAtomic replaces contents and leaves no temp behind" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const io = testing.io;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(io, .{ .sub_path = "cmd.zig", .data = "original" });
+    try writeFileAtomic(tmp.dir, io, a, "cmd.zig", "replaced contents");
+
+    const got = try tmp.dir.readFileAlloc(io, "cmd.zig", a, .limited(1024));
+    try testing.expectEqualStrings("replaced contents", got);
+    // The temp is renamed away, not left as debris next to the target.
+    try testing.expect(!fileExists(tmp.dir, io, "cmd.zig.tmp"));
+}
+
+fn fileExists(base: std.Io.Dir, io: std.Io, path: []const u8) bool {
+    base.access(io, path, .{}) catch return false;
+    return true;
 }
 
 fn dirExists(base: std.Io.Dir, io: std.Io, path: []const u8) bool {


### PR DESCRIPTION
## Problem

The `zcli add option` / `add arg` / `rm arg` / `rm option` commands edit the
user's existing command source in place. Each did:

```zig
var file = try std.Io.Dir.cwd().createFile(io, file_path, .{}); // truncates!
defer file.close(io);
try file.writeStreamingAll(io, updated);
```

`createFile` truncates the target first, then the new content is streamed in.
A failure mid-write (disk full, interrupt, crash) leaves the user's command
source truncated or corrupt with no backup. `mv.zig` already avoids this by
using an atomic `rename`.

## Fix

Add a shared `scaffold.fs.writeFileAtomic(base, io, arena, path, data)` helper
that writes to a sibling `<path>.tmp` and then `rename`s it over the target
(the same pattern `mv.zig` uses). Route all four edit sites through it. A crash
now discards only the throwaway temp; the original file is untouched until the
atomic rename succeeds.

## Testing

- `zig build test` (repo root) — pass (EXIT 0, all 12 sub-project suites green)
- `cd projects/zcli && zig build && zig build test` — pass
- Added unit test `writeFileAtomic replaces contents and leaves no temp behind`
  in `scaffold/fs.zig` (writes over an existing file, asserts new content and
  that no `.tmp` debris remains).

## Deviation from the issue sketch

The issue suggested inlining write-temp-then-rename at each of the four sites.
I extracted a single `writeFileAtomic` helper into the existing `scaffold/fs.zig`
instead, so the four sites share one tested implementation rather than four
copies. Behavior matches the sketch.

Fixes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4