### PR TITLE
ui: blank a wide grapheme torn by copyRows clip boundary (#443)

### DIFF
--- a/packages/ui/src/diff.zig
+++ b/packages/ui/src/diff.zig
@@ -106,7 +106,10 @@ pub const Renderer = struct {
         if (!dirty) return;
 
         while (first > 0 and next.cell(first, row).isContinuation()) first -= 1;
-        if (next.cell(last, row).width == 2) last += 1;
+        // Extend the span over a wide grapheme's continuation. Bound-check so a
+        // torn head at the last column (width 2 with no continuation cell) can
+        // never push `last` past the surface edge.
+        if (last + 1 < next.width and next.cell(last, row).width == 2) last += 1;
 
         try st.moveTo(row, first);
         try st.emitCells(next, row, first, last);
@@ -263,6 +266,23 @@ test "sync guard wraps the paint when enabled" {
     defer testing.allocator.free(out);
     try testing.expect(std.mem.startsWith(u8, out, "\x1b[?2026h"));
     try testing.expect(std.mem.endsWith(u8, out, "\x1b[?2026l"));
+}
+
+test "diff never extends a span past the surface edge on a torn wide head" {
+    var prev = try Surface.init(testing.allocator, 4, 1);
+    defer prev.deinit();
+    var next = try Surface.init(testing.allocator, 4, 1);
+    defer next.deinit();
+    // Synthesize a torn wide head at the last column: a width-2 cell whose
+    // continuation would fall at column 4, off the surface edge. copyRows now
+    // prevents this tear at the source, but the diff's wide-span extension must
+    // still stay in bounds — `last + 1 < next.width` guards `last += 1` from
+    // ever addressing column `width`.
+    next.cells[3] = .{ .width = 2 };
+
+    const out = try paintToString(testing.allocator, .{ .capability = .ansi_16, .sync = false }, &prev, &next);
+    defer testing.allocator.free(out);
+    try testing.expect(out.len > 0);
 }
 
 test "no_color paints text but never SGR" {

--- a/packages/ui/src/surface.zig
+++ b/packages/ui/src/surface.zig
@@ -246,7 +246,15 @@ pub const Region = struct {
             var x: u16 = 0;
             while (x < cols) : (x += 1) {
                 const c = src.cell(x, sy);
-                try self.surface.putCell(self.rect.x + x, self.rect.y + dy, c, src.cellText(c));
+                // A wide grapheme whose continuation falls outside the copied
+                // columns would leave a torn head — a width-2 cell with no
+                // continuation — which the diff renderer reads past. Dissolve it
+                // to a styled blank instead of copying the head verbatim.
+                if (c.width == 2 and x + 1 >= cols) {
+                    self.surface.blankAt(self.rect.x + x, self.rect.y + dy, c.style);
+                } else {
+                    try self.surface.putCell(self.rect.x + x, self.rect.y + dy, c, src.cellText(c));
+                }
             }
         }
     }
@@ -506,6 +514,39 @@ test "clear resets cells and byte storage" {
     s.clear();
     try testing.expectEqual(@as(usize, 0), s.bytes.items.len);
     for (s.cells) |c| try testing.expect(c.isBlank());
+}
+
+test "copyRows blanks a wide grapheme torn by the clip boundary" {
+    // Source: "你" occupies cols 0-1 (head + continuation).
+    var src = try Surface.init(testing.allocator, 4, 1);
+    defer src.deinit();
+    _ = try src.root().writeText(0, 0, "你a", .{});
+    try testing.expectEqual(@as(u8, 2), src.cell(0, 0).width);
+
+    // Copy into a 1-wide region: only col 0 (the wide head) fits, so its
+    // continuation is clipped off. The head must dissolve to a blank rather
+    // than land as a torn width-2 cell.
+    var dst = try Surface.init(testing.allocator, 1, 1);
+    defer dst.deinit();
+    try dst.root().copyRows(&src, 0);
+
+    try testing.expect(dst.cell(0, 0).isBlank());
+    try testing.expectEqual(@as(u8, 1), dst.cell(0, 0).width);
+}
+
+test "copyRows preserves a wide grapheme that fits within the clip" {
+    var src = try Surface.init(testing.allocator, 4, 1);
+    defer src.deinit();
+    _ = try src.root().writeText(0, 0, "你a", .{});
+
+    // 2-wide region: the wide grapheme fits whole (head + continuation).
+    var dst = try Surface.init(testing.allocator, 2, 1);
+    defer dst.deinit();
+    try dst.root().copyRows(&src, 0);
+
+    try testing.expectEqual(@as(u8, 2), dst.cell(0, 0).width);
+    try testing.expect(dst.cell(1, 0).isContinuation());
+    try testing.expectEqualStrings("你", dst.cellText(dst.cell(0, 0)));
 }
 
 test "styleEql compares hex colors by content" {


### PR DESCRIPTION
## Problem

`Region.copyRows` (packages/ui/src/surface.zig) copies `@min(rect.w, src.width)` columns using `putCell`, which sets cells verbatim and — unlike `put` — applies no wide-char straddle guard. When the clip boundary falls between a wide grapheme's head (width 2) and its continuation (width 0), only the head is copied, leaving a **torn wide head**: a width-2 cell with no continuation to its right.

The diff renderer then does `if (next.cell(last, row).width == 2) last += 1;` (packages/ui/src/diff.zig) with no bound check, so a torn head at the last column would push the paint span past the surface edge.

Latent today: the sole caller (viewport, ui.zig) keeps `src.width == rect.w`, but the API documents a wider source, so the next caller would trip it.

## Fix

- **copyRows**: when the last copied column holds a wide head whose continuation is clipped off (`c.width == 2 and x + 1 >= cols`), dissolve it to a styled blank via `blankAt` instead of copying the torn head.
- **diff**: bound-check the wide-span extension (`last + 1 < next.width` before `last += 1`) as defense in depth, so `last` can never address column `width`.

## Testing

- `zig build test` (repo root): all packages pass.
- `packages/ui` `zig build test`: 178/178 tests pass.
- `zig build e2e`: pass (ui rendering touched).
- New regression test `copyRows blanks a wide grapheme torn by the clip boundary` fails before the fix (leaves a torn width-2 cell) and passes after; companion test confirms a wide grapheme that fits within the clip is preserved whole.

Note: the diff-renderer OOB is not independently reproducible as a crash — `emitCells` steps by cell width and jumps over the phantom column — so the bound-check is correct defense-in-depth (per the issue's fix sketch) rather than a separately failing case. The included diff test asserts in-bounds handling of a synthesized torn head.

Fixes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4