### PR TITLE
scaffold: reject Zig reserved words in command paths and project names (#437)

### DIFF
--- a/projects/zcli/src/commands/add/_wizard.zig
+++ b/projects/zcli/src/commands/add/_wizard.zig
@@ -161,8 +161,12 @@ fn resolveCommandPath(
         };
         seed_opt = null;
 
-        const parts = parsePath(arena, raw) catch {
-            try warn(w, theme, "  Use letters, digits, '_' and '/' (e.g. users/create).");
+        const parts = parsePath(arena, raw) catch |e| {
+            const msg = switch (e) {
+                error.ReservedCommandPath => "  That path uses a Zig keyword \u{2014} pick another name.",
+                else => "  Use letters, digits, '_' and '/' (e.g. users/create).",
+            };
+            try warn(w, theme, msg);
             try w.writeAll("\r\n");
             continue;
         };

--- a/projects/zcli/src/commands/add/command.zig
+++ b/projects/zcli/src/commands/add/command.zig
@@ -69,8 +69,9 @@ fn skeleton(arena: std.mem.Allocator, context: *Context, args: Args, options: Op
         return context.fail("Error: A command path is required when input is not interactive\nUsage: zcli add command <path> [--description \"...\"]", .{});
     };
 
-    const parts = parsePath(arena, raw_path) catch {
-        return context.fail("Error: Invalid command path: '{s}'", .{raw_path});
+    const parts = parsePath(arena, raw_path) catch |e| switch (e) {
+        error.ReservedCommandPath => return context.fail("Error: Command path uses a Zig reserved word: '{s}'\n  Reserved words compile to invalid identifiers in the generated registry.", .{raw_path}),
+        else => return context.fail("Error: Invalid command path: '{s}'", .{raw_path}),
     };
 
     const file_path = try buildFilePath(arena, parts);

--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const zcli = @import("zcli");
 const Context = @import("command_registry").Context;
+const scaffold = @import("scaffold");
 
 /// A built-in plugin the user can opt into during `init`. `tag` is the enum
 /// tag passed to `zcli.builtin(.<tag>, <config>)` in the generated build.zig;
@@ -115,6 +116,13 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         break :blk sanitized;
     };
     defer allocator.free(project_identifier);
+
+    // The identifier lands in build.zig.zon as `.name = .<identifier>` — an enum
+    // literal. A Zig keyword there produces uncompilable generated source, so
+    // reject reserved words up front.
+    if (scaffold.spec.isReservedWord(project_identifier)) {
+        return context.fail("Error: Invalid project name '{s}'{s}\n  '{s}' is a Zig reserved word and cannot be used as a package name", .{ project_name, name_origin, project_identifier });
+    }
 
     // Free-text options are embedded in generated string literals — escape so
     // `--description 'say "hi"'` scaffolds a project that still compiles

--- a/projects/zcli/src/scaffold/spec.zig
+++ b/projects/zcli/src/scaffold/spec.zig
@@ -251,6 +251,10 @@ pub fn parsePath(arena: std.mem.Allocator, raw: []const u8) ![]const []const u8 
     while (it.next()) |segment| {
         if (segment.len == 0) continue;
         if (!isValidIdentifier(segment)) return error.InvalidCommandPath;
+        // A segment becomes a bare identifier in generated code (import name,
+        // struct field, file stem). Zig keywords compile fine as file names but
+        // break the generated registry — refuse them up front.
+        if (isReservedWord(segment)) return error.ReservedCommandPath;
         // Underscore-prefixed names are helper files/dirs to command
         // discovery, never commands — refuse to scaffold one.
         if (segment[0] == '_') return error.InvalidCommandPath;
@@ -404,6 +408,19 @@ test "parsePath rejects underscore-prefixed segments (discovery treats them as h
 
     try testing.expectError(error.InvalidCommandPath, parsePath(a, "_wizard"));
     try testing.expectError(error.InvalidCommandPath, parsePath(a, "users/_create"));
+}
+
+test "parsePath rejects Zig reserved words (would break generated registry)" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    try testing.expectError(error.ReservedCommandPath, parsePath(a, "error"));
+    try testing.expectError(error.ReservedCommandPath, parsePath(a, "fn"));
+    try testing.expectError(error.ReservedCommandPath, parsePath(a, "users/struct"));
+    // A keyword substring is fine — only exact keywords are rejected.
+    const ok = try parsePath(a, "errors/structure");
+    try testing.expectEqual(@as(usize, 2), ok.len);
 }
 
 test "parsePath accepts slash and space separators" {

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -297,6 +297,19 @@ test "init rejects a project name that would break generated source" {
     try testing.expect(!fileExists(tmp.dir, "bad\"name"));
 }
 
+test "init rejects a Zig reserved word as the project name" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // `error` is a keyword: `.name = .error` in build.zig.zon won't compile.
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "error" });
+    defer r.deinit();
+    try testing.expect(r.exit_code != 0);
+    try expectContains(r.stderr, "Invalid project name");
+    try expectContains(r.stderr, "reserved word");
+    try testing.expect(!fileExists(tmp.dir, "error"));
+}
+
 test "init . scaffolds into the current directory" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();


### PR DESCRIPTION
## Problem

`parsePath` (scaffold/spec.zig) validated command-path segments with `isValidIdentifier` only, while `normalizeName` additionally rejected reserved words via `isReservedWord`. As a result:

- `zcli add command struct` → scaffolded a command named after a keyword.
- `zcli init error` → wrote `.name = .error` into `build.zig.zon`, an enum literal spelled with a keyword that fails to compile downstream.

## Fix

- `parsePath` now rejects reserved-word segments with `error.ReservedCommandPath`. The non-interactive `add command` skeleton and the interactive wizard both surface a clear "Zig keyword" message instead of the generic invalid-path hint.
- `init` rejects a reserved-word project identifier up front (the identifier is what lands in the zon `.name` enum literal), reusing `scaffold.spec.isReservedWord`.

Note: the issue also cited `zcli add command type`. `type` is a Zig primitive-type name, not a keyword in `isReservedWord`'s list, and generated command module names are prefixed (`cmd_<name>`), so command files themselves no longer break on it. This change follows the issue's fix sketch (apply `isReservedWord`) which covers the real breakage — bare keywords like `error`/`struct`/`fn` — and the `.name = .error` init case.

## Testing

- `zig build test` (root) — pass
- `cd projects/zcli && zig build && zig build test && zig build e2e` — pass
- Added unit test `parsePath rejects Zig reserved words` in scaffold/spec.zig
- Added e2e test `init rejects a Zig reserved word as the project name`

Fixes #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4