### PR TITLE
progress: key TTY detection to the writer's own target (#444)

### DIFF
--- a/packages/progress/src/Progress.zig
+++ b/packages/progress/src/Progress.zig
@@ -40,7 +40,9 @@
 //! In a zcli command, `context.progress()` returns an instance pre-wired to the
 //! command's stderr, `io`, arena allocator, and theme. Progress goes to stderr
 //! by convention so it survives stdout redirection (`myapp | tee`) while keeping
-//! piped stdout clean; interactivity keys on whether stderr is a TTY.
+//! piped stdout clean. Interactivity keys on the `writer`'s own target when its
+//! handle is recoverable (a standalone user writing to stdout gets it right),
+//! falling back to stderr otherwise.
 
 writer: *std.Io.Writer,
 /// The framework's `std.Io` — powers each indicator's `ui.App` (animation
@@ -87,6 +89,28 @@ pub fn progressBar(self: Progress, config: ProgressBarConfig) !ProgressBar {
 /// writer, `io`, allocator, and theme.
 pub fn multiBar(self: Progress, config: MultiBarConfig) !MultiBar {
     return MultiBar.init(self.allocator, self.writer, self.io, self.theme, config);
+}
+
+/// Recover the OS handle behind `writer` when it is a `std.Io.File.Writer`
+/// interface (the common case: stdout/stderr streams). Discriminates by vtable
+/// so it never `@fieldParentPtr`s a foreign writer (e.g. `Allocating`, `fixed`).
+fn writerHandle(writer: *std.Io.Writer) ?std.Io.File.Handle {
+    if (writer.vtable.drain != std.Io.File.Writer.drain) return null;
+    const file_writer: *const std.Io.File.Writer = @fieldParentPtr("interface", writer);
+    return file_writer.file.handle;
+}
+
+/// Whether animation should run: key interactivity to the writer's own target
+/// when we can recover its handle, falling back to stderr when we can't.
+fn writerInteractive(writer: *std.Io.Writer) bool {
+    if (writerHandle(writer)) |handle| return terminal.isTty(handle);
+    return terminal.isStderrTty();
+}
+
+/// The handle the App polls for terminal state (size, TTY probes): the writer's
+/// own handle when determinable, else stderr — matching `writerInteractive`.
+fn writerOutHandle(writer: *std.Io.Writer) std.Io.File.Handle {
+    return writerHandle(writer) orelse std.Io.File.stderr().handle;
 }
 
 /// Spinner animation styles
@@ -177,8 +201,8 @@ pub const Spinner = struct {
             .app = try ui.App.init(allocator, writer, .{
                 .capability = theme.capability(),
                 .unicode = config.unicode,
-                .interactive = terminal.isStderrTty(),
-                .out_handle = std.Io.File.stderr().handle,
+                .interactive = writerInteractive(writer),
+                .out_handle = writerOutHandle(writer),
             }),
         };
     }
@@ -371,8 +395,8 @@ pub const ProgressBar = struct {
             .app = try ui.App.init(allocator, writer, .{
                 .capability = theme.capability(),
                 .unicode = config.unicode,
-                .interactive = terminal.isStderrTty(),
-                .out_handle = std.Io.File.stderr().handle,
+                .interactive = writerInteractive(writer),
+                .out_handle = writerOutHandle(writer),
             }),
             .start_time = nowMsIo(io),
         };
@@ -548,8 +572,8 @@ pub const MultiBar = struct {
             .app = try ui.App.init(allocator, writer, .{
                 .capability = theme.capability(),
                 .unicode = config.unicode,
-                .interactive = terminal.isStderrTty(),
-                .out_handle = std.Io.File.stderr().handle,
+                .interactive = writerInteractive(writer),
+                .out_handle = writerOutHandle(writer),
             }),
         };
     }
@@ -656,6 +680,26 @@ const testing = std.testing;
 fn forceInteractive(app: *ui.App) void {
     app.options.interactive = true;
     app.options.term_size = .{ .w = 80, .h = 24 };
+}
+
+test "writerHandle discriminates file writers from foreign writers" {
+    // A `fixed` writer (foreign vtable) has no OS handle to recover.
+    var buf: [64]u8 = undefined;
+    var fixed: std.Io.Writer = .fixed(&buf);
+    try testing.expect(writerHandle(&fixed) == null);
+    // Interactivity/out-handle fall back to stderr when the handle is unknown.
+    try testing.expectEqual(writerInteractive(&fixed), terminal.isStderrTty());
+    try testing.expectEqual(writerOutHandle(&fixed), std.Io.File.stderr().handle);
+
+    // A real file writer exposes its target handle, so interactivity keys on
+    // that stream rather than always stderr.
+    var stream_buf: [64]u8 = undefined;
+    var file_writer = std.Io.File.stderr().writerStreaming(testing.io, &stream_buf);
+    const handle = writerHandle(&file_writer.interface);
+    try testing.expect(handle != null);
+    try testing.expectEqual(std.Io.File.stderr().handle, handle.?);
+    try testing.expectEqual(std.Io.File.stderr().handle, writerOutHandle(&file_writer.interface));
+    try testing.expectEqual(terminal.isTty(std.Io.File.stderr().handle), writerInteractive(&file_writer.interface));
 }
 
 test "spinner style frames" {


### PR DESCRIPTION
## Problem

In `packages/progress`, TTY detection was hardcoded to stderr in all three indicator constructors (`Spinner`, `ProgressBar`, `MultiBar`), regardless of where the bundle's `writer` field actually points:

```zig
.interactive = terminal.isStderrTty(),
.out_handle = std.Io.File.stderr().handle,
```

`writer` is a free field, so a standalone package consumer can set `writer = stdout`. When stdout is piped while stderr is a TTY, they got animation escapes in the piped output; the inverse (stdout is a TTY, stderr redirected) silently disabled animation. In-tree usage always writes to stderr, so this only bit standalone consumers.

## Fix

Recover the writer's own OS handle when it is a `std.Io.File.Writer` interface and key both `interactive` and `out_handle` to it, falling back to stderr when the handle can't be determined (per the issue's fix sketch):

- `writerHandle` discriminates by comparing `writer.vtable.drain` against `std.Io.File.Writer.drain`, so a foreign writer (`Allocating`, `fixed`) is never `@fieldParentPtr`'d — it returns `null` and the callers fall back to stderr.
- `writerInteractive` / `writerOutHandle` wrap that with the stderr fallback.

In-tree behavior (stderr writer) is unchanged.

## Testing

- Added unit test `writerHandle discriminates file writers from foreign writers`: a `fixed` writer yields `null` (fallback to stderr for both interactivity and out-handle); a real `std.Io.File.stderr().writerStreaming(...)` writer yields the stderr handle and keys interactivity to `terminal.isTty(handle)`.
- `zig build test` at repo root: **EXITCODE=0** — all in-process package tests plus every subproject (zcli, tasks, repostat, ghauth, notes, vault, ...) passed.

The end-to-end TTY-vs-pipe distinction cannot be exercised in unit tests (no real TTY in CI); the unit test instead verifies the handle-recovery logic that drives it.

Fixes #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4