### PR TITLE
docs: correct stale ROADMAP/TODOS claims (#450)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -138,12 +138,13 @@ regret freezing around." **1.0 is deliberately not scheduled.** 0.20 shipped
   [minisign](https://jedisct1.github.io/minisign/) key ([ADR-0023](docs/adr/0023-release-signing-minisign.md));
   `install.sh` and `zcli upgrade` verify fail-closed. The install/upgrade path
   freezes with publisher-level integrity already in place.
+- **Split the unit-testing tier out of `testing`** (TODOS). `unit.zig` is now its
+  own module (`zcli_testing_unit`); the `testing` module no longer drags
+  zcli/vterm/serde into subprocess/PTY-only consumers. The public `zcli-testing`
+  import name is unchanged.
 
 **NON-blockers (fine to defer past 1.0 — all additive or internal):**
 
-- **Split the unit-testing tier out of `testing`** (TODOS). Internal dependency
-  hygiene; a module split can happen in any 1.x without breaking the public
-  `zcli-testing` API.
 - **Re-pressure-test config formats / HTML doc-gen** (TODOS). Scope-boundary
   review, not a compatibility issue.
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -136,5 +136,6 @@ Implemented via [ADR-0023](docs/adr/0023-release-signing-minisign.md): `checksum
 signed with a minisign (Ed25519) key held offline (never in CI), verified against a pinned
 public key in both `install.sh` (verify-if-able, checksum fail-closed) and the
 `zcli_github_upgrade` plugin (pure-Zig `std.crypto` verify, fail closed). Ceremony, custody,
-rotation, and compromise procedure: `docs/RELEASE-SIGNING.md`. Only remaining step is the
-one-time keygen ceremony to mint and pin zcli's production key.
+rotation, and compromise procedure: `docs/RELEASE-SIGNING.md`. The production key has been
+minted and pinned (key id 1638B69B8EF680FD): `projects/zcli/build.zig` (upgrade plugin) and
+`install.sh` both carry the real public key, and `docs/zcli-minisign.pub` holds the full key.


### PR DESCRIPTION
## Problem

Two stale documentation claims flagged by grade8 repo review (#450):

1. **ROADMAP.md** listed "Split the unit-testing tier out of `testing`" as a pending NON-blocker for 1.0 — but the split already shipped. `packages/testing/build.zig` splits `testing`/`unit`/`e2e` into separate modules, and `TODOS.md:122-131` already marks it DONE.
2. **TODOS.md** "Sign releases" section said the one-time keygen ceremony was "the only remaining step" — false. The production key (id `1638B69B8EF680FD`) is pinned live in `projects/zcli/build.zig:91`, `install.sh:28`, and `docs/zcli-minisign.pub`.

## Fix

- ROADMAP: moved the unit-testing-tier bullet from NON-blockers to "Already landed", describing the shipped state.
- TODOS: replaced the "only remaining step is keygen" sentence with a note that the key is minted and pinned, citing the pin sites.

Verified each claim against the code/files before editing (build.zig module split, build.zig/install.sh key pins, non-empty pubkey file).

## Testing

- `zig build test` at repo root — all example/project test suites pass. Docs-only change; no new test needed.

Fixes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4