### PR TITLE
testing/e2e: drain trailing ConPTY burst after child exit (#446)

### DIFF
--- a/packages/testing/src/conpty.zig
+++ b/packages/testing/src/conpty.zig
@@ -386,3 +386,54 @@ test "ConPTY smoke: spawn, read output, clean exit (#404)" {
     try std.testing.expect(std.mem.indexOf(u8, out.items, "conpty-smoke") != null);
     try std.testing.expectEqual(@as(?u8, 0), session.waitExit(5000));
 }
+
+test "ConPTY drain-after-exit captures a trailing output burst (#446)" {
+    // Regression for the exit-drain: the driver used to break out of the drain
+    // loop the moment waitExit(0) reported the child gone, even though conhost
+    // renders on its own thread and can still be flushing a final burst into the
+    // output pipe. This drives the same pattern as runInteractiveWindows' drain
+    // (pollRead until empty, then on exit keep draining until the pipe reports
+    // nothing) and asserts the LAST line — the tail of a large burst that exits
+    // immediately after — is present. The race is inherently timing-dependent
+    // and cannot be forced deterministically, so this guards against gross
+    // regressions (draining removed → large-burst truncation) rather than the
+    // exact millisecond window.
+    if (builtin.os.tag != .windows) return;
+    const alloc = std.testing.allocator;
+
+    // A big burst (many lines) that outruns the pipe buffer, ending in a unique
+    // sentinel, immediately followed by process exit.
+    var session = try ConPtySession.spawn(
+        alloc,
+        &.{ "cmd.exe", "/c", "for /L %i in (1,1,600) do @echo zcli-drain-line-%i" },
+        null,
+        null,
+        24,
+        80,
+    );
+    defer session.deinit(alloc);
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+    var buf: [4096]u8 = undefined;
+
+    // Mirror the fixed drain loop from runInteractiveWindows exactly.
+    var attempts: usize = 0;
+    drain: while (attempts < 500) : (attempts += 1) {
+        const n = session.pollRead(&buf, 50);
+        if (n > 0) {
+            try out.appendSlice(alloc, buf[0..n]);
+            continue;
+        }
+        if (session.waitExit(0)) |_| {
+            while (true) {
+                const remaining = session.pollRead(&buf, 50);
+                if (remaining == 0) break;
+                try out.appendSlice(alloc, buf[0..remaining]);
+            }
+            break :drain;
+        }
+    }
+
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "zcli-drain-line-600") != null);
+}

--- a/packages/testing/src/e2e.zig
+++ b/packages/testing/src/e2e.zig
@@ -1428,6 +1428,19 @@ fn runInteractiveWindows(
         }
         if (cp.waitExit(0)) |code| {
             exit_code = code;
+            // The process object has signaled, but ConPTY's conhost renders the
+            // child's console on its own thread and may still be flushing a final
+            // burst of VT into the output pipe. waitExit reports the process, not
+            // the pipe, and a single empty 50ms pollRead window above is not proof
+            // the pipe is drained. Keep reading until a full window elapses with
+            // nothing available (PeekNamedPipe reporting 0 / broken pipe) so a
+            // trailing write is never dropped — the ConPTY analogue of the POSIX
+            // drain-to-HUP edge.
+            while (true) {
+                const remaining = cp.pollRead(&temp_buffer, 50);
+                if (remaining == 0) break;
+                try output_buffer.appendSlice(allocator, temp_buffer[0..remaining]);
+            }
             break;
         }
         const elapsed: u64 = @intCast(nowMs(io) - start_time);


### PR DESCRIPTION
## Problem

The Windows interactive e2e drain loop (`runInteractiveWindows`, `packages/testing/src/e2e.zig`) broke out of its drain loop the moment `waitExit(0)` reported the child gone. But ConPTY's conhost renders the child's console on its own thread and can still be flushing a final burst of rendered VT into the output pipe *after* the process object signals exit. A single empty 50 ms `pollRead` window is not proof the pipe is drained — so a trailing output burst at child exit could be dropped from the captured output.

`pollRead` conflates timeout / empty / broken-pipe (all return 0), and the POSIX path has the drain-to-HUP edge that the Windows path lacked.

## Fix

After exit is confirmed (`waitExit(0)` returns a code), keep draining until `pollRead` returns 0 across a full 50 ms poll window — i.e. `PeekNamedPipe` reports 0 bytes available (or the pipe is broken). This is the ConPTY analogue of the POSIX drain-to-HUP edge, and guarantees the final write is captured before the loop breaks.

Scope is strictly the ConPTY exit-drain; the snapshot settle heuristic (#447) is untouched.

## Testing

- `zig build test` (repo root) — PASS
- `zig build e2e` (repo root) — PASS
- `packages/testing`: `zig build test` — PASS; `zig build test -Dtarget=x86_64-windows` compiles+links the Windows path (only host-can't-execute at run stage)
- `zig test conpty.zig -target x86_64-windows --test-no-exec` — PASS (Windows path compiles)
- Added a Windows-only regression test `ConPTY drain-after-exit captures a trailing output burst (#446)` in `conpty.zig` that drives the exact fixed drain pattern against a large burst that exits immediately, asserting the tail line is captured.

Note: the underlying race is inherently timing-dependent and Windows-only (dev box is macOS), so a deterministic fail-before test is not feasible. The added test guards against gross regressions (draining removed → large-burst truncation) and runs on Windows CI; the pure-logic path also cross-compiles clean.

Fixes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4