### PR TITLE
docs: correct core README ADR range to 0001-0027 (#451)

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -49,4 +49,4 @@ All of these also run from the repo root: `zig build test-core` aggregates the `
 - [docs/DESIGN.md](../../docs/DESIGN.md) — architecture and runtime design
 - [docs/BUILD.md](../../docs/BUILD.md) — the codegen pipeline
 - [zcli.sh/testing](https://zcli.sh/testing/) — the testing tiers
-- [docs/adr/](../../docs/adr/) — the decision record (0001–0009)
+- [docs/adr/](../../docs/adr/) — the decision record (0001–0027)


### PR DESCRIPTION
## Problem
`packages/core/README.md:52` cited the ADR decision record as "(0001–0009)", but `docs/adr/` now contains 27 records (0001–0027). Cosmetic docs drift flagged by the grade8 repo review (#451).

## Fix
Update the range to `(0001–0027)` to match the actual ADR set.

The second half of #451 — `docs/BUILD.md` omitting the `onStartup` lifecycle hook — was already resolved by #428/#461 (commit a1cf1c9, now on main); the hook is present at BUILD.md:150. No further change needed there, so this PR touches only the README line.

## Testing
- `zig build test` at repo root: all package + example test suites pass, no errors.

Fixes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4