### PR TITLE
ci: add per-job timeout-minutes; deflake edit-distance resource test (#449)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
   fmt:
     name: zig fmt check
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -72,6 +73,7 @@ jobs:
   version-sync:
     name: version consistency
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -151,6 +153,7 @@ jobs:
   test:
     name: unit tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -195,6 +198,7 @@ jobs:
   windows-release-build:
     name: windows release build
     runs-on: windows-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -227,6 +231,7 @@ jobs:
   linux-musl-release-build:
     name: linux musl release build (${{ matrix.zig_target }})
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -273,6 +278,7 @@ jobs:
   secrets:
     name: zcli_secrets backend (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -365,6 +371,7 @@ jobs:
   examples:
     name: canonical examples compile
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -398,6 +405,7 @@ jobs:
   e2e:
     name: zcli end-to-end tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # Every deploy republishes install.sh/install.ps1 — the curl|sh trust root —
     # so the job is gated behind a protected environment with required reviewers
     # (grade6 #293). Inert until the "docs-deploy" environment is created in

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
   setup:
     name: Resolve release plan
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
     outputs:
@@ -155,6 +156,7 @@ jobs:
   test:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     needs: setup
     if: needs.setup.outputs.do_cli == 'true' || needs.setup.outputs.do_lib == 'true'
     strategy:
@@ -190,6 +192,7 @@ jobs:
   build:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     needs: [setup, test]
     if: needs.setup.outputs.do_cli == 'true'
     strategy:
@@ -301,6 +304,7 @@ jobs:
   finalize:
     name: Promote staged release to main
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [setup, build]
     if: github.event_name == 'workflow_dispatch'
     environment: release
@@ -349,6 +353,7 @@ jobs:
 
   release:
     name: Create Release
+    timeout-minutes: 15
     needs: [setup, build, finalize]
     if: |
       always() &&
@@ -420,6 +425,7 @@ jobs:
 
   library-release:
     name: Create Library Release
+    timeout-minutes: 15
     needs: [setup, test, finalize]
     if: |
       always() &&

--- a/packages/core/src/security_test.zig
+++ b/packages/core/src/security_test.zig
@@ -269,19 +269,18 @@ test "security: resource limits - absurd option names are rejected" {
     );
 }
 
-test "security: resource exhaustion - processing time limits" {
+test "security: resource exhaustion - processing bounded regardless of input" {
     const allocator = testing.allocator;
 
-    const io = std.testing.io;
-    const start = std.Io.Timestamp.now(io, .awake);
-
-    // Test that the edit-distance kernel (the core of suggestion matching) has
-    // reasonable performance across many candidates.
+    // Score many candidates against a typo, mirroring the suggestion hot loop,
+    // and assert it completes with a well-defined result. (This deliberately
+    // does NOT assert on wall-clock time: an elapsed-time bound flakes on a
+    // loaded CI runner. The resource-exhaustion guard below is what actually
+    // matters, and it's deterministic.)
     const command_count = 50; // Reasonable test size
     const similar_commands = try generateSimilarStrings(allocator, command_count, "command");
     defer freeSimilarStrings(allocator, similar_commands);
 
-    // Score every candidate against a typo, mirroring the suggestion hot loop.
     var closest: usize = std.math.maxInt(usize);
     for (similar_commands) |candidate| {
         const distance = levenshtein.editDistance("commnd", candidate);
@@ -289,10 +288,37 @@ test "security: resource exhaustion - processing time limits" {
     }
     try testing.expect(closest != std.math.maxInt(usize));
 
-    const elapsed = start.untilNow(io, .awake).nanoseconds;
+    // The real DoS guard: the edit-distance kernel is O(m*n), so attacker-
+    // controlled input length must NOT translate into unbounded work. The
+    // kernel caps each operand to max_practical_len (256) before filling the
+    // matrix, so the matrix it fills is bounded by 256*256 no matter how long
+    // the inputs are. Verify that cap deterministically: the distance computed
+    // over a megabyte-long input must equal the distance over its first 256
+    // bytes — i.e. everything past the cap is ignored, so there is no O(m*n)
+    // blow-up on huge inputs. (No wall clock involved.)
+    const cap = 256;
+    const huge = try allocator.alloc(u8, 1024 * 1024);
+    defer allocator.free(huge);
+    @memset(huge, 'a');
 
-    // Should complete within reasonable time (1 second for testing)
-    try testing.expect(elapsed < 1000 * std.time.ns_per_ms);
+    // A short query against a huge candidate (both operand orderings).
+    try testing.expectEqual(
+        levenshtein.editDistance("commnd", huge[0..cap]),
+        levenshtein.editDistance("commnd", huge),
+    );
+    try testing.expectEqual(
+        levenshtein.editDistance(huge[0..cap], "commnd"),
+        levenshtein.editDistance(huge, "commnd"),
+    );
+
+    // Two huge strings: only the first 256 bytes of each can matter.
+    const huge2 = try allocator.alloc(u8, 1024 * 1024);
+    defer allocator.free(huge2);
+    @memset(huge2, 'b');
+    try testing.expectEqual(
+        levenshtein.editDistance(huge[0..cap], huge2[0..cap]),
+        levenshtein.editDistance(huge, huge2),
+    );
 }
 
 // ============================================================================


### PR DESCRIPTION
## Problem

Two findings from the grade8 repo review (#449):

1. **No `timeout-minutes` on any CI job.** None of `ci.yml`, `release.yml`, or `deploy-docs.yml` set a per-job timeout, so a hung test or download runs to the 360-minute GitHub runner default before failing — a consumer-style hang in CI would burn 6 hours.
2. **One wall-clock timing assertion can flake.** `security_test.zig`'s "resource exhaustion - processing time limits" test asserted `elapsed < 1000ms` for a 50-candidate levenshtein loop — a wall-clock bound that flakes on a slow/loaded runner.

## Fix

**Timeouts** — added `timeout-minutes` to every job:
- `ci.yml`: fmt/version-sync 10; test/e2e 30; windows-release/musl/secrets/examples 20.
- `release.yml`: setup/finalize/release/library-release 15; test 30; build 20.
- `deploy-docs.yml`: deploy 15.

(The environment-gated jobs' timeouts don't include the required-reviewer wait — GitHub only starts the clock once the job begins executing.)

**Flaky timing test** — replaced the wall-clock assertion with a deterministic complexity-bound check. `editDistance` caps each operand to `max_practical_len` (256) before filling its matrix, so work is bounded regardless of input length. The new assertion proves that guard directly: the distance computed over a megabyte-long input equals the distance over its first 256 bytes (both operand orderings, plus two huge strings). No wall clock involved.

This is a stronger security assertion than the old one (it verifies the actual DoS guard, not just "it ran fast this time"), and it's load-independent.

### Deviation from the issue's fix sketch
The sketch offered either "raise the bound generously" or "convert to an operation-count/complexity bound." I took the complexity-bound route because raising a wall-clock bound only reduces flake probability, while the truncation-equivalence check removes the wall-clock dependency entirely and tests the real property (bounded work).

## Testing
- `zig build test` at repo root — all package + example suites pass (including the rewritten security test).
- All three workflow files parse as valid YAML (ruby YAML.load_file).

Fixes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4