### PR TITLE
args: report accepted-count range in ArgumentTooMany diagnostic (#453)

### DIFF
--- a/packages/core/src/args.zig
+++ b/packages/core/src/args.zig
@@ -199,7 +199,8 @@ fn parseArgsInternal(comptime ArgsType: type, args: []const []const u8, diag: ?*
     // Check if there are too many arguments (only if no varargs field)
     if (!hasVarArgs(ArgsType) and arg_index < args.len) {
         if (diag) |d| d.* = .{ .ArgumentTooMany = .{
-            .expected_count = getRequiredArgCount(ArgsType),
+            .min_count = getRequiredArgCount(ArgsType),
+            .max_count = getMaxArgCount(ArgsType),
             .actual_count = args.len,
         } };
         return ZcliError.ArgumentTooMany;
@@ -301,6 +302,22 @@ fn getRequiredArgCount(comptime T: type) usize {
     var count: usize = 0;
     inline for (type_info.@"struct".fields) |field| {
         if (!isVarArgs(field.type) and @typeInfo(field.type) != .optional) {
+            count += 1;
+        }
+    }
+    return count;
+}
+
+/// Count the maximum number of accepted positional arguments: every
+/// non-varargs field, whether required, optional, or defaulted. This is the
+/// upper bound reported by the `ArgumentTooMany` diagnostic.
+fn getMaxArgCount(comptime T: type) usize {
+    const type_info = @typeInfo(T);
+    if (type_info != .@"struct") return 0;
+
+    var count: usize = 0;
+    inline for (type_info.@"struct".fields) |field| {
+        if (!isVarArgs(field.type)) {
             count += 1;
         }
     }
@@ -1012,5 +1029,21 @@ test "diagnostics: argument error sites fill precise context" {
         const args = [_][]const u8{ "one", "two" };
         try std.testing.expectError(ZcliError.ArgumentTooMany, parseArgs(Exact, &args, &diag));
         try std.testing.expectEqual(@as(usize, 2), diag.?.ArgumentTooMany.actual_count);
+        // No optional positionals: min == max == the single required field.
+        try std.testing.expectEqual(@as(usize, 1), diag.?.ArgumentTooMany.min_count);
+        try std.testing.expectEqual(@as(usize, 1), diag.?.ArgumentTooMany.max_count);
+    }
+
+    // Too many arguments with an optional positional: the accepted count is a
+    // range (1 required, up to 2 with the optional). Regression for #453 where
+    // the diagnostic under-reported the max as the required count.
+    {
+        const Range = struct { a: []const u8, b: ?[]const u8 = null };
+        var diag: ?ZcliDiagnostic = null;
+        const args = [_][]const u8{ "one", "two", "three" };
+        try std.testing.expectError(ZcliError.ArgumentTooMany, parseArgs(Range, &args, &diag));
+        try std.testing.expectEqual(@as(usize, 3), diag.?.ArgumentTooMany.actual_count);
+        try std.testing.expectEqual(@as(usize, 1), diag.?.ArgumentTooMany.min_count);
+        try std.testing.expectEqual(@as(usize, 2), diag.?.ArgumentTooMany.max_count);
     }
 }

--- a/packages/core/src/diagnostic_errors.zig
+++ b/packages/core/src/diagnostic_errors.zig
@@ -63,7 +63,12 @@ pub const ZcliDiagnostic = union(enum) {
         reason: ?[]const u8 = null,
     },
     ArgumentTooMany: struct {
-        expected_count: usize,
+        /// Minimum accepted positional count (required args only).
+        min_count: usize,
+        /// Maximum accepted positional count (required + optional + defaulted,
+        /// excluding varargs). Equals `min_count` when there are no optional
+        /// positionals.
+        max_count: usize,
         actual_count: usize,
     },
     /// A positional arg's `meta.args.<field>.validate` rejected the parsed value.
@@ -347,7 +352,10 @@ pub fn formatDiagnostic(diagnostic: ZcliDiagnostic, allocator: std.mem.Allocator
             std.fmt.allocPrint(allocator, "Invalid value '{s}' for argument '{s}' at position {d}. Expected {s}. Did you mean '{s}'?", .{ ctx.provided_value, ctx.field_name, ctx.position + 1, humanType(ctx.expected_type), s })
         else
             std.fmt.allocPrint(allocator, "Invalid value '{s}' for argument '{s}' at position {d}. Expected {s}.", .{ ctx.provided_value, ctx.field_name, ctx.position + 1, humanType(ctx.expected_type) }),
-        .ArgumentTooMany => |ctx| std.fmt.allocPrint(allocator, "Too many arguments provided. Expected {d} arguments, got {d}", .{ ctx.expected_count, ctx.actual_count }),
+        .ArgumentTooMany => |ctx| if (ctx.max_count == ctx.min_count)
+            std.fmt.allocPrint(allocator, "Too many arguments provided. Expected {d} arguments, got {d}", .{ ctx.max_count, ctx.actual_count })
+        else
+            std.fmt.allocPrint(allocator, "Too many arguments provided. Expected {d}-{d} arguments, got {d}", .{ ctx.min_count, ctx.max_count, ctx.actual_count }),
         .ArgumentValidationFailed => |ctx| std.fmt.allocPrint(allocator, "Invalid value '{s}' for argument '{s}' at position {d}: {s}.", .{ ctx.provided_value, ctx.field_name, ctx.position + 1, ctx.reason }),
         .OptionUnknown => |ctx| blk: {
             const base_msg = try std.fmt.allocPrint(allocator, "Unknown option '{s}{s}'", .{ if (ctx.is_short) "-" else "--", ctx.option_name });


### PR DESCRIPTION
## Problem

`packages/core/src/args.zig` filled the `ArgumentTooMany` diagnostic's `expected_count` from `getRequiredArgCount`, which excludes optional/defaulted positionals. For `Args{ a: []const u8, b: ?[]const u8 }` given 3 args, the error correctly fired but said "expected 1" even though 2 positionals are accepted — misleading whenever optional positionals exist.

## Fix

Report a range instead of a single count:
- `min_count` — required positionals only (`getRequiredArgCount`)
- `max_count` — all non-varargs fields (new `getMaxArgCount`)

The renderer in `diagnostic_errors.zig` prints "Expected N arguments" when `min == max` (unchanged wording for the common case) and "Expected M-N arguments" when a range exists.

## Testing

- `zig build test` at repo root — all packages pass, no errors.
- Added a regression case to the "argument error sites fill precise context" test in `args.zig`: an `Args{ a, b: ?[]const u8 }` with 3 args now asserts `min_count == 1`, `max_count == 2`; the existing single-required case asserts `min == max == 1`.

Fixes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4