### PR TITLE
discovery: follow symlinked commands, hard-error on too-deep trees (#455)

### DIFF
--- a/packages/core/src/build_integration_test.zig
+++ b/packages/core/src/build_integration_test.zig
@@ -149,21 +149,18 @@ test "build integration: empty directories and edge cases" {
     try testing.expect(no_index.subcommands.?.contains("subcmd"));
 }
 
-test "build integration: maximum nesting depth" {
+test "build integration: within the nesting depth limit" {
     const io = testing.io;
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
 
     // Within the depth limit (6): discovered.
     try writeNested(tmp.dir, io, "level1/level2/level3/level4/level5/cmd.zig", placeholder);
-    // Beyond the limit: the whole chain ends up empty and is dropped.
-    try writeNested(tmp.dir, io, "deep/l1/l2/l3/l4/l5/l6/l7/ignored.zig", placeholder);
 
     var discovered = try discover(&tmp);
     defer discovered.deinit();
 
     try testing.expect(discovered.root.contains("level1"));
-    try testing.expect(!discovered.root.contains("deep"));
 
     // The command at level5 is reachable through the group chain.
     var current = discovered.root.get("level1").?;
@@ -172,6 +169,33 @@ test "build integration: maximum nesting depth" {
     current = current.subcommands.?.get("level4").?;
     current = current.subcommands.?.get("level5").?;
     try testing.expect(current.subcommands.?.contains("cmd"));
+}
+
+test "build integration: exceeding the nesting depth limit is a hard error" {
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // Beyond the limit (6): rather than silently dropping the subtree — which
+    // hid commands from the CLI with only a stray build-log line — discovery
+    // now fails loudly so the too-deep tree can't slip by unnoticed.
+    try writeNested(tmp.dir, io, "deep/l1/l2/l3/l4/l5/l6/l7/ignored.zig", placeholder);
+
+    // discover() partially allocates before erroring; that memory is owned by
+    // the process arena in a real build. Here we can't call deinit on a value
+    // we never received, so route through an arena to keep the leak detector
+    // satisfied on this intentional error path.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var dir = try tmp.dir.openDir(io, ".", .{ .iterate = true });
+    defer dir.close(io);
+
+    try testing.expectError(
+        error.MaxCommandDepthExceeded,
+        command_discovery.discoverInDir(allocator, io, dir),
+    );
 }
 
 test "build integration: registry source generation from a discovered tree" {

--- a/packages/core/src/build_utils/command_discovery.zig
+++ b/packages/core/src/build_utils/command_discovery.zig
@@ -54,20 +54,41 @@ fn scanDirectory(
     depth: u32,
     max_depth: u32,
 ) !void {
-    // Prevent excessive nesting
+    // Prevent excessive nesting. Exceeding the cap is a hard error rather
+    // than a silent truncation: the old behavior logged one build-log line
+    // and made the whole subtree vanish from the CLI, which is trivial to
+    // miss. The cap also doubles as a symlink-loop guard now that symlinked
+    // directories are followed (see below).
     if (depth >= max_depth) {
         // Convert path array to string for logging. On OOM log without the
         // path — the old `catch "unknown"` fallback flowed into the free
         // below, which is UB on a string literal.
         const joined: ?[]u8 = if (current_path.len == 0) null else std.mem.join(allocator, "/", current_path) catch null;
         defer if (joined) |p| allocator.free(p);
-        logging.maxNestingDepthReached(max_depth, joined orelse "");
-        return;
+        logging.maxNestingDepthExceeded(max_depth, joined orelse "");
+        return error.MaxCommandDepthExceeded;
     }
     var iterator = dir.iterate();
 
     while (try iterator.next(io)) |entry| {
-        switch (entry.kind) {
+        // Resolve symlinks to their target kind so symlinked command files
+        // and directories are discovered exactly like real ones — a monorepo
+        // may symlink a shared command tree into commands/. Without this the
+        // .sym_link entry fell through to the `else` arm and was silently
+        // dropped. statFile follows symlinks, so its reported kind is the
+        // target's; openDir/statFile below likewise follow the link.
+        const kind = switch (entry.kind) {
+            .sym_link => blk: {
+                const stat = dir.statFile(io, entry.name, .{}) catch {
+                    logging.invalidCommandName(entry.name, "cannot resolve symlink target");
+                    continue;
+                };
+                break :blk stat.kind;
+            },
+            else => entry.kind,
+        };
+
+        switch (kind) {
             .file => {
                 if (std.mem.endsWith(u8, entry.name, ".zig")) {
                     const name_without_ext = entry.name[0 .. entry.name.len - 4];
@@ -269,6 +290,73 @@ test "discovery skips underscore-prefixed helper files and directories" {
     try testing.expect(commands.root.get("deploy") != null);
     try testing.expect(commands.root.get("_generate") == null);
     try testing.expect(commands.root.get("_helpers") == null);
+}
+
+test "discovery follows symlinked command files and directories" {
+    const testing = std.testing;
+    const io = testing.io;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // A real command, plus a shared command file and a shared command
+    // directory that a monorepo symlinks into commands/. All must be
+    // discovered — previously the symlink entries fell through to the
+    // `else => continue` arm and vanished from the CLI with no warning.
+    try tmp.dir.writeFile(io, .{ .sub_path = "deploy.zig", .data = "pub fn execute() void {}" });
+
+    try tmp.dir.createDir(io, "shared_src", .default_dir);
+    try tmp.dir.writeFile(io, .{ .sub_path = "shared_src/status.zig", .data = "pub fn execute() void {}" });
+    try tmp.dir.createDir(io, "shared_group_src", .default_dir);
+    try tmp.dir.writeFile(io, .{ .sub_path = "shared_group_src/list.zig", .data = "pub fn execute() void {}" });
+
+    // status.zig symlinks a shared command file; group/ symlinks a shared dir.
+    try tmp.dir.symLink(io, "shared_src/status.zig", "status.zig", .{});
+    try tmp.dir.symLink(io, "shared_group_src", "group", .{ .is_directory = true });
+
+    var dir = try tmp.dir.openDir(io, ".", .{ .iterate = true });
+    defer dir.close(io);
+
+    var commands = try discoverInDir(testing.allocator, io, dir);
+    defer commands.deinit();
+
+    try testing.expect(commands.root.get("deploy") != null);
+    // The symlinked file resolves to a leaf command.
+    try testing.expect(commands.root.get("status") != null);
+    // The symlinked directory resolves to a group whose subcommand is found.
+    const group = commands.root.get("group") orelse return error.TestUnexpectedResult;
+    try testing.expect(group.subcommands != null);
+    try testing.expect(group.subcommands.?.get("list") != null);
+}
+
+test "discovery errors loudly when nesting exceeds the depth cap" {
+    const testing = std.testing;
+    const io = testing.io;
+
+    // Deliberately hitting the hard-error path leaks the partial subtree
+    // allocations (fine in production: b.allocator is an arena and the build
+    // aborts). Use an arena here so the leak detector doesn't flag it.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDir(io, "group", .default_dir);
+    try tmp.dir.writeFile(io, .{ .sub_path = "group/leaf.zig", .data = "pub fn execute() void {}" });
+
+    var dir = try tmp.dir.openDir(io, ".", .{ .iterate = true });
+    defer dir.close(io);
+
+    var commands = std.StringHashMap(DiscoveredCommand).init(allocator);
+
+    // max_depth = 1: recursing into group/ reaches the cap. This must be a
+    // hard error, not a silent drop that would hide `group leaf` from the CLI.
+    try testing.expectError(
+        error.MaxCommandDepthExceeded,
+        scanDirectory(allocator, io, dir, &commands, &.{}, 0, 1),
+    );
 }
 
 test "sortedByName yields alphabetical order regardless of discovery order" {

--- a/packages/core/src/logging.zig
+++ b/packages/core/src/logging.zig
@@ -112,9 +112,10 @@ pub fn invalidCommandName(name: []const u8, reason: []const u8) void {
     logBuildWarning("Skipping invalid command name: {s} ({s})", .{ name, reason });
 }
 
-/// Format build warning for maximum nesting depth
-pub fn maxNestingDepthReached(max_depth: u32, path: []const u8) void {
-    logBuildWarning("Maximum command nesting depth ({d}) reached at path: {s}", .{ max_depth, path });
+/// Format build error for exceeding the maximum nesting depth. This is a hard
+/// error, not a warning: silently dropping a too-deep subtree hides commands.
+pub fn maxNestingDepthExceeded(max_depth: u32, path: []const u8) void {
+    logBuildError("Maximum command nesting depth ({d}) exceeded at path: {s}", .{ max_depth, path });
 }
 
 /// Format build warning for field name too long
@@ -191,7 +192,7 @@ test "logging utility functions" {
     optionNameTooLong("very-long-option-name", 16);
 
     invalidCommandName("bad name", "contains spaces");
-    maxNestingDepthReached(6, "/deep/path/here");
+    maxNestingDepthExceeded(6, "/deep/path/here");
     fieldNameTooLong("very_long_field_name_that_exceeds_limits", 32);
 
     buildError("Test Error", "/path/to/file", "Test description", "Test suggestion");


### PR DESCRIPTION
## Problem

Command discovery (`packages/core/src/build_utils/command_discovery.zig`) silently dropped two classes of input:

1. **Symlinked command files/directories** — the `switch (entry.kind)` in `scanDirectory` only handled `.file`/`.directory`; `.sym_link` fell through to `else => continue`. A monorepo symlinking a shared command tree into `commands/` got nothing discovered, with no warning.
2. **Subtrees deeper than the max nesting depth (6)** — exceeding the cap logged one build-log warning and made the whole subtree vanish from the CLI, trivially easy to miss.

## Fix

- `.sym_link` entries are now resolved via `dir.statFile` (which follows symlinks) to their **target kind** and dispatched as a real file or directory. `openDir`/`statFile` for the group path likewise follow the link. If the target can't be resolved, we emit the existing invalid-name warning instead of silently skipping.
- Exceeding the depth cap is now a **hard error** (`error.MaxCommandDepthExceeded`) via a new `logging.maxNestingDepthExceeded` (build-error level), instead of a silent truncation. The cap now doubles as a symlink-loop guard since symlinked directories are followed.

Both fixes land in the shared discovery core, so the build path (`discoverCommands`) and runtime tooling (`zcli tree` / `zcli dev` via `discoverInDir`) stay consistent.

## Deviations from the issue sketch

The sketch offered "follow symlinks OR emit a loud notice" and "configurable depth cap OR hard build error". I chose the cleaner option in each pair: actually follow symlinks (so the commands work, not just warn), and a hard error (no new config surface to thread through `generate()`).

## Testing

- `zig build test` (repo root) — pass (EXIT=0), no leaks.
- `cd projects/zcli && zig build` — pass (EXIT=0).
- New unit tests in `command_discovery.zig`: symlinked file + symlinked directory are discovered; exceeding the cap returns `error.MaxCommandDepthExceeded`.
- Updated `build_integration_test.zig`: split the old "maximum nesting depth" test into a within-limit case and a hard-error case (`expectError`).

Fixes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4