### PR TITLE
security: charset-validate installer version + validate app_name at build time (#454)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -107,7 +107,10 @@ function Get-LatestVersion {
         exit 1
     }
 
-    if ($release.tag_name -notmatch '^zcli-v(.+)$') {
+    # Defense-in-depth: validate the version against a strict charset before it
+    # is interpolated into download URLs, mirroring the in-binary isValidVersionArg
+    # check. Rejects '/', '..' and other path-traversal characters.
+    if ($release.tag_name -notmatch '^zcli-v([A-Za-z0-9._-]+)$') {
         Write-ErrorMsg "Unexpected release tag format: $($release.tag_name)"
         exit 1
     }

--- a/install.sh
+++ b/install.sh
@@ -121,14 +121,24 @@ verify_signature() {
 
 # Get latest release version from GitHub
 get_latest_version() {
-    if command -v curl >/dev/null 2>&1; then
-        curl -fsSL --proto '=https' --tlsv1.2 "https://api.github.com/repos/${REPO}/releases/latest" | \
-            grep '"tag_name":' | \
-            sed -E 's/.*"tag_name": "zcli-v([^"]+)".*/\1/'
-    else
+    if ! command -v curl >/dev/null 2>&1; then
         print_error "curl is required but not found"
         exit 1
     fi
+
+    version=$(curl -fsSL --proto '=https' --tlsv1.2 "https://api.github.com/repos/${REPO}/releases/latest" | \
+        grep '"tag_name":' | \
+        sed -E 's/.*"tag_name": "zcli-v([^"]+)".*/\1/')
+
+    # Defense-in-depth: validate the version against a strict charset before it
+    # is interpolated into download URLs, mirroring the in-binary isValidVersionArg
+    # check. Rejects '/', '..' and other path-traversal characters.
+    if ! printf '%s' "${version}" | grep -qE '^[A-Za-z0-9._-]+$'; then
+        print_error "Invalid version string from GitHub API: '${version}'"
+        exit 1
+    fi
+
+    printf '%s\n' "${version}"
 }
 
 # Download binary

--- a/packages/core/src/registry/builder.zig
+++ b/packages/core/src/registry/builder.zig
@@ -55,9 +55,34 @@ pub const CommandEntry = struct {
     module: type,
 };
 
+/// Validate `app_name` against a strict identifier charset at compile time.
+///
+/// The app name is interpolated unescaped into generated shell completion
+/// scripts as function names and `complete` targets (see zcli_completions/
+/// {bash,zsh,fish}.zig). Rather than escaping it per-shell, we reject any name
+/// that isn't a safe identifier — a developer-controlled comptime value should
+/// never contain shell metacharacters, whitespace, quotes, or path separators.
+fn validateAppName(comptime app_name: []const u8) void {
+    if (app_name.len == 0) {
+        @compileError("app_name must not be empty");
+    }
+    for (app_name) |c| {
+        const ok = (c >= 'A' and c <= 'Z') or
+            (c >= 'a' and c <= 'z') or
+            (c >= '0' and c <= '9') or
+            c == '_' or c == '-' or c == '.';
+        if (!ok) {
+            @compileError("app_name \"" ++ app_name ++
+                "\" contains an invalid character; only [A-Za-z0-9._-] are allowed " ++
+                "(it is interpolated unescaped into generated shell completion scripts)");
+        }
+    }
+}
+
 /// Registry builder for comptime command registration
 pub const Registry = struct {
     pub fn init(comptime config: Config) RegistryBuilder(config, &.{}, &.{}) {
+        comptime validateAppName(config.app_name);
         return RegistryBuilder(config, &.{}, &.{}).init();
     }
 };
@@ -170,4 +195,20 @@ pub fn discoverPluginCommands(comptime CommandsStruct: type, comptime path_prefi
     }
 
     return entries;
+}
+
+test "validateAppName accepts safe identifier charset" {
+    // These must all compile without a @compileError. If any of them were
+    // rejected, this test file would fail to build.
+    comptime validateAppName("myapp");
+    comptime validateAppName("my-app");
+    comptime validateAppName("my_app");
+    comptime validateAppName("my.app");
+    comptime validateAppName("App123");
+    // Registry.init runs the same check on the way in.
+    _ = Registry.init(.{
+        .app_name = "safe-name_1.0",
+        .app_version = "1.0.0",
+        .app_description = "desc",
+    });
 }


### PR DESCRIPTION
## Problem
Grade8 security audit (defense-in-depth hardening; no exploitable finding):

1. `install.sh` / `install.ps1` extract the version from the GitHub API `tag_name` and interpolate it into download URLs without charset-validating it — unlike the in-binary `isValidVersionArg` (`zcli_github_upgrade/plugin.zig:56`), which rejects `/` and path-traversal characters.
2. `app_name` is interpolated unescaped into generated shell completion scripts as function names / `complete` targets (`zsh.zig`, `fish.zig`, `bash.zig`) with no validation.

## Fix
- **install.sh**: `get_latest_version` now validates the extracted version with `grep -qE '^[A-Za-z0-9._-]+$'` and aborts on mismatch — exactly mirroring `isValidVersionArg`'s charset.
- **install.ps1**: tightened the tag regex from `^zcli-v(.+)$` to `^zcli-v([A-Za-z0-9._-]+)$`.
- **registry builder** (`packages/core/src/registry/builder.zig`): added `validateAppName`, run at comptime in `Registry.init`, which raises a compile error if `app_name` contains anything outside `[A-Za-z0-9._-]` (or is empty). Chosen over per-shell escaping because `app_name` is a developer-controlled comptime constant that should never contain shell metacharacters.

## Testing
- `sh -n install.sh` / `bash -n install.sh`: pass.
- Manually verified the version regex rejects `../etc` and `1/2`, accepts `1.2.3` / `v1.0-beta`.
- Added unit test `validateAppName accepts safe identifier charset` in builder.zig (also exercises `Registry.init`). The compile-error path can't be runtime-tested (it fails compilation by design).
- Root `zig build test`: pass (exit 0, all packages/examples green).

Fixes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4