### PR TITLE
prompts: flush before blocking non-TTY reads; document error.UserAborted (#456)

### DIFF
--- a/packages/prompts/src/confirm.zig
+++ b/packages/prompts/src/confirm.zig
@@ -19,8 +19,9 @@ pub const ConfirmConfig = struct {
 };
 
 /// Prompt for yes/no confirmation. Returns the answer, `error.Interrupted`
-/// if the user presses one of `config.interrupt_keys`, or `error.EndOfStream`
-/// if stdin closes with no answer to submit.
+/// if the user presses one of `config.interrupt_keys`, `error.UserAborted` if
+/// the user presses Ctrl-C, or `error.EndOfStream` if stdin closes with no
+/// answer to submit.
 pub fn confirm(p: Prompts, config: ConfirmConfig) !bool {
     const writer = p.writer;
     const reader = p.reader;
@@ -30,6 +31,9 @@ pub fn confirm(p: Prompts, config: ConfirmConfig) !bool {
 
     if (!is_tty) {
         try writer.print("{s}{s} {s} ", .{ config.prefix, config.message, hint });
+        // Flush so the prompt is visible before we block reading the reply —
+        // buffered writers otherwise strand it until after input arrives.
+        Prompts.flushWriter(writer);
         // A closed stdin (nothing to read) errors; a submitted blank line
         // (leading '\n') takes the default like an empty text entry.
         const first = terminal.key.readByteFn(reader) catch return error.EndOfStream;

--- a/packages/prompts/src/editor.zig
+++ b/packages/prompts/src/editor.zig
@@ -23,8 +23,9 @@ pub const EditorConfig = struct {
     environ: ?*const std.process.Environ.Map = null,
 };
 
-/// Launch the user's editor for multiline input. Returns owned string, or
-/// `error.EndOfStream` if stdin closes with no input to submit.
+/// Launch the user's editor for multiline input. Returns owned string,
+/// `error.UserAborted` if the user presses Ctrl-C, or `error.EndOfStream` if
+/// stdin closes with no input to submit.
 pub fn editor(p: Prompts, config: EditorConfig) ![]u8 {
     const writer = p.writer;
     const reader = p.reader;
@@ -35,6 +36,9 @@ pub fn editor(p: Prompts, config: EditorConfig) ![]u8 {
         try writer.print("{s}{s}", .{ config.prefix, config.message });
         // Non-TTY: read all remaining input until EOF.
         try writer.writeAll("\n");
+        // Flush so the prompt is visible before we block reading input —
+        // buffered writers otherwise strand it until after input arrives.
+        Prompts.flushWriter(writer);
         var buf = std.ArrayList(u8).empty;
         errdefer buf.deinit(allocator);
         while (true) {

--- a/packages/prompts/src/multi_select.zig
+++ b/packages/prompts/src/multi_select.zig
@@ -19,7 +19,8 @@ pub const MultiSelectConfig = struct {
 };
 
 /// Prompt to select multiple items. Returns owned slice of selected indices,
-/// or `error.EndOfStream` if stdin closes with no line to submit.
+/// `error.UserAborted` if the user presses Ctrl-C, or `error.EndOfStream` if
+/// stdin closes with no line to submit.
 pub fn multiSelect(p: Prompts, config: MultiSelectConfig) ![]usize {
     const writer = p.writer;
     const reader = p.reader;
@@ -37,6 +38,9 @@ pub fn multiSelect(p: Prompts, config: MultiSelectConfig) ![]usize {
         }
         try writer.writeAll("> ");
 
+        // Flush so the prompt is visible before we block reading the reply —
+        // buffered writers otherwise strand it until after input arrives.
+        Prompts.flushWriter(writer);
         // A submitted blank line accepts the defaults; a closed stdin errors.
         const line = try readLine(reader, allocator);
         defer allocator.free(line);

--- a/packages/prompts/src/number.zig
+++ b/packages/prompts/src/number.zig
@@ -23,8 +23,9 @@ pub const NumberConfig = struct {
 };
 
 /// Prompt for numeric input. Returns the entered number, `error.Interrupted`
-/// if the user presses one of `config.interrupt_keys`, or `error.EndOfStream`
-/// if stdin closes with no line to submit.
+/// if the user presses one of `config.interrupt_keys`, `error.UserAborted` if
+/// the user presses Ctrl-C, or `error.EndOfStream` if stdin closes with no line
+/// to submit.
 pub fn number(p: Prompts, config: NumberConfig) !i64 {
     const writer = p.writer;
     const reader = p.reader;
@@ -40,6 +41,9 @@ pub fn number(p: Prompts, config: NumberConfig) !i64 {
         }
         try writer.writeAll(" ");
 
+        // Flush so the prompt is visible before we block reading the reply —
+        // buffered writers otherwise strand it until after input arrives.
+        Prompts.flushWriter(writer);
         const value = try readNumberNonTty(reader, config);
 
         // Validate range

--- a/packages/prompts/src/password.zig
+++ b/packages/prompts/src/password.zig
@@ -16,8 +16,9 @@ pub const PasswordConfig = struct {
     prefix: []const u8 = "? ",
 };
 
-/// Prompt for password input with masking. Returns owned string, or
-/// `error.EndOfStream` if stdin closes with no line to submit.
+/// Prompt for password input with masking. Returns owned string,
+/// `error.UserAborted` if the user presses Ctrl-C, or `error.EndOfStream` if
+/// stdin closes with no line to submit.
 pub fn password(p: Prompts, config: PasswordConfig) ![]u8 {
     const writer = p.writer;
     const reader = p.reader;
@@ -27,6 +28,9 @@ pub fn password(p: Prompts, config: PasswordConfig) ![]u8 {
     if (!is_tty) {
         // Non-TTY: read line (no masking possible)
         try writer.print("{s}{s} ", .{ config.prefix, config.message });
+        // Flush so the prompt is visible before we block reading the reply —
+        // buffered writers otherwise strand it until after input arrives.
+        Prompts.flushWriter(writer);
         const line = try readLine(reader, allocator);
         try writer.writeAll("\n");
         return line;

--- a/packages/prompts/src/search.zig
+++ b/packages/prompts/src/search.zig
@@ -17,8 +17,8 @@ pub const SearchConfig = struct {
 };
 
 /// Prompt with search filtering. Returns the index of the selected item in the
-/// original choices array, or `error.EndOfStream` if stdin closes with no line
-/// to submit.
+/// original choices array, `error.UserAborted` if the user presses Ctrl-C, or
+/// `error.EndOfStream` if stdin closes with no line to submit.
 pub fn search(p: Prompts, config: SearchConfig) !usize {
     const writer = p.writer;
     const reader = p.reader;
@@ -33,6 +33,9 @@ pub fn search(p: Prompts, config: SearchConfig) !usize {
             try writer.print("  {d}) {s}\n", .{ i, choice });
         }
         try writer.writeAll("> ");
+        // Flush so the prompt is visible before we block reading the reply —
+        // buffered writers otherwise strand it until after input arrives.
+        Prompts.flushWriter(writer);
         const line = try readLine(reader, allocator);
         defer allocator.free(line);
         const num = std.fmt.parseInt(usize, line, 10) catch return 0;

--- a/packages/prompts/src/select.zig
+++ b/packages/prompts/src/select.zig
@@ -23,8 +23,9 @@ pub const SelectConfig = struct {
 };
 
 /// Prompt to select one item from a list. Returns the chosen index,
-/// `error.Interrupted` if the user presses one of `config.interrupt_keys`, or
-/// `error.EndOfStream` if stdin closes with no line to submit.
+/// `error.Interrupted` if the user presses one of `config.interrupt_keys`,
+/// `error.UserAborted` if the user presses Ctrl-C, or `error.EndOfStream` if
+/// stdin closes with no line to submit.
 pub fn select(p: Prompts, config: SelectConfig) !usize {
     const writer = p.writer;
     const reader = p.reader;
@@ -38,6 +39,9 @@ pub fn select(p: Prompts, config: SelectConfig) !usize {
             try writer.print("  {d}) {s}\n", .{ i, choice });
         }
         try writer.writeAll("> ");
+        // Flush so the prompt is visible before we block reading the reply —
+        // buffered writers otherwise strand it until after input arrives.
+        Prompts.flushWriter(writer);
         const line = try readLine(reader, p.allocator);
         defer p.allocator.free(line);
         const num = std.fmt.parseInt(usize, line, 10) catch return 0;

--- a/packages/prompts/src/text.zig
+++ b/packages/prompts/src/text.zig
@@ -33,8 +33,9 @@ pub const TextConfig = struct {
 };
 
 /// Prompt for text input. Returns an owned string (caller frees),
-/// `error.Interrupted` if the user presses one of `config.interrupt_keys`, or
-/// `error.EndOfStream` if stdin closes with no line to submit.
+/// `error.Interrupted` if the user presses one of `config.interrupt_keys`,
+/// `error.UserAborted` if the user presses Ctrl-C, or `error.EndOfStream` if
+/// stdin closes with no line to submit.
 pub fn text(p: Prompts, config: TextConfig) ![]u8 {
     const writer = p.writer;
     const reader = p.reader;
@@ -48,6 +49,9 @@ pub fn text(p: Prompts, config: TextConfig) ![]u8 {
             try writer.print(" ({s})", .{def});
         }
         try writer.writeAll(" ");
+        // Flush so the prompt is visible before we block reading the reply —
+        // buffered writers otherwise strand it until after input arrives.
+        Prompts.flushWriter(writer);
         const line = try readLine(reader, allocator);
         defer allocator.free(line);
         if (line.len == 0) {
@@ -265,6 +269,67 @@ test "text: prompt message appears in output" {
     const written = output_writer.buffer[0..output_writer.end];
     try std.testing.expect(std.mem.indexOf(u8, written, "Enter name:") != null);
     try std.testing.expect(std.mem.indexOf(u8, written, "(foo)") != null);
+}
+
+// A genuinely buffered writer: bytes accumulate in an internal buffer and only
+// reach `sink` when the writer is drained (i.e. flushed, or the buffer fills).
+// `std.Io.Writer.fixed` can't model the bug because its bytes are observable in
+// its buffer immediately; this one keeps them hidden until a flush, exactly like
+// a real buffered stdout.
+const BufferedSpy = struct {
+    writer: std.Io.Writer,
+    sink: *std.ArrayList(u8),
+    gpa: std.mem.Allocator,
+
+    fn init(buffer: []u8, sink: *std.ArrayList(u8), gpa: std.mem.Allocator) BufferedSpy {
+        return .{
+            .writer = .{ .vtable = &.{ .drain = drain }, .buffer = buffer },
+            .sink = sink,
+            .gpa = gpa,
+        };
+    }
+
+    fn drain(w: *std.Io.Writer, data: []const []const u8, splat: usize) std.Io.Writer.Error!usize {
+        const self: *BufferedSpy = @fieldParentPtr("writer", w);
+        self.sink.appendSlice(self.gpa, w.buffered()) catch return error.WriteFailed;
+        _ = w.consume(w.end);
+        var written: usize = 0;
+        for (data[0 .. data.len - 1]) |bytes| {
+            self.sink.appendSlice(self.gpa, bytes) catch return error.WriteFailed;
+            written += bytes.len;
+        }
+        const last = data[data.len - 1];
+        var i: usize = 0;
+        while (i < splat) : (i += 1) {
+            self.sink.appendSlice(self.gpa, last) catch return error.WriteFailed;
+        }
+        return written + last.len * splat;
+    }
+};
+
+test "text: non-TTY flushes the prompt before blocking on the read" {
+    // Regression for #456: the non-TTY path must flush the writer before it
+    // blocks reading the reply, or a buffered writer strands the prompt in its
+    // buffer and the user sees nothing until after they've typed. The only flush
+    // in this path is the one before the read, so anything reaching `sink` mid-
+    // call proves it happened. Without the fix `sink` stays empty (the prompt is
+    // never drained during the call).
+    const allocator = std.testing.allocator;
+
+    var sink = std.ArrayList(u8).empty;
+    defer sink.deinit(allocator);
+    var buffer: [256]u8 = undefined;
+    var spy = BufferedSpy.init(&buffer, &sink, allocator);
+
+    var input = "hello\n".*;
+    var input_reader: std.Io.Reader = .fixed(&input);
+
+    const result = try text(.{ .writer = &spy.writer, .reader = &input_reader, .allocator = allocator }, .{
+        .message = "Name:",
+    });
+    defer allocator.free(result);
+
+    try std.testing.expect(std.mem.indexOf(u8, sink.items, "Name:") != null);
 }
 
 test "frameNode: prompt line with input; preview row above wears the hint token" {


### PR DESCRIPTION
## Problem

All 8 prompts (`text`, `confirm`, `select`, `multi_select`, `search`, `password`, `number`, `editor`) skipped the flush-before-blocking-read on the non-TTY fallback path. With a buffered writer (real stdout), the prompt text sat in the buffer while the process blocked on `readLine` — piped/redirected callers saw nothing before input was expected. The TTY path already flushed correctly via `flushWriter`/`renderFrame`.

Additionally, `error.UserAborted` (the Ctrl-C result) was undocumented in every prompt's doc comment, so callers couldn't know to handle it without reading source.

## Fix

- Add `Prompts.flushWriter(writer)` immediately before each non-TTY blocking read in all 8 prompt files. For `number` the flush sits inside the retry loop (the prompt is re-printed on range violations); for `editor` it lands after the header line, before the read-to-EOF loop.
- Document `error.UserAborted` in every prompt's doc comment, alongside the existing `error.Interrupted`/`error.EndOfStream` documentation.

## Testing

- New regression test in `packages/prompts/src/text.zig`: a `BufferedSpy` writer whose bytes only reach the sink when drained (a fixed-buffer writer can't model the bug — its bytes are observable immediately). The only flush in the non-TTY path is the one before the read, so the prompt appearing in the sink proves the flush happened. Verified it fails without the fix (`sink` stays empty) and passes with it.
- `zig build test` at repo root: green (all packages + examples).
- `zig build e2e`: green (`Build Summary: 2/2 steps succeeded`).

Fixes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4