### PR TITLE
terminal: UTF-8 output codepage, guard re-arm race, and misc (#458)

### DIFF
--- a/packages/core/src/levenshtein.zig
+++ b/packages/core/src/levenshtein.zig
@@ -1,40 +1,66 @@
 const std = @import("std");
 
-/// Calculate Levenshtein edit distance between two strings
-/// This is the core algorithm for finding similar command names
-/// Uses a more memory-efficient approach for larger strings
+// For very long strings, use a practical limit to avoid excessive computation
+// (and to bound the stack matrix below). Counted in codepoints, not bytes.
+const max_practical_len = 256;
+
+/// Decode `s` as UTF-8 into `out` (one entry per codepoint), returning the count
+/// — truncated at `out.len`. Malformed bytes decode to themselves (Latin-1
+/// style) so a bad identifier never errors; ASCII maps 1:1, so pure-ASCII names
+/// are unchanged. `out.len` must be `max_practical_len`.
+fn decodeCodepoints(s: []const u8, out: *[max_practical_len]u21) usize {
+    var n: usize = 0;
+    var i: usize = 0;
+    while (i < s.len and n < out.len) : (n += 1) {
+        const seq_len = std.unicode.utf8ByteSequenceLength(s[i]) catch {
+            out[n] = s[i];
+            i += 1;
+            continue;
+        };
+        if (i + seq_len > s.len) {
+            out[n] = s[i];
+            i += 1;
+            continue;
+        }
+        out[n] = std.unicode.utf8Decode(s[i .. i + seq_len]) catch {
+            out[n] = s[i];
+            i += 1;
+            continue;
+        };
+        i += seq_len;
+    }
+    return n;
+}
+
+/// Calculate Levenshtein edit distance between two strings, measured in Unicode
+/// codepoints (not bytes) so distances aren't skewed for non-ASCII identifiers.
+/// This is the core algorithm for finding similar command names.
+/// Uses a memory-efficient two-row approach: O(min(n,m)) instead of O(n*m).
 pub fn editDistance(a: []const u8, b: []const u8) usize {
-    if (a.len == 0) return b.len;
-    if (b.len == 0) return a.len;
+    // Comptime callers (the plugin-hook typo guard) evaluate the decode + DP for
+    // identifier-length strings, which exceeds the default 1000-branch budget;
+    // raise it here so every comptime call site doesn't have to. No-op at runtime.
+    @setEvalBranchQuota(10_000);
+    var a_buf: [max_practical_len]u21 = undefined;
+    var b_buf: [max_practical_len]u21 = undefined;
+    const a_len = decodeCodepoints(a, &a_buf);
+    const b_len = decodeCodepoints(b, &b_buf);
 
-    // For very long strings, use a practical limit to avoid excessive computation
-    const max_practical_len = 256;
-    // Explicit usize annotations keep the loop bounds usize when the function
-    // runs at comptime (comptime-known @min/@max results otherwise narrow to
-    // tiny integer types, overflowing the `for (1..len + 1)` ranges below).
-    const a_len: usize = @min(a.len, max_practical_len);
-    const b_len: usize = @min(b.len, max_practical_len);
+    if (a_len == 0) return b_len;
+    if (b_len == 0) return a_len;
 
-    // Use a more memory-efficient approach with two arrays instead of a full matrix
-    // This reduces memory usage from O(n*m) to O(min(n,m))
-
-    // Use two arrays instead of full matrix - more memory efficient
-    // We'll work with the shorter string as columns to minimize memory usage
+    // Work with the shorter string as columns to minimize the row width.
+    // Explicit usize annotations keep the loop bounds usize at comptime
+    // (comptime-known @min/@max results otherwise narrow to a tiny integer
+    // type, overflowing the `for (1..len + 1)` ranges below).
     const shorter_len: usize = @min(a_len, b_len);
     const longer_len: usize = @max(a_len, b_len);
 
-    const shorter_str = if (a_len <= b_len) a[0..a_len] else b[0..b_len];
-    const longer_str = if (a_len <= b_len) b[0..b_len] else a[0..a_len];
+    const shorter = if (a_len <= b_len) a_buf[0..a_len] else b_buf[0..b_len];
+    const longer = if (a_len <= b_len) b_buf[0..b_len] else a_buf[0..a_len];
 
-    // Use stack arrays for reasonable sizes, otherwise return simple difference
-    if (shorter_len > 512) {
-        // For very long strings, fall back to simple length difference
-        // This avoids stack overflow while still providing some useful metric
-        return if (longer_len > shorter_len) longer_len - shorter_len else 0;
-    }
-
-    var prev_row: [513]usize = undefined; // +1 for initialization
-    var curr_row: [513]usize = undefined;
+    var prev_row: [max_practical_len + 1]usize = undefined; // +1 for initialization
+    var curr_row: [max_practical_len + 1]usize = undefined;
 
     // Initialize first row
     for (0..shorter_len + 1) |j| {
@@ -46,7 +72,7 @@ pub fn editDistance(a: []const u8, b: []const u8) usize {
         curr_row[0] = i;
 
         for (1..shorter_len + 1) |j| {
-            const cost: usize = if (longer_str[i - 1] == shorter_str[j - 1]) 0 else 1;
+            const cost: usize = if (longer[i - 1] == shorter[j - 1]) 0 else 1;
 
             curr_row[j] = @min(@min(prev_row[j] + 1, // deletion
                 curr_row[j - 1] + 1 // insertion
@@ -94,4 +120,17 @@ test "editDistance edge cases" {
 
     // Very different strings
     try std.testing.expectEqual(@as(usize, 6), editDistance("abc", "xyz123"));
+}
+
+test "editDistance counts codepoints, not bytes (#458)" {
+    // 'é' is two UTF-8 bytes; a byte-wise distance would report 2 (substitute
+    // the two bytes) instead of the true single-codepoint substitution.
+    try std.testing.expectEqual(@as(usize, 1), editDistance("café", "cafe"));
+    // Identical multibyte strings are distance 0, not skewed by byte count.
+    try std.testing.expectEqual(@as(usize, 0), editDistance("naïve", "naïve"));
+    // Multibyte length semantics: "" vs a 5-codepoint word is 5, not its 6 bytes.
+    try std.testing.expectEqual(@as(usize, 5), editDistance("", "café!"));
+    // A 4-byte codepoint (emoji) is a single unit — one substitution.
+    try std.testing.expectEqual(@as(usize, 1), editDistance("😀", "😁"));
+    try std.testing.expectEqual(@as(usize, 0), editDistance("a😀b", "a😀b"));
 }

--- a/packages/terminal/src/backend_windows.zig
+++ b/packages/terminal/src/backend_windows.zig
@@ -19,9 +19,13 @@ const Winsize = backend.Winsize;
 const TerminalError = backend.TerminalError;
 
 const DWORD = windows.DWORD;
+const UINT = windows.UINT;
 const HANDLE = windows.HANDLE;
 const SHORT = windows.SHORT;
 const COORD = windows.COORD;
+
+/// Code page identifier for UTF-8 (see the Win32 "Code Page Identifiers" list).
+const CP_UTF8: UINT = 65001;
 
 // Console input mode flags.
 const ENABLE_PROCESSED_INPUT: DWORD = 0x0001;
@@ -68,6 +72,12 @@ extern "kernel32" fn GetConsoleScreenBufferInfo(hConsoleOutput: HANDLE, lpInfo: 
 extern "kernel32" fn WaitForSingleObject(hHandle: HANDLE, dwMilliseconds: DWORD) callconv(.winapi) DWORD;
 extern "kernel32" fn PeekConsoleInputW(hConsoleInput: HANDLE, lpBuffer: [*]INPUT_RECORD, nLength: DWORD, lpNumberOfEventsRead: *DWORD) callconv(.winapi) c_int;
 extern "kernel32" fn ReadConsoleInputW(hConsoleInput: HANDLE, lpBuffer: [*]INPUT_RECORD, nLength: DWORD, lpNumberOfEventsRead: *DWORD) callconv(.winapi) c_int;
+// Console output code page: query/switch so UTF-8 box-drawing renders on legacy
+// conhost. `GetConsoleOutputCP` returns 0 when the process has no console;
+// `SetConsoleOutputCP` returns a BOOL (0 on failure), typed `c_int` to compare
+// against 0 like the other kernel32 externs here.
+extern "kernel32" fn GetConsoleOutputCP() callconv(.winapi) UINT;
+extern "kernel32" fn SetConsoleOutputCP(wCodePageID: UINT) callconv(.winapi) c_int;
 
 /// Saved console state for restoring after raw mode. Raw mode touches both the
 /// input handle (to stop line buffering/echo and turn on VT input) and the
@@ -78,11 +88,15 @@ pub const RawMode = struct {
     out: Handle,
     out_mode: DWORD,
     out_changed: bool,
+    /// The console output code page raw mode replaced, for `disable()` to put
+    /// back. 0 means "left unchanged" (no console, or it was already UTF-8).
+    out_prev_cp: UINT,
 
     /// Restore original console settings.
     pub fn disable(self: RawMode) void {
         _ = SetConsoleMode(self.in, self.in_mode);
         if (self.out_changed) _ = SetConsoleMode(self.out, self.out_mode);
+        if (self.out_prev_cp != 0) _ = SetConsoleOutputCP(self.out_prev_cp);
     }
 };
 
@@ -122,8 +136,17 @@ pub fn enableRawMode(in: Handle) TerminalError!RawMode {
 
     if (SetConsoleMode(in, rawInputMode(in_mode)) == 0) return error.TerminalSettingsError;
 
+    var out_prev_cp: UINT = 0;
     if (out_is_console) {
         _ = SetConsoleMode(out, vtOutputMode(out_mode));
+        // Legacy conhost starts on an OEM code page (e.g. 437), so the UTF-8
+        // box-drawing / symbols the ANSI output emits render as mojibake.
+        // Switch the console output code page to UTF-8 for the raw-mode session
+        // and restore it on `disable()`. Best-effort, and captured only when it
+        // wasn't already UTF-8 (Windows Terminal — and a zcli app whose registry
+        // ran `console_utf8.enable()` — already is, so this is a no-op there).
+        const cur_cp = GetConsoleOutputCP();
+        if (cur_cp != 0 and cur_cp != CP_UTF8 and SetConsoleOutputCP(CP_UTF8) != 0) out_prev_cp = cur_cp;
     }
 
     return .{
@@ -132,6 +155,7 @@ pub fn enableRawMode(in: Handle) TerminalError!RawMode {
         .out = out,
         .out_mode = out_mode,
         .out_changed = out_is_console,
+        .out_prev_cp = out_prev_cp,
     };
 }
 

--- a/packages/terminal/src/guard.zig
+++ b/packages/terminal/src/guard.zig
@@ -33,8 +33,11 @@ const RawMode = backend.RawMode;
 /// (mouse `?1002l?1006l`, focus `?1004l`). 48B covers all of them at once.
 const blob_max = 48;
 
-/// Set last by `arm` (release) and cleared first by `disarm` — so a handler that
-/// fires mid-`arm` either sees `false` (does nothing) or a fully written `g`.
+/// Gates every read of `g` by the async restore path. `arm` withdraws it before
+/// touching `g` and republishes it after (release), `restore`/`disarm` read it
+/// with acquire — so a handler that fires mid-`arm` (including a *re*-arm over an
+/// already-armed guard) sees `false` and replays nothing rather than a
+/// half-written `g`. Never a torn read of the blob.
 var armed = std.atomic.Value(bool).init(false);
 
 var g: struct {
@@ -50,11 +53,21 @@ var g: struct {
 /// from the main thread.
 pub fn arm(out: Handle, blob: []const u8, raw: ?RawMode) void {
     std.debug.assert(blob.len <= blob_max);
+    // Withdraw first: a re-arm over an already-armed guard (e.g. hybrid's
+    // `start` re-arming with the cursor-show blob) would otherwise race the
+    // async restore path reading `g` — a POSIX signal handler interrupting this
+    // thread, or Windows' console-ctrl handler on its own thread. The acq_rel
+    // swap fences the `g` stores below to happen after the withdrawal, so no
+    // handler observes a torn `g`; the tiny window where `armed` is false just
+    // means such a handler restores nothing (the same disarm-then-arm tradeoff).
+    _ = armed.swap(false, .acq_rel);
     g.out = out;
     @memcpy(g.blob[0..blob.len], blob);
     g.blob_len = blob.len;
     g.raw = raw;
     impl.install();
+    // Republish as a unit: the acquire load in `restore` pairs with this release
+    // store, so a handler that sees `true` sees every `g` write above.
     armed.store(true, .release);
 }
 
@@ -189,6 +202,7 @@ const test_raw: RawMode = if (builtin.os.tag == .windows) .{
     .out = test_handle,
     .out_mode = 0,
     .out_changed = false,
+    .out_prev_cp = 0,
 } else std.mem.zeroes(RawMode);
 
 test "arm registers the blob and raw mode; disarm clears the armed flag" {
@@ -211,6 +225,22 @@ test "arm with a null raw registers cursor-only restore" {
     defer disarm();
     arm(test_handle, "\x1b[?25h", null);
     try std.testing.expect(armed.load(.acquire));
+    try std.testing.expect(g.raw == null);
+}
+
+test "re-arm over an armed guard replaces the blob and raw mode" {
+    defer disarm();
+    // The hybrid path arms with an empty blob in `init`, then `start` re-arms
+    // with the cursor-show blob over the still-armed guard (#458 item 2).
+    arm(test_handle, "", test_raw);
+    try std.testing.expect(armed.load(.acquire));
+    try std.testing.expectEqual(@as(usize, 0), g.blob_len);
+
+    arm(test_handle, "\x1b[?25h", null);
+    try std.testing.expect(armed.load(.acquire));
+    try std.testing.expectEqual(@as(usize, 6), g.blob_len);
+    try std.testing.expectEqualStrings("\x1b[?25h", g.blob[0..g.blob_len]);
+    // The re-arm's fields fully replaced the prior arm's — no stale raw mode.
     try std.testing.expect(g.raw == null);
 }
 

--- a/packages/testing/src/conpty.zig
+++ b/packages/testing/src/conpty.zig
@@ -78,6 +78,10 @@ extern "kernel32" fn GetExitCodeProcess(hProcess: HANDLE, lpExitCode: *DWORD) ca
 extern "kernel32" fn TerminateProcess(hProcess: HANDLE, uExitCode: c_uint) callconv(.winapi) BOOL;
 extern "kernel32" fn CloseHandle(hObject: HANDLE) callconv(.winapi) BOOL;
 extern "kernel32" fn Sleep(dwMilliseconds: DWORD) callconv(.winapi) void;
+extern "kernel32" fn SetConsoleOutputCP(wCodePageID: windows.UINT) callconv(.winapi) BOOL;
+
+/// Code page identifier for UTF-8 (see the Win32 "Code Page Identifiers" list).
+const CP_UTF8: windows.UINT = 65001;
 
 pub const ConPtyError = error{
     PipeFailed,
@@ -107,6 +111,13 @@ pub const ConPtySession = struct {
         rows: u16,
         cols: u16,
     ) ConPtyError!ConPtySession {
+        // On a legacy conhost the parent (this harness) echoes the captured
+        // child frames to its own console when an e2e assertion fails — UTF-8
+        // box-drawing / symbols mojibake unless the parent's console output code
+        // page is UTF-8. Best-effort, once per spawn; a no-op on Windows
+        // Terminal (already UTF-8) and when output is redirected (no console).
+        _ = SetConsoleOutputCP(CP_UTF8);
+
         // Command line + optional cwd/env, all UTF-16.
         const cmdline = try buildCommandLineW(alloc, argv);
         defer alloc.free(cmdline);

--- a/packages/ui/src/app.zig
+++ b/packages/ui/src/app.zig
@@ -255,6 +255,13 @@ pub const App = struct {
     /// no `defer`, so only `ui.panic` restores it. Zig resolves the handler as
     /// `@import("root").panic` — a root-module decl an imported module can't
     /// provide — so this checks the root source file for it.
+    ///
+    /// This can only check that a `panic` decl *exists*, not that it restores
+    /// the terminal (its identity is unknowable at comptime): a root `panic`
+    /// that doesn't call `terminal.guard.restore()` (directly, or by delegating
+    /// to `ui.panic`) satisfies the check yet still strands the terminal on a
+    /// panic. The error text spells that out so a hand-rolled handler doesn't
+    /// silently reopen the hole.
     fn assertPanicInstalled() void {
         // `zig test` roots at the test runner (no panic hook) and builds Apps
         // only headlessly (fixed `term_size`, no real terminal to strand), so
@@ -265,7 +272,11 @@ pub const App = struct {
                 "(the alt-screen in full-screen; raw mode with a hidden cursor in hybrid — " ++
                 "every prompt and progress indicator). Add to your root source file (main.zig):\n\n" ++
                 "    pub const panic = zcli.ui.panic;\n\n" ++
-                "(standalone ui users: `pub const panic = ui.panic;`)",
+                "(standalone ui users: `pub const panic = ui.panic;`)\n\n" ++
+                "A custom handler is only safe if it calls `terminal.guard.restore()` " ++
+                "before it aborts (`ui.panic` does this first, then delegates to the " ++
+                "default handler) — this check can't verify that, only that some " ++
+                "`panic` decl exists.",
         );
     }
 


### PR DESCRIPTION
## Problem
Grade8 review grouped four low-severity terminal items (#458):

1. Neither `backend_windows.zig` nor `conpty.zig` set `SetConsoleOutputCP(CP_UTF8)`, so UTF-8 box-drawing/symbols mojibake on legacy conhost (OEM 437). zcli apps get this via the registry's `console_utf8.enable()`, but standalone terminal-package consumers and the ConPTY harness don't.
2. `guard.arm` rewrote the process-global restore blob with plain stores while a signal handler / Windows console-ctrl handler could concurrently read it — a formal data race on re-arm (hybrid's `start`).
3. The comptime panic-hook enforcement only checks that a `panic` decl exists, not that it restores the terminal — a hand-rolled handler silently reopens the hole.
4. `levenshtein.editDistance` iterated bytes, not codepoints, skewing "did you mean" distances for non-ASCII identifiers.

## Fix
1. `backend_windows.enableRawMode` switches the console output code page to UTF-8 for the raw-mode session and restores it on `disable()` (new `RawMode.out_prev_cp`). Captured only when it wasn't already UTF-8, so it's a no-op under Windows Terminal / an already-`console_utf8.enable()`'d app. This also covers ConPTY-launched interactive children (they enter raw mode). `conpty.zig` sets its own parent console output CP so captured child frames echoed on an assertion failure render.
2. `guard.arm` withdraws `armed` first (acq_rel swap fences the field stores to happen after it) and republishes with a release store — the acquire load in `restore`/`disarm` pairs with it, so no handler ever observes a torn blob. Disarm-then-arm tradeoff: the nanosecond window where `armed` is false just means a handler firing exactly then restores nothing (the issue's endorsed option).
3. Sharpened `assertPanicInstalled`'s doc comment and compile-error text to state a custom handler must call `terminal.guard.restore()` (as `ui.panic` does) — identity is unknowable at comptime, so the text is the only safeguard.
4. `editDistance` decodes UTF-8 into codepoints (malformed bytes decode to themselves so it never errors) and runs the DP over codepoints. ASCII is unchanged. Added `@setEvalBranchQuota` so comptime callers (the plugin-hook typo guard) stay under budget.

## Testing
- Root `zig build test` — pass (exit 0), including the new guard re-arm regression test and levenshtein codepoint cases (`café`/`cafe` = 1, emoji = 1 unit, etc.).
- `zig build e2e` (`projects/zcli`) — 32/32 pass.
- Windows parts cross-compile-checked on macOS: `zig build test -Dtarget=x86_64-windows` compiles clean (only cross-run exec errors, no compile errors); `conpty.zig` build-obj for Windows clean. CI runs Windows for real execution.
- `projects/zcli` `zig build` — pass.

Kept scoped to #458; did not touch `backend_posix.zig`'s POLLHUP logic (#448 / PR #474).

Fixes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4