### PR TITLE
options: short flags are explicit-only + comptime dup-guard (#439)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -497,7 +497,10 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
 **Option Formats:**
 
 - Long options: `--option value` or `--option=value`
-- Short options: `-o value` or `-ovalue` (no space)
+- Short options: `-o value` or `-ovalue` (no space). A short exists **only** when
+  explicitly declared via `meta.options.<field>.short` — a field never derives a
+  short from the first letter of its name. An undeclared short is an unknown
+  option (this mirrors global options, which are also explicit-only).
 - Boolean flags: `--verbose` (presence = true), `--no-verbose` (= false).
   Negation is long-form only; short flags have no negation.
 
@@ -536,7 +539,8 @@ files: [][]const u8
 
 **Option Conflicts:**
 
-- Build-time validation prevents duplicate short flags
+- Build-time validation prevents two options in one command from declaring the
+  same short flag, or resolving to the same long name (`@compileError`)
 - Global vs command options with same name: command wins
 
 ## 7. Key Design Decisions

--- a/packages/core/src/command_parser.zig
+++ b/packages/core/src/command_parser.zig
@@ -1102,7 +1102,7 @@ test "#287 non-integer negative as an option value (both positions agree)" {
 test "#427 bundled short with value-taker last consumes the separated value" {
     const allocator = std.testing.allocator;
     const Options = struct { verbose: bool = false, file: []const u8 = "" };
-    const meta = .{ .options = .{ .file = .{ .short = 'f' } } };
+    const meta = .{ .options = .{ .verbose = .{ .short = 'v' }, .file = .{ .short = 'f' } } };
 
     const result = try parseCommandLine(struct {}, Options, meta, allocator, null, &.{ "-vf", "out.txt" }, null);
     defer result.deinit();
@@ -1113,7 +1113,7 @@ test "#427 bundled short with value-taker last consumes the separated value" {
 test "#427 bundled short with attached value" {
     const allocator = std.testing.allocator;
     const Options = struct { verbose: bool = false, file: []const u8 = "" };
-    const meta = .{ .options = .{ .file = .{ .short = 'f' } } };
+    const meta = .{ .options = .{ .verbose = .{ .short = 'v' }, .file = .{ .short = 'f' } } };
 
     const result = try parseCommandLine(struct {}, Options, meta, allocator, null, &.{"-vfout.txt"}, null);
     defer result.deinit();
@@ -1124,7 +1124,7 @@ test "#427 bundled short with attached value" {
 test "#427 unbundled short value-taker still works" {
     const allocator = std.testing.allocator;
     const Options = struct { verbose: bool = false, file: []const u8 = "" };
-    const meta = .{ .options = .{ .file = .{ .short = 'f' } } };
+    const meta = .{ .options = .{ .verbose = .{ .short = 'v' }, .file = .{ .short = 'f' } } };
 
     const result = try parseCommandLine(struct {}, Options, meta, allocator, null, &.{ "-v", "-f", "out.txt" }, null);
     defer result.deinit();
@@ -1136,7 +1136,7 @@ test "#427 all-boolean bundle keeps a following word as a positional" {
     const allocator = std.testing.allocator;
     const Args = struct { path: []const u8 };
     const Options = struct { verbose: bool = false, debug: bool = false };
-    const meta = .{ .options = .{ .debug = .{ .short = 'd' } } };
+    const meta = .{ .options = .{ .verbose = .{ .short = 'v' }, .debug = .{ .short = 'd' } } };
 
     const result = try parseCommandLine(Args, Options, meta, allocator, null, &.{ "-vd", "input.txt" }, null);
     defer result.deinit();
@@ -1149,7 +1149,7 @@ test "#427 value-taker mid-bundle takes the rest as attached value, next word st
     const allocator = std.testing.allocator;
     const Args = struct { path: []const u8 };
     const Options = struct { verbose: bool = false, file: []const u8 = "", debug: bool = false };
-    const meta = .{ .options = .{ .file = .{ .short = 'f' }, .debug = .{ .short = 'd' } } };
+    const meta = .{ .options = .{ .verbose = .{ .short = 'v' }, .file = .{ .short = 'f' }, .debug = .{ .short = 'd' } } };
 
     // `-vfd`: v is boolean, f is the first value-taker and is not the last char,
     // so the remaining `d` is f's attached value (NOT a boolean flag). The

--- a/packages/core/src/options/parser.zig
+++ b/packages/core/src/options/parser.zig
@@ -638,10 +638,10 @@ fn parseShortOptionsWithMeta(
         var char_field_found = false;
         var char_is_boolean = false;
         inline for (@typeInfo(OptionsType).@"struct".fields) |field| {
-            // Get the expected short option character for this field (comptime)
+            // The field's declared short char, if any (undeclared → no match).
             const expected_char = comptime utils.shortCharForField(meta, field.name);
 
-            const matches = expected_char == char;
+            const matches = if (expected_char) |ec| ec == char else false;
 
             if (matches) {
                 char_field_found = true;
@@ -662,7 +662,7 @@ fn parseShortOptionsWithMeta(
                 _ = i; // Unused for boolean flags
                 const expected_char = comptime utils.shortCharForField(meta, field.name);
 
-                const matches = expected_char == char;
+                const matches = if (expected_char) |ec| ec == char else false;
 
                 if (matches) {
                     if (comptime utils.isBooleanFlag(field.type)) {
@@ -685,10 +685,10 @@ fn parseShortOptionsWithMeta(
 
             var char_found = false;
             inline for (@typeInfo(OptionsType).@"struct".fields, 0..) |field, i| {
-                // Get the expected short option character for this field (comptime)
+                // The field's declared short char, if any (undeclared → no match).
                 const expected_char = comptime utils.shortCharForField(meta, field.name);
 
-                const matches = expected_char == char;
+                const matches = if (expected_char) |ec| ec == char else false;
 
                 if (matches and !char_found) {
                     char_found = true;
@@ -856,17 +856,48 @@ test "parseOptions basic" {
     }
 }
 
+test "short flags are explicit-only: an undeclared first-letter short is unknown (#439)" {
+    const TestOptions = struct {
+        verbose: bool = false,
+        output: []const u8 = "stdout",
+    };
+    const allocator = std.testing.allocator;
+
+    // With NO meta, no field declares a short — so `-v`/`-o` are not the
+    // first-letter shorts of `verbose`/`output`; they are simply unknown.
+    {
+        var diag: ?ZcliDiagnostic = null;
+        try std.testing.expectError(ZcliError.OptionUnknown, parseOptions(TestOptions, allocator, &.{"-v"}, &diag));
+        try std.testing.expect(diag.?.OptionUnknown.is_short);
+        try std.testing.expectEqualStrings("v", diag.?.OptionUnknown.option_name);
+    }
+    {
+        try std.testing.expectError(ZcliError.OptionUnknown, parseOptions(TestOptions, allocator, &.{ "-o", "file.txt" }, null));
+    }
+
+    // Declaring the short makes exactly that short resolve — nothing else.
+    {
+        const meta = .{ .options = .{ .output = .{ .short = 'o' } } };
+        const parsed = try parseOptionsWithMeta(TestOptions, meta, allocator, null, &.{ "-o", "file.txt" }, null);
+        try std.testing.expectEqualStrings("file.txt", parsed.options.output);
+        // `verbose` still has no short even though a sibling declared one.
+        try std.testing.expectError(ZcliError.OptionUnknown, parseOptionsWithMeta(TestOptions, meta, allocator, null, &.{"-v"}, null));
+    }
+}
+
 test "parseOptions short flags" {
     const TestOptions = struct {
         verbose: bool = false,
         quiet: bool = false,
     };
+    // Shorts are explicit-only, so a short-flag test must declare them.
+    const meta = .{ .options = .{ .verbose = .{ .short = 'v' }, .quiet = .{ .short = 'q' } } };
 
     const allocator = std.testing.allocator;
 
     {
         const args = [_][]const u8{"-vq"};
-        const parsed = try parseOptions(TestOptions, allocator, &args, null);
+        const parsed = try parseOptionsWithMeta(TestOptions, meta, allocator, null, &args, null);
         try std.testing.expect(parsed.options.verbose);
         try std.testing.expect(parsed.options.quiet);
     }
@@ -894,13 +925,15 @@ test "parseOptions short option with value" {
         name: []const u8 = "default",
         port: u16 = 8080,
     };
+    // Shorts are explicit-only.
+    const meta = .{ .options = .{ .name = .{ .short = 'n' }, .port = .{ .short = 'p' } } };
 
     const allocator = std.testing.allocator;
 
     // Test with space
     {
         const args = [_][]const u8{ "-n", "test", "-p", "9000" };
-        const parsed = try parseOptions(TestOptions, allocator, &args, null);
+        const parsed = try parseOptionsWithMeta(TestOptions, meta, allocator, null, &args, null);
         try std.testing.expectEqualStrings("test", parsed.options.name);
         try std.testing.expectEqual(@as(u16, 9000), parsed.options.port);
     }
@@ -908,7 +941,7 @@ test "parseOptions short option with value" {
     // Test without space
     {
         const args = [_][]const u8{ "-ntest2", "-p9001" };
-        const parsed = try parseOptions(TestOptions, allocator, &args, null);
+        const parsed = try parseOptionsWithMeta(TestOptions, meta, allocator, null, &args, null);
         try std.testing.expectEqualStrings("test2", parsed.options.name);
         try std.testing.expectEqual(@as(u16, 9001), parsed.options.port);
     }
@@ -1038,6 +1071,8 @@ test "repeated boolean is a duplicate error" {
     const TestOptions = struct {
         verbose: bool = false,
     };
+    // Declared short so the `-v` cases have a short at all (explicit-only).
+    const meta = .{ .options = .{ .verbose = .{ .short = 'v' } } };
     const allocator = std.testing.allocator;
 
     const cases = [_][]const []const u8{
@@ -1049,7 +1084,7 @@ test "repeated boolean is a duplicate error" {
         &.{"-vv"}, // short, bundled
     };
     for (cases) |args| {
-        try std.testing.expectError(ZcliError.OptionDuplicate, parseOptions(TestOptions, allocator, args, null));
+        try std.testing.expectError(ZcliError.OptionDuplicate, parseOptionsWithMeta(TestOptions, meta, allocator, null, args, null));
     }
 }
 
@@ -1181,11 +1216,13 @@ test "parseOptions array accumulation with short flags" {
         files: [][]const u8 = &.{},
         numbers: []i32 = &.{},
     };
+    // Shorts are explicit-only.
+    const meta = .{ .options = .{ .files = .{ .short = 'f' }, .numbers = .{ .short = 'n' } } };
 
     const allocator = std.testing.allocator;
 
     const args = [_][]const u8{ "-f", "first.txt", "-f", "second.txt", "-n", "10", "-n", "20" };
-    const parsed = try parseOptions(TestOptions, allocator, &args, null);
+    const parsed = try parseOptionsWithMeta(TestOptions, meta, allocator, null, &args, null);
     defer cleanupOptions(TestOptions, parsed.options, allocator);
 
     try std.testing.expectEqual(@as(usize, 2), parsed.options.files.len);
@@ -1203,6 +1240,8 @@ test "parseOptions comma-separated array values" {
         numbers: []i32 = &.{},
         label: ?[]const u8 = null,
     };
+    // Shorts are explicit-only.
+    const meta = .{ .options = .{ .files = .{ .short = 'f' }, .numbers = .{ .short = 'n' } } };
 
     const allocator = std.testing.allocator;
 
@@ -1215,7 +1254,7 @@ test "parseOptions comma-separated array values" {
         "-n3,4", // attached short form
         "--label", "x,y", // scalar option — NOT split
     };
-    const parsed = try parseOptions(TestOptions, allocator, &args, null);
+    const parsed = try parseOptionsWithMeta(TestOptions, meta, allocator, null, &args, null);
     defer cleanupOptions(TestOptions, parsed.options, allocator);
 
     try std.testing.expectEqual(@as(usize, 3), parsed.options.files.len);
@@ -1361,13 +1400,20 @@ test "parseOptions bundled short options" {
         force: bool = false,
         all: bool = false,
     };
+    // Shorts are explicit-only.
+    const meta = .{ .options = .{
+        .verbose = .{ .short = 'v' },
+        .quiet = .{ .short = 'q' },
+        .force = .{ .short = 'f' },
+        .all = .{ .short = 'a' },
+    } };
 
     const allocator = std.testing.allocator;
 
     // Test various bundled combinations
     {
         const args = [_][]const u8{"-vqf"};
-        const parsed = try parseOptions(TestOptions, allocator, &args, null);
+        const parsed = try parseOptionsWithMeta(TestOptions, meta, allocator, null, &args, null);
 
         try std.testing.expect(parsed.options.verbose);
         try std.testing.expect(parsed.options.quiet);
@@ -1378,7 +1424,7 @@ test "parseOptions bundled short options" {
     // Test mixed bundled and separate
     {
         const args = [_][]const u8{ "-vq", "-f", "-a" };
-        const parsed = try parseOptions(TestOptions, allocator, &args, null);
+        const parsed = try parseOptionsWithMeta(TestOptions, meta, allocator, null, &args, null);
 
         try std.testing.expect(parsed.options.verbose);
         try std.testing.expect(parsed.options.quiet);
@@ -1393,13 +1439,19 @@ test "parseOptions bundled short options with trailing value-taker (GNU getopt)"
         quiet: bool = false,
         file: []const u8 = "",
     };
+    // Shorts are explicit-only.
+    const meta = .{ .options = .{
+        .verbose = .{ .short = 'v' },
+        .quiet = .{ .short = 'q' },
+        .file = .{ .short = 'f' },
+    } };
 
     const allocator = std.testing.allocator;
 
     // -vf X: boolean then value-taker taking the next argument
     {
         const args = [_][]const u8{ "-vf", "out.txt" };
-        const parsed = try parseOptions(TestOptions, allocator, &args, null);
+        const parsed = try parseOptionsWithMeta(TestOptions, meta, allocator, null, &args, null);
 
         try std.testing.expect(parsed.options.verbose);
         try std.testing.expectEqualStrings("out.txt", parsed.options.file);
@@ -1409,7 +1461,7 @@ test "parseOptions bundled short options with trailing value-taker (GNU getopt)"
     // -vvf X: repeated boolean errors as duplicate, not silently dropped
     {
         const args = [_][]const u8{ "-vqf", "out.txt" };
-        const parsed = try parseOptions(TestOptions, allocator, &args, null);
+        const parsed = try parseOptionsWithMeta(TestOptions, meta, allocator, null, &args, null);
 
         try std.testing.expect(parsed.options.verbose);
         try std.testing.expect(parsed.options.quiet);
@@ -1419,7 +1471,7 @@ test "parseOptions bundled short options with trailing value-taker (GNU getopt)"
     // -vfout.txt: value attached directly after the value-taker
     {
         const args = [_][]const u8{"-vfout.txt"};
-        const parsed = try parseOptions(TestOptions, allocator, &args, null);
+        const parsed = try parseOptionsWithMeta(TestOptions, meta, allocator, null, &args, null);
 
         try std.testing.expect(parsed.options.verbose);
         try std.testing.expectEqualStrings("out.txt", parsed.options.file);
@@ -1428,7 +1480,7 @@ test "parseOptions bundled short options with trailing value-taker (GNU getopt)"
     // -fv X: value-taker first consumes the rest of the bundle as its value
     {
         const args = [_][]const u8{ "-fv", "ignored" };
-        const parsed = try parseOptions(TestOptions, allocator, &args, null);
+        const parsed = try parseOptionsWithMeta(TestOptions, meta, allocator, null, &args, null);
 
         try std.testing.expect(!parsed.options.verbose);
         try std.testing.expectEqualStrings("v", parsed.options.file);
@@ -1437,14 +1489,14 @@ test "parseOptions bundled short options with trailing value-taker (GNU getopt)"
     // -vz: unknown char after a boolean errors
     {
         const args = [_][]const u8{"-vz"};
-        const result = parseOptions(TestOptions, allocator, &args, null);
+        const result = parseOptionsWithMeta(TestOptions, meta, allocator, null, &args, null);
         try std.testing.expectError(error.OptionUnknown, result);
     }
 
     // -vf with no value following errors MissingOptionValue
     {
         const args = [_][]const u8{"-vf"};
-        const result = parseOptions(TestOptions, allocator, &args, null);
+        const result = parseOptionsWithMeta(TestOptions, meta, allocator, null, &args, null);
         try std.testing.expectError(error.OptionMissingValue, result);
     }
 }

--- a/packages/core/src/options/utils.zig
+++ b/packages/core/src/options/utils.zig
@@ -720,17 +720,21 @@ pub fn negatedLongNameMatchesField(
 }
 
 /// The short flag character for a field: `meta.options.<field>.short` when
-/// declared, otherwise the field name's first character.
-pub fn shortCharForField(comptime meta: anytype, comptime field_name: []const u8) u8 {
+/// explicitly declared, otherwise `null`. Shorts are declaration-only — a field
+/// gets NO short from its name (mirroring the global-options model). This is why
+/// help and completions, which read the declared short directly, and the parser,
+/// which reads it through this accessor, all agree that an undeclared short does
+/// not exist (an undeclared first-letter short is `error.UnknownOption`).
+pub fn shortCharForField(comptime meta: anytype, comptime field_name: []const u8) ?u8 {
     if (@TypeOf(meta) != @TypeOf(null) and @hasField(@TypeOf(meta), "options")) {
         if (@hasField(@TypeOf(meta.options), field_name)) {
             const field_meta = @field(meta.options, field_name);
-            if (@TypeOf(field_meta) != []const u8 and @hasField(@TypeOf(field_meta), "short")) {
+            if (@typeInfo(@TypeOf(field_meta)) == .@"struct" and @hasField(@TypeOf(field_meta), "short")) {
                 return field_meta.short;
             }
         }
     }
-    return if (field_name.len > 0) field_name[0] else 0;
+    return null;
 }
 
 // ============================================================================
@@ -833,8 +837,8 @@ pub fn shortOptionTakesValue(
     char: u8,
 ) ?bool {
     inline for (@typeInfo(OptionsType).@"struct".fields) |field| {
-        if (shortCharForField(meta, field.name) == char) {
-            return !isBooleanFlag(field.type);
+        if (shortCharForField(meta, field.name)) |sc| {
+            if (sc == char) return !isBooleanFlag(field.type);
         }
     }
     return null;
@@ -873,6 +877,17 @@ test "negatedLongNameMatchesField matches only the no- form" {
     try std.testing.expect(!negatedLongNameMatchesField(meta, "fast", "no-fast"));
 }
 
+test "shortCharForField is explicit-only (no first-letter fallback) (#439)" {
+    // Declared short resolves; an undeclared field has no short (null), even
+    // though its name starts with a letter that used to auto-derive.
+    const meta = .{ .options = .{ .output = .{ .short = 'o' } } };
+    try std.testing.expectEqual(@as(?u8, 'o'), shortCharForField(meta, "output"));
+    try std.testing.expectEqual(@as(?u8, null), shortCharForField(meta, "verbose"));
+    // No meta at all: nothing has a short.
+    try std.testing.expectEqual(@as(?u8, null), shortCharForField(null, "verbose"));
+    try std.testing.expectEqual(@as(?u8, null), shortCharForField(.{}, "verbose"));
+}
+
 test "takes-value resolution matches parser semantics" {
     const Options = struct {
         verbose: bool = false,
@@ -887,8 +902,10 @@ test "takes-value resolution matches parser semantics" {
     try std.testing.expectEqual(@as(?bool, null), longOptionTakesValue(Options, meta, "output-file")); // custom name shadows
     try std.testing.expectEqual(@as(?bool, null), longOptionTakesValue(Options, meta, "bogus"));
 
-    try std.testing.expectEqual(@as(?bool, false), shortOptionTakesValue(Options, meta, 'v'));
-    try std.testing.expectEqual(@as(?bool, true), shortOptionTakesValue(Options, meta, 'c'));
+    // Shorts are explicit-only: `verbose`/`count` declare none, so their first
+    // letters are NOT shorts (null = unknown). Only the declared `-o` resolves.
+    try std.testing.expectEqual(@as(?bool, null), shortOptionTakesValue(Options, meta, 'v'));
+    try std.testing.expectEqual(@as(?bool, null), shortOptionTakesValue(Options, meta, 'c'));
     try std.testing.expectEqual(@as(?bool, true), shortOptionTakesValue(Options, meta, 'o'));
     try std.testing.expectEqual(@as(?bool, null), shortOptionTakesValue(Options, meta, 'x'));
 }

--- a/packages/core/src/zcli.zig
+++ b/packages/core/src/zcli.zig
@@ -486,6 +486,33 @@ pub fn validateCommand(comptime path: []const u8, comptime Module: type) void {
                 }
             }
         }
+
+        // No two options may collide on a spelling: the parser resolves a flag by
+        // the first field that matches, so a duplicate effective long name or a
+        // duplicate *explicitly declared* short (#439) would leave the later field
+        // unreachable via that spelling with no diagnostic. Shorts are
+        // declaration-only, so only declared shorts can collide (an undeclared
+        // first-letter short does not exist). Compared pairwise over the fields.
+        const opt_fields = @typeInfo(OptionsType).@"struct".fields;
+        inline for (opt_fields, 0..) |a, ai| {
+            inline for (opt_fields[0..ai]) |b| {
+                const a_long = option_utils.effectiveLongName(opts_meta, a.name);
+                const b_long = option_utils.effectiveLongName(opts_meta, b.name);
+                if (std.mem.eql(u8, a_long, b_long)) {
+                    @compileError(loc ++ "options '" ++ b.name ++ "' and '" ++ a.name ++
+                        "' both resolve to the long flag `--" ++ a_long ++ "`. Rename one, or give it a " ++
+                        "distinct `meta.options.<field>.name`.");
+                }
+                if (option_utils.shortCharForField(opts_meta, a.name)) |a_short| {
+                    if (option_utils.shortCharForField(opts_meta, b.name)) |b_short| {
+                        if (a_short == b_short) {
+                            @compileError(loc ++ "options '" ++ b.name ++ "' and '" ++ a.name ++
+                                "' both declare the short flag `-" ++ &[_]u8{a_short} ++ "`. Give them distinct shorts.");
+                        }
+                    }
+                }
+            }
+        }
     }
 
     if (@hasDecl(Module, "meta")) {
@@ -795,6 +822,20 @@ test "validateCommand accepts a well-formed command" {
     };
     comptime validateCommand("group", Group);
 
+    // Distinct shorts and distinct effective long names are fine — the dup-guard
+    // (#439) only fires on a collision. Two fields whose names share a first
+    // letter no longer collide, because shorts are explicit-only.
+    const Distinct = struct {
+        pub const meta = .{ .options = .{
+            .verbose = .{ .short = 'v' },
+            .version = .{ .short = 'V' },
+        } };
+        pub const Args = struct {};
+        pub const Options = struct { verbose: bool = false, version: bool = false };
+        pub fn execute(_: Args, _: Options, _: anytype) !void {}
+    };
+    comptime validateCommand("distinct", Distinct);
+
     try testing.expect(true);
 }
 
@@ -829,6 +870,17 @@ test "validateCommand accepts a well-formed command" {
 //
 //   command 'broken': option 'a' lists itself in `requires`
 //     pub const meta = .{ .options = .{ .a = .{ .requires = .{.a} } } };
+//
+//   Option spelling collisions (#439). Shorts are explicit-only, so only a
+//   *declared* short can collide; two names that resolve to the same long form
+//   collide too. Each guard below is verified by hand:
+//
+//   command 'broken': options 'a' and 'b' both declare the short flag `-x`. ...
+//     pub const meta = .{ .options = .{ .a = .{ .short = 'x' }, .b = .{ .short = 'x' } } };
+//     pub const Options = struct { a: bool = false, b: bool = false };
+//
+//   command 'broken': options 'dry_run' and 'dry-run' both resolve to the long flag `--dry-run`. ...
+//     pub const Options = struct { @"dry-run": bool = false, dry_run: bool = false };
 
 test "Context creation" {
     const allocator = testing.allocator;


### PR DESCRIPTION
## Problem

Short flags were being **auto-derived from the field name's first character**. The `shortCharForField` fallback (`return field_name[0]`, in `packages/core/src/options/utils.zig`) has existed since the initial commit but was never intended: help, completions, and global options only ever advertise **explicitly declared** shorts. So the parser silently accepted shorts that nothing documented, and — the reported half of #439 — two fields sharing a first letter (`verbose` + `version`) both resolved `-v` to whichever came first, leaving the other unreachable with no diagnostic.

Prior attempt PR #476 (now closed) kept auto-derivation and added a collision guard. Per the maintainer decision, this PR instead **removes auto-derivation entirely**.

## Fix

**BREAKING:** a short exists ONLY when explicitly declared via `meta.options.<field>.short`. An undeclared first-letter short is now `error.UnknownOption`.

- `shortCharForField` now returns `?u8` (`null` = no short). The parser, the shared pre-split classifiers (`shortOptionTakesValue` / `isValueToken`, the deliberate shared-classifier invariant with `command_parser.zig`), help, and completions all agree an undeclared short does not exist. Help/completions already read the declared `.short` directly, so they were already correct — this aligns the parser with them.
- `validateCommand` gains a slim comptime dup-guard: `@compileError` when two fields in one `Options` struct declare the **same explicit short**, or resolve to the **same effective long name** (the surviving half of #439).
- Fixed in-repo callers that relied on auto-derived shorts: the `parser` / `command_parser` unit tests that exercised short-flag machinery via `parseOptions` (meta = `null`) now pass a meta declaring the shorts. No command, example, or e2e advertised an auto-derived short (help/completions never showed them), so none lost a user-facing short; the `projects/zcli` e2e already declares `-v`/`-c` explicitly.
- Docs: `DESIGN.md` now states shorts are explicit-only and documents the build-time dup-flag validation.

## Testing

- `zig build test` (root) — **pass** (was 28 failing before the caller fixes; all short-flag unit tests that relied on auto-derivation).
- `cd projects/zcli && zig build && zig build test` — **pass**.
- `zig build e2e` (scaffolded projects; completions/help surface) — **pass**.

New regression tests:
- `short flags are explicit-only: an undeclared first-letter short is unknown (#439)` — proves `-v`/`-o` are `OptionUnknown` with no meta, and that declaring a sibling's short does not grant one to `verbose` (fails before this change, passes after).
- `shortCharForField is explicit-only (no first-letter fallback) (#439)` — unit test on the accessor.
- `validateCommand accepts a well-formed command` — extended with a positive compile test that distinct shorts + distinct longs compile.

The two `@compileError` branches can't be unit-asserted (comptime errors abort compilation), so they were verified by hand against scratch colliding commands:

```
error: command 'distinct': options 'verbose' and 'version' both declare the short flag `-v`. Give them distinct shorts.
error: command 'distinct': options 'verbose' and 'version' both resolve to the long flag `--verbose`. Rename one, or give it a distinct `meta.options.<field>.name`.
```

Hand-verifiable negative cases are documented alongside the existing ones in `zcli.zig`.

## Interactions

Branched from `main`, so independent of open PR #460 (`fix/427-bundled-short-presplit`), which touches the same classifiers — conflicts to be resolved at merge. The change is kept well-factored (the classifiers remain the single source of truth shared with `command_parser.zig`).

Fixes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsA13fZCHHbPdctJi4D4t4