### PR TITLE
vterm: fix absolute cursor addressing desync after scrolling (#504)

### DIFF
--- a/packages/vterm/src/tests/cursor_test.zig
+++ b/packages/vterm/src/tests/cursor_test.zig
@@ -32,3 +32,54 @@ test "cursor advancement" {
     try testing.expectEqual(@as(u16, 0), term.cursor.x);
     try testing.expectEqual(@as(u16, 1), term.cursor.y);
 }
+
+// Regression tests for #504: absolute cursor addressing (CUP/CUU/CUD) must map
+// viewport-relative rows to absolute logical lines once output has scrolled
+// past one screen, otherwise writes land on scrolled-off lines the viewport
+// never shows.
+
+test "CUP home-and-repaint lands on viewport after scrolling (#504)" {
+    var term = try VTerm.init(testing.allocator, 4, 2);
+    defer term.deinit();
+
+    // Four lines into a two-row viewport: the buffer scrolls, viewport row 0
+    // is absolute line 2 ('c'), row 1 is line 3 ('d').
+    term.write("a\nb\nc\nd");
+    try testing.expectEqual(@as(u21, 'c'), term.getCell(0, 0).char);
+    try testing.expectEqual(@as(u21, 'd'), term.getCell(0, 1).char);
+
+    // Home (ESC[1;1H) then write: 'Z' must land on viewport cell (0,0).
+    term.write("\x1b[1;1H");
+    term.write("Z");
+    try testing.expectEqual(@as(u21, 'Z'), term.getCell(0, 0).char);
+    // Row 1 is untouched.
+    try testing.expectEqual(@as(u21, 'd'), term.getCell(0, 1).char);
+}
+
+test "CUU at scrolled bottom moves up one viewport row (#504)" {
+    var term = try VTerm.init(testing.allocator, 4, 2);
+    defer term.deinit();
+
+    term.write("a\nb\nc\nd");
+    // Cursor is on the bottom viewport row (line 3) at column 1 (after 'd').
+    // ESC[A moves up one row but leaves the column unchanged.
+    term.write("\x1b[A");
+    try testing.expectEqual(@as(u16, 0), term.cursor.y);
+    // The write lands on the top viewport row, at the current column.
+    term.write("Z");
+    try testing.expectEqual(@as(u21, 'Z'), term.getCell(1, 0).char);
+    // The original 'c' in column 0 of that row is untouched.
+    try testing.expectEqual(@as(u21, 'c'), term.getCell(0, 0).char);
+}
+
+test "CUP addressing unchanged before scrolling (#504)" {
+    var term = try VTerm.init(testing.allocator, 4, 3);
+    defer term.deinit();
+
+    // Only two lines written into a three-row viewport: nothing scrolled.
+    term.write("a\nb");
+    term.write("\x1b[1;1H"); // home
+    term.write("Z");
+    try testing.expectEqual(@as(u21, 'Z'), term.getCell(0, 0).char);
+    try testing.expectEqual(@as(u21, 'b'), term.getCell(0, 1).char);
+}

--- a/packages/vterm/src/vterm.zig
+++ b/packages/vterm/src/vterm.zig
@@ -165,6 +165,26 @@ pub const VTerm = struct {
         return self.total_lines_written - 1;
     }
 
+    /// Convert a viewport-relative row (0..height-1) to the ABSOLUTE logical
+    /// line number the write path uses (`virtual_cursor_y`, `setCellDirect`,
+    /// `openLine`). CSI cursor moves (CUP/CUU/CUD) are addressed in viewport
+    /// coordinates, but writes and reads operate on absolute lines — without
+    /// this conversion, repositioning after the buffer scrolls past one
+    /// screen lands subsequent output on scrolled-off lines the viewport never
+    /// shows (#504). Mirrors the present-view mapping in `viewportToBuffer`
+    /// (user scrollback offset excluded: the cursor always addresses the live
+    /// bottom of the buffer).
+    fn viewportToLogicalLine(self: *VTerm, viewport_y: u16) u32 {
+        // Mirror viewportToBuffer's special case: before the buffer has filled
+        // one screen the bottom line sits above viewport row height-1, so the
+        // scroll formula would underflow — viewport rows map straight through.
+        if (self.total_lines_written <= self.height) {
+            return viewport_y;
+        }
+        const bottom_line = self.getBottomLine();
+        return bottom_line - (self.height - 1) + viewport_y;
+    }
+
     // Bounds checking
     fn isValidPos(self: VTerm, x: u16, y: u16) bool {
         return x < self.width and y < self.height;
@@ -390,8 +410,10 @@ pub const VTerm = struct {
         // Clamp to valid bounds
         self.cursor.x = @min(x, self.width - 1);
         self.cursor.y = @min(y, self.height - 1);
-        // Update virtual cursor to match visible cursor
-        self.virtual_cursor_y = self.cursor.y;
+        // Map the viewport-relative row to the absolute logical line the write
+        // path addresses, so output after repositioning lands on the row the
+        // viewport shows even once the buffer has scrolled (#504).
+        self.virtual_cursor_y = self.viewportToLogicalLine(self.cursor.y);
     }
 
     // Screen Operations
@@ -689,12 +711,14 @@ pub const VTerm = struct {
                 self.cursor.y = if (n > self.cursor.y) 0 else self.cursor.y - @as(u16, @intCast(n));
                 // Keep the write position (virtual_cursor_y) in sync, as CUP does,
                 // so text written after moving up overwrites the right rows.
-                self.virtual_cursor_y = self.cursor.y;
+                // Convert the viewport row to an absolute logical line (#504).
+                self.virtual_cursor_y = self.viewportToLogicalLine(self.cursor.y);
             },
             'B' => { // CUD - Cursor Down
                 const n = self.getParam(0, 1);
                 self.cursor.y = @min(self.cursor.y + @as(u16, @intCast(n)), self.height - 1);
-                self.virtual_cursor_y = self.cursor.y;
+                // Convert the viewport row to an absolute logical line (#504).
+                self.virtual_cursor_y = self.viewportToLogicalLine(self.cursor.y);
             },
             'C' => { // CUF - Cursor Forward
                 const n = self.getParam(0, 1);


### PR DESCRIPTION
Fixes #504

## Problem
In `packages/vterm/src/vterm.zig`, vertical cursor moves — `moveCursor`, CUU (`A`), CUD (`B`), and CUP (`H`/`f`) — set `virtual_cursor_y` from `cursor.y`, a **viewport-relative** row (0..height-1). But the write path (`putChar`/`openLine`/`setCellDirect`) treats `virtual_cursor_y` as an **absolute** logical buffer line, while reads map viewport rows through `viewportToBuffer` (`bottom_line - (height-1) + y`).

Once output scrolls past one screen the two interpretations diverge: a home-and-repaint (`ESC[1;1H`) writes to the scrolled-off absolute line 0 instead of the viewport's top row, so the text is invisible to viewport reads — silently corrupting what the testing package asserts against. (Before the buffer fills one screen a special case in `viewportToBuffer` masked the bug.)

## Fix
Added `viewportToLogicalLine()`, which converts a viewport-relative row to the absolute logical line using the same present-view mapping reads use (`bottom_line - (height-1) + y`), including the matching pre-fill special case to avoid underflow before one screen of output exists. Every site that assigns `virtual_cursor_y` from viewport coordinates (`moveCursor`, CUU, CUD; CUP goes through `moveCursor`) now routes through it. The plain `\n` write path already maintained absolute lines and is untouched.

## Tests
Added three regression tests in `cursor_test.zig`:
1. Home-and-repaint after scrolling past one screen — `Z` lands on viewport cell (0,0).
2. `ESC[A` (CUU) at a scrolled bottom — write lands one viewport row up.
3. Pre-scroll addressing unchanged.

`zig build` and `zig build test` both pass from the repo root; no downstream (testing-package) fallout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)