### PR TITLE
vterm: fix extended-color SGR, unterminated-OSC re-parse, and 1-col wide-char panic

### DIFF
--- a/packages/vterm/src/tests/parser_test.zig
+++ b/packages/vterm/src/tests/parser_test.zig
@@ -336,13 +336,29 @@ test "a bare ESC after OSC-escape that isn't ST re-enters escape handling" {
     var term = try VTerm.init(testing.allocator, 80, 24);
     defer term.deinit();
 
-    // ESC inside the OSC payload not followed by '\\' should not terminate
-    // the OSC as ST and also should not itself get printed; the parser
-    // resumes discarding as OSC payload.
+    // ESC inside the OSC payload not followed by '\\' terminates the OSC and
+    // introduces a fresh escape sequence (#528). Here `ESC Z` is consumed as a
+    // two-byte escape, and the text after it prints as normal ground content.
+    // The OSC payload (`0;abc`) and the escape bytes never print.
     term.write("\x1b]0;abc\x1bZhello\x07world");
     try testing.expect(!term.containsText("abc"));
-    try testing.expect(!term.containsText("hello"));
+    try testing.expect(!term.containsText("Z"));
+    try testing.expect(term.containsText("hello"));
     try testing.expect(term.containsText("world"));
+}
+
+test "unterminated OSC followed by CSI still executes the CSI (#528)" {
+    var term = try VTerm.init(testing.allocator, 80, 24);
+    defer term.deinit();
+
+    // Prime the screen with content, then send an unterminated OSC directly
+    // followed by an ED clear-screen (`ESC[2J`). The ESC must terminate the
+    // OSC and let the CSI run — the screen ends up cleared.
+    term.write("visible");
+    try testing.expect(term.containsText("visible"));
+    term.write("\x1b]0;title-without-terminator\x1b[2J");
+    try testing.expect(!term.containsText("visible"));
+    try testing.expect(!term.containsText("title"));
 }
 
 test "CSI with colon sub-parameters is consumed, not leaked" {

--- a/packages/vterm/src/tests/sgr_test.zig
+++ b/packages/vterm/src/tests/sgr_test.zig
@@ -116,6 +116,89 @@ test "SGR attribute disable" {
     try testing.expect(!cell.underline);
 }
 
+test "256-color foreground and background (semicolon form)" {
+    var term = try VTerm.init(testing.allocator, 80, 24);
+    defer term.deinit();
+
+    // ESC[38;5;9m — 256-color fg index 9 (bright red). Must set the color and
+    // set NO other attributes.
+    term.write("\x1b[38;5;9mX");
+    var cell = term.getCell(0, 0);
+    try testing.expectEqual(@as(u8, 9), cell.fg);
+    try testing.expect(!cell.bold);
+    try testing.expect(!cell.italic);
+    try testing.expect(!cell.underline);
+
+    // ESC[48;5;3m — 256-color bg index 3. The `3` must NOT become italic.
+    term.write("\x1b[48;5;3mY");
+    cell = term.getCell(1, 0);
+    try testing.expectEqual(@as(u8, 3), cell.bg);
+    try testing.expect(!cell.italic);
+}
+
+test "256-color foreground (colon form)" {
+    var term = try VTerm.init(testing.allocator, 80, 24);
+    defer term.deinit();
+
+    // ESC[38:5:9m — colon-separated 256-color fg. Same result as semicolon.
+    term.write("\x1b[38:5:9mX");
+    const cell = term.getCell(0, 0);
+    try testing.expectEqual(@as(u8, 9), cell.fg);
+    try testing.expect(!cell.bold);
+    try testing.expect(!cell.italic);
+    try testing.expect(!cell.underline);
+}
+
+test "truecolor SGR is consumed without corrupting attributes" {
+    var term = try VTerm.init(testing.allocator, 80, 24);
+    defer term.deinit();
+
+    // ESC[38;2;1;2;3m — truecolor fg. u8 cell color can't hold RGB, so the
+    // value is discarded. Critically, the sub-params 1/2/3 must NOT be applied
+    // as independent SGR codes (bold / italic).
+    term.write("\x1b[38;2;1;2;3mX");
+    var cell = term.getCell(0, 0);
+    try testing.expect(!cell.bold);
+    try testing.expect(!cell.italic);
+    try testing.expect(!cell.underline);
+
+    // ESC[38;2;34;0;0m — the `34` must NOT set fg to blue (SGR 34).
+    term.write("\x1b[38;2;34;0;0mY");
+    cell = term.getCell(1, 0);
+    try testing.expectEqual(@as(u8, 7), cell.fg); // unchanged default
+
+    // Colon-form truecolor likewise consumed cleanly.
+    term.write("\x1b[38:2:255:0:0mZ");
+    cell = term.getCell(2, 0);
+    try testing.expect(!cell.bold);
+    try testing.expect(!cell.italic);
+}
+
+test "extended color interleaved with real attributes" {
+    var term = try VTerm.init(testing.allocator, 80, 24);
+    defer term.deinit();
+
+    // ESC[1;38;5;2m — bold, then 256-color fg index 2. Bold set exactly once,
+    // fg set to 2, and the trailing `2` sub-param not misread.
+    term.write("\x1b[1;38;5;2mX");
+    const cell = term.getCell(0, 0);
+    try testing.expect(cell.bold);
+    try testing.expectEqual(@as(u8, 2), cell.fg);
+    try testing.expect(!cell.italic);
+}
+
+test "extended color followed by more SGR params" {
+    var term = try VTerm.init(testing.allocator, 80, 24);
+    defer term.deinit();
+
+    // ESC[38;5;9;1m — 256-color fg then bold. The `1` after the color unit is
+    // a real bold code and must apply.
+    term.write("\x1b[38;5;9;1mX");
+    const cell = term.getCell(0, 0);
+    try testing.expectEqual(@as(u8, 9), cell.fg);
+    try testing.expect(cell.bold);
+}
+
 test "default colors" {
     var term = try VTerm.init(testing.allocator, 80, 24);
     defer term.deinit();

--- a/packages/vterm/src/tests/wide_char_test.zig
+++ b/packages/vterm/src/tests/wide_char_test.zig
@@ -127,3 +127,19 @@ test "mixed ASCII and wide characters" {
     // Cursor should be at (7, 0)
     try testing.expect(term.cursorAt(7, 0));
 }
+
+test "wide char on 1-column terminal with DECAWM off does not panic (#529)" {
+    var term = try VTerm.init(testing.allocator, 1, 2);
+    defer term.deinit();
+
+    // Disable autowrap (DECAWM off), then write a wide (2-cell) CJK char on a
+    // 1-column terminal. Previously `self.width - 2` underflowed u16 and the
+    // continuation `cursor.x + 1` overflowed -> panic. Now the wide glyph is
+    // degraded to a single-cell write; no continuation cell, no panic.
+    term.write("\x1b[?7l");
+    term.write("你");
+
+    // The glyph lands in the single available cell; nothing overflows.
+    try testing.expect(term.getCell(0, 0).char == 0x4F60);
+    try testing.expect(!term.getCell(0, 0).wide_continuation);
+}

--- a/packages/vterm/src/vterm.zig
+++ b/packages/vterm/src/vterm.zig
@@ -305,7 +305,14 @@ pub const VTerm = struct {
     }
 
     pub fn putChar(self: *VTerm, char: u21) void {
-        const width = charWidth(char);
+        var width = charWidth(char);
+
+        // A 2-cell character cannot fit on a terminal narrower than 2 columns.
+        // Degrade it to a single-cell write so the `self.width - 2` math below
+        // never underflows u16 (and the continuation `cursor.x + 1` never
+        // overflows) on a 1-column terminal (#529). The wide glyph still lands
+        // in the single available cell; no continuation cell is written.
+        if (width == 2 and self.width < 2) width = 1;
 
         // Handle delayed wrapping: if cursor is at width, wrap before writing
         // (with DECAWM off, clamp to the last column and overwrite instead)
@@ -596,12 +603,14 @@ pub const VTerm = struct {
         switch (byte) {
             '\\' => self.parser_state = .ground, // ST terminator (ESC \)
             else => {
-                // Not a valid ST; the ESC could start a new escape sequence,
-                // or just be more payload garbage. Re-enter escape handling
-                // for this byte so a genuine `ESC ]`/`ESC [` inside a
-                // malformed OSC still gets parsed rather than silently eaten.
-                self.parser_state = .osc;
-                self.handleOsc(byte);
+                // Not a valid ST. Per the spec, the ESC terminates the OSC and
+                // introduces a new escape sequence. Terminate the OSC and feed
+                // this byte back through the escape state machine so a genuine
+                // `ESC [`/`ESC ]` inside an unterminated OSC is re-parsed
+                // (e.g. an unterminated OSC followed by `ESC[2J` must still
+                // clear the screen) rather than being swallowed as payload.
+                self.parser_state = .escape;
+                self.handleEscape(byte);
             },
         }
     }
@@ -623,11 +632,17 @@ pub const VTerm = struct {
                 }
             },
             // Colon sub-parameter separator (e.g. `ESC[38:2:255:0:0m` colon
-            // truecolor) and other parameter bytes 0x3C-0x3F (`<=>?`). vterm
-            // does not model sub-parameters, but it must stay in the CSI state
-            // and consume them so the sequence's final byte is not leaked as
-            // literal grid text.
-            ':', '<'...'>' => {
+            // truecolor). vterm does not distinguish sub-parameters from
+            // parameters, so treat a colon like a semicolon: start a new
+            // parameter slot. This lets colon-form extended colors reach
+            // handleSGR as separate params (`38`, `2`, `255`, …) and be
+            // consumed the same way as the semicolon form (#505).
+            ':' => {
+                self.nextParameter();
+            },
+            // Other parameter bytes 0x3C-0x3F (`<=>?`). Consume and discard;
+            // remain in the CSI state so the final byte is not leaked.
+            '<'...'>' => {
                 // Consume and discard; remain in the CSI state.
             },
             // Intermediate bytes: 0x20-0x2F (space, `!"#$%&'()*+,-./`). These
@@ -796,8 +811,47 @@ pub const VTerm = struct {
                 // Bright background colors
                 100...107 => self.current_bg = @as(u8, @intCast(param - 100 + 8)),
 
+                // Extended foreground / background color. The following
+                // sub-params form a single logical value: `5;n` (256-color
+                // palette index) or `2;r;g;b` (truecolor). Consume them as a
+                // unit so they are never interpreted as independent SGR codes
+                // (which would corrupt bold/italic/etc). Advance `i` past the
+                // consumed sub-params (#505).
+                38 => i += self.applyExtendedColor(i, true),
+                48 => i += self.applyExtendedColor(i, false),
+
                 else => {}, // Ignore unsupported SGR codes
             }
+        }
+    }
+
+    /// Apply an extended-color SGR (`38`/`48`) whose selector is at index
+    /// `start`, and return how many *additional* params were consumed so the
+    /// caller can advance past them. `is_fg` selects foreground vs background.
+    ///
+    /// `5;n`   → 256-color palette index; modeled directly (fits u8).
+    /// `2;r;g;b` → truecolor; the u8 cell color cannot hold RGB, so the value
+    ///             is consumed and discarded (color left unchanged) rather than
+    ///             corrupting other attributes.
+    fn applyExtendedColor(self: *VTerm, start: usize, is_fg: bool) usize {
+        const count: usize = self.param_count;
+        // Need at least the color-space selector after 38/48.
+        if (start + 1 > count) return 0;
+        switch (self.params[start + 1]) {
+            5 => {
+                // 256-color: one index param.
+                if (start + 2 > count) return 1;
+                const idx: u8 = @truncate(self.params[start + 2]);
+                if (is_fg) self.current_fg = idx else self.current_bg = idx;
+                return 2;
+            },
+            2 => {
+                // Truecolor: r;g;b (3 params). Consume up to 4 (selector + rgb),
+                // clamped to what is actually present. Discarded — see doc.
+                return @min(@as(usize, 4), count - start);
+            },
+            // Unknown color space; consume just the selector.
+            else => return 1,
         }
     }
 


### PR DESCRIPTION
Fixes three escape/character-handling bugs in `packages/vterm` found by the grade9 whole-repo review.

Fixes #505
Fixes #528
Fixes #529

## #505 [P1] — extended-color SGR
`handleSGR` had no case for `38`/`48`, so the sub-params of a semicolon-form extended color were interpreted as independent SGR codes (`ESC[38;2;1;2;3m` wrongly applied bold + italic; `ESC[38;5;9m` set no color). The colon form was collapsed into a single garbage param.

- `handleSGR` now consumes the extended-color unit: `5;n` (256-color) is modeled directly into the cell color (fits `u8`); `2;r;g;b` (truecolor) is consumed and **discarded** (the `u8` cell color can't hold RGB) so it never corrupts other attributes.
- The `:` separator in `handleCSI` is now treated like `;` (a new parameter slot), so the colon form (`ESC[38:5:9m`, `ESC[38:2:255:0:0m`) parses identically to the semicolon form.
- Interleaving with real attributes is preserved (`ESC[1;38;5;2m` → bold once + fg 2; `ESC[38;5;9;1m` → fg 9 + bold).

## #528 [P2] — unterminated-OSC re-parse
An `ESC` inside an OSC that wasn't followed by `\` (ST) fell back into `handleOsc`, which discarded everything — so an unterminated OSC followed by `ESC[2J` swallowed the clear-screen. The handler now terminates the OSC and feeds the byte back through the escape state machine, matching the documented intent and the spec (ESC always ends the string and introduces a new sequence).

## #529 [P2] — 1-column wide-char panic
With DECAWM off and a wide (2-cell) char at the right edge of a `<2`-column terminal, `self.width - 2` underflowed `u16` and the continuation `cursor.x + 1` overflowed → panic. A wide char on a terminal narrower than 2 columns is now degraded to a single-cell write (no continuation cell), giving defined behavior and no panic.

## Tests
Added regression tests (`sgr_test.zig`, `parser_test.zig`, `wide_char_test.zig`) covering all scenarios above, and updated the one existing OSC-escape test that had locked in the #528 buggy behavior. `zig build && zig build test` green from the repo root (all packages + examples).

🤖 Generated with [Claude Code](https://claude.com/claude-code)