### PR TITLE
grade9: honor `--` terminator and unshadow hook errors in global-option parsing

### DIFF
--- a/packages/core/src/plugin_pipeline_test.zig
+++ b/packages/core/src/plugin_pipeline_test.zig
@@ -561,6 +561,32 @@ test "pipeline: a failing onError hook falls through to the next handler (#390)"
     try testing.expectEqual(@as(?anyerror, error.Boom), SuppressErrPlugin.seen);
 }
 
+// The global-option parse-error path must dispatch onError through the same
+// catch-warn-continue machinery as every other error site — a bare
+// `try Plugin.onError` there would let a hook error shadow the original global
+// parse diagnostic and skip later hooks (#512, the #390 regression at a
+// different layer). `--verbose=x` is a boolean-with-value error raised inside
+// parseGlobalOptions before any command routing.
+test "pipeline: a failing onError hook at the global-option layer does not swallow the parse error (#512)" {
+    const App = zcli.Registry.init(test_config)
+        .register("greet", Greet)
+        .registerPlugin(GlobalOptPlugin)
+        .registerPlugin(ThrowingOnError)
+        .registerPlugin(SuppressErrPlugin)
+        .build();
+
+    SuppressErrPlugin.seen = null;
+    const cap = try runCapture(App, &.{ "--verbose=x", "greet" });
+    defer cap.deinit(testing.allocator);
+
+    // The throwing hook ran first and its failure was surfaced, not dropped.
+    try testing.expect(contains(cap.stderr, "onError hook failed with HookBoom"));
+    // The lower-priority handler still saw the ORIGINAL global parse error
+    // (not the hook's HookBoom) and suppressed it.
+    try testing.expectEqual(@as(?anyerror, null), cap.err);
+    try testing.expectEqual(@as(?anyerror, error.OptionBooleanWithValue), SuppressErrPlugin.seen);
+}
+
 test "pipeline: onError returning true suppresses CommandNotFound" {
     const App = zcli.Registry.init(test_config)
         .register("greet", Greet)

--- a/packages/core/src/registry/compiled.zig
+++ b/packages/core/src/registry/compiled.zig
@@ -726,16 +726,11 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
             // diagnostic when unhandled.
             const global_result = self.parseGlobalOptions(&context, current_args) catch |err| {
                 if (!isReportedCliError(err)) return err;
-                var error_handled = false;
-                inline for (sorted_plugins) |Plugin| {
-                    if (@hasDecl(Plugin, "onError")) {
-                        if (try Plugin.onError(&context, err)) {
-                            error_handled = true;
-                            break;
-                        }
-                    }
-                }
-                if (!error_handled) {
+                // Dispatch through runOnErrorHooks (not a bare `try Plugin.onError`)
+                // so a hook that itself errors can't shadow the original parse
+                // diagnostic — the same catch-warn-continue contract every other
+                // error site uses (#390/#512).
+                if (!try runOnErrorHooks(&context, err)) {
                     try reportParseError(&context, context.diagnostic);
                     return err;
                 }
@@ -844,11 +839,20 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
             defer remaining.deinit(context.allocator);
 
             var i: usize = 0;
+            // Once a bare `--` is seen, stop matching global options for the rest
+            // of argv — the command-level parsers honor `--` as an end-of-options
+            // terminator (options/parser.zig, command_parser.zig), so the global
+            // layer must too or the two disagree (#501). The `--` itself and every
+            // token after it flow untouched into `remaining` so the command parser
+            // still sees its own terminator.
+            var options_ended = false;
             while (i < args.len) {
                 const arg = args[i];
                 var handled = false;
 
-                if (std.mem.startsWith(u8, arg, "--")) {
+                if (!options_ended and std.mem.eql(u8, arg, "--")) {
+                    options_ended = true;
+                } else if (!options_ended and std.mem.startsWith(u8, arg, "--")) {
                     // Split `--name=value` before matching, mirroring the
                     // command-option long path (#391).
                     const opt_body = arg[2..];
@@ -896,7 +900,7 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
                             break;
                         }
                     }
-                } else if (std.mem.startsWith(u8, arg, "-") and arg.len == 2) {
+                } else if (!options_ended and std.mem.startsWith(u8, arg, "-") and arg.len == 2) {
                     // Single short option: mirrors the long path, including
                     // values for non-boolean globals (`-c config.json`).
                     const short_char = arg[1];
@@ -926,7 +930,7 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
                             break;
                         }
                     }
-                } else if (std.mem.startsWith(u8, arg, "-") and arg.len > 2) {
+                } else if (!options_ended and std.mem.startsWith(u8, arg, "-") and arg.len > 2) {
                     // Bundled shorts (-abc): consumed as globals only when
                     // EVERY char is a boolean global — a partial match would
                     // silently drop the other chars, and a value-taking short

--- a/packages/core/src/registry/tests.zig
+++ b/packages/core/src/registry/tests.zig
@@ -1150,6 +1150,11 @@ const TypedGlobalsPlugin = struct {
     var captured_err: ?anyerror = null;
     var captured_diag: ?zcli.ZcliDiagnostic = null;
     var command_ran: bool = false;
+    // Positional args the `echo` command received — lets tests confirm that a
+    // token which looks like a global option lands in the command's positionals
+    // (rather than being consumed by the global layer) after a bare `--`.
+    var echo_first: []const u8 = "";
+    var echo_second: []const u8 = "";
 
     pub fn reset() void {
         level = -1;
@@ -1161,6 +1166,8 @@ const TypedGlobalsPlugin = struct {
         captured_err = null;
         captured_diag = null;
         command_ran = false;
+        echo_first = "";
+        echo_second = "";
     }
 
     pub const global_options = [_]zcli.GlobalOption{
@@ -1204,6 +1211,22 @@ const TypedGlobalsPlugin = struct {
                 _ = args;
                 _ = options;
                 _ = context;
+                TypedGlobalsPlugin.command_ran = true;
+            }
+        };
+
+        // Two positionals so tests can send option-shaped tokens after `--`
+        // (including a value-taking global's name and its value) and confirm
+        // they arrive as the command's positionals untouched.
+        pub const echo = struct {
+            pub const meta = .{ .description = "echoes two positionals" };
+            pub const Args = struct { first: []const u8, second: []const u8 };
+            pub const Options = struct {};
+            pub fn execute(args: Args, options: Options, context: anytype) !void {
+                _ = options;
+                _ = context;
+                TypedGlobalsPlugin.echo_first = args.first;
+                TypedGlobalsPlugin.echo_second = args.second;
                 TypedGlobalsPlugin.command_ran = true;
             }
         };
@@ -1342,6 +1365,57 @@ test "global options: defaultValue recovers the typed comptime default" {
             try testing.expectEqualStrings("", opt.defaultValue(opt.type));
         }
     }
+}
+
+// A bare `--` at the global layer terminates global-option matching, exactly as
+// the command parsers do (options/parser.zig, command_parser.zig). Tokens after
+// `--` — even option-shaped ones — flow to the command as positionals instead of
+// being consumed as globals, so the two layers can no longer disagree (#501).
+test "global options: a bare `--` shields following tokens from the global layer (#501)" {
+    const TestApp = typedGlobalsApp();
+    var app = TestApp.init();
+    const test_environ = std.process.Environ.Map.init(testing.allocator);
+
+    // A boolean global's long form after `--` is a positional, not a global.
+    TypedGlobalsPlugin.reset();
+    try runQuiet(&app, &test_environ, &.{ "echo", "--", "--verbose", "hello" });
+    try testing.expect(TypedGlobalsPlugin.command_ran);
+    try testing.expect(!TypedGlobalsPlugin.verbose);
+    try testing.expectEqualStrings("--verbose", TypedGlobalsPlugin.echo_first);
+    try testing.expectEqualStrings("hello", TypedGlobalsPlugin.echo_second);
+
+    // A value-taking global after `--` keeps BOTH its name and its value as
+    // positionals — the global layer must not steal `--level 5`.
+    TypedGlobalsPlugin.reset();
+    try runQuiet(&app, &test_environ, &.{ "echo", "--", "--level", "5" });
+    try testing.expect(TypedGlobalsPlugin.command_ran);
+    try testing.expectEqual(@as(i64, -1), TypedGlobalsPlugin.level); // never dispatched
+    try testing.expectEqualStrings("--level", TypedGlobalsPlugin.echo_first);
+    try testing.expectEqualStrings("5", TypedGlobalsPlugin.echo_second);
+
+    // Short global forms after `--` are also just positionals.
+    TypedGlobalsPlugin.reset();
+    try runQuiet(&app, &test_environ, &.{ "echo", "--", "-v", "-l" });
+    try testing.expect(TypedGlobalsPlugin.command_ran);
+    try testing.expect(!TypedGlobalsPlugin.verbose);
+    try testing.expectEqualStrings("-v", TypedGlobalsPlugin.echo_first);
+    try testing.expectEqualStrings("-l", TypedGlobalsPlugin.echo_second);
+}
+
+// Only the terminator and what follows are shielded; globals BEFORE `--` are
+// still consumed normally (#501).
+test "global options: globals before `--` still parse (#501)" {
+    const TestApp = typedGlobalsApp();
+    var app = TestApp.init();
+    const test_environ = std.process.Environ.Map.init(testing.allocator);
+
+    TypedGlobalsPlugin.reset();
+    try runQuiet(&app, &test_environ, &.{ "-v", "echo", "--", "-l", "x" });
+    try testing.expect(TypedGlobalsPlugin.command_ran);
+    try testing.expect(TypedGlobalsPlugin.verbose); // consumed before `--`
+    try testing.expectEqual(@as(i64, -1), TypedGlobalsPlugin.level); // shielded after `--`
+    try testing.expectEqualStrings("-l", TypedGlobalsPlugin.echo_first);
+    try testing.expectEqualStrings("x", TypedGlobalsPlugin.echo_second);
 }
 
 // ============================================================================


### PR DESCRIPTION
Fixes #501
Fixes #512

## #501 [P1] — `--` end-of-options terminator at the global layer
`parseGlobalOptions` scanned all of argv for global options but never
special-cased a bare `--`, so a positional after `--` that looks like an option
(`myapp greet -- --version`, `myapp run -- --config x`) was consumed by the
global layer even though the command-level parsers honor `--`.

**Fix:** track an `options_ended` flag in the scan loop. On the first bare `--`,
stop matching global options for the remainder; the `--` itself and every
following token flow untouched into `remaining` so the command parser still sees
its own terminator (options/parser.zig, command_parser.zig). Globals *before*
`--` still parse normally.

## #512 [P2] — hook-error shadowing on the global parse-error path
The global-option parse-error path dispatched onError with a bare
`try Plugin.onError`, reintroducing the #390 bug: a hook that itself errors
would propagate in place of the real diagnostic and skip later hooks.

**Fix:** route through `runOnErrorHooks`, the catch-warn-continue helper written
for #390 that every other error site already uses, so a failing hook is noted on
stderr and dispatch continues without losing the original diagnostic.

## Tests
- `packages/core/src/registry/tests.zig`: a two-positional `echo` fixture drives
  `--`-terminator coverage — bool, value-taking, and short globals after `--`
  land as command positionals; globals before `--` still parse.
- `packages/core/src/plugin_pipeline_test.zig`: a #512 regression mirroring the
  #390 fall-through test, triggered at the global-option layer
  (`--verbose=x`): a throwing hook is surfaced (not swallowed) and the
  lower-priority handler still sees the original parse error.

`zig build` and `zig build test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)