### PR TITLE
command_discovery: fail loud on name collisions and invalid/reserved names

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -16,6 +16,16 @@ src/commands/
 
 Discovery happens at build time — see [BUILD.md](BUILD.md) for how the registry is generated.
 
+### Naming rules (build errors, not silent skips)
+
+Discovery fails the build loudly rather than dropping a command, so mistakes can't vanish from your CLI:
+
+- **Name collisions** — a leaf and a same-named group (e.g. `users.zig` *and* `users/`) both resolve to the command `users`. This is rejected; delete one, or use `users/index.zig` for an executable parent that also has subcommands.
+- **Reserved names** — Windows DOS device names (`con`, `prn`, `aux`, `nul`, `com1`–`com9`, `lpt1`–`lpt9`) are rejected on **all** platforms, not just Windows targets. This is portability-by-default: a `commands/aux.zig` that builds on macOS/Linux would break the Windows build in a far more confusing way. If you hit this on a POSIX-only project, rename the command.
+- **Invalid characters** — names must start with a letter or underscore and contain only letters, digits, `_`, or `-`.
+
+Files and directories prefixed with `_` (helpers) or `.` (hidden) are skipped silently by design.
+
 Every command is one file with up to four exports:
 
 ```zig

--- a/packages/core/src/build_integration_test.zig
+++ b/packages/core/src/build_integration_test.zig
@@ -92,7 +92,7 @@ test "build integration: nested command groups" {
     try testing.expectEqual(@as(u32, 1), permissions_group.subcommands.?.count());
 }
 
-test "build integration: invalid and hidden names are skipped" {
+test "build integration: hidden and helper names are skipped silently" {
     const io = testing.io;
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -101,10 +101,10 @@ test "build integration: invalid and hidden names are skipped" {
     try tmp.dir.writeFile(io, .{ .sub_path = "valid_name.zig", .data = placeholder });
     try tmp.dir.writeFile(io, .{ .sub_path = "ValidName123.zig", .data = placeholder });
 
-    try tmp.dir.writeFile(io, .{ .sub_path = "invalid name.zig", .data = placeholder }); // space
-    try tmp.dir.writeFile(io, .{ .sub_path = "invalid@name.zig", .data = placeholder }); // special char
-    try tmp.dir.writeFile(io, .{ .sub_path = ".hidden.zig", .data = placeholder }); // hidden file
-    try tmp.dir.writeFile(io, .{ .sub_path = "_helper.zig", .data = placeholder }); // helper convention
+    // Hidden (dot) and helper (underscore) files are skipped silently by
+    // convention — they never reach the hard-error name check below.
+    try tmp.dir.writeFile(io, .{ .sub_path = ".hidden.zig", .data = placeholder });
+    try tmp.dir.writeFile(io, .{ .sub_path = "_helper.zig", .data = placeholder });
 
     var discovered = try discover(&tmp);
     defer discovered.deinit();
@@ -113,12 +113,23 @@ test "build integration: invalid and hidden names are skipped" {
     try testing.expect(discovered.root.contains("valid_name"));
     try testing.expect(discovered.root.contains("ValidName123"));
 
-    try testing.expect(!discovered.root.contains("invalid name"));
-    try testing.expect(!discovered.root.contains("invalid@name"));
     try testing.expect(!discovered.root.contains(".hidden"));
     try testing.expect(!discovered.root.contains("_helper"));
 
     try testing.expectEqual(@as(u32, 3), discovered.root.count());
+}
+
+test "build integration: an invalid command name fails the build" {
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // A special character is not a valid command-name char. Unlike hidden and
+    // helper files, this is a genuine mistake and must fail loudly rather than
+    // dropping the command from the CLI with only a build-log line (#517).
+    try tmp.dir.writeFile(io, .{ .sub_path = "invalid@name.zig", .data = placeholder });
+
+    try testing.expectError(error.InvalidCommandName, discover(&tmp));
 }
 
 test "build integration: empty directories and edge cases" {

--- a/packages/core/src/build_utils/command_discovery.zig
+++ b/packages/core/src/build_utils/command_discovery.zig
@@ -99,13 +99,19 @@ fn scanDirectory(
                     }
 
                     // Underscore-prefixed files are helpers a command file
-                    // imports (e.g. `_wizard.zig`), not commands.
-                    if (entry.name[0] == '_') continue;
+                    // imports (e.g. `_wizard.zig`), not commands. Dot-prefixed
+                    // files are hidden (editor swap files, `.DS_Store.zig`,
+                    // etc.). Both are skipped silently — same convention as the
+                    // directory branch — BEFORE the hard-error name check below,
+                    // so a legitimately hidden file never fails the build.
+                    if (entry.name[0] == '_' or entry.name[0] == '.') continue;
 
-                    // Skip invalid command names
-                    if (!isValidCommandName(name_without_ext)) {
-                        logging.invalidCommandName(name_without_ext, "contains invalid characters or patterns");
-                        continue;
+                    // Reject invalid command names loudly. Skipping silently
+                    // (the old behavior) made the command vanish from the CLI
+                    // with only an easy-to-miss build-log line.
+                    if (commandNameRejection(name_without_ext)) |reason| {
+                        logging.invalidCommandNameError(name_without_ext, reason);
+                        return error.InvalidCommandName;
                     }
 
                     // Build command path as array of components
@@ -136,7 +142,17 @@ fn scanDirectory(
                         .subcommands = null,
                     };
 
-                    try commands.put(try allocator.dupe(u8, name_without_ext), command_info);
+                    // A leaf and a same-named group (foo.zig + foo/) would both
+                    // key this map; put()-ing the second silently drops the
+                    // first, and which survives depends on iteration order.
+                    // Detect the collision and fail loudly instead (#502).
+                    const gop = try commands.getOrPut(name_without_ext);
+                    if (gop.found_existing) {
+                        logging.duplicateCommandName(name_without_ext, gop.value_ptr.file_path, file_path);
+                        return error.DuplicateCommandName;
+                    }
+                    gop.key_ptr.* = try allocator.dupe(u8, name_without_ext);
+                    gop.value_ptr.* = command_info;
                 }
             },
             .directory => {
@@ -144,10 +160,10 @@ fn scanDirectory(
                 // directories (same convention as `_helper.zig` files).
                 if (entry.name[0] == '.' or entry.name[0] == '_') continue;
 
-                // Skip invalid command names
-                if (!isValidCommandName(entry.name)) {
-                    logging.invalidCommandName(entry.name, "contains invalid characters or patterns");
-                    continue;
+                // Reject invalid command names loudly (see the .file branch).
+                if (commandNameRejection(entry.name)) |reason| {
+                    logging.invalidCommandNameError(entry.name, reason);
+                    return error.InvalidCommandName;
                 }
 
                 // Open subdirectory
@@ -203,7 +219,15 @@ fn scanDirectory(
                         .subcommands = subcommands,
                     };
 
-                    try commands.put(try allocator.dupe(u8, entry.name), command_info);
+                    // Same collision guard as the .file branch: a group and a
+                    // same-named leaf must not clobber each other (#502).
+                    const gop = try commands.getOrPut(entry.name);
+                    if (gop.found_existing) {
+                        logging.duplicateCommandName(entry.name, gop.value_ptr.file_path, group_file_path);
+                        return error.DuplicateCommandName;
+                    }
+                    gop.key_ptr.* = try allocator.dupe(u8, entry.name);
+                    gop.value_ptr.* = command_info;
                 } else {
                     // No subcommands and no index file, cleanup and skip
                     subcommands.deinit();
@@ -225,22 +249,33 @@ fn hasIndexFile(io: std.Io, dir: std.Io.Dir) bool {
     return true;
 }
 
-/// Validate command name according to security and naming rules
-pub fn isValidCommandName(name: []const u8) bool {
-    if (name.len == 0) return false;
+/// Validate a command name, returning `null` when valid or a human-readable
+/// reason it was rejected. Used to produce actionable hard-error messages at
+/// the discovery call sites (see #517: a rejected name is a build error, never
+/// a silent skip).
+///
+/// Windows DOS device names (con, aux, nul, com1..lpt9) are rejected on ALL
+/// platforms — not just Windows targets. This is deliberate portability-by-
+/// default for a framework whose apps may later be built for Windows: a name
+/// that works on macOS/Linux today would make the Windows build fail in a far
+/// more confusing way. Because it's a hard error, a POSIX-only project that
+/// genuinely wants `commands/aux.zig` sees the reason immediately and can pick
+/// another name, rather than losing the command silently. See docs/COMMANDS.md.
+pub fn commandNameRejection(name: []const u8) ?[]const u8 {
+    if (name.len == 0) return "name is empty";
 
     // Security checks: prevent directory traversal and other dangerous patterns
-    if (std.mem.indexOf(u8, name, "..") != null) return false;
-    if (std.mem.indexOf(u8, name, "/") != null) return false;
-    if (std.mem.indexOf(u8, name, "\\") != null) return false;
-    if (std.mem.indexOf(u8, name, "\x00") != null) return false;
+    if (std.mem.indexOf(u8, name, "..") != null) return "contains '..'";
+    if (std.mem.indexOf(u8, name, "/") != null) return "contains '/'";
+    if (std.mem.indexOf(u8, name, "\\") != null) return "contains '\\'";
+    if (std.mem.indexOf(u8, name, "\x00") != null) return "contains a null byte";
 
     // Basic naming rules
     const first = name[0];
-    if (!std.ascii.isAlphabetic(first) and first != '_') return false;
+    if (!std.ascii.isAlphabetic(first) and first != '_') return "must start with a letter or underscore";
 
     for (name[1..]) |char| {
-        if (!std.ascii.isAlphanumeric(char) and char != '_' and char != '-') return false;
+        if (!std.ascii.isAlphanumeric(char) and char != '_' and char != '-') return "contains invalid characters (allowed: letters, digits, '_', '-')";
     }
 
     // Reserved names that could conflict with system operations
@@ -254,10 +289,15 @@ pub fn isValidCommandName(name: []const u8) bool {
     };
 
     for (reserved_names) |reserved| {
-        if (std.ascii.eqlIgnoreCase(name, reserved)) return false;
+        if (std.ascii.eqlIgnoreCase(name, reserved)) return "reserved name (Windows DOS device names are rejected on all platforms for portability)";
     }
 
-    return true;
+    return null;
+}
+
+/// Validate command name according to security and naming rules.
+pub fn isValidCommandName(name: []const u8) bool {
+    return commandNameRejection(name) == null;
 }
 
 // ============================================================================
@@ -356,6 +396,66 @@ test "discovery errors loudly when nesting exceeds the depth cap" {
     try testing.expectError(
         error.MaxCommandDepthExceeded,
         scanDirectory(allocator, io, dir, &commands, &.{}, 0, 1),
+    );
+}
+
+test "discovery errors loudly when a leaf and a group share a name" {
+    const testing = std.testing;
+    const io = testing.io;
+
+    // The error path leaks the partial subtree allocations (fine in
+    // production: a hard build error aborts on an arena). Use an arena so the
+    // leak detector stays quiet — same rationale as the depth-cap test.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // A leftover `users.zig` leaf alongside a `users/` group is the realistic
+    // mistake (refactor half-done). Both would key `commands` under "users",
+    // so exactly one used to survive depending on iteration order (#502).
+    try tmp.dir.writeFile(io, .{ .sub_path = "users.zig", .data = "pub fn execute() void {}" });
+    try tmp.dir.createDir(io, "users", .default_dir);
+    try tmp.dir.writeFile(io, .{ .sub_path = "users/list.zig", .data = "pub fn execute() void {}" });
+
+    var dir = try tmp.dir.openDir(io, ".", .{ .iterate = true });
+    defer dir.close(io);
+
+    var commands = std.StringHashMap(DiscoveredCommand).init(allocator);
+
+    // Must be a hard error regardless of which entry the iterator visits first.
+    try testing.expectError(
+        error.DuplicateCommandName,
+        scanDirectory(allocator, io, dir, &commands, &.{}, 0, default_max_depth),
+    );
+}
+
+test "discovery errors loudly on a reserved command name" {
+    const testing = std.testing;
+    const io = testing.io;
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // `aux.zig` is valid on POSIX but a reserved DOS device name; discovery
+    // rejects it on every platform, and must do so loudly rather than dropping
+    // the command with only an easy-to-miss log line (#517).
+    try tmp.dir.writeFile(io, .{ .sub_path = "aux.zig", .data = "pub fn execute() void {}" });
+
+    var dir = try tmp.dir.openDir(io, ".", .{ .iterate = true });
+    defer dir.close(io);
+
+    var commands = std.StringHashMap(DiscoveredCommand).init(allocator);
+
+    try testing.expectError(
+        error.InvalidCommandName,
+        scanDirectory(allocator, io, dir, &commands, &.{}, 0, default_max_depth),
     );
 }
 

--- a/packages/core/src/build_utils/main.zig
+++ b/packages/core/src/build_utils/main.zig
@@ -177,6 +177,11 @@ fn generatePluginRegistry(
                 logging.buildError("Command Discovery Error", config.commands_dir, "Access denied to commands directory", "Please check file permissions for the directory");
             },
             error.OutOfMemory => @panic("OOM"),
+            error.DuplicateCommandName, error.InvalidCommandName, error.MaxCommandDepthExceeded => {
+                // The specific, actionable message (naming the exact file(s))
+                // was already logged at the point of discovery; adding the
+                // generic block here would only bury it.
+            },
             else => {
                 logging.buildError("Command Discovery Error", config.commands_dir, "Failed to discover commands", "Check the command directory structure and file permissions");
                 std.debug.print("Error details: {any}\n", .{err});

--- a/packages/core/src/logging.zig
+++ b/packages/core/src/logging.zig
@@ -112,6 +112,26 @@ pub fn invalidCommandName(name: []const u8, reason: []const u8) void {
     logBuildWarning("Skipping invalid command name: {s} ({s})", .{ name, reason });
 }
 
+/// Format build error for an invalid command name. This is a hard error, not a
+/// warning: silently skipping the file makes the command vanish from the CLI
+/// with no reliable signal (mirrors the depth-cap and collision errors).
+pub fn invalidCommandNameError(name: []const u8, reason: []const u8) void {
+    logBuildError("Invalid command name '{s}': {s}", .{ name, reason });
+}
+
+/// Format build error for two commands that resolve to the same command name
+/// (e.g. `foo.zig` leaf and `foo/` group). Hard error: `put`-ing the same key
+/// twice would otherwise silently drop one, non-deterministically, depending on
+/// filesystem iteration order.
+pub fn duplicateCommandName(name: []const u8, first_path: []const u8, second_path: []const u8) void {
+    logBuildError(
+        "Duplicate command '{s}': defined by both '{s}' and '{s}'. " ++
+            "A leaf command and a command group cannot share a name — " ++
+            "delete one, or use '{s}/index.zig' for an executable parent with subcommands.",
+        .{ name, first_path, second_path, name },
+    );
+}
+
 /// Format build error for exceeding the maximum nesting depth. This is a hard
 /// error, not a warning: silently dropping a too-deep subtree hides commands.
 pub fn maxNestingDepthExceeded(max_depth: u32, path: []const u8) void {


### PR DESCRIPTION
## Summary
Two fixes in `packages/core/src/build_utils/command_discovery.zig`, the discovery core shared by the build (`discoverCommands`) and runtime tooling (`discoverInDir`, used by `zcli tree`). Both replace silent, non-deterministic drops with hard, actionable build errors — matching the pipeline's existing fail-loud philosophy (depth cap, module-name collisions).

### Fixes #502 — file + directory with the same base name silently clobbered each other
`foo.zig` (leaf) and `foo/` (group) both keyed the discovery map under `"foo"`; `commands.put()` overwrote unconditionally, so exactly one survived depending on `dir.iterate()` order (filesystem-dependent, non-reproducible). `findModuleNameCollision` never caught it (module names differ: `cmd_foo` vs `foo_index`).

- Both `put` sites now use `getOrPut`; on a collision they log `duplicateCommandName` (naming **both** conflicting paths, suggesting `foo/index.zig` for an executable parent) and return `error.DuplicateCommandName`.

### Fixes #517 — DOS device names / invalid names silently dropped
`isValidCommandName` rejected invalid and Windows-reserved names (`con`, `aux`, `nul`, `com1..lpt9`), but the caller only logged an easy-to-miss warning and skipped the file, so the command vanished.

- Decision: keep the reserved-name restriction on **all** platforms (portability-by-default for a framework whose apps may target Windows) but **upgrade the skip to a hard error** (`error.InvalidCommandName`) naming the file and a precise reason. This is issue option (b): simpler than threading target info into runtime discovery, and consistent with fail-loud.
- `isValidCommandName` is refactored on top of a new `commandNameRejection` that returns the reason string used in the message.
- The `.file` branch now also skips dot-prefixed (hidden) files silently — matching the `.directory` branch — so a legitimately hidden `.foo.zig` never reaches (and fails) the name check.
- Documented in `docs/COMMANDS.md`.

## Tests
- New regression tests in `command_discovery.zig`: leaf+group collision → `error.DuplicateCommandName`; reserved `aux.zig` → `error.InvalidCommandName`.
- Updated `build_integration_test.zig`: split the old "invalid and hidden names are skipped" test into (a) hidden/helper skipped silently, (b) invalid name → hard build error.
- `zig build && zig build test` both green (whole repo, 2517 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)