### PR TITLE
Fix stray input from modified Delete/PageUp/PageDown keys (#503)

### DIFF
--- a/packages/terminal/src/key.zig
+++ b/packages/terminal/src/key.zig
@@ -216,21 +216,29 @@ fn parseEscapeSequence(reader: anytype, esc_handle: ?backend.Handle, paste: ?Pas
             // SGR mouse (DECSET 1006): ESC [ < Cb ; Cx ; Cy (M|m).
             '<' => parseMouseSgr(reader),
             '3' => blk: {
-                // ESC [ 3 ~ = Delete
+                // ESC [ 3 ~ = Delete. A modified variant (e.g. Ctrl-Delete
+                // `ESC[3;5~`) puts a non-`~` byte here; consume the rest of
+                // the sequence so the trailing `;5~` isn't misparsed as
+                // separate keystrokes.
                 const tilde = readByteFn(reader) catch break :blk keyIn(.escape);
                 if (tilde == '~') break :blk keyIn(.delete);
+                skipCsiTail(reader, tilde);
                 break :blk keyIn(.escape);
             },
             '5' => blk: {
-                // ESC [ 5 ~ = Page Up
+                // ESC [ 5 ~ = Page Up (e.g. Shift-PageUp `ESC[5;2~` is a
+                // modified variant — consume its tail).
                 const tilde = readByteFn(reader) catch break :blk keyIn(.escape);
                 if (tilde == '~') break :blk keyIn(.pageup);
+                skipCsiTail(reader, tilde);
                 break :blk keyIn(.escape);
             },
             '6' => blk: {
-                // ESC [ 6 ~ = Page Down
+                // ESC [ 6 ~ = Page Down (e.g. Shift-PageDown `ESC[6;2~` is a
+                // modified variant — consume its tail).
                 const tilde = readByteFn(reader) catch break :blk keyIn(.escape);
                 if (tilde == '~') break :blk keyIn(.pagedown);
+                skipCsiTail(reader, tilde);
                 break :blk keyIn(.escape);
             },
             '2' => blk: {
@@ -650,6 +658,23 @@ test "modified Home/End does not desync the stream" {
     var reader: std.Io.Reader = .fixed(&buf);
     try std.testing.expectEqual(Key.escape, try readKey(&reader));
     try std.testing.expectEqual(Key.escape, try readKey(&reader));
+    try std.testing.expectError(error.EndOfStream, readKey(&reader));
+}
+
+test "modified Delete/PageUp/PageDown do not desync the stream" {
+    // Ctrl-Delete = ESC[3;5~, Shift-PageUp = ESC[5;2~, Shift-PageDown =
+    // ESC[6;2~. The '3'/'5'/'6' arms must consume the whole `;N~` tail
+    // instead of leaving it to be misparsed as literal `;`, digit, and `~`
+    // keystrokes. Each sequence yields exactly one escape event, then the
+    // following real letter survives intact.
+    var buf = "\x1b[3;5~a\x1b[5;2~b\x1b[6;2~c".*;
+    var reader: std.Io.Reader = .fixed(&buf);
+    try std.testing.expectEqual(Key.escape, try readKey(&reader));
+    try std.testing.expectEqual(Key{ .char = 'a' }, try readKey(&reader));
+    try std.testing.expectEqual(Key.escape, try readKey(&reader));
+    try std.testing.expectEqual(Key{ .char = 'b' }, try readKey(&reader));
+    try std.testing.expectEqual(Key.escape, try readKey(&reader));
+    try std.testing.expectEqual(Key{ .char = 'c' }, try readKey(&reader));
     try std.testing.expectError(error.EndOfStream, readKey(&reader));
 }
 


### PR DESCRIPTION
Fixes #503

## Problem
In `packages/terminal/src/key.zig`, the `'3'`, `'5'`, and `'6'` CSI arms read exactly one byte expecting `'~'`; on any other byte they broke to `.escape` **without** consuming the rest of the sequence. Their siblings — the `'2'` arm and the `else` arm — both call `skipCsiTail` for exactly this case, but these three were missed.

As a result, pressing a modified variant such as Ctrl-Delete (`ESC[3;5~`), Shift-PageUp (`ESC[5;2~`), or Shift-PageDown (`ESC[6;2~`) left `;5~` / `;2~` unconsumed in the stream. Those bytes were then parsed as separate keypresses — literal `;`, digit, and `~` characters typed into text inputs or triggering spurious actions.

## Fix
Mirror the `'2'`/`else` arms: on a non-`~` byte after `3`/`5`/`6`, call `skipCsiTail` to consume through the CSI final byte, then report `.escape` (minimal consume-and-ignore, as the issue recommends).

## Tests
Added a unit test feeding `ESC[3;5~a ESC[5;2~b ESC[6;2~c`: each modified sequence yields exactly one `.escape` event and the following real letter survives intact, ending in `EndOfStream`. Existing plain `ESC[3~/5~/6~` tests stay green.

- `zig build` — pass
- `zig build test` — pass (terminal package: 68/68)
- `zig build e2e` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)