### PR TITLE
Bind release signature to the version (downgrade guard) — fixes #510

### DIFF
--- a/packages/core/src/plugin_github_upgrade_integration_test.zig
+++ b/packages/core/src/plugin_github_upgrade_integration_test.zig
@@ -63,8 +63,16 @@ fn base64Alloc(allocator: std.mem.Allocator, bytes: []const u8) ![]u8 {
     return out;
 }
 
-/// Build a self-consistent release fixture with a fresh keypair.
+/// Build a self-consistent release fixture with a fresh keypair, whose signed
+/// artifacts install as `version`.
 fn makeFixture(allocator: std.mem.Allocator, io: std.Io) !Fixture {
+    return makeFixtureTagged(allocator, io, version);
+}
+
+/// Like `makeFixture`, but the trusted comment binds `tag_version` — pass a value
+/// other than `version` to model a replayed/downgraded release whose signature is
+/// genuine but whose embedded tag does not match the version being installed.
+fn makeFixtureTagged(allocator: std.mem.Allocator, io: std.Io, tag_version: []const u8) !Fixture {
     const kp = Ed25519.KeyPair.generate(io);
     const key_id = [_]u8{ 1, 2, 3, 4, 5, 6, 7, 8 };
 
@@ -87,18 +95,41 @@ fn makeFixture(allocator: std.mem.Allocator, io: std.Io) !Fixture {
     var pre: [Blake2b512.digest_length]u8 = undefined;
     Blake2b512.hash(checksums, &pre, .{});
     const sig = try kp.sign(&pre, null);
+    const sig_bytes = sig.toBytes();
 
     var sig_blob: [2 + 8 + 64]u8 = undefined;
     @memcpy(sig_blob[0..2], "ED");
     @memcpy(sig_blob[2..10], &key_id);
-    @memcpy(sig_blob[10..74], &sig.toBytes());
+    @memcpy(sig_blob[10..74], &sig_bytes);
     const sig_b64 = try base64Alloc(allocator, &sig_blob);
     defer allocator.free(sig_b64);
 
+    // Trusted comment binds the release tag, exactly as scripts/sign-release.sh
+    // does (`-t "zcli <tag> — signed release checksums"`). minisign's global
+    // (line-4) signature covers `primary_sig_bytes || trusted_comment_text`, so
+    // we sign that concatenation with the same key to produce a GENUINE global
+    // signature — the fixture faithfully reproduces a real signed release, and
+    // the happy path therefore exercises version binding too.
+    const trusted_comment = try std.fmt.allocPrint(
+        allocator,
+        "{s} {s}-v{s} — signed release checksums",
+        .{ cli_name, cli_name, tag_version },
+    );
+    defer allocator.free(trusted_comment);
+
+    const global_msg = try allocator.alloc(u8, sig_bytes.len + trusted_comment.len);
+    defer allocator.free(global_msg);
+    @memcpy(global_msg[0..sig_bytes.len], &sig_bytes);
+    @memcpy(global_msg[sig_bytes.len..], trusted_comment);
+    const global_sig = try kp.sign(global_msg, null);
+    const global_sig_bytes = global_sig.toBytes();
+    const global_sig_b64 = try base64Alloc(allocator, &global_sig_bytes);
+    defer allocator.free(global_sig_b64);
+
     const minisig = try std.fmt.allocPrint(
         allocator,
-        "untrusted comment: signature from test key\n{s}\ntrusted comment: test\ntrusted-sig-unused==\n",
-        .{sig_b64},
+        "untrusted comment: signature from test key\n{s}\ntrusted comment: {s}\n{s}\n",
+        .{ sig_b64, trusted_comment, global_sig_b64 },
     );
     errdefer allocator.free(minisig);
 
@@ -281,6 +312,31 @@ test "pipeline: tampered checksums.txt fails signature verification" {
         error.SignatureVerificationFailed,
         runDownloadVerify(allocator, io, tmp.dir, assets, fx.public_key_b64),
     );
+}
+
+test "pipeline: a replayed older release (signed, wrong version) is rejected (#510)" {
+    const allocator = testing.allocator;
+    const io = testing.io;
+
+    // Model a compromised publisher replaying an OLDER, genuinely-signed release
+    // under the newer tag: every artifact (binary, checksums.txt, .minisig) is
+    // internally consistent and the primary signature verifies — but the trusted
+    // comment binds `app-v1.0.0`, not the `app-v1.2.3` being installed. The
+    // version binding must catch it even though checksum + primary signature pass.
+    var fx = try makeFixtureTagged(allocator, io, "1.0.0");
+    defer fx.deinit(allocator);
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const assets = Assets{ .binary = binary_contents, .checksums = fx.checksums, .minisig = fx.minisig };
+    try testing.expectError(
+        error.VersionVerificationFailed,
+        runDownloadVerify(allocator, io, tmp.dir, assets, fx.public_key_b64),
+    );
+
+    // Fail-closed: nothing was installed.
+    try testing.expectError(error.FileNotFound, tmp.dir.openFile(io, "current", .{}));
 }
 
 test "pipeline: a binary that does not match its checksum aborts" {

--- a/packages/core/src/plugins/zcli_github_upgrade/minisign.zig
+++ b/packages/core/src/plugins/zcli_github_upgrade/minisign.zig
@@ -7,10 +7,21 @@
 //! fail-closed where the POSIX `install.sh` cannot (see ADR-0023).
 //!
 //! It verifies exactly what matters for release integrity: the signature over
-//! the signed file (here, `checksums.txt`) under a pinned public key. minisign's
-//! second, "global" signature covers only the trusted comment — informational
-//! metadata that plays no part in our trust decision — so it is intentionally
-//! not checked. The security guarantee is entirely in the primary signature.
+//! the signed file (here, `checksums.txt`) under a pinned public key. That
+//! primary signature is the core guarantee — a tampered `checksums.txt` cannot
+//! survive it.
+//!
+//! The primary signature alone is version-agnostic, though: `checksums.txt`
+//! names the artifacts but not the release they belong to, so a compromised
+//! publisher could replay an *older*, genuinely-signed release under a newer
+//! tag (a downgrade / rollback attack — CWE-294). To close that, this module
+//! also verifies minisign's second, "global" signature, which covers the
+//! trusted comment. The signing ceremony embeds the release tag in that comment
+//! (`scripts/sign-release.sh`: `-t "zcli <tag> — signed release checksums"`),
+//! so `verifyTrustedComment` authenticates the comment under the same pinned
+//! key and asserts it binds the tag being installed. The comment is only
+//! trusted once its global signature checks out — reading it unverified would
+//! defeat the point.
 //!
 //! Both minisign signature algorithms are accepted so verification never depends
 //! on which minisign version cut the release:
@@ -27,6 +38,8 @@ const base64 = std.base64.standard;
 const public_key_blob_len = 2 + 8 + 32;
 /// Signature-line blob length: 2-byte algorithm id + 8-byte key id + 64-byte sig.
 const signature_blob_len = 2 + 8 + 64;
+/// The fixed prefix minisign writes before the trusted-comment text on line 3.
+const trusted_comment_prefix = "trusted comment: ";
 
 /// The two-byte algorithm markers minisign writes into its blobs.
 const alg_pubkey = "Ed".*; // public keys are always tagged "Ed"
@@ -51,6 +64,18 @@ pub const VerifyError = error{
     /// The signature is not valid for this data under this key. The load-bearing
     /// check — this is what a tampered `checksums.txt` fails on.
     SignatureMismatch,
+    /// The trusted-comment line (line 3) or its global-signature line (line 4)
+    /// was missing or the wrong shape — e.g. no `trusted comment: ` prefix or a
+    /// global signature that isn't 64 base64-decoded bytes.
+    MalformedTrustedComment,
+    /// The trusted comment is present but its global signature does not verify
+    /// under the pinned key. The comment's contents cannot be trusted, so the
+    /// version binding it carries is worthless — fail closed.
+    TrustedCommentSignatureMismatch,
+    /// The trusted comment verified, but it does not bind the release tag being
+    /// installed. This is the downgrade/rollback guard: an older but genuinely
+    /// signed release replayed under a newer tag is rejected here.
+    VersionMismatch,
 };
 
 /// A parsed, pinned minisign public key.
@@ -106,6 +131,76 @@ pub fn verify(public_key: PublicKey, signature_file: []const u8, signed_data: []
     } else {
         return VerifyError.UnsupportedSignatureAlgorithm;
     }
+}
+
+/// Verify minisign's global signature over the trusted comment and assert the
+/// comment binds `expected_tag`.
+///
+/// The primary `verify` above proves `checksums.txt` is authentic, but that file
+/// carries no version — so a compromised publisher can replay an older, validly
+/// signed release under a newer tag and pass `verify` (CWE-294 downgrade). The
+/// signing ceremony defends against this by putting the release tag in minisign's
+/// trusted comment, which is covered by a *second* ("global") Ed25519 signature
+/// on line 4 of the `.minisig`. minisign computes that global signature over the
+/// 64-byte primary signature concatenated with the raw trusted-comment text, so
+/// we reconstruct exactly those bytes and verify them under the same pinned key.
+///
+/// Only after the comment is authenticated do we trust its contents: we require
+/// `expected_tag` to appear as a whole whitespace-delimited token (so `-v0.2`
+/// cannot masquerade as `-v0.20.0`). `signature_file` is the full `.minisig`
+/// body; `expected_tag` is the release tag being installed, e.g. `zcli-v0.20.0`.
+/// Returns normally only on a match; every other outcome is an error, so callers
+/// get fail-closed version binding for free.
+pub fn verifyTrustedComment(
+    public_key: PublicKey,
+    signature_file: []const u8,
+    expected_tag: []const u8,
+) VerifyError!void {
+    var lines = std.mem.splitScalar(u8, signature_file, '\n');
+    _ = lines.next() orelse return VerifyError.MalformedSignature; // untrusted comment
+    const sig_line = lines.next() orelse return VerifyError.MalformedSignature;
+    const comment_line = lines.next() orelse return VerifyError.MalformedTrustedComment;
+    const global_sig_line = lines.next() orelse return VerifyError.MalformedTrustedComment;
+
+    // Line 2 again: the global signature commits to its raw 64-byte signature,
+    // not the algorithm/key-id header, so extract just that tail.
+    var blob: [signature_blob_len]u8 = undefined;
+    decodeExact(&blob, std.mem.trim(u8, sig_line, " \t\r\n")) catch return VerifyError.MalformedSignature;
+    const primary_signature = blob[10..74];
+
+    // Line 3: `trusted comment: <text>`. The signed message is <text> exactly —
+    // no prefix, no trailing newline. Only a stray CR is stripped (\n was the
+    // line split); interior bytes are part of what minisign signed.
+    const comment = std.mem.trimEnd(u8, comment_line, "\r");
+    if (!std.mem.startsWith(u8, comment, trusted_comment_prefix)) return VerifyError.MalformedTrustedComment;
+    const trusted_comment = comment[trusted_comment_prefix.len..];
+
+    // Line 4: base64 of the 64-byte global Ed25519 signature.
+    var global_sig_bytes: [64]u8 = undefined;
+    decodeExact(&global_sig_bytes, std.mem.trim(u8, global_sig_line, " \t\r\n")) catch return VerifyError.MalformedTrustedComment;
+    const global_sig = Ed25519.Signature.fromBytes(global_sig_bytes);
+
+    // Verify Ed25519(primary_signature || trusted_comment) under the pinned key,
+    // streaming the two segments so no concatenation buffer is needed.
+    var verifier = global_sig.verifier(public_key.key) catch return VerifyError.TrustedCommentSignatureMismatch;
+    verifier.update(primary_signature);
+    verifier.update(trusted_comment);
+    verifier.verify() catch return VerifyError.TrustedCommentSignatureMismatch;
+
+    // The comment is now authentic; bind the version it carries.
+    if (!trustedCommentHasTag(trusted_comment, expected_tag)) return VerifyError.VersionMismatch;
+}
+
+/// True when `expected_tag` appears in `comment` as a whole whitespace-delimited
+/// token. Token-exact (not substring) so a shorter tag like `zcli-v0.2` can't be
+/// satisfied by a longer one like `zcli-v0.20.0`.
+fn trustedCommentHasTag(comment: []const u8, expected_tag: []const u8) bool {
+    if (expected_tag.len == 0) return false;
+    var tokens = std.mem.tokenizeAny(u8, comment, " \t\r\n");
+    while (tokens.next()) |token| {
+        if (std.mem.eql(u8, token, expected_tag)) return true;
+    }
+    return false;
 }
 
 /// Base64-decode `src` into `dst`, requiring the decoded length to be exactly
@@ -214,4 +309,77 @@ test "verify - rejects an unknown signature algorithm" {
     var buf: [512]u8 = undefined;
     const forged = try std.fmt.bufPrint(&buf, "comment\n{s}\n", .{encoded});
     try std.testing.expectError(VerifyError.UnsupportedSignatureAlgorithm, verify(pk, forged, test_checksums));
+}
+
+// ----------------------------------------------------------------------------
+// Trusted-comment / version-binding tests.
+//
+// `test_sig_prehashed` carries a REAL minisign global signature over its trusted
+// comment ("zcli test release 0.0.0"), so these tests exercise the genuine
+// global-signature path — not a mock. The production signing ceremony writes the
+// release tag as a token in that comment (`zcli zcli-vX.Y.Z — signed ...`), so a
+// token match against the comment is exactly the version binding we enforce.
+// ----------------------------------------------------------------------------
+
+// The three body lines of `test_sig_prehashed`, split out so tamper tests can
+// rebuild the file with one line changed.
+const tc_sig_line = "RURvG5gVNm3fQ3x/RKJBNezC4n+PUTp5CY87HNpU6vDZVxVDtOcF3mSeqIneSiPfKQmwk1czB+nTwXY/55JyUjO5p6SKvmebIQs=";
+const tc_comment_line = "trusted comment: zcli test release 0.0.0";
+const tc_global_sig_line = "XVcRgBG5hS8H1mckUiHcmeFr2u6lmzBKu3qFKDDLzPLrlKq9I4KRRkF6GNw9WhY5NHa02h86n1NbCIK8PjV7Dw==";
+
+test "verifyTrustedComment - accepts a genuine comment binding the expected token" {
+    const pk = try PublicKey.parse(test_pubkey);
+    // The tag token the ceremony would embed; here the version token in the
+    // real fixture comment ("zcli test release 0.0.0").
+    try verifyTrustedComment(pk, test_sig_prehashed, "0.0.0");
+    // Any whole token matches (the real ceremony's token is `zcli-vX.Y.Z`).
+    try verifyTrustedComment(pk, test_sig_prehashed, "zcli");
+}
+
+test "verifyTrustedComment - rejects a version mismatch (downgrade guard)" {
+    const pk = try PublicKey.parse(test_pubkey);
+    // A different version than the (authentic) comment binds -> reject.
+    try std.testing.expectError(VerifyError.VersionMismatch, verifyTrustedComment(pk, test_sig_prehashed, "1.0.0"));
+    // Token-exact, so a substring of a real token is NOT a match.
+    try std.testing.expectError(VerifyError.VersionMismatch, verifyTrustedComment(pk, test_sig_prehashed, "0.0"));
+    try std.testing.expectError(VerifyError.VersionMismatch, verifyTrustedComment(pk, test_sig_prehashed, ""));
+}
+
+test "verifyTrustedComment - rejects a rewritten trusted comment (global sig fails)" {
+    const pk = try PublicKey.parse(test_pubkey);
+    // Swap the comment for an attacker-chosen newer version while keeping the
+    // genuine global signature. Because the global sig covers the comment, it no
+    // longer verifies — the version cannot be forged by editing the text.
+    var buf: [512]u8 = undefined;
+    const forged = try std.fmt.bufPrint(&buf, "untrusted comment: x\n{s}\ntrusted comment: zcli test release 9.9.9\n{s}\n", .{ tc_sig_line, tc_global_sig_line });
+    try std.testing.expectError(VerifyError.TrustedCommentSignatureMismatch, verifyTrustedComment(pk, forged, "9.9.9"));
+}
+
+test "verifyTrustedComment - rejects a wrong-but-well-formed global signature" {
+    const pk = try PublicKey.parse(test_pubkey);
+    // Genuine comment, but the global signature is a valid-length 64-byte blob of
+    // the wrong bytes -> fails closed as a signature mismatch, not accepted.
+    var zero_sig: [64]u8 = @splat(0);
+    var encoded: [base64.Encoder.calcSize(64)]u8 = undefined;
+    _ = base64.Encoder.encode(&encoded, &zero_sig);
+    var buf: [512]u8 = undefined;
+    const forged = try std.fmt.bufPrint(&buf, "untrusted comment: x\n{s}\n{s}\n{s}\n", .{ tc_sig_line, tc_comment_line, encoded });
+    try std.testing.expectError(VerifyError.TrustedCommentSignatureMismatch, verifyTrustedComment(pk, forged, "0.0.0"));
+}
+
+test "verifyTrustedComment - rejects malformed / missing comment lines" {
+    const pk = try PublicKey.parse(test_pubkey);
+    // Missing the trusted-comment line entirely (only 2 lines).
+    var buf: [512]u8 = undefined;
+    const two_line = try std.fmt.bufPrint(&buf, "untrusted comment: x\n{s}\n", .{tc_sig_line});
+    try std.testing.expectError(VerifyError.MalformedTrustedComment, verifyTrustedComment(pk, two_line, "0.0.0"));
+    // Line 3 present but lacking the `trusted comment: ` prefix.
+    var buf2: [512]u8 = undefined;
+    const no_prefix = try std.fmt.bufPrint(&buf2, "untrusted comment: x\n{s}\nzcli test release 0.0.0\n{s}\n", .{ tc_sig_line, tc_global_sig_line });
+    try std.testing.expectError(VerifyError.MalformedTrustedComment, verifyTrustedComment(pk, no_prefix, "0.0.0"));
+    // Global-signature line is not valid base64 of 64 bytes (legacy fixture's
+    // placeholder). Real body lines, garbage global sig.
+    var buf3: [512]u8 = undefined;
+    const bad_global = try std.fmt.bufPrint(&buf3, "untrusted comment: x\n{s}\n{s}\nnot-valid-base64!\n", .{ tc_sig_line, tc_comment_line });
+    try std.testing.expectError(VerifyError.MalformedTrustedComment, verifyTrustedComment(pk, bad_global, "0.0.0"));
 }

--- a/packages/core/src/plugins/zcli_github_upgrade/plugin.zig
+++ b/packages/core/src/plugins/zcli_github_upgrade/plugin.zig
@@ -848,6 +848,23 @@ fn verifyChecksumsSignature(
         err_out.print("The release may have been tampered with. Refusing to install.\n", .{}) catch {};
         return error.SignatureVerificationFailed;
     };
+
+    // Bind the signature to THIS release. The primary signature above only
+    // authenticates checksums.txt, which names artifacts but carries no version
+    // — so a compromised publisher could drop an older release's binary,
+    // checksums.txt, and its genuine .minisig into the latest tag and pass every
+    // check above, silently rolling the user back to a previously-signed
+    // (possibly vulnerable) build (CWE-294 downgrade). minisign's global
+    // signature covers the trusted comment, into which the signing ceremony
+    // embeds the release tag; verifying that comment binds the artifact to the
+    // exact tag we are installing and defeats the replay.
+    const expected_tag = try std.fmt.allocPrint(allocator, "{s}-v{s}", .{ cli_name, version });
+    defer allocator.free(expected_tag);
+    minisign.verifyTrustedComment(pinned, response.body, expected_tag) catch |err| {
+        err_out.print("Error: release version verification failed for {s} ({s}).\n", .{ expected_tag, @errorName(err) }) catch {};
+        err_out.print("The signed release does not match the version being installed — refusing a possible downgrade/replay.\n", .{}) catch {};
+        return error.VersionVerificationFailed;
+    };
 }
 
 /// Find the expected checksum for `binary_name` in a `checksums.txt` body.


### PR DESCRIPTION
Fixes #510

## Problem (CWE-294 / CWE-345)

The upgrade verifier authenticated `checksums.txt` under the pinned minisign key but never checked **which release** the signature belonged to. `checksums.txt` lists artifact digests but carries no version, and the downgrade guard compared only the tag *string* from the releases feed — not signed bytes.

## Threat model

Adversary = a compromised GitHub release publisher / leaked release token (exactly the adversary ADR-0023 signing exists to defeat), or a MITM/malicious redirect of the download. They cannot forge new binaries (no key), but they **can** copy an older release's three artifacts unchanged — old binary, its `checksums.txt`, its genuine `.minisig` — into the latest tag. `zcli upgrade` reads the latest tag string, downloads the swapped assets, the primary signature passes, the checksum passes, the string-based guard is fooled, and the user is silently rolled back to a previously-signed, possibly-vulnerable build.

## Fix

The signing ceremony already embeds the release tag in minisign's **trusted comment** (`scripts/sign-release.sh`: `-t "zcli <tag> — signed release checksums"`), and minisign's **global signature** covers that comment — the verifier just ignored both.

- New `minisign.verifyTrustedComment` reconstructs the exact bytes minisign signs (the 64-byte primary signature `||` the raw trusted-comment text), verifies the global Ed25519 signature over them under the **same pinned key**, and only then asserts the now-authenticated comment binds the tag being installed as a whole whitespace-delimited token (so `app-v0.2` cannot masquerade as `app-v0.20.0`). The comment is never read for trust before its signature checks out.
- `verifyChecksumsSignature` calls it after the primary check and fails closed with `error.VersionVerificationFailed` on any mismatch.

## Tests

- `minisign.zig` unit tests: accept (genuine comment over **real** minisign global-sig bytes), version mismatch / substring / empty (downgrade guard), rewritten comment (global sig fails), wrong-but-well-formed global sig, malformed/missing comment lines.
- Integration fixture now emits a genuine version-bound trusted comment + global signature, so the happy path exercises version binding, plus a new #510 replay test: an older signed release served under a newer tag is rejected with nothing installed.

`zig build` and `zig build test` both pass (2514 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)