### PR TITLE
zcli_completions: skip value-taking global option values in the command path (#511)

### DIFF
--- a/packages/core/src/plugin_completions_test.zig
+++ b/packages/core/src/plugin_completions_test.zig
@@ -842,6 +842,124 @@ test "functional bash - COMPREPLY at root and at depth 2" {
 }
 
 // ============================================================================
+// Layer 3b: value-taking global option before the command (issue #511) — the
+// option's VALUE must not be mis-counted as part of the command path.
+// ============================================================================
+
+// A global option set with a value-taking global (`--config`, boolean `--verbose`).
+const gopt_globals = [_]zcli.OptionInfo{
+    .{ .name = "verbose", .short = 'v', .description = "Verbose output" },
+    .{ .name = "config", .short = 'c', .description = "Config file", .takes_value = true },
+};
+
+test "bash gen - value-taking global option skips its value in the command path" {
+    const script = try bash.generate(std.testing.allocator, app_name, &commands, &gopt_globals);
+    defer std.testing.allocator.free(script);
+
+    // The look-ahead skip machinery is emitted...
+    try std.testing.expect(contains(script, "skip_val=0"));
+    // ...keyed on the value-taking global's long AND short forms (single-quoted),
+    // and NOT on the boolean `--verbose` (which consumes no following word).
+    try std.testing.expect(contains(script, "'--config'|'-c') skip_val=1"));
+    try std.testing.expect(!contains(script, "'--verbose'"));
+}
+
+test "bash gen - no skip machinery when no global option takes a value" {
+    // The default `global_options` fixture is all-boolean → no look-ahead case.
+    const script = try bash.generate(std.testing.allocator, app_name, &commands, &global_options);
+    defer std.testing.allocator.free(script);
+    try std.testing.expect(!contains(script, "skip_val=1"));
+}
+
+test "powershell gen - value-taking global option skips its value in the command path" {
+    const script = try powershell.generate(std.testing.allocator, app_name, &commands, &gopt_globals);
+    defer std.testing.allocator.free(script);
+
+    // The look-ahead skip machinery is emitted, keyed on the value-taking global's
+    // long AND short forms; the boolean `--verbose` contributes no skip case.
+    try std.testing.expect(contains(script, "$skipVal = $false"));
+    try std.testing.expect(contains(script, "'--config' { $skipVal = $true }"));
+    try std.testing.expect(contains(script, "'-c' { $skipVal = $true }"));
+    try std.testing.expect(!contains(script, "'--verbose' { $skipVal"));
+}
+
+test "functional bash - value-taking global option before the command keys correctly" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const sh = findShell("bash") orelse return error.SkipZigTest;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const script = try bash.generate(a, app_name, &commands, &gopt_globals);
+    const script_path = try writeTemp(a, tmp.dir, "zcli_gopt_completion.bash", script);
+
+    // Drive completion with a value-taking global (`--config x.json`) preceding the
+    // command. The value `x.json` must be skipped, so the command path resolves to
+    // `sprint` (depth 2) / the root — NOT to `x.json` (which matches no case → no
+    // completions, the bug in #511). The `=`-joined and boolean forms must also work.
+    const harness = try std.fmt.allocPrint(a,
+        \\source "{s}"
+        \\
+        \\run() {{
+        \\    COMP_WORDS=("$@")
+        \\    COMP_CWORD=$(( ${{#COMP_WORDS[@]}} - 1 ))
+        \\    COMPREPLY=()
+        \\    _tasks_completions
+        \\    echo "${{COMPREPLY[@]}}"
+        \\}}
+        \\
+        \\echo "SEP:$(run tasks --config x.json sprint '')"
+        \\echo "EQ:$(run tasks --config=x.json sprint '')"
+        \\echo "ROOT:$(run tasks --config x.json '')"
+        \\echo "BOOL:$(run tasks --verbose '')"
+        \\
+    , .{script_path});
+    const harness_path = try writeTemp(a, tmp.dir, "zcli_gopt_harness.bash", harness);
+
+    const result = try std.process.run(a, io, .{
+        .argv = &.{ sh, harness_path },
+    });
+    const out = result.stdout;
+
+    var sep_line: ?[]const u8 = null;
+    var eq_line: ?[]const u8 = null;
+    var root_line: ?[]const u8 = null;
+    var bool_line: ?[]const u8 = null;
+    var lines = std.mem.splitScalar(u8, out, '\n');
+    while (lines.next()) |line| {
+        if (std.mem.startsWith(u8, line, "SEP:")) sep_line = line["SEP:".len..];
+        if (std.mem.startsWith(u8, line, "EQ:")) eq_line = line["EQ:".len..];
+        if (std.mem.startsWith(u8, line, "ROOT:")) root_line = line["ROOT:".len..];
+        if (std.mem.startsWith(u8, line, "BOOL:")) bool_line = line["BOOL:".len..];
+    }
+
+    try std.testing.expect(sep_line != null);
+    try std.testing.expect(eq_line != null);
+    try std.testing.expect(root_line != null);
+    try std.testing.expect(bool_line != null);
+
+    // `tasks --config x.json sprint <TAB>` → sprint subcommands (value skipped).
+    try std.testing.expect(contains(sep_line.?, "create"));
+    try std.testing.expect(contains(sep_line.?, "list"));
+    try std.testing.expect(!contains(sep_line.?, "add"));
+
+    // The `=`-joined form resolves identically.
+    try std.testing.expect(contains(eq_line.?, "create"));
+    try std.testing.expect(contains(eq_line.?, "list"));
+
+    // `tasks --config x.json <TAB>` → the root commands (key is empty, not x.json).
+    try std.testing.expect(contains(root_line.?, "add"));
+    try std.testing.expect(contains(root_line.?, "sprint"));
+
+    // A boolean global consumes no value, so the root commands still complete.
+    try std.testing.expect(contains(bool_line.?, "add"));
+    try std.testing.expect(contains(bool_line.?, "sprint"));
+}
+
+// ============================================================================
 // Layer 3c: dynamic-completion escaping (ADR-0026) — the generated read paths
 // must pass adversarial candidate values through as SINGLE candidates, verbatim.
 // ============================================================================

--- a/packages/core/src/plugins/zcli_completions/bash.zig
+++ b/packages/core/src/plugins/zcli_completions/bash.zig
@@ -50,12 +50,27 @@ pub fn generate(
     try writer.writeAll("    fi\n\n");
 
     // Build the command path key: non-option words between app name and cursor.
+    // A value-taking global option (e.g. `--config x.json`) is followed by its
+    // VALUE, which is NOT a command word — skip it so the value never becomes
+    // the key. The `--opt=value` form carries its value in the same token (which
+    // is already skipped as an option word), so only the separate-word form
+    // needs the look-ahead.
     try writer.writeAll("    local cmd_path=()\n");
-    try writer.writeAll("    local i\n");
+    try writer.writeAll("    local i skip_val=0\n");
     try writer.writeAll("    for ((i=1; i<cword; i++)); do\n");
-    try writer.writeAll("        if [[ \"${words[i]}\" != -* ]]; then\n");
-    try writer.writeAll("            cmd_path+=(\"${words[i]}\")\n");
+    try writer.writeAll("        if [[ $skip_val == 1 ]]; then skip_val=0; continue; fi\n");
+    try writer.writeAll("        if [[ \"${words[i]}\" == -* ]]; then\n");
+    if (anyValueTakingOption(global_options)) {
+        // A bare value-taking option word consumes the NEXT word as its value.
+        try writer.writeAll("            case \"${words[i]}\" in\n");
+        try writer.writeAll("                ");
+        try writeValueOptionPatterns(arena, writer, global_options);
+        try writer.writeAll(") skip_val=1 ;;\n");
+        try writer.writeAll("            esac\n");
+    }
+    try writer.writeAll("            continue\n");
     try writer.writeAll("        fi\n");
+    try writer.writeAll("        cmd_path+=(\"${words[i]}\")\n");
     try writer.writeAll("    done\n");
     // Join into a single word so `case` subjects match single-word patterns.
     try writer.writeAll("    local key=\"${cmd_path[*]}\"\n\n");
@@ -131,6 +146,29 @@ pub fn generate(
 
     var al = aw.toArrayList();
     return al.toOwnedSlice(allocator);
+}
+
+/// True if any option in the set takes a value (so a bare `--opt <value>` on the
+/// command line consumes the following word — which must not be mistaken for a
+/// command word when reconstructing the command path).
+fn anyValueTakingOption(options: []const zcli.OptionInfo) bool {
+    for (options) |opt| if (opt.takes_value) return true;
+    return false;
+}
+
+/// Emit `'--name'|'-s'` case patterns (joined with `|`) for every value-taking
+/// option, for the look-ahead `case` in the command-path loop. Names are
+/// escape.bash'd inside single-quoted literals so an exotic identifier can't
+/// break out of the pattern.
+fn writeValueOptionPatterns(arena: std.mem.Allocator, writer: anytype, options: []const zcli.OptionInfo) !void {
+    var first = true;
+    for (options) |opt| {
+        if (!opt.takes_value) continue;
+        if (!first) try writer.writeAll("|");
+        first = false;
+        try writer.print("'--{s}'", .{try escape.bash(arena, opt.name)});
+        if (opt.short) |short| try writer.print("|'-{c}'", .{short});
+    }
 }
 
 /// Emit `--name -s ` for each option into a space-separated list. Names are

--- a/packages/core/src/plugins/zcli_completions/powershell.zig
+++ b/packages/core/src/plugins/zcli_completions/powershell.zig
@@ -46,7 +46,7 @@ pub fn generate(
     try writer.print("Register-ArgumentCompleter -Native -CommandName '{s}' -ScriptBlock {{\n", .{esc_app});
     try writer.writeAll("    param($wordToComplete, $commandAst, $cursorPosition)\n\n");
 
-    try writePreamble(writer, esc_app);
+    try writePreamble(arena, writer, esc_app, global_options);
 
     // 1. Option-name completion (the current word starts with '-').
     try writeOptionNameBlock(arena, writer, root, global_options);
@@ -78,16 +78,22 @@ pub fn generate(
 
 /// Emit the shared preamble: reconstruct `$key`/`$prev`/`$dynWords`/`$cword` from
 /// the AST and define the `Add-Result`/`Complete-*` helpers every block uses.
-fn writePreamble(writer: anytype, esc_app: []const u8) !void {
+fn writePreamble(arena: std.mem.Allocator, writer: anytype, esc_app: []const u8, global_options: []const zcli.OptionInfo) !void {
     try writer.writeAll("    $elements = $commandAst.CommandElements\n");
     try writer.print("    $exe = if ($elements.Count -gt 0) {{ $elements[0].Extent.Text }} else {{ '{s}' }}\n\n", .{esc_app});
 
     // Walk the tokens that lie fully before the word being completed. Option words
     // are skipped for `$key` (the command path) but kept for `$dynWords` (passed to
     // `__complete`). `$prev` is the token immediately before the completion word.
+    // A value-taking global option (`--config x.json`) is followed by its VALUE,
+    // which is NOT a command word — skip it for `$key` (but keep it in `$dynWords`
+    // and as `$prev`). The `--opt=value` form carries its value in the same token,
+    // already excluded from `$key` as an option word.
+    const has_value_opt = anyValueTakingOption(global_options);
     try writer.writeAll("    $path = @()\n");
     try writer.writeAll("    $prev = ''\n");
     try writer.print("    $dynWords = @('{s}')\n", .{esc_app});
+    if (has_value_opt) try writer.writeAll("    $skipVal = $false\n");
     try writer.writeAll("    for ($i = 1; $i -lt $elements.Count; $i++) {\n");
     try writer.writeAll("        $el = $elements[$i]\n");
     try writer.writeAll("        if ($el.Extent.StartOffset -ge $cursorPosition) { break }\n");
@@ -95,7 +101,17 @@ fn writePreamble(writer: anytype, esc_app: []const u8) !void {
     try writer.writeAll("        $t = $el.Extent.Text\n");
     try writer.writeAll("        $dynWords += $t\n");
     try writer.writeAll("        $prev = $t\n");
-    try writer.writeAll("        if (-not $t.StartsWith('-')) { $path += $t }\n");
+    if (has_value_opt) {
+        try writer.writeAll("        if ($skipVal) { $skipVal = $false }\n");
+        try writer.writeAll("        elseif ($t.StartsWith('-')) {\n");
+        try writer.writeAll("            switch -CaseSensitive ($t) {\n");
+        try writeValueOptionCasesPS(arena, writer, global_options);
+        try writer.writeAll("            }\n");
+        try writer.writeAll("        }\n");
+        try writer.writeAll("        else { $path += $t }\n");
+    } else {
+        try writer.writeAll("        if (-not $t.StartsWith('-')) { $path += $t }\n");
+    }
     try writer.writeAll("    }\n");
     try writer.writeAll("    $key = ($path -join ' ')\n");
     try writer.writeAll("    $dynWords += $wordToComplete\n");
@@ -122,6 +138,28 @@ fn writePreamble(writer: anytype, esc_app: []const u8) !void {
     try writer.writeAll("        if ($dirsOnly) { $fc = $fc | Where-Object { $_.ResultType -eq [System.Management.Automation.CompletionResultType]::ProviderContainer } }\n");
     try writer.writeAll("        foreach ($f in $fc) { [void]$results.Add($f) }\n");
     try writer.writeAll("    }\n\n");
+}
+
+/// True if any option in the set takes a value (so a bare `--opt <value>` on the
+/// command line consumes the following word — which must not be mistaken for a
+/// command word when reconstructing the command path).
+fn anyValueTakingOption(options: []const zcli.OptionInfo) bool {
+    for (options) |opt| if (opt.takes_value) return true;
+    return false;
+}
+
+/// Emit `'--name' { $skipVal = $true }` (and the short form) switch cases for
+/// every value-taking option — the look-ahead that keeps an option's VALUE out
+/// of the command path. Names are escaped for their single-quoted labels.
+fn writeValueOptionCasesPS(arena: std.mem.Allocator, writer: anytype, options: []const zcli.OptionInfo) !void {
+    for (options) |opt| {
+        if (!opt.takes_value) continue;
+        const esc_name = try escape.powershell(arena, opt.name);
+        try writer.print("                '--{s}' {{ $skipVal = $true }}\n", .{esc_name});
+        if (opt.short) |short| {
+            try writer.print("                '-{c}' {{ $skipVal = $true }}\n", .{short});
+        }
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Fixes #511 — the generated **bash** and **PowerShell** completion scripts mis-keyed the command path when a value-taking global option preceded the command.

Both scripts rebuilt the command path from every non-dash word:

```bash
for ((i=1; i<cword; i++)); do
    if [[ "${words[i]}" != -* ]]; then cmd_path+=("${words[i]}"); fi
done
```

So for `myapp --config x.json dep<TAB>` the option `--config` was skipped but its **value** `x.json` was not — the lookup key became `x.json`, matched no `case` label, and produced no completions. Any app shipping the config plugin (`--config`, a value-taking global) hit this. `zsh` is unaffected because `_arguments` knows option arity.

## Fix

The generator knows the value-taking global options at build time, so it now emits their names (long + short) into the scripts and skips the following word when a bare option is seen:

- **bash**: a `skip_val` look-ahead flag in the command-path loop, driven by a `case "${words[i]}"` over the value-taking globals (`'--config'|'-c') skip_val=1`).
- **PowerShell**: a `$skipVal` flag in the preamble loop with a `switch -CaseSensitive ($t)` over the same set. The value is still kept in `$dynWords`/`$prev` (only excluded from `$key`).

The `--opt=value` form needs no handling — it's a single token already excluded as an option word. Boolean globals take no value and emit no skip case, so the machinery is omitted entirely when no global option takes a value.

## Tests

- `bash gen` / `powershell gen` structural assertions: the skip machinery is emitted for a value-taking global (long + short) and NOT for a boolean one; nothing is emitted when no global takes a value.
- `functional bash` test: sources the script and drives `--config x.json sprint <TAB>` (→ sprint subcommands), the `--config=x.json` joined form, `--config x.json <TAB>` (→ root), and `--verbose <TAB>` (boolean → root).

`zig build` and `zig build test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)