### PR TITLE
grade9: enforce CSV option budget (#515) and optional positional fall-through (#516)

### DIFF
--- a/packages/core/src/args.zig
+++ b/packages/core/src/args.zig
@@ -128,20 +128,35 @@ fn parseArgsInternal(comptime ArgsType: type, args: []const []const u8, diag: ?*
             // Optional field - consume the next argument if present
             const next_positional: ?usize = if (arg_index < args.len) arg_index else null;
             if (next_positional) |pos| {
-                @field(result, field.name) = parseValue(field_type, args[pos]) catch |err| {
-                    if (err == ZcliError.ArgumentInvalidValue) {
-                        if (diag) |d| d.* = .{ .ArgumentInvalidValue = .{
-                            .field_name = field.name,
-                            .position = field_index,
-                            .provided_value = args[pos],
-                            .expected_type = diagnostic_errors.expectedTypeName(field_type),
-                            .suggestion = diagnostic_errors.nearestEnumValue(field_type, args[pos]),
-                            .reason = custom_type.describeError(field_type, args[pos]),
-                        } };
+                const is_last = comptime (field_index == struct_info.fields.len - 1);
+                if (parseValue(field_type, args[pos])) |value| {
+                    @field(result, field.name) = value;
+                    arg_index = pos + 1;
+                } else |err| {
+                    // A NON-TRAILING typed optional that fails to parse falls
+                    // through: leave it null and DON'T consume the token, so a
+                    // later positional can claim it (e.g. `{ level: ?u32, rest }`
+                    // invoked as `foo bar` yields level=null, rest=["foo","bar"]
+                    // instead of hard-erroring on `foo`). A TRAILING optional
+                    // keeps the strict error — there is no later field the token
+                    // could belong to. String optionals always parse, so only
+                    // typed optionals ever reach this branch.
+                    if (err == ZcliError.ArgumentInvalidValue and !is_last) {
+                        @field(result, field.name) = null;
+                    } else {
+                        if (err == ZcliError.ArgumentInvalidValue) {
+                            if (diag) |d| d.* = .{ .ArgumentInvalidValue = .{
+                                .field_name = field.name,
+                                .position = field_index,
+                                .provided_value = args[pos],
+                                .expected_type = diagnostic_errors.expectedTypeName(field_type),
+                                .suggestion = diagnostic_errors.nearestEnumValue(field_type, args[pos]),
+                                .reason = custom_type.describeError(field_type, args[pos]),
+                            } };
+                        }
+                        return err;
                     }
-                    return err;
-                };
-                arg_index = pos + 1;
+                }
             } else {
                 // Use null for optional
                 @field(result, field.name) = null;
@@ -792,6 +807,79 @@ test "parseArgs optional at end" {
         try std.testing.expectEqual(@as(?[]const u8, null), parsed.optional1);
         try std.testing.expectEqual(@as(?i32, null), parsed.optional2);
     }
+}
+
+test "parseArgs non-trailing typed optional falls through to null on parse failure" {
+    // A typed optional followed by more positionals must NOT greedily consume
+    // and hard-error when its token doesn't parse — it leaves itself null and
+    // lets the token match the later field.
+    const TestArgs = struct {
+        level: ?u32 = null,
+        rest: [][]const u8,
+    };
+
+    // `foo bar`: `foo` doesn't parse as u32, so level=null and both tokens
+    // flow to `rest`.
+    {
+        const args = [_][]const u8{ "foo", "bar" };
+        const parsed = try parseArgs(TestArgs, &args, null);
+        try std.testing.expectEqual(@as(?u32, null), parsed.level);
+        try std.testing.expectEqual(@as(usize, 2), parsed.rest.len);
+        try std.testing.expectEqualStrings("foo", parsed.rest[0]);
+        try std.testing.expectEqualStrings("bar", parsed.rest[1]);
+    }
+
+    // Regression: a value that DOES parse is still consumed greedily.
+    {
+        const args = [_][]const u8{ "3", "foo" };
+        const parsed = try parseArgs(TestArgs, &args, null);
+        try std.testing.expectEqual(@as(?u32, 3), parsed.level);
+        try std.testing.expectEqual(@as(usize, 1), parsed.rest.len);
+        try std.testing.expectEqualStrings("foo", parsed.rest[0]);
+    }
+
+    // No tokens at all: optional stays null, varargs empty.
+    {
+        const args = [_][]const u8{};
+        const parsed = try parseArgs(TestArgs, &args, null);
+        try std.testing.expectEqual(@as(?u32, null), parsed.level);
+        try std.testing.expectEqual(@as(usize, 0), parsed.rest.len);
+    }
+}
+
+test "parseArgs non-trailing typed optional falls through to a required field" {
+    const TestArgs = struct {
+        count: ?u32 = null,
+        name: []const u8,
+    };
+
+    // `alice`: doesn't parse as u32 → count=null, name="alice".
+    {
+        const args = [_][]const u8{"alice"};
+        const parsed = try parseArgs(TestArgs, &args, null);
+        try std.testing.expectEqual(@as(?u32, null), parsed.count);
+        try std.testing.expectEqualStrings("alice", parsed.name);
+    }
+
+    // `5 alice`: count parses → count=5, name="alice".
+    {
+        const args = [_][]const u8{ "5", "alice" };
+        const parsed = try parseArgs(TestArgs, &args, null);
+        try std.testing.expectEqual(@as(?u32, 5), parsed.count);
+        try std.testing.expectEqualStrings("alice", parsed.name);
+    }
+}
+
+test "parseArgs trailing typed optional keeps the strict invalid-value error" {
+    // When the typed optional IS the last field there is no later positional to
+    // hand the token to, so a non-parsing value is a genuine error (unchanged).
+    const TestArgs = struct {
+        name: []const u8,
+        level: ?u32 = null,
+    };
+
+    const args = [_][]const u8{ "svc", "notnum" };
+    try std.testing.expectError(ZcliError.ArgumentInvalidValue, parseArgs(TestArgs, &args, null));
 }
 
 test "parseArgs unicode strings" {

--- a/packages/core/src/options/parser.zig
+++ b/packages/core/src/options/parser.zig
@@ -12,6 +12,7 @@ const ZcliError = diagnostic_errors.ZcliError;
 const ZcliDiagnostic = diagnostic_errors.ZcliDiagnostic;
 const ResourceLimits = @import("../resource_limits.zig").ResourceLimits;
 const ResourceTracker = @import("../resource_limits.zig").ResourceTracker;
+const ResourceLimitError = @import("../resource_limits.zig").ResourceLimitError;
 
 /// Parse command-line options into a struct using default field names.
 ///
@@ -250,13 +251,13 @@ pub fn parseOptionsWithMeta(
                 return ZcliError.ResourceLimitExceeded;
             };
 
-            const consumed = parseLongOptions(OptionsType, meta, &result, &option_counts, args, arg_index, &array_lists, allocator, diag) catch |err| {
+            const consumed = parseLongOptions(OptionsType, meta, &result, &option_counts, args, arg_index, &array_lists, allocator, &resource_tracker, diag) catch |err| {
                 return convertLongOptionError(err);
             };
             arg_index += consumed;
         } else {
             // Short option(s)
-            const consumed = parseShortOptionsWithMeta(OptionsType, meta, &result, &option_counts, args, arg_index, &array_lists, allocator, diag) catch |err| {
+            const consumed = parseShortOptionsWithMeta(OptionsType, meta, &result, &option_counts, args, arg_index, &array_lists, allocator, &resource_tracker, diag) catch |err| {
                 return convertShortOptionError(err);
             };
             arg_index += consumed;
@@ -310,6 +311,10 @@ fn convertLongOptionError(err: anyerror) ZcliError {
         error.BooleanOptionWithValue => ZcliError.OptionBooleanWithValue,
         error.DuplicateOption => ZcliError.OptionDuplicate,
         error.OutOfMemory => ZcliError.SystemOutOfMemory,
+        // CSV array elements are counted against the option budget; overflow
+        // surfaces as the same resource-limit error as the per-token check, its
+        // diagnostic already set at the counting site.
+        error.TooManyOptions => ZcliError.ResourceLimitExceeded,
         // The helpers' error sets are hand-listed above; anything new must be
         // mapped (and given a diagnostic) rather than silently misclassified.
         else => ZcliError.OptionInvalidValue,
@@ -325,6 +330,9 @@ fn convertShortOptionError(err: anyerror) ZcliError {
         error.BooleanOptionWithValue => ZcliError.OptionBooleanWithValue,
         error.DuplicateOption => ZcliError.OptionDuplicate,
         error.OutOfMemory => ZcliError.SystemOutOfMemory,
+        // See convertLongOptionError: CSV element overflow maps to the
+        // resource-limit error with its diagnostic already set.
+        error.TooManyOptions => ZcliError.ResourceLimitExceeded,
         // See convertLongOptionError: map new helper errors explicitly.
         else => ZcliError.OptionInvalidValue,
     };
@@ -491,6 +499,34 @@ fn markBooleanFlagOnce(
     try option_counts.put(field_name, 1);
 }
 
+/// Count each additional comma-separated element of an array-option value
+/// against the option budget. The option token itself was already counted once
+/// by `checkOptionCount` at the top of the parse loop, but `--tags a,b,c`
+/// expands to N accumulated elements — so the remaining N-1 must also be
+/// counted. Without this a single CSV flag could push an array option past
+/// `max_total_options` unbounded, violating the invariant documented in
+/// resource_limits.zig ("grow by one element per flag occurrence"). On overflow
+/// it records the ResourceLimitExceeded diagnostic and returns the error;
+/// callers map `TooManyOptions` to `ZcliError.ResourceLimitExceeded`.
+fn countCsvArrayElements(
+    resource_tracker: *ResourceTracker,
+    value: []const u8,
+    diag: ?*?ZcliDiagnostic,
+) ResourceLimitError!void {
+    const extra = std.mem.count(u8, value, ",");
+    for (0..extra) |_| {
+        resource_tracker.checkOptionCount() catch {
+            if (diag) |d| d.* = .{ .ResourceLimitExceeded = .{
+                .limit_type = "total options",
+                .limit_value = resource_tracker.limits.max_total_options,
+                .actual_value = resource_tracker.option_count,
+                .suggestion = null,
+            } };
+            return ResourceLimitError.TooManyOptions;
+        };
+    }
+}
+
 /// Parse a long option with metadata support (--option or --option=value)
 fn parseLongOptions(
     comptime OptionsType: type,
@@ -501,6 +537,7 @@ fn parseLongOptions(
     arg_index: usize,
     array_lists: anytype,
     allocator: std.mem.Allocator,
+    resource_tracker: *ResourceTracker,
     diag: ?*?ZcliDiagnostic,
 ) !usize {
     const arg = args[arg_index];
@@ -562,6 +599,8 @@ fn parseLongOptions(
                 // Handle array accumulation
                 const element_type = @typeInfo(field.type).pointer.child;
                 if (array_lists[i]) |*list_union| {
+                    // CSV elements each count against the option budget.
+                    try countCsvArrayElements(resource_tracker, value, diag);
                     try array_utils.appendCsvToArrayListUnion(element_type, allocator, list_union, value, option_name);
                 }
             } else {
@@ -618,6 +657,7 @@ fn parseShortOptionsWithMeta(
     arg_index: usize,
     array_lists: anytype,
     allocator: std.mem.Allocator,
+    resource_tracker: *ResourceTracker,
     diag: ?*?ZcliDiagnostic,
 ) !usize {
     const arg = args[arg_index];
@@ -729,6 +769,8 @@ fn parseShortOptionsWithMeta(
                             // For array types, accumulate values
                             if (array_lists.*[i]) |*list_union| {
                                 const element_type = @typeInfo(field.type).pointer.child;
+                                // CSV elements each count against the option budget.
+                                try countCsvArrayElements(resource_tracker, value, diag);
                                 try array_utils.appendCsvToArrayListUnionShort(element_type, allocator, list_union, value, char);
                             }
                         } else {
@@ -1241,6 +1283,50 @@ test "parseOptions comma-separated rejects empty segments" {
     inline for (.{ "a,,b", ",a", "a," }) |bad| {
         const args = [_][]const u8{ "--files", bad };
         try std.testing.expectError(ZcliError.OptionInvalidValue, parseOptions(TestOptions, allocator, &args, null));
+    }
+}
+
+test "parseOptions CSV array elements count against the option budget" {
+    // #515: a single `--opt a,b,c,...` token expands to one accumulated element
+    // per segment, so every segment must count against max_total_options — one
+    // flag must not add unbounded elements.
+    const TestOptions = struct {
+        nums: []i32 = &.{},
+    };
+
+    const allocator = std.testing.allocator;
+
+    // Build a single --nums token with 101 comma-separated elements. The default
+    // max_total_options is 100, so this one flag must trip the resource limit.
+    var buf = std.ArrayList(u8).empty;
+    defer buf.deinit(allocator);
+    for (0..101) |k| {
+        if (k != 0) try buf.append(allocator, ',');
+        try buf.append(allocator, '1');
+    }
+    {
+        const args = [_][]const u8{ "--nums", buf.items };
+        try std.testing.expectError(ZcliError.ResourceLimitExceeded, parseOptions(TestOptions, allocator, &args, null));
+    }
+
+    // The same overflow via the attached short form.
+    {
+        const short = try std.fmt.allocPrint(allocator, "-n{s}", .{buf.items});
+        defer allocator.free(short);
+        const args = [_][]const u8{short};
+        const NumOpts = struct {
+            nums: []i32 = &.{},
+        };
+        const meta = .{ .options = .{ .nums = .{ .short = 'n' } } };
+        try std.testing.expectError(ZcliError.ResourceLimitExceeded, parseOptionsWithMeta(NumOpts, meta, allocator, null, &args, null));
+    }
+
+    // A CSV comfortably under the limit still parses fine.
+    {
+        const args = [_][]const u8{ "--nums", "1,2,3" };
+        const parsed = try parseOptions(TestOptions, allocator, &args, null);
+        defer cleanupOptions(TestOptions, parsed.options, allocator);
+        try std.testing.expectEqual(@as(usize, 3), parsed.options.nums.len);
     }
 }
 


### PR DESCRIPTION
Fixes #515
Fixes #516

Two argument/option parsing bounds fixes found by the grade9 whole-repo review.

## #515 — CSV array options violate the documented `max_total_options` element bound
`resource_limits.zig` documents that accumulated array options "grow by one element per flag occurrence, so they can never exceed `max_total_options` elements." But `--tags a,b,c` was counted as a single occurrence (`ResourceTracker.checkOptionCount`, once per argv token) while `appendCsvToArrayListUnion` appended one element per comma segment — so a single flag could add unbounded elements.

Fix (option a from the issue): a new `countCsvArrayElements` counts each additional comma-separated segment against the option budget on both the long and short array-append paths. The token is still counted once at the top of the loop; the remaining `N-1` segments are counted so an array option can never exceed `max_total_options` elements. Overflow surfaces as `ResourceLimitExceeded` with the existing diagnostic (`TooManyOptions` mapped in both `convert*OptionError`). The `resource_limits.zig` doc is now accurate as written, so no doc change was needed.

Test: a single `--nums` (and attached-short `-n…`) token with 101 CSV elements trips `ResourceLimitExceeded`; a small CSV still parses.

## #516 — Non-trailing typed optional positional greedily consumes and hard-errors
In `args.zig`, an optional positional unconditionally consumed the next token and returned `ArgumentInvalidValue` if it didn't parse — it never fell through to null to let a later field take the token.

Fix (option a): a typed optional that is NOT the last field now falls through on a parse failure — it stays `null` and does not consume the token, so a later positional can claim it. A trailing optional keeps the strict error (no later field can take the token). String optionals always parse, so only typed optionals reach this path.

`Args = struct { level: ?u32 = null, rest: [][]const u8 }` invoked as `foo bar` now yields `level=null, rest=["foo","bar"]`; `3 foo` still sets `level=3`.

Tests: fall-through into varargs and into a required field, the greedy-success regression, and the trailing-optional strict-error case.

## Verification
`zig build && zig build test` pass from repo root; `zig build test-core` passes (core unit tests, where both new test blocks live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)