### PR TITLE
grade9: harden build_utils — escape/validate external plugin names + unit tests

### DIFF
--- a/packages/core/src/build_utils.zig
+++ b/packages/core/src/build_utils.zig
@@ -22,4 +22,6 @@ test {
     _ = @import("build_utils/main.zig");
     _ = @import("build_utils/module_creation.zig");
     _ = @import("build_utils/plugin_system.zig");
+    _ = @import("build_utils/config_application.zig");
+    _ = @import("build_utils/command_tests.zig");
 }

--- a/packages/core/src/build_utils/code_generation.zig
+++ b/packages/core/src/build_utils/code_generation.zig
@@ -112,12 +112,18 @@ fn generatePluginImports(writer: anytype, plugins: []const PluginInfo, allocator
         const plugin_var_name = try pluginVarName(allocator, plugin_info.name);
         defer allocator.free(plugin_var_name);
 
+        // Escape the import path into the string literal — belt-and-braces with
+        // the up-front name validation in main.zig, and the right thing for
+        // built-in `.path` imports too.
+        const import_lit = try escapeStringLiteral(allocator, plugin_info.import_name);
+        defer allocator.free(import_lit);
+
         if (plugin_info.init) |init_code| {
             // Plugin has initialization code - call it on import
-            try writer.print("const {s} = @import(\"{s}\"){s};\n", .{ plugin_var_name, plugin_info.import_name, init_code });
+            try writer.print("const {s} = @import(\"{s}\"){s};\n", .{ plugin_var_name, import_lit, init_code });
         } else {
             // Normal plugin without config - import directly
-            try writer.print("const {s} = @import(\"{s}\");\n", .{ plugin_var_name, plugin_info.import_name });
+            try writer.print("const {s} = @import(\"{s}\");\n", .{ plugin_var_name, import_lit });
         }
     }
     if (plugins.len > 0) {
@@ -433,6 +439,39 @@ test "plugin registry generation with imports" {
     try std.testing.expect(std.mem.indexOf(u8, source, ".build();") != null);
     // Note: In the new comptime approach, plugins are registered and called through the registry
     // rather than generating complex pipeline code
+}
+
+test "plugin import path is escaped into a valid string literal" {
+    // main.zig rejects such an external plugin name up front; this is the
+    // belt-and-braces guarantee that codegen never emits a raw quote/backslash
+    // into `@import("...")` even if a bad import_name reaches it.
+    const allocator = std.testing.allocator;
+    var test_plugins = PluginTestHelper.init(allocator);
+    defer test_plugins.deinit();
+
+    try test_plugins.addExternal("foo\"bar\\baz");
+
+    var commands = DiscoveredCommands{
+        .allocator = allocator,
+        .root = std.StringHashMap(DiscoveredCommand).init(allocator),
+    };
+    defer commands.deinit();
+
+    const config = BuildConfig{
+        .commands_dir = "src/commands",
+        .plugins_dir = null,
+        .plugins = test_plugins.plugins.items,
+        .app_name = "test-app",
+        .app_version = "1.0.0",
+        .app_description = "Test app",
+    };
+
+    const source = try generateComptimeRegistrySource(allocator, commands, config, test_plugins.plugins.items);
+    defer allocator.free(source);
+
+    // The quote and backslash must be escaped inside the import literal, never raw.
+    try std.testing.expect(std.mem.indexOf(u8, source, "@import(\"foo\\\"bar\\\\baz\")") != null);
+    try std.testing.expect(std.mem.indexOf(u8, source, "@import(\"foo\"bar") == null);
 }
 
 test "plugin name sanitization for imports" {

--- a/packages/core/src/build_utils/command_tests.zig
+++ b/packages/core/src/build_utils/command_tests.zig
@@ -143,12 +143,7 @@ const Ctx = struct {
 
         // Module name from the sanitized command path (unique, and distinct from
         // generate()'s `cmd_*`/`*_index` registry modules).
-        var parts = std.ArrayList([]const u8).empty;
-        defer parts.deinit(b.allocator);
-        for (info.path) |part| {
-            parts.append(b.allocator, std.mem.replaceOwned(u8, b.allocator, part, "-", "_") catch part) catch @panic("OOM");
-        }
-        const module_name = b.fmt("cmdtest_{s}", .{std.mem.join(b.allocator, "_", parts.items) catch @panic("OOM")});
+        const module_name = cmdTestModuleName(b.allocator, info.path) catch @panic("OOM");
 
         const mod = b.addModule(module_name, .{
             .root_source_file = b.path(full_path),
@@ -164,3 +159,47 @@ const Ctx = struct {
         self.test_step.dependOn(&b.addRunArtifact(t).step);
     }
 };
+
+/// Derive the unique test-module identifier for a command from its path:
+/// `cmdtest_<parts joined by '_'>`, with '-' in each part replaced by '_' so a
+/// dash-named command file yields a valid Zig identifier. Extracted from the
+/// std.Build-graph wiring in `addOne` so the derivation rule can be unit-tested
+/// directly (a regression fails here, not an opaque example build). Caller owns
+/// the returned string.
+fn cmdTestModuleName(allocator: std.mem.Allocator, path: []const []const u8) ![]u8 {
+    var parts = std.ArrayList([]const u8).empty;
+    defer {
+        for (parts.items) |p| allocator.free(p);
+        parts.deinit(allocator);
+    }
+    for (path) |part| {
+        try parts.append(allocator, try std.mem.replaceOwned(u8, allocator, part, "-", "_"));
+    }
+    const joined = try std.mem.join(allocator, "_", parts.items);
+    defer allocator.free(joined);
+    return std.fmt.allocPrint(allocator, "cmdtest_{s}", .{joined});
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+const testing = std.testing;
+
+test "cmdTestModuleName joins path parts under a cmdtest_ prefix" {
+    const name = try cmdTestModuleName(testing.allocator, &.{ "users", "list" });
+    defer testing.allocator.free(name);
+    try testing.expectEqualStrings("cmdtest_users_list", name);
+}
+
+test "cmdTestModuleName replaces dashes so the identifier stays valid" {
+    const name = try cmdTestModuleName(testing.allocator, &.{ "gh", "add-item" });
+    defer testing.allocator.free(name);
+    try testing.expectEqualStrings("cmdtest_gh_add_item", name);
+}
+
+test "cmdTestModuleName for a single top-level command" {
+    const name = try cmdTestModuleName(testing.allocator, &.{"init"});
+    defer testing.allocator.free(name);
+    try testing.expectEqualStrings("cmdtest_init", name);
+}

--- a/packages/core/src/build_utils/config_application.zig
+++ b/packages/core/src/build_utils/config_application.zig
@@ -1,6 +1,20 @@
 const std = @import("std");
 const types = @import("types.zig");
 
+/// Whether a module config implies libc must be linked. Explicit `link_libc`
+/// wins; otherwise it is auto-detected from the presence of C sources or system
+/// libraries. Pure decision rule, unit-tested below — kept out of the
+/// std.Build-graph plumbing so a regression fails a targeted test.
+fn needsLibc(config: types.CommandModuleConfig) bool {
+    return config.link_libc orelse (config.c_sources != null or config.system_libs != null);
+}
+
+/// Whether a module config implies libc++ must be linked. Explicit
+/// `link_libcpp` wins; otherwise auto-detected from the presence of C++ sources.
+fn needsLibcpp(config: types.CommandModuleConfig) bool {
+    return config.link_libcpp orelse (config.cpp_sources != null);
+}
+
 /// Collect and apply all C/C++ dependencies from command_configs to the executable
 /// Since modules don't support C linking in Zig, all C dependencies must be applied
 /// to the final executable that links everything together
@@ -26,15 +40,9 @@ pub fn applyCommandConfigsToExecutable(
     for (command_configs) |cmd_config| {
         for (cmd_config.modules) |module_config| {
             if (module_config.config) |config| {
-                // Auto-detect libc linking
-                if (config.link_libc orelse (config.c_sources != null or config.system_libs != null)) {
-                    needs_libc = true;
-                }
-
-                // Auto-detect libc++ linking
-                if (config.link_libcpp orelse (config.cpp_sources != null)) {
-                    needs_libcpp = true;
-                }
+                // Auto-detect libc / libc++ linking (see needsLibc/needsLibcpp)
+                if (needsLibc(config)) needs_libc = true;
+                if (needsLibcpp(config)) needs_libcpp = true;
 
                 // Add include paths (deduplicate)
                 if (config.include_paths) |paths| {
@@ -94,4 +102,42 @@ pub fn applyCommandConfigsToExecutable(
     if (needs_libcpp) {
         exe.root_module.link_libcpp = true;
     }
+}
+
+// ============================================================================
+// Tests — the pure libc/libc++ auto-detection rules. The apply loop above is
+// std.Build-graph plumbing, but the merge decision it makes per module is pure.
+// ============================================================================
+
+const testing = std.testing;
+
+test "needsLibc: nothing set is false" {
+    try testing.expect(!needsLibc(.{}));
+}
+
+test "needsLibc: auto-detected from C sources and system libs" {
+    try testing.expect(needsLibc(.{ .c_sources = &.{"foo.c"} }));
+    try testing.expect(needsLibc(.{ .system_libs = &.{"curl"} }));
+}
+
+test "needsLibc: explicit link_libc overrides auto-detection both ways" {
+    // Explicit false wins even though C sources would auto-detect true.
+    try testing.expect(!needsLibc(.{ .link_libc = false, .c_sources = &.{"foo.c"} }));
+    // Explicit true wins with nothing else set.
+    try testing.expect(needsLibc(.{ .link_libc = true }));
+}
+
+test "needsLibc: C++ sources alone do not pull in libc" {
+    try testing.expect(!needsLibc(.{ .cpp_sources = &.{"foo.cpp"} }));
+}
+
+test "needsLibcpp: auto-detected only from C++ sources" {
+    try testing.expect(!needsLibcpp(.{}));
+    try testing.expect(needsLibcpp(.{ .cpp_sources = &.{"foo.cpp"} }));
+    try testing.expect(!needsLibcpp(.{ .c_sources = &.{"foo.c"} }));
+}
+
+test "needsLibcpp: explicit link_libcpp overrides auto-detection both ways" {
+    try testing.expect(!needsLibcpp(.{ .link_libcpp = false, .cpp_sources = &.{"foo.cpp"} }));
+    try testing.expect(needsLibcpp(.{ .link_libcpp = true }));
 }

--- a/packages/core/src/build_utils/discovery_types.zig
+++ b/packages/core/src/build_utils/discovery_types.zig
@@ -102,3 +102,52 @@ pub const DiscoveredCommands = struct {
         self.root.deinit();
     }
 };
+
+// ============================================================================
+// Tests — sortedByName is the pure helper that makes generated command order
+// deterministic; discovery stores entries in an unordered StringHashMap.
+// ============================================================================
+
+const testing = std.testing;
+
+fn putBare(map: *std.StringHashMap(DiscoveredCommand), allocator: std.mem.Allocator, name: []const u8) !void {
+    try map.put(try allocator.dupe(u8, name), .{
+        .name = try allocator.dupe(u8, name),
+        .path = &.{},
+        .file_path = try allocator.dupe(u8, name),
+        .command_type = .leaf,
+        .subcommands = null,
+    });
+}
+
+test "sortedByName returns entries alphabetically regardless of insertion order" {
+    const allocator = testing.allocator;
+    var commands = DiscoveredCommands.init(allocator);
+    defer commands.deinit();
+
+    // Insert deliberately out of alphabetical order.
+    try putBare(&commands.root, allocator, "delta");
+    try putBare(&commands.root, allocator, "alpha");
+    try putBare(&commands.root, allocator, "charlie");
+    try putBare(&commands.root, allocator, "bravo");
+
+    const sorted = try sortedByName(allocator, &commands.root);
+    defer allocator.free(sorted);
+
+    try testing.expectEqual(@as(usize, 4), sorted.len);
+    try testing.expectEqualStrings("alpha", sorted[0].name);
+    try testing.expectEqualStrings("bravo", sorted[1].name);
+    try testing.expectEqualStrings("charlie", sorted[2].name);
+    try testing.expectEqualStrings("delta", sorted[3].name);
+}
+
+test "sortedByName on an empty map yields an empty slice" {
+    const allocator = testing.allocator;
+    var commands = DiscoveredCommands.init(allocator);
+    defer commands.deinit();
+
+    const sorted = try sortedByName(allocator, &commands.root);
+    defer allocator.free(sorted);
+
+    try testing.expectEqual(@as(usize, 0), sorted.len);
+}

--- a/packages/core/src/build_utils/main.zig
+++ b/packages/core/src/build_utils/main.zig
@@ -24,6 +24,9 @@ pub const GenerateError = error{
     PluginDiscoveryFailed,
     /// A `PluginConfig` set neither `path` nor `dependency` (or set both).
     PluginConfigInvalid,
+    /// An external plugin's `name` is not a valid package/identifier name and
+    /// would break out of the generated `@import("...")` string literal.
+    PluginNameInvalid,
     /// Two discovered commands sanitize to the same generated module identifier.
     CommandNameCollision,
 };
@@ -264,6 +267,17 @@ pub fn generate(b: *std.Build, exe: *std.Build.Step.Compile, zcli_dep: *std.Buil
             if (plugin_config.path != null) {
                 logging.buildError("Plugin Config Error", plugin_config.name, "A plugin sets both '.path' and '.dependency'", "Use '.path' (via zcli.builtin) for a built-in, or '.dependency' for an external package — not both");
                 return error.PluginConfigInvalid;
+            }
+            // The external plugin's name is emitted verbatim as its
+            // `@import("<name>")` string in the generated registry. Reject a
+            // name that isn't a valid package/identifier here — otherwise a
+            // quote/backslash/space in it produces an opaque compile error in
+            // zcli_generated.zig instead of this clean diagnostic. (Built-in
+            // `.path` plugins import a filesystem-relative path, not the name,
+            // and that path is escaped at emission.)
+            if (!plugin_system.isValidPluginName(plugin_config.name)) {
+                logging.buildError("Plugin Config Error", plugin_config.name, "External plugin name is not a valid package name", "Use letters, digits, '_' and '-' only, starting with a letter or '_' (no spaces, quotes, or path separators)");
+                return error.PluginNameInvalid;
             }
             // External package plugin: its module is resolved from the
             // dependency in module_creation.addPluginModulesToRegistry via

--- a/packages/core/src/build_utils/plugin_system.zig
+++ b/packages/core/src/build_utils/plugin_system.zig
@@ -143,7 +143,12 @@ pub fn combinePlugins(b: *std.Build, local_plugins: []const PluginInfo, external
 /// Validate a plugin file/directory name: identifier-style first char,
 /// then alphanumeric/underscore/dash; path separators and traversal
 /// rejected. (Looser than isValidCommandName — no reserved-name list.)
-fn isValidPluginName(name: []const u8) bool {
+///
+/// Also the gate for externally-configured plugin names: `generate()` emits an
+/// external plugin's name verbatim into an `@import("...")` string literal, so a
+/// name containing a quote, backslash, or newline would break out of that
+/// literal. Rejecting anything but this identifier-ish shape closes that path.
+pub fn isValidPluginName(name: []const u8) bool {
     if (name.len == 0) return false;
 
     // Check for forbidden patterns
@@ -181,6 +186,11 @@ test "isValidPluginName: accepts plugin-ish names, rejects traversal and junk" {
     try testing.expect(!isValidPluginName("../escape"));
     try testing.expect(!isValidPluginName("a/b"));
     try testing.expect(!isValidPluginName("a\\b"));
+
+    // Names that would break out of the generated `@import("...")` literal.
+    try testing.expect(!isValidPluginName("foo\"bar"));
+    try testing.expect(!isValidPluginName("foo\nbar"));
+    try testing.expect(!isValidPluginName("foo\")); pub const x = @import(\"evil"));
 }
 
 /// Free everything `scanInDir` allocated for a result slice.


### PR DESCRIPTION
## Summary

Two grade9 build-system hardening fixes in `packages/core/src/build_utils`.

### Fixes #518 — external plugin name emitted unescaped into `@import("...")`
`generate()` copied `PluginConfig.name` verbatim into the generated `@import("<name>")` string for external (dependency) plugins. A name containing `"` or `\` broke out of the string literal, producing an opaque compile error in `zcli_generated.zig` (or, in theory, code injection).

- `main.zig` now validates external plugin names up front with `plugin_system.isValidPluginName` (made `pub`) and fails with a clean `Plugin Config Error` / new `GenerateError.PluginNameInvalid` — the same identifier-shape gate already used for discovered local plugins.
- `code_generation.zig` additionally routes the plugin import path through the existing `escapeStringLiteral` helper as belt-and-braces (also correct for built-in `.path` imports).

### Fixes #540 — orchestration files had zero direct unit tests
Extracted pure decision logic out of the `*std.Build`-graph plumbing and unit-tested it directly, so a rule regression fails a fast targeted test instead of an opaque example build:

- `config_application.zig`: `needsLibc` / `needsLibcpp` libc/libc++ auto-detect merge rules.
- `command_tests.zig`: `cmdTestModuleName` derivation (`cmdtest_<sanitized path>`).
- `discovery_types.zig`: `sortedByName` alphabetical ordering.
- `plugin_system.zig`: external-name gate regression cases (quote/newline/injection).
- `code_generation.zig`: plugin import-path escaping regression.

Wired `config_application.zig` and `command_tests.zig` into the `build_utils.zig` test root (they were previously uncollected) so the new blocks run under `zig build test`.

## Testing
`zig build` and `zig build test` both pass from the repo root (exercises codegen through all example projects) and in `packages/core`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)