### PR TITLE
grade9: atomic file writes in the zcli meta-CLI

### DIFF
--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -197,6 +197,13 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
     // Now that the destination is validated and plugins are chosen, create and
     // open the project directory.
     if (!use_current_dir) try cwd.createDir(io, args.name, .default_dir);
+    // If init created the directory, tear the whole tree down on any later
+    // scaffold failure so a retry isn't blocked by a "Directory already exists"
+    // half-created project. deleteTree is safe here: the directory did not exist
+    // before this run (validated above). Declared before `project_dir.close` so
+    // the dir handle is closed first (Windows won't delete an open dir). For
+    // use_current_dir we deliberately don't clean up — we didn't create the dir.
+    errdefer if (!use_current_dir) cwd.deleteTree(io, args.name) catch {};
     var project_dir = try cwd.openDir(io, if (use_current_dir) "." else args.name, .{});
     defer project_dir.close(io);
 

--- a/projects/zcli/src/commands/release.zig
+++ b/projects/zcli/src/commands/release.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const zcli = @import("zcli");
+const scaffold = @import("scaffold");
 
 pub const meta = .{
     .description = "Create and manage project releases",
@@ -493,34 +494,51 @@ fn updateBuildZonVersion(allocator: std.mem.Allocator, io: std.Io, new_version: 
     const content = try std.Io.Dir.cwd().readFileAlloc(io, zon_path, allocator, .limited(1024 * 1024));
     defer allocator.free(content);
 
-    // Find and replace the version line
-    var new_content = std.ArrayList(u8).empty;
-    defer new_content.deinit(allocator);
+    const new_content = try rewriteZonVersion(allocator, content, new_version);
+    defer allocator.free(new_content);
+
+    // Write back atomically (temp + rename) so a crash/interrupt mid-write can
+    // never leave build.zig.zon empty or truncated — the original stays intact
+    // until the rename swaps in the fully-written replacement.
+    try scaffold.fs.writeFileAtomic(std.Io.Dir.cwd(), io, allocator, zon_path, new_content);
+}
+
+/// Return a copy of `content` with the `.version` field rewritten to
+/// `new_version`. The match is anchored to a line whose first non-whitespace
+/// token is `.version`, so `.minimum_zig_version` (or any other field that
+/// merely contains the substring) is left untouched. Pure — no I/O — so the
+/// rewrite is unit-testable.
+fn rewriteZonVersion(allocator: std.mem.Allocator, content: []const u8, new_version: []const u8) ![]u8 {
+    var out = std.ArrayList(u8).empty;
+    defer out.deinit(allocator);
 
     var lines = std.mem.splitScalar(u8, content, '\n');
+    var first = true;
     while (lines.next()) |line| {
-        if (std.mem.indexOf(u8, line, ".version")) |_| {
-            // Replace the version value
-            const indent = blk: {
-                var i: usize = 0;
-                while (i < line.len and (line[i] == ' ' or line[i] == '\t')) : (i += 1) {}
-                break :blk line[0..i];
-            };
-            {
-                const s = try std.fmt.allocPrint(allocator, "{s}.version = \"{s}\",\n", .{ indent, new_version });
-                defer allocator.free(s);
-                try new_content.appendSlice(allocator, s);
-            }
+        // Re-insert the '\n' between lines (not after the last) so the file's
+        // exact structure — including a trailing newline or lack thereof — is
+        // preserved rather than gaining a spurious blank line.
+        if (!first) try out.append(allocator, '\n');
+        first = false;
+
+        const indent = leadingWhitespace(line);
+        if (std.mem.startsWith(u8, line[indent.len..], ".version")) {
+            const s = try std.fmt.allocPrint(allocator, "{s}.version = \"{s}\",", .{ indent, new_version });
+            defer allocator.free(s);
+            try out.appendSlice(allocator, s);
         } else {
-            try new_content.appendSlice(allocator, line);
-            try new_content.append(allocator, '\n');
+            try out.appendSlice(allocator, line);
         }
     }
 
-    // Write back to file
-    const out_file = try std.Io.Dir.cwd().createFile(io, zon_path, .{});
-    defer out_file.close(io);
-    try out_file.writeStreamingAll(io, new_content.items);
+    return out.toOwnedSlice(allocator);
+}
+
+/// The leading run of spaces/tabs on `line` (its indentation).
+fn leadingWhitespace(line: []const u8) []const u8 {
+    var i: usize = 0;
+    while (i < line.len and (line[i] == ' ' or line[i] == '\t')) : (i += 1) {}
+    return line[0..i];
 }
 
 /// Whether a local git tag named `tag_name` currently exists. Used to detect a
@@ -1180,4 +1198,33 @@ test "runCommand - captures stdout and surfaces failure stderr" {
     defer bad.deinit(allocator);
     try testing.expect(!bad.success);
     try testing.expect(bad.stderr.len > 0);
+}
+
+test "rewriteZonVersion - rewrites .version and leaves .minimum_zig_version alone" {
+    const allocator = testing.allocator;
+
+    const manifest =
+        \\.{
+        \\    .name = .myapp,
+        \\    .version = "0.1.0",
+        \\    .fingerprint = 0x1234,
+        \\    .minimum_zig_version = "0.16.0",
+        \\    .dependencies = .{},
+        \\}
+        \\
+    ;
+    const expected =
+        \\.{
+        \\    .name = .myapp,
+        \\    .version = "2.0.0",
+        \\    .fingerprint = 0x1234,
+        \\    .minimum_zig_version = "0.16.0",
+        \\    .dependencies = .{},
+        \\}
+        \\
+    ;
+
+    const got = try rewriteZonVersion(allocator, manifest, "2.0.0");
+    defer allocator.free(got);
+    try testing.expectEqualStrings(expected, got);
 }

--- a/projects/zcli/src/scaffold/fs.zig
+++ b/projects/zcli/src/scaffold/fs.zig
@@ -38,6 +38,10 @@ pub fn groupPath(arena: std.mem.Allocator, segments: []const []const u8) ![]cons
 /// affected) instead of a truncated/corrupt command source.
 pub fn writeFileAtomic(base: std.Io.Dir, io: std.Io, arena: std.mem.Allocator, path: []const u8, data: []const u8) !void {
     const tmp_path = try std.fmt.allocPrint(arena, "{s}.tmp", .{path});
+    // Clean up the temp on any failure so a failed write or rename leaves no
+    // `<path>.tmp` debris beside the target. Covers both the write below and the
+    // rename; runs after `file.close` (declared later, so it unwinds first).
+    errdefer base.deleteFile(io, tmp_path) catch {};
     {
         var file = try base.createFile(io, tmp_path, .{});
         defer file.close(io);
@@ -109,6 +113,27 @@ test "writeFileAtomic replaces contents and leaves no temp behind" {
     try testing.expectEqualStrings("replaced contents", got);
     // The temp is renamed away, not left as debris next to the target.
     try testing.expect(!fileExists(tmp.dir, io, "cmd.zig.tmp"));
+}
+
+test "writeFileAtomic cleans up the temp file when the rename fails" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const io = testing.io;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // Make the target an existing directory so the final `rename` of the temp
+    // file over it fails — exercising the errdefer cleanup path.
+    try tmp.dir.createDir(io, "target", .default_dir);
+
+    if (writeFileAtomic(tmp.dir, io, a, "target", "data")) |_| {
+        return error.TestExpectedRenameFailure;
+    } else |_| {}
+
+    // The temp file must not be left behind as debris.
+    try testing.expect(!fileExists(tmp.dir, io, "target.tmp"));
 }
 
 fn fileExists(base: std.Io.Dir, io: std.Io, path: []const u8) bool {


### PR DESCRIPTION
Fixes #519
Fixes #520
Fixes #521

File-write robustness fixes in the zcli meta-CLI (`projects/zcli`).

## #519 — release rewrites build.zig.zon non-atomically
`updateBuildZonVersion` did `createFile` (truncate in place) then `writeStreamingAll`; a crash/interrupt/disk-full mid-write left the manifest empty or partial. Now the rewrite goes through `scaffold.fs.writeFileAtomic` (temp + rename), so the original stays intact until the fully-written replacement is renamed in. Also anchored the `.version` match to the first non-whitespace token of the line (was a substring `indexOf`), so `.minimum_zig_version` and friends are never rewritten. The line-rewrite logic was extracted into a pure `rewriteZonVersion` and now faithfully preserves the file's trailing-newline structure instead of adding a blank line.

## #520 — init leaves a half-scaffolded directory on a mid-scaffold failure
After `createDir(args.name)`, ~5 files were created with no cleanup, so an I/O error mid-scaffold left a partial project that blocked re-running with "Directory already exists". Added `errdefer cwd.deleteTree(io, args.name)` scoped to the case where init created the directory (safe: the dir did not exist before this run, validated up front). Declared before the `project_dir` handle's `defer close` so the handle is closed before the tree is removed. `use_current_dir` is intentionally left alone (init didn't create that dir).

## #521 — writeFileAtomic leaks the .tmp file on failed write/rename
Added `errdefer base.deleteFile(io, tmp_path) catch {}` covering both the write and the rename failure paths, so a failed run leaves no `<path>.tmp` debris beside the target.

## Tests
- `rewriteZonVersion` round-trips a manifest, rewriting `.version` while leaving `.minimum_zig_version` untouched (release.zig; already wired in `command_test_files`).
- `writeFileAtomic` cleans up the temp file when the rename fails (scaffold/fs.zig).
- `zig build` + `zig build test` green from repo root; `zig build e2e` (init coverage) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)