### PR TITLE
release.yml: fix setup-zig cache thrash + document pre-gate scratch push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,15 @@ jobs:
     name: Resolve release plan
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # This job runs BEFORE the `release` environment's required-reviewer gate
+    # (that gate only wraps finalize/release/library-release below) and holds
+    # contents: write to force-push the `_release-staging/$VERSION` scratch
+    # branch (see the Plan step). This is intentionally NOT gated: it is not
+    # a privilege escalation (workflow_dispatch already requires repo write
+    # access to trigger), $VERSION is strict-semver-validated before any
+    # interpolation, and the write is confined to a disposable scratch
+    # branch — main and the real tags are only ever touched by `finalize`,
+    # which IS gated. See #541.
     permissions:
       contents: write
     outputs:
@@ -234,10 +243,17 @@ jobs:
         with:
           ref: ${{ needs.setup.outputs.ref }}
 
+      # mlugg/setup-zig's cache key includes the runner OS automatically but
+      # NOT matrix variables. Three of these six legs share os: ubuntu-latest
+      # while cross-compiling genuinely different zig_target values, so an
+      # explicit cache-key is required or those legs would thrash a single
+      # shared cache entry. Mirrors ci.yml's linux-musl-release-build job,
+      # which documents the identical hazard for its own ubuntu-latest matrix.
       - name: Setup Zig
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.16.0
+          cache-key: ${{ matrix.zig_target }}
 
       - name: Build zcli
         run: |


### PR DESCRIPTION
## Summary
- **#530 (P2)**: The release build job's cross-compile matrix has 6 legs, 3 of which share `os: ubuntu-latest` (x86_64/aarch64-linux, x86_64/aarch64-windows) while cross-compiling genuinely different `zig_target` values. `mlugg/setup-zig`'s default cache key includes the runner OS but not matrix variables, so those legs were thrashing a single shared cache entry. Added `cache-key: ${{ matrix.zig_target }}` to the build job's Setup Zig step, mirroring the pattern ci.yml already uses (and documents) for its own `linux-musl-release-build` job. (The `test` job's matrix varies by `os` directly, so it's already disambiguated for free — no change needed there.)
- **#541 (P3)**: The `setup` job runs on `workflow_dispatch` with `contents: write` and force-pushes a `_release-staging/$VERSION` scratch branch before the `release` environment's required-reviewer gate (which only wraps `finalize`/`release`/`library-release`). Per the issue's own risk assessment this isn't a privilege escalation and the blast radius is confined to a disposable branch, so rather than restructure the release flow I added a comment on the `setup` job documenting why the pre-gate write is acceptable, so a future audit doesn't re-litigate it.

## Test plan
- [x] `actionlint .github/workflows/release.yml` — no new findings (pre-existing shellcheck style nits only, unrelated to this diff)
- [x] YAML parses cleanly (`Psych`/Ruby YAML load)
- [ ] Release dry-run via `workflow_dispatch` still succeeds (can't run this from the worktree; relies on repo maintainer / CI)

Fixes #530
Fixes #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)