### PR TITLE
prompts: fix double-free, SIGWINCH, scratch-file leak, i64 overflow

### DIFF
--- a/packages/prompts/src/confirm.zig
+++ b/packages/prompts/src/confirm.zig
@@ -53,7 +53,9 @@ pub fn confirm(p: Prompts, config: ConfirmConfig) !bool {
     // TTY: single keypress
     Prompts.flushWriter(writer);
     const raw = terminal.enableRawMode(std.Io.File.stdin().handle) catch return config.default;
+    var watcher = terminal.ResizeWatcher.init();
     defer {
+        watcher.deinit();
         raw.disable();
         Prompts.flushWriter(writer);
     }
@@ -63,13 +65,22 @@ pub fn confirm(p: Prompts, config: ConfirmConfig) !bool {
     });
     defer app.deinit();
 
+    const stdin = std.Io.File.stdin().handle;
+
     try renderFrame(&app, config, hint);
 
     while (true) {
-        const k = if (config.interrupt_keys.len > 0)
-            try terminal.readKeyOpt(reader, std.Io.File.stdin().handle)
-        else
-            try terminal.readKey(reader);
+        // A SIGWINCH arrives out-of-band via the watcher, not as a key: repaint
+        // so the wrapped prompt/cursor reflow to the new width without waiting
+        // for the next keystroke.
+        const k = switch (try terminal.readEvent(reader, stdin, &watcher)) {
+            .resize => {
+                try renderFrame(&app, config, hint);
+                continue;
+            },
+            .key => |key| key,
+            else => continue,
+        };
         if (Prompts.isInterrupt(k, config.interrupt_keys)) {
             try persist(&app, config, hint, null);
             return error.Interrupted;

--- a/packages/prompts/src/editor.zig
+++ b/packages/prompts/src/editor.zig
@@ -59,6 +59,14 @@ pub fn editor(p: Prompts, config: EditorConfig) ![]u8 {
     };
     var raw_active = true;
     errdefer if (raw_active) raw.disable();
+    // Watches for SIGWINCH so a resize while the user is at the hint line
+    // repaints instead of leaving the wrapped prompt stale. Torn down (along
+    // with raw mode) before the child editor is spawned so it inherits a clean
+    // terminal and default signal disposition.
+    var watcher = terminal.ResizeWatcher.init();
+    var watcher_active = true;
+    errdefer if (watcher_active) watcher.deinit();
+    const stdin = std.Io.File.stdin().handle;
     var app = try ui.App.init(p.allocator, writer, .{
         .capability = p.theme.capability(),
         .hybrid_raw = raw,
@@ -67,7 +75,14 @@ pub fn editor(p: Prompts, config: EditorConfig) ![]u8 {
     try renderFrame(&app, p.theme, config);
 
     while (true) {
-        const k = try terminal.readKey(reader);
+        const k = switch (try terminal.readEvent(reader, stdin, &watcher)) {
+            .resize => {
+                try renderFrame(&app, p.theme, config);
+                continue;
+            },
+            .key => |key| key,
+            else => continue,
+        };
         switch (k) {
             .enter => break,
             .ctrl => |c| {
@@ -75,6 +90,8 @@ pub fn editor(p: Prompts, config: EditorConfig) ![]u8 {
                     try app.clear();
                     try app.emit("{s}{s}", .{ config.prefix, config.message });
                     app.deinit();
+                    watcher.deinit();
+                    watcher_active = false;
                     raw.disable();
                     raw_active = false;
                     Prompts.flushWriter(writer);
@@ -85,10 +102,12 @@ pub fn editor(p: Prompts, config: EditorConfig) ![]u8 {
         }
     }
     // Persist the prompt line and hand the editor a clean terminal: region
-    // closed, cursor restored, raw mode off.
+    // closed, cursor restored, resize watcher and raw mode off.
     try app.clear();
     try app.emit("{s}{s}", .{ config.prefix, config.message });
     app.deinit();
+    watcher.deinit();
+    watcher_active = false;
     raw.disable();
     raw_active = false;
     Prompts.flushWriter(writer);
@@ -109,11 +128,18 @@ pub fn editor(p: Prompts, config: EditorConfig) ![]u8 {
         .exclusive = true,
         .permissions = @enumFromInt(0o600),
     });
-    if (config.default) |def| {
-        try tmp_file.writeStreamingAll(config.io, def);
-    }
-    tmp_file.close(config.io);
+    // Remove the scratch file on every exit path. Registered immediately after
+    // createFile — before the write below — so a failed initial write can't
+    // leak a 0600 file that may hold sensitive pre-fill content.
     defer cwd.deleteFile(config.io, tmp_name) catch {};
+    {
+        // Close the fd on any exit from this block (success or a write error)
+        // so a failed write doesn't leak the descriptor either.
+        defer tmp_file.close(config.io);
+        if (config.default) |def| {
+            try tmp_file.writeStreamingAll(config.io, def);
+        }
+    }
 
     // Spawn editor
     var child = try std.process.spawn(config.io, .{
@@ -130,6 +156,7 @@ pub fn editor(p: Prompts, config: EditorConfig) ![]u8 {
 
     // Read back content
     const raw_content = try cwd.readFileAlloc(config.io, tmp_name, allocator, .limited(1024 * 1024));
+    errdefer allocator.free(raw_content);
 
     // Trim trailing newlines
     const trimmed = std.mem.trimEnd(u8, raw_content, "\n\r");

--- a/packages/prompts/src/number.zig
+++ b/packages/prompts/src/number.zig
@@ -73,7 +73,9 @@ fn numberTty(p: Prompts, config: NumberConfig) !i64 {
     const raw = terminal.enableRawMode(std.Io.File.stdin().handle) catch {
         return config.default orelse error.InvalidNumber;
     };
+    var watcher = terminal.ResizeWatcher.init();
     defer {
+        watcher.deinit();
         raw.disable();
         Prompts.flushWriter(writer);
     }
@@ -83,6 +85,8 @@ fn numberTty(p: Prompts, config: NumberConfig) !i64 {
     });
     defer app.deinit();
 
+    const stdin = std.Io.File.stdin().handle;
+
     var buf: [32]u8 = undefined;
     var len: usize = 0;
     var error_msg: ?[]const u8 = null;
@@ -91,10 +95,17 @@ fn numberTty(p: Prompts, config: NumberConfig) !i64 {
     try renderFrame(&app, config, buf[0..len], error_msg);
 
     while (true) {
-        const k = if (config.interrupt_keys.len > 0)
-            try terminal.readKeyOpt(reader, std.Io.File.stdin().handle)
-        else
-            try terminal.readKey(reader);
+        // A SIGWINCH arrives out-of-band via the watcher, not as a key: repaint
+        // so the wrapped prompt/cursor reflow to the new width without waiting
+        // for the next keystroke.
+        const k = switch (try terminal.readEvent(reader, stdin, &watcher)) {
+            .resize => {
+                try renderFrame(&app, config, buf[0..len], error_msg);
+                continue;
+            },
+            .key => |key| key,
+            else => continue,
+        };
         if (Prompts.isInterrupt(k, config.interrupt_keys)) {
             try persistLine(&app, config, buf[0..len]);
             return error.Interrupted;
@@ -104,7 +115,14 @@ fn numberTty(p: Prompts, config: NumberConfig) !i64 {
                 const value = if (len == 0)
                     config.default orelse continue
                 else
-                    std.fmt.parseInt(i64, buf[0..len], 10) catch continue;
+                    std.fmt.parseInt(i64, buf[0..len], 10) catch {
+                        // A digit string can be well-formed yet overflow i64
+                        // (e.g. 20 nines). Surface it the same way a range
+                        // violation is, rather than silently swallowing Enter.
+                        error_msg = "number out of range";
+                        try renderFrame(&app, config, buf[0..len], error_msg);
+                        continue;
+                    };
 
                 if (config.min) |min| {
                     if (value < min) {
@@ -283,6 +301,20 @@ test "non-TTY: EOF errors instead of falling back to the default" {
     try std.testing.expectError(error.EndOfStream, number(.{ .writer = &writer_stream, .reader = &reader_stream, .allocator = std.testing.allocator }, .{
         .message = "Port:",
         .default = 3000,
+    }));
+}
+
+test "non-TTY: a value that overflows i64 is rejected, not silently accepted" {
+    // Regression for #527: 20 nines is all digits but overflows i64. It must
+    // surface as an error rather than being swallowed (the TTY path renders a
+    // "number out of range" message; the non-TTY path errors here).
+    var input = "99999999999999999999\n".*;
+    var reader_stream: std.Io.Reader = .fixed(&input);
+    var output: [256]u8 = undefined;
+    var writer_stream: std.Io.Writer = .fixed(&output);
+
+    try std.testing.expectError(error.InvalidNumber, number(.{ .writer = &writer_stream, .reader = &reader_stream, .allocator = std.testing.allocator }, .{
+        .message = "Count:",
     }));
 }
 

--- a/packages/prompts/src/password.zig
+++ b/packages/prompts/src/password.zig
@@ -42,7 +42,9 @@ pub fn password(p: Prompts, config: PasswordConfig) ![]u8 {
         try writer.print("{s}{s} \n", .{ config.prefix, config.message });
         return try allocator.dupe(u8, "");
     };
+    var watcher = terminal.ResizeWatcher.init();
     defer {
+        watcher.deinit();
         raw.disable();
         Prompts.flushWriter(writer);
     }
@@ -51,6 +53,8 @@ pub fn password(p: Prompts, config: PasswordConfig) ![]u8 {
         .hybrid_raw = raw,
     });
     defer app.deinit();
+
+    const stdin = std.Io.File.stdin().handle;
 
     var buf = std.ArrayList(u8).empty;
     defer {
@@ -64,7 +68,17 @@ pub fn password(p: Prompts, config: PasswordConfig) ![]u8 {
     try renderFrame(&app, config, buf.items);
 
     while (true) {
-        const k = try terminal.readKey(reader);
+        // A SIGWINCH arrives out-of-band via the watcher, not as a key: repaint
+        // so the wrapped mask/cursor reflow to the new width without waiting for
+        // the next keystroke.
+        const k = switch (try terminal.readEvent(reader, stdin, &watcher)) {
+            .resize => {
+                try renderFrame(&app, config, buf.items);
+                continue;
+            },
+            .key => |key| key,
+            else => continue,
+        };
         switch (k) {
             .enter => {
                 try persistLine(&app, config, buf.items);

--- a/packages/prompts/src/search.zig
+++ b/packages/prompts/src/search.zig
@@ -95,8 +95,13 @@ pub fn search(p: Prompts, config: SearchConfig) !usize {
                 .backspace => {
                     if (query.items.len > 0) {
                         Prompts.popTrailingGrapheme(&query);
+                        // Build the replacement first: if it OOMs, `filtered`
+                        // still points at the live slice, so the deferred free
+                        // (and the next rebuild) stay valid — freeing first would
+                        // leave a dangling pointer to double-free.
+                        const next = try buildFiltered(allocator, config.choices, query.items);
                         allocator.free(filtered);
-                        filtered = try buildFiltered(allocator, config.choices, query.items);
+                        filtered = next;
                         cursor = 0;
                         try renderFrame(&app, p.theme, config, query.items, filtered, cursor);
                     }
@@ -109,8 +114,10 @@ pub fn search(p: Prompts, config: SearchConfig) !usize {
                 },
                 .char => |c| {
                     _ = try Prompts.appendCodepoint(allocator, &query, c);
+                    // See the backspace branch: build then swap, never free-then-build.
+                    const next = try buildFiltered(allocator, config.choices, query.items);
                     allocator.free(filtered);
-                    filtered = try buildFiltered(allocator, config.choices, query.items);
+                    filtered = next;
                     cursor = 0;
                     try renderFrame(&app, p.theme, config, query.items, filtered, cursor);
                 },
@@ -258,6 +265,25 @@ test "buildFiltered matches all on empty query" {
     const result = try buildFiltered(allocator, choices, "");
     defer allocator.free(result);
     try std.testing.expectEqual(@as(usize, 3), result.len);
+}
+
+test "buildFiltered failure leaves the caller's slice intact (rebuild is OOM-safe)" {
+    // Regression for the rebuild double-free: the interactive loop now builds the
+    // new filtered slice *before* freeing the old one, so an OOM mid-rebuild
+    // can't dangle `filtered`. That relies on buildFiltered neither freeing nor
+    // mutating anything the caller still owns when it fails — assert exactly that.
+    const allocator = std.testing.allocator;
+    const choices = &[_][]const u8{ "alpha", "beta", "gamma" };
+
+    const filtered = try buildFiltered(allocator, choices, "");
+    defer allocator.free(filtered); // must stay valid and be freed exactly once
+
+    // Force the rebuild allocation to fail.
+    var failing = std.testing.FailingAllocator.init(allocator, .{ .fail_index = 0 });
+    try std.testing.expectError(error.OutOfMemory, buildFiltered(failing.allocator(), choices, "a"));
+
+    // The original slice is untouched: still the full match set, still freeable.
+    try std.testing.expectEqual(@as(usize, 3), filtered.len);
 }
 
 test "buildFiltered filters by substring" {

--- a/packages/prompts/src/text.zig
+++ b/packages/prompts/src/text.zig
@@ -67,7 +67,9 @@ pub fn text(p: Prompts, config: TextConfig) ![]u8 {
         try writer.print("{s}{s} \n", .{ config.prefix, config.message });
         return try allocator.dupe(u8, config.default orelse "");
     };
+    var watcher = terminal.ResizeWatcher.init();
     defer {
+        watcher.deinit();
         raw.disable();
         Prompts.flushWriter(writer);
     }
@@ -77,16 +79,25 @@ pub fn text(p: Prompts, config: TextConfig) ![]u8 {
     });
     defer app.deinit();
 
+    const stdin = std.Io.File.stdin().handle;
+
     var buf = std.ArrayList(u8).empty;
     defer buf.deinit(allocator);
 
     try renderFrame(&app, p.theme, config, buf.items);
 
     while (true) {
-        const k = if (config.interrupt_keys.len > 0)
-            try terminal.readKeyOpt(reader, std.Io.File.stdin().handle)
-        else
-            try terminal.readKey(reader);
+        // A SIGWINCH arrives out-of-band via the watcher, not as a key: repaint
+        // so the wrapped prompt/cursor reflow to the new width without waiting
+        // for the next keystroke.
+        const k = switch (try terminal.readEvent(reader, stdin, &watcher)) {
+            .resize => {
+                try renderFrame(&app, p.theme, config, buf.items);
+                continue;
+            },
+            .key => |key| key,
+            else => continue,
+        };
         if (Prompts.isInterrupt(k, config.interrupt_keys)) {
             try persistLine(&app, config, buf.items);
             return error.Interrupted;


### PR DESCRIPTION
Fixes four grade9 P2 issues in `packages/prompts`.

Fixes #524
Fixes #525
Fixes #526
Fixes #527

## #524 — search: double-free of `filtered` on allocator failure during rebuild
The filter rebuild did `allocator.free(filtered); filtered = try buildFiltered(...)`. If `buildFiltered` OOMs, `filtered` still holds the freed pointer, so the `defer allocator.free(filtered)` (and the next rebuild) double-frees it. Fixed both rebuild sites to build the replacement first, then swap:
```zig
const next = try buildFiltered(...);
allocator.free(filtered);
filtered = next;
```
Added a `FailingAllocator` unit test asserting the caller's slice stays intact (and freeable exactly once) when the rebuild allocation fails.

## #525 — single-line prompt editors ignored SIGWINCH
`text`, `number`, `password`, `confirm`, and `editor` blocked on `readKey`/`readKeyOpt` with no `ResizeWatcher`, so a resize mid-prompt left the wrapped line and cursor stale until the next keystroke. Switched all five to the `terminal.readEvent` + `.resize` repaint pattern the list prompts (`select`/`search`) already use — add a `ResizeWatcher` (torn down in the cleanup path; for `editor`, before the child editor is spawned so it inherits a clean terminal), repaint on `.resize`, and keep the existing key handling (including `interrupt_keys`).

## #526 — editor leaked the 0600 scratch file (and fd) when the initial write failed
The `defer cwd.deleteFile(tmp_name)` was registered *after* `createFile`/`writeStreamingAll`/`close`, so a failed initial write leaked the 0600 temp file (which may hold sensitive pre-fill content) and its fd. Registered the delete-defer immediately after `createFile`, close the fd via a scoped `defer` (covers the write-error path), and added the missing `errdefer allocator.free(raw_content)`.

## #527 — number prompt swallowed Enter on i64 overflow
A digit string like 20 nines is well-formed but overflows i64, hitting `parseInt(i64, ...) catch continue` — Enter did nothing and no error rendered. Now sets `error_msg = "number out of range"` and repaints, matching the range-violation path. Added a non-TTY regression test asserting the overflow value is rejected rather than silently accepted.

## Testing
- `zig build` — pass
- `zig build test` — pass (includes new unit tests)
- `zig build e2e` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)