### PR TITLE
Fix hidden-group leak in help/completions and global-options alignment

### DIFF
--- a/packages/core/src/plugin_completions_test.zig
+++ b/packages/core/src/plugin_completions_test.zig
@@ -382,6 +382,22 @@ test "tree.build - drops hidden commands entirely" {
     try std.testing.expectEqualStrings("visible", root.children[0].name);
 }
 
+test "tree.build - a hidden group suppresses its visible children" {
+    // `secret/index.zig` is hidden but `secret/list.zig` is visible. Hiddenness
+    // must propagate downward: neither `secret` nor its child may appear, so
+    // completions never offer the hidden group via a materialised child node.
+    const cmds = [_]zcli.CommandInfo{
+        .{ .path = &.{"visible"}, .description = "Shown" },
+        .{ .path = &.{"secret"}, .description = "Hidden group", .hidden = true },
+        .{ .path = &.{ "secret", "list" }, .description = "List secrets" },
+    };
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const root = try tree.build(arena.allocator(), &cmds);
+    try std.testing.expectEqual(@as(usize, 1), root.children.len);
+    try std.testing.expectEqualStrings("visible", root.children[0].name);
+}
+
 // ============================================================================
 // Layer 2: escapers (adversarial input)
 // ============================================================================

--- a/packages/core/src/plugins/zcli_completions/tree.zig
+++ b/packages/core/src/plugins/zcli_completions/tree.zig
@@ -75,6 +75,11 @@ pub fn build(
     for (commands) |cmd| {
         if (cmd.hidden) continue;
         if (cmd.path.len == 0) continue;
+        // Hiddenness propagates to descendants: a hidden group (e.g. a hidden
+        // `secret/index.zig`) must also suppress its visible children, which
+        // would otherwise materialise the intermediate node and offer the group
+        // name in completions. Skip any command sitting under a hidden ancestor.
+        if (hasHiddenAncestor(commands, cmd.path)) continue;
         // The registry emits each alias as its OWN command entry (so `app ls`
         // resolves) that still carries the module's `meta.aliases`. Such an
         // entry's leaf name equals one of its own aliases — a signal a real
@@ -97,6 +102,24 @@ pub fn build(
 
     sortRec(root);
     return root;
+}
+
+/// True if any hidden command in `commands` is a strict prefix (ancestor) of
+/// `path` — i.e. `path` lives under a hidden group and should be suppressed.
+fn hasHiddenAncestor(commands: []const zcli.CommandInfo, path: []const []const u8) bool {
+    for (commands) |cmd| {
+        if (!cmd.hidden) continue;
+        if (cmd.path.len == 0 or cmd.path.len >= path.len) continue;
+        var is_prefix = true;
+        for (cmd.path, 0..) |segment, i| {
+            if (!std.mem.eql(u8, segment, path[i])) {
+                is_prefix = false;
+                break;
+            }
+        }
+        if (is_prefix) return true;
+    }
+    return false;
 }
 
 /// True when `cmd` is an auto-generated alias entry: its leaf (invoked name)

--- a/packages/core/src/plugins/zcli_help/app_help.zig
+++ b/packages/core/src/plugins/zcli_help/app_help.zig
@@ -140,6 +140,19 @@ fn showCommandList(context: anytype, fmt: anytype) !void {
     var displayed_names: std.ArrayList([]const u8) = .empty;
     defer displayed_names.deinit(context.allocator);
 
+    // A group marked hidden hides its whole subtree from listings: a hidden
+    // `secret/index.zig` (path == {"secret"}, hidden) must also suppress a
+    // visible `secret/list.zig`, which would otherwise re-insert "secret" into
+    // the top-level list with no description. Collect the top-level names of all
+    // hidden groups first so we can filter their descendants below.
+    var hidden_groups = std.StringHashMap(void).init(context.allocator);
+    defer hidden_groups.deinit();
+    for (command_infos) |cmd_info| {
+        if (cmd_info.hidden and cmd_info.path.len == 1) {
+            try hidden_groups.put(cmd_info.path[0], {});
+        }
+    }
+
     // First pass: collect unique command names and find the best description for each
     // Use CommandDisplayInfo to also track aliases
     var command_map = std.StringHashMap(CommandDisplayInfo).init(context.allocator);
@@ -150,6 +163,8 @@ fn showCommandList(context: anytype, fmt: anytype) !void {
         if (cmd_info.hidden) continue;
 
         if (cmd_info.path.len < 1) continue;
+        // Skip descendants of a hidden group (hiddenness propagates downward).
+        if (hidden_groups.contains(cmd_info.path[0])) continue;
         const display_name = cmd_info.path[0];
         // Exact match if this is a top-level command (path.len == 1); a nested
         // command contributes its top-level name but no description.
@@ -312,6 +327,39 @@ test "showCommandList: dedups, sorts alphabetically, and renders aliases" {
 
     // The nested subcommand does not leak into the top-level list.
     try std.testing.expect(std.mem.indexOf(u8, out, "sub") == null);
+}
+
+test "showCommandList: a hidden group suppresses its visible children" {
+    const allocator = std.testing.allocator;
+
+    const Ctx = zcli.TestContext(&.{});
+    var stdio: zcli.Stdio = undefined;
+    stdio.init(std.testing.io);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    stdio.stdout_override = &aw.writer;
+
+    const environ = std.process.Environ.Map.init(allocator);
+    var ctx = Ctx.init(allocator, std.testing.io, &stdio, &environ);
+    defer ctx.deinit();
+
+    // `secret` is a hidden group (its index is hidden) but has a visible child
+    // `secret list`. Hiddenness must propagate: neither `secret` nor its child
+    // may appear in the top-level command list. `apple` stays visible.
+    ctx.plugin_command_info = &.{
+        .{ .path = &.{"apple"}, .description = "Apple command" },
+        .{ .path = &.{"secret"}, .description = "Secret group", .hidden = true },
+        .{ .path = &.{ "secret", "list" }, .description = "List secrets" },
+    };
+
+    var fmt = md.formatterWithPalette(ctx.stdout(), ctx.theme.capability(), app_palette);
+    try showCommandList(&ctx, &fmt);
+    try ctx.stdout().flush();
+
+    const out = aw.written();
+
+    try std.testing.expect(std.mem.indexOf(u8, out, "apple") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "secret") == null);
 }
 
 test "isAlias: name in aliases list" {

--- a/packages/core/src/plugins/zcli_help/format.zig
+++ b/packages/core/src/plugins/zcli_help/format.zig
@@ -269,8 +269,8 @@ pub fn writeGlobalOptionsSection(writer: *std.Io.Writer, fmt: anytype, context: 
     for (global_opts) |opt| {
         if (opt.short) |short| {
             try fmt.write("    <flag>-{c}</flag>, <flag>--{s}</flag>", .{ short, opt.name });
-            // Pad to align descriptions
-            const used = 8 + opt.name.len; // "-x, --name"
+            // Pad to align descriptions. Visible prefix is "-x, --" (6) + name.
+            const used = 6 + opt.name.len; // "-x, --name"
             if (used < NAME_COLUMN_WIDTH) {
                 var i: usize = 0;
                 while (i < NAME_COLUMN_WIDTH - used) : (i += 1) {
@@ -281,7 +281,8 @@ pub fn writeGlobalOptionsSection(writer: *std.Io.Writer, fmt: anytype, context: 
             }
         } else {
             try fmt.write("    <flag>--{s}</flag>", .{opt.name});
-            const used = 4 + opt.name.len;
+            // Visible prefix is "--" (2) + name.
+            const used = 2 + opt.name.len;
             if (used < NAME_COLUMN_WIDTH) {
                 var i: usize = 0;
                 while (i < NAME_COLUMN_WIDTH - used) : (i += 1) {


### PR DESCRIPTION
Fixes #513
Fixes #514

## #513 — Hidden group leaked via visible children
A command group marked `hidden` still appeared in top-level help and completions when it had a visible nested child: the child re-inserted the group name (description-less) into the listing. Hiddenness now propagates to the whole subtree.

- `packages/core/src/plugins/zcli_help/app_help.zig`: `showCommandList` pre-scans for hidden top-level group names and skips any command whose `path[0]` matches, so a hidden `secret/index.zig` also suppresses a visible `secret/list.zig`.
- `packages/core/src/plugins/zcli_completions/tree.zig`: `build` skips any command that has a hidden ancestor (new `hasHiddenAncestor` prefix check), so intermediate nodes are no longer materialized for children of hidden groups.

Commands remain directly invokable (`myapp secret list` still works); they are only removed from listings and completion candidates.

## #514 — GLOBAL OPTIONS column misaligned
`writeGlobalOptionsSection` in `packages/core/src/plugins/zcli_help/format.zig` computed the name-column width as `8 + name.len` / `4 + name.len`, but the rendered prefixes `-x, --` and `--` are 6 and 2 visible characters. This padded every GLOBAL OPTIONS description 2 columns left of the (correctly-computed) OPTIONS/ARGUMENTS sections. Corrected the constants to 6 and 2 so all sections align; the secondary length-12/13 overflow into the single-space branch is also fixed.

## Tests
- New regression test in `app_help.zig`: hidden group + visible child → group absent from top-level help.
- New regression test in `plugin_completions_test.zig`: hidden group + visible child → not offered in completions.
- `zig build`, `zig build test`, and `zig build e2e` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)