### PR TITLE
docs: fix meta-field, ADR-0026, and CHANGELOG drift (grade9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,4 +86,4 @@ Zig 0.15.1 era. Windows support landed (v0.15.0), `std.posix.getenv` was dropped
 
 ## v0.1.0 – v0.13.1 — 2025-10-09 to 2025-10-19
 
-The foundation, built in ten days: build-time command discovery and routing, the plugin system (help, version, not-found, completions, config, output, upgrade), shell completions, hidden commands, shared modules, the `zcli` meta-CLI with `init`/`release`/`upgrade`, and the `curl | sh` install script. The dual-tag release scheme (`v*` library / `zcli-v*` CLI) was established at v0.11.0.
+The foundation, built in ten days: build-time command discovery and routing, the plugin system (help, version, not-found, completions, config, upgrade), shell completions, hidden commands, shared modules, the `zcli` meta-CLI with `init`/`release`/`upgrade`, and the `curl | sh` install script. The dual-tag release scheme (`v*` library / `zcli-v*` CLI) was established during the 0.11–0.14 series.

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -40,7 +40,24 @@ pub fn execute(args: Args, options: Options, context: anytype) !void {
 }
 ```
 
-- **`meta`** — help text and parsing metadata (`description`, `examples`, per-arg/option descriptions, `short` flags, `aliases`, `.env` fallbacks, cross-field constraints, and per-field `validate` hooks).
+- **`meta`** — help text and parsing metadata. Top-level fields: `description`,
+  `examples`, `aliases`, `hidden`, and `args`/`options` (per-field metadata,
+  below), plus `exclusive` — sets of options where at most one may be supplied
+  (see [DESIGN.md](DESIGN.md) and [ADR-0022](adr/0022-option-constraints.md)).
+  Per-field metadata (`meta.args.<field>` / `meta.options.<field>`) accepts
+  `description`, a `validate` hook (`fn(T) ?[]const u8`, refining an
+  already-typed value — [ADR-0025](adr/0025-field-validation-and-custom-parse-types.md)),
+  and a `complete` hook for dynamic shell completion (`.file`/`.dir` builtins,
+  or a function returning runtime candidates —
+  [ADR-0026](adr/0026-dynamic-shell-completion.md)). Options additionally
+  accept `short` (single-char flag alias), `name` (override the flag's long
+  name — e.g. `.output_dir = .{ .name = "out" }` makes the flag `--out`
+  instead of `--output-dir`), `env` (fallback environment variable), and
+  `requires` (this option, if supplied, requires another option to also be
+  supplied; see ADR-0022). For values that don't map onto a plain scalar
+  (`u16`, `enum`, `[]const u8`, …), a field's type can itself declare
+  `pub fn parse(s: []const u8) E!@This()` instead of relying on `validate` —
+  see ADR-0025.
 - **`Args`** — positional arguments as a struct; a `[]const []const u8` field is variadic.
 - **`Options`** — `bool`/`?bool` fields are flags; other types take values, with defaults from the initializers.
 - **`execute`** — the command body, receiving the parsed, typed `Args` and `Options` plus the app context.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -496,7 +496,13 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
 
 **Option Formats:**
 
-- Long options: `--option value` or `--option=value`
+- Long options: `--option value` or `--option=value`. By default the long flag
+  is the field name with underscores replaced by dashes (`output_dir` →
+  `--output-dir`). A field can override this via `meta.options.<field>.name`
+  (e.g. `.output_dir = .{ .name = "out" }` makes the flag `--out` instead of
+  `--output-dir`); the field name in `Options`/`execute` is unaffected — only
+  the flag text on the command line, and in generated help/completions,
+  changes.
 - Short options: `-o value` or `-ovalue` (no space). A short exists **only** when
   explicitly declared via `meta.options.<field>.short` — a field never derives a
   short from the first letter of its name. An undeclared short is an unknown

--- a/docs/adr/0026-dynamic-shell-completion.md
+++ b/docs/adr/0026-dynamic-shell-completion.md
@@ -2,9 +2,9 @@
 
 Status: accepted (implemented — all three increments shipped)
 
-Shell completion (the `zcli_completions` plugin) generates a static bash/zsh/fish
-script from the app's compiled command tree. It knows everything derivable at
-build time: the command/subcommand names, each command's options, and — after the
+Shell completion (the `zcli_completions` plugin) generates a static
+bash/zsh/fish/PowerShell script from the app's compiled command tree. It knows
+everything derivable at build time: the command/subcommand names, each command's options, and — after the
 positional-argument work — each positional's name, description, and enum choices.
 So `tasks done <TAB>` can offer `open done blocked` (an enum), and `tasks edit
 <TAB>` can show a `Task ID` hint. What it *cannot* do is offer the **actual ids** —
@@ -195,21 +195,28 @@ for takes-value, `utils.isNegativeNumber`, `utils.effectiveLongName`). `__comple
 them. Reinventing that logic is the single biggest way this feature could ship
 subtly wrong.
 
-Because of this, the wire is **not** a reconstructed command line with a `--`
-delimiter — a real line can *contain* `--`, which would collide. Instead the
-scripts pass the shell's own word array plus the **cursor word index**, the way
-Cobra/clap do:
+Because of this, the wire is not a reconstructed command line at all — it is the
+shell's own word array plus the **cursor word index**, the way Cobra/clap do.
+The scripts invoke `__complete` as:
 
 ```
-tasks __complete <cword> <word0> <word1> …
-# bash:  "$COMP_CWORD" "${COMP_WORDS[@]}"
-# zsh:   "$CURRENT"    "$words[@]"
-# fish:  (count of tokens) (commandline -opc) + current token
+tasks __complete <cword> -- <word0> <word1> …
+# bash:  "$COMP_CWORD" -- "${COMP_WORDS[@]}"
+# zsh:   "$CURRENT"    -- "$words[@]"
+# fish:  (count of tokens) -- (commandline -opc) + current token
+# pwsh:  $cword         '--' @dynWords
 ```
 
-`__complete` treats everything after `<cword>` as literal words (no option parsing
-of its own args), so no word can be mistaken for a flag to `__complete` and there
-is no delimiter to collide. It then: resolves the command via the **same
+The `--` is there for a narrower reason than the wire shape itself: `__complete`
+is a command like any other, so its own `Args`/`Options` parsing would otherwise
+see the shell's words — and a word that starts with `-` (a real flag the user
+typed, or a negative-number positional) would be misread as an option *to
+`__complete`*. The single `--` ends `__complete`'s own option parsing up front, so
+everything after it — including any `--` the user typed — is captured as literal
+`words` data, never reinterpreted. `__complete` then treats all of `words` as
+opaque strings (no option parsing of its own args beyond that leading `--`), so
+no word can be mistaken for a flag and a user-typed `--` cannot collide with it.
+It then: resolves the command via the **same
 `cmd_entries` path→module walk `executeCommand` already does** (`compiled.zig:1107`,
 longest-path-first — no second dispatch table); runs the parser primitives over the
 post-command words up to `<cword>` to decide *positional slot N* vs *value of
@@ -344,3 +351,14 @@ escaping); 2 and 3 are additive, lower-risk wiring on top.
   Acceptable (near-zero real cases); revisit only if it bites.
 - **Caching.** A slow hook run per `<TAB>` could warrant per-directory caching
   (some shells do it). Out of scope; revisit only if a real hook proves too slow.
+
+## Addendum: PowerShell
+
+The three increments above shipped for bash/zsh/fish first; PowerShell support
+(`powershell.zig`) followed the same design — `Register-ArgumentCompleter`
+invokes `<app> __complete $cword -- @dynWords`, the identical wire format
+described in "Resolution reuses the real parser" above, including the
+`.also_files`/`.also_dirs` combine directive. No protocol changes were needed;
+this is purely another script generator consuming the same `__complete`
+contract. PowerShell is included alongside bash/zsh/fish everywhere in this ADR
+that lists supported shells.


### PR DESCRIPTION
## Summary

Three grade9 documentation-drift fixes.

**Fixes #537** — `docs/COMMANDS.md` and `docs/DESIGN.md` omitted several shipped `meta` fields and the option-level `name` override:
- Added `.complete` (per-field dynamic completion hooks, ADR-0026), `.exclusive` (ADR-0022), `.requires` (ADR-0022), and custom `parse` types (ADR-0025) to COMMANDS.md's field summary, cross-checked against `validateMeta`'s allowlists in `packages/core/src/zcli.zig`.
- Documented the option-level `meta.options.<field>.name` override (long-flag rename, e.g. `.output_dir = .{ .name = "out" }` → `--out`) in both COMMANDS.md and DESIGN.md — it was previously undocumented anywhere.

**Fixes #538** — `docs/adr/0026-dynamic-shell-completion.md`'s wire-format section contradicted the shipped scripts:
- Corrected the "wire is a word array + cursor index" section: the shipped scripts *do* invoke `__complete "$cword" -- "${words[@]}"` (bash.zig:108, zsh.zig:146, fish.zig:181, powershell.zig:271) — the ADR previously claimed no `--` delimiter was used. Replaced the incorrect rationale with the real one (per plugin.zig:12-19): the `--` ends `__complete`'s own arg parsing so a leading `-` in a user's word isn't misread as an option to `__complete` itself.
- Added PowerShell to the ADR's supported-shell list (intro line + a new "Addendum: PowerShell" section) — it ships full support including `.also_files`/`.also_dirs`, previously undocumented in this ADR.

**Fixes #543** — `CHANGELOG.md:89` historical inaccuracies:
- Softened "the dual-tag scheme was established at v0.11.0" → "established during the 0.11–0.14 series" — `git tag` shows no `v0.11.0` lib tag exists; lib tags don't consistently pair with `zcli-v*` counterparts until `v0.13.1`/`v0.14.0`.
- Dropped the phantom `output` plugin from the original plugin list — no such plugin exists in `packages/core/src/plugins/` (current set: `zcli_completions`, `zcli_config`, `zcli_github_upgrade`, `zcli_help`, `zcli_not_found`, `zcli_secrets`, `zcli_version`).

## Test plan

- [x] Docs-only change; no code affected.
- [x] Every correction verified against current source (`packages/core/src/zcli.zig` validateMeta, `packages/core/src/plugins/zcli_completions/*.zig`, `git tag`, `packages/core/src/plugins/`) before writing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)