### PR TITLE
docs: fix doc/code drift in DESIGN.md, BUILD.md, ROADMAP.md

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,7 +29,8 @@ by the CI-compiled canonical examples:
   settled enough to splice mechanically.
 - **The plugin system** — lifecycle hooks (`preExecute`, `onError`,
   `handleGlobalOption`), `global_options`, plugin-owned commands, and typed
-  `context.plugins.<id>` data. Eight plugins ship in-box on this surface.
+  `context.plugins.<id>` data. Seven plugins ship in-box on this surface (see
+  [docs/PLUGINS.md](docs/PLUGINS.md) for the canonical list).
 - **The testing tiers** — in-process unit tests against a real vterm emulator,
   subprocess integration tests, and an e2e/PTY harness. Releases are gated on the
   full suite, including native Windows.

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -42,8 +42,13 @@ zcli achieves zero-cost dispatch by discovering commands and plugins, then gener
 
 Plugins use a lifecycle hook system with struct-based commands:
 
+The excerpt below is trimmed from the real `zcli_help` plugin
+(`packages/core/src/plugins/zcli_help/plugin.zig`) — comments condensed and the
+full help-rendering bodies omitted, but every hook name and signature matches
+the actual file:
+
 ```zig
-// Example plugin: zcli_help/plugin.zig
+// Excerpt: packages/core/src/plugins/zcli_help/plugin.zig
 const std = @import("std");
 const zcli = @import("zcli");
 
@@ -59,11 +64,7 @@ pub const ContextData = struct {
 
 // Global options the plugin provides
 pub const global_options = [_]zcli.GlobalOption{
-    zcli.option("help", bool, .{ 
-        .short = 'h', 
-        .default = false, 
-        .description = "Show help message" 
-    }),
+    zcli.option("help", bool, .{ .short = 'h', .default = false, .description = "Show help message" }),
 };
 
 // Handle global options. `context` is `anytype`: a plugin is compiled
@@ -74,9 +75,8 @@ pub fn handleGlobalOption(
     option_name: []const u8,
     value: anytype,
 ) !void {
-    if (std.mem.eql(u8, option_name, "help")) {
-        const enabled = if (@TypeOf(value) == bool) value else false;
-        if (enabled) context.plugins.zcli_help.help_requested = true;
+    if (std.mem.eql(u8, option_name, "help") and value) {
+        context.plugins.zcli_help.help_requested = true;
     }
 }
 
@@ -86,19 +86,24 @@ pub fn preExecute(
     args: zcli.ParsedArgs,
 ) !?zcli.ParsedArgs {
     if (context.plugins.zcli_help.help_requested) {
-        try showHelp(context, context.command_path);
+        // command_path == 0 → app help; otherwise the resolved command's help.
+        try command_help.showCommand(context, true);
         return null; // Stop execution
     }
     return args; // Continue execution
 }
 
 // Lifecycle hook: handle an error. Return true if handled (suppresses it).
+// zcli_help's onError renders help for a bare command group (e.g. `myapp
+// remote` with no subcommand) on a CommandNotFound — it does NOT handle
+// suggestions for unknown commands; that's zcli_not_found's job.
 pub fn onError(
     context: anytype,
     err: anyerror,
 ) !bool {
-    if (err == error.CommandNotFound) {
-        try showSuggestions(context, context.command_path);
+    if (err == error.CommandNotFound and context.command_path.len > 0) {
+        // ... walk command_path to find the deepest registered group and
+        // render its help via command_help.showCommand(context, false) ...
         return true; // Error handled, don't let it propagate
     }
     return false;
@@ -107,41 +112,26 @@ pub fn onError(
 // Commands provided by the plugin
 pub const commands = struct {
     pub const help = struct {
-        pub const Args = struct {
-            command: ?[]const u8 = null,
-        };
+        pub const Args = struct {};
         pub const Options = struct {};
-        pub const meta = .{
-            .description = "Show help for commands",
-        };
-        
+        pub const meta = .{ .description = "Show help for commands" };
+
+        // `help <cmd...>` is rewritten by transformArgs (not shown) before this
+        // ever runs, so this only fires for a bare `help` and shows app help.
         pub fn execute(args: Args, options: Options, context: anytype) !void {
-            if (args.command) |cmd| {
-                try showCommandHelp(context, cmd);
-            } else {
-                try showAppHelp(context);
-            }
+            _ = args;
+            _ = options;
+            try app_help.showApp(context, true);
         }
     };
 };
-
-// Optional setup hook for ContextData, called once per invocation before any
-// lifecycle hook. Capture references off `context` (allocator, io, app_name,
-// environ, streams) so `context.plugins.<plugin_id>` methods can serve calls
-// without re-threading `context`. Pairs with deinitContextData below.
-pub fn initContextData(data: *ContextData, context: anytype) !void {
-    _ = data;
-    _ = context;
-}
-
-// Optional cleanup hook for ContextData, called from Context.deinit().
-// Only needed when ContextData owns resources (allocations, handles, etc.).
-// Runs whether or not initContextData ran, so it must be safe on default data.
-pub fn deinitContextData(data: *ContextData, allocator: std.mem.Allocator) void {
-    _ = data;
-    _ = allocator;
-}
 ```
+
+Plugins may also implement `initContextData(data: *ContextData, context: anytype) !void`
+and `deinitContextData(data: *ContextData, allocator: std.mem.Allocator) void` as
+optional setup/cleanup hooks for `ContextData` — `zcli_help` doesn't need them
+(its `ContextData` owns no resources), but a plugin that does (e.g. one holding
+an arena or a file handle) would use them instead of doing setup inline.
 
 ### Plugin Lifecycle Hooks
 
@@ -574,20 +564,24 @@ Plugins can be distributed as:
 
 ## Built-in Plugins
 
-### zcli_help Plugin
+zcli ships seven built-in plugins, enabled individually via `zcli.builtin(.<name>, .{})`
+in `build.zig`:
 
-Provides comprehensive help system:
-- Registers `--help` global option
-- Provides `help` command
-- Intercepts help requests in `preExecute` hook
-- Shows command-specific and application help
+- **zcli_help** — registers `--help`/`-h` and a `help` command; renders per-command
+  and application help.
+- **zcli_version** — registers `--version`/`-V` and shows app version information.
+- **zcli_not_found** — intercepts `CommandNotFound` errors and suggests the closest
+  matching command using edit distance.
+- **zcli_completions** — generates and serves shell completions for bash, zsh, fish,
+  and PowerShell, including dynamic per-field completion.
+- **zcli_config** — loads JSON/TOML/YAML config files and fills option defaults
+  below CLI/env precedence.
+- **zcli_secrets** — reads secrets from the OS keychain (or a platform-appropriate
+  fallback) into the environment.
+- **zcli_github_upgrade** — self-upgrades the CLI from GitHub releases, with
+  signature verification.
 
-### zcli_not_found Plugin  
-
-Provides intelligent command suggestions:
-- Implements `onError` hook for `CommandNotFound` errors
-- Uses Levenshtein distance for suggestions
-- Shows available commands when command not found
+See [PLUGINS.md](PLUGINS.md) for the canonical, up-to-date list and usage details.
 
 ## Advanced Features
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -131,7 +131,8 @@ const Context = @import("command_registry").Context;
 
 pub const meta = .{
     .description = "Search for users by name",
-    .usage = "search <query> [files...] [--limit <n>]",
+    // Usage lines are NOT part of meta — they're generated automatically
+    // from Args/Options when help is rendered.
     .examples = &.{
         "search John",
         "search Jane --limit 10",
@@ -813,10 +814,15 @@ pub fn onError(context: anytype, err: anyerror) !bool { }
 // CLI + env parsing but before required/dependency validation. `provided` has
 // one flag per Options field (declaration order), true when CLI or the field's
 // env fallback already set it — the hook MUST skip those fields, which is what
-// makes CLI > env > config hold. `options` is mutated in place; no error union,
-// so a malformed source warns-and-skips rather than bricking the command. Any
-// values written must outlive execution (zcli_config uses a ContextData arena).
-pub fn applyConfigDefaults(context: anytype, comptime OptionsType: type, options: *OptionsType, provided: []const bool) void { }
+// makes CLI > env > config hold. `applied` (same keying, caller-zeroed) is the
+// hook's report back: it MUST mark every field it fills — the registry's
+// required-option and constraint checks treat `provided[i] or applied[i]` as
+// "supplied", with no value diffing, so a config value equal to a field's
+// placeholder still counts as supplied. `options` is mutated in place; no
+// error union, so a malformed source warns-and-skips rather than bricking the
+// command. Any values written must outlive execution (zcli_config uses a
+// ContextData arena).
+pub fn applyConfigDefaults(context: anytype, comptime OptionsType: type, options: *OptionsType, provided: []const bool, applied: []bool) void { }
 
 // Plugin can provide commands (also app-agnostic, so `context: anytype`)
 pub const commands = struct {
@@ -864,8 +870,9 @@ const cmd_registry = try zcli.generate(b, exe, zcli_dep, .{
 
 **Built-in Plugins:**
 
-- **zcli_help**: Provides `--help` flag and help command
-- **zcli_not_found**: Provides command suggestions using edit distance
+zcli ships seven built-in plugins — `zcli_help`, `zcli_version`, `zcli_not_found`,
+`zcli_completions`, `zcli_config`, `zcli_secrets`, and `zcli_github_upgrade`. See
+[PLUGINS.md](PLUGINS.md) for the full, canonical list and what each one provides.
 
 ## 12. Advanced Features
 


### PR DESCRIPTION
## Summary

Fixes four grade9 doc-drift issues found across DESIGN.md, BUILD.md, and ROADMAP.md.

- **Fixes #509** — DESIGN.md's flagship command example (`## 3. Command Interface Contract`) included a `.usage` field in `meta`, which `validateMeta` (packages/core/src/zcli.zig:577-590) rejects — only `description, examples, args, options, hidden, aliases, exclusive` are allowed. Copy-pasting the doc's centerpiece example gave a `@compileError`. Removed the field and added a one-line note that usage lines are generated automatically from `Args`/`Options`.

- **Fixes #534** — DESIGN.md documented `applyConfigDefaults` with 4 parameters. The real hook (packages/core/src/plugin_types.zig, call site packages/core/src/registry/compiled.zig, reference impl packages/core/src/plugins/zcli_config/plugin.zig) takes 5 — a `applied: []bool` out-param. Updated the signature and expanded the explanatory comment to cover `provided` vs `applied` semantics (the `provided[i] or applied[i]` "supplied" check used by required/constraint validation).

- **Fixes #535** — Built-in plugin count drifted: DESIGN.md and BUILD.md each listed only 2 plugins, ROADMAP.md said "eight." The `Builtin` enum (packages/core/src/build_utils/types.zig:174-181) and `packages/core/src/plugins/` both confirm exactly 7: help, version, not_found, completions, config, secrets, github_upgrade. Updated all three docs to say 7 and point to `docs/PLUGINS.md` as the canonical list.

- **Fixes #536** — BUILD.md's "Example plugin: zcli_help/plugin.zig" snippet attributed `onError` → `showSuggestions` for `CommandNotFound` to zcli_help; that behavior actually lives in `zcli_not_found`. The real zcli_help `onError` (packages/core/src/plugins/zcli_help/plugin.zig) renders help for a bare command group instead. Replaced the snippet with an accurate, labeled excerpt of the real file (verified every hook name/signature against plugin_types.zig), and moved the note about `initContextData`/`deinitContextData` (real hooks zcli_help simply doesn't use) to prose below the snippet instead of presenting them as part of zcli_help.

## Test plan

- [x] Verified each correction against current source (validateMeta allowlist, plugin_types.zig hook signatures, the Builtin enum, and the real zcli_help/plugin.zig) rather than trusting the issue bodies verbatim, since they were filed at an earlier commit.
- [x] `zig build` passes (docs-only change; confirms nothing else was touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)