### PR TITLE
zcli_secrets: migrate macOS backend to the SecItem API (#542)

### DIFF
--- a/packages/core/src/plugins/zcli_secrets/keychain_macos.zig
+++ b/packages/core/src/plugins/zcli_secrets/keychain_macos.zig
@@ -6,22 +6,31 @@
 //!
 //! ## Why this makes the plugin opt-in
 //!
-//! These calls live in `Security.framework` (and `CoreFoundation` for
-//! `CFRelease`). Linking a framework requires dynamic linking, which would
-//! break zcli's static single-binary (libc-free musl) property if forced on
-//! every CLI. That is exactly why secrets are a plugin: this backend — and the
-//! framework linking it needs — is compiled in *only* when an app registers
-//! `zcli_secrets` on macOS (see the plugin's build wiring). A CLI that does not
-//! opt in never references these symbols and stays static.
+//! These calls live in `Security.framework` (and `CoreFoundation` for the
+//! CoreFoundation object graph and `CFRelease`). Linking a framework requires
+//! dynamic linking, which would break zcli's static single-binary (libc-free
+//! musl) property if forced on every CLI. That is exactly why secrets are a
+//! plugin: this backend — and the framework linking it needs — is compiled in
+//! *only* when an app registers `zcli_secrets` on macOS (see the plugin's build
+//! wiring). A CLI that does not opt in never references these symbols and stays
+//! static.
 //!
 //! ## API choice
 //!
-//! This uses the classic `SecKeychain*GenericPassword` C API. It is marked
-//! deprecated in the macOS SDK in favor of the `SecItem*` / CFDictionary API,
-//! but it remains present and functional, and its flat C signatures need no
-//! CoreFoundation dictionary marshalling — which keeps this FFI small and
-//! auditable. (Zig declares its own `extern` prototypes, so the SDK's
-//! deprecation attribute produces no warning here.)
+//! This uses the modern `SecItem*` / CFDictionary API
+//! (`SecItemAdd`/`SecItemCopyMatching`/`SecItemUpdate`/`SecItemDelete`) with
+//! `kSecClassGenericPassword`. The item attributes (`kSecAttrService` /
+//! `kSecAttrAccount`) map 1:1 onto the `(service, account)` key scheme the older
+//! `SecKeychain*GenericPassword` C API used, so a secret written by a prior zcli
+//! build remains readable after this migration. The classic `SecKeychain*` API
+//! this replaced was deprecated in the macOS SDK (since macOS 12) in favor of
+//! exactly these `SecItem*` calls.
+//!
+//! The `SecItem*` API is CFDictionary-based, so every call marshals a small
+//! CoreFoundation dictionary of typed attributes rather than a flat C argument
+//! list. Zig declares its own `extern` prototypes for the handful of symbols
+//! used, so the SDK's deprecation attributes are irrelevant here (there were
+//! none to begin with on the new API).
 
 const std = @import("std");
 
@@ -40,189 +49,263 @@ fn keychainFailure(status: OSStatus) Error {
 /// `OSStatus` is a signed 32-bit result code. `0` (`errSecSuccess`) is success.
 const OSStatus = i32;
 const errSecSuccess: OSStatus = 0;
-/// Returned by find/delete/update when the requested item does not exist.
+/// Returned by copy-matching/update/delete when the requested item does not exist.
 const errSecItemNotFound: OSStatus = -25300;
 /// Returned by add when an item with the same service+account already exists.
 const errSecDuplicateItem: OSStatus = -25299;
 
-/// Opaque `SecKeychainItemRef` (a CoreFoundation type).
-const SecKeychainItemRef = ?*anyopaque;
+// CoreFoundation object references. Each `CF*Ref` is an opaque pointer; the
+// immutable ones are `const`, the mutable dictionary is not. `CFTypeRef` is the
+// generic supertype every CF object coerces to.
+const CFTypeRef = ?*const anyopaque;
+const CFAllocatorRef = ?*const anyopaque;
+const CFStringRef = ?*const anyopaque;
+const CFDataRef = ?*const anyopaque;
+const CFBooleanRef = ?*const anyopaque;
+const CFDictionaryRef = ?*const anyopaque;
+const CFMutableDictionaryRef = ?*anyopaque;
 
-extern "c" fn SecKeychainAddGenericPassword(
-    keychain: ?*anyopaque,
-    serviceNameLength: u32,
-    serviceName: [*]const u8,
-    accountNameLength: u32,
-    accountName: [*]const u8,
-    passwordLength: u32,
-    passwordData: [*]const u8,
-    itemRef: ?*SecKeychainItemRef,
-) callconv(.c) OSStatus;
+/// `CFIndex` is CoreFoundation's signed size type (`signed long` → `isize`).
+const CFIndex = isize;
+/// `CFStringEncoding`; `0x08000100` is `kCFStringEncodingUTF8`.
+const CFStringEncoding = u32;
+const kCFStringEncodingUTF8: CFStringEncoding = 0x08000100;
 
-extern "c" fn SecKeychainFindGenericPassword(
-    keychainOrArray: ?*anyopaque,
-    serviceNameLength: u32,
-    serviceName: [*]const u8,
-    accountNameLength: u32,
-    accountName: [*]const u8,
-    passwordLength: ?*u32,
-    passwordData: ?*?*anyopaque,
-    itemRef: ?*SecKeychainItemRef,
-) callconv(.c) OSStatus;
+/// The default CoreFoundation allocator is a null `CFAllocatorRef`.
+const kCFAllocatorDefault: CFAllocatorRef = null;
 
-extern "c" fn SecKeychainItemModifyAttributesAndData(
-    itemRef: SecKeychainItemRef,
-    attrList: ?*const anyopaque,
-    length: u32,
-    data: ?*const anyopaque,
-) callconv(.c) OSStatus;
+// The dictionary key/value callback tables are opaque structs; we only ever need
+// their addresses. `kCFTypeDictionaryKeyCallBacks` / `...ValueCallBacks` make the
+// dictionary retain/release + hash/equal its CF-object keys and values, which is
+// what lets us release the strings/data we insert while the dictionary keeps them
+// alive for the duration of the call.
+const CFDictionaryKeyCallBacks = opaque {};
+const CFDictionaryValueCallBacks = opaque {};
+extern "c" const kCFTypeDictionaryKeyCallBacks: CFDictionaryKeyCallBacks;
+extern "c" const kCFTypeDictionaryValueCallBacks: CFDictionaryValueCallBacks;
 
-extern "c" fn SecKeychainItemDelete(itemRef: SecKeychainItemRef) callconv(.c) OSStatus;
+// Boolean singleton used for the `kSecReturnData` query flag.
+extern "c" const kCFBooleanTrue: CFBooleanRef;
 
-extern "c" fn SecKeychainItemFreeContent(
-    attrList: ?*anyopaque,
-    data: ?*anyopaque,
-) callconv(.c) OSStatus;
+// Security.framework attribute keys (all `CFStringRef` globals). These identify
+// the fields of the query/attribute dictionaries we build.
+extern "c" const kSecClass: CFStringRef;
+extern "c" const kSecClassGenericPassword: CFStringRef;
+extern "c" const kSecAttrService: CFStringRef;
+extern "c" const kSecAttrAccount: CFStringRef;
+extern "c" const kSecValueData: CFStringRef;
+extern "c" const kSecReturnData: CFStringRef;
+extern "c" const kSecMatchLimit: CFStringRef;
+extern "c" const kSecMatchLimitOne: CFStringRef;
 
-extern "c" fn CFRelease(cf: ?*anyopaque) callconv(.c) void;
+extern "c" fn CFStringCreateWithBytes(
+    alloc: CFAllocatorRef,
+    bytes: [*]const u8,
+    numBytes: CFIndex,
+    encoding: CFStringEncoding,
+    isExternalRepresentation: u8,
+) callconv(.c) CFStringRef;
+
+extern "c" fn CFDataCreate(
+    alloc: CFAllocatorRef,
+    bytes: [*]const u8,
+    length: CFIndex,
+) callconv(.c) CFDataRef;
+
+extern "c" fn CFDataGetBytePtr(data: CFDataRef) callconv(.c) ?[*]const u8;
+extern "c" fn CFDataGetLength(data: CFDataRef) callconv(.c) CFIndex;
+
+extern "c" fn CFDictionaryCreateMutable(
+    allocator: CFAllocatorRef,
+    capacity: CFIndex,
+    keyCallBacks: ?*const CFDictionaryKeyCallBacks,
+    valueCallBacks: ?*const CFDictionaryValueCallBacks,
+) callconv(.c) CFMutableDictionaryRef;
+
+extern "c" fn CFDictionaryAddValue(
+    theDict: CFMutableDictionaryRef,
+    key: ?*const anyopaque,
+    value: ?*const anyopaque,
+) callconv(.c) void;
+
+extern "c" fn CFRelease(cf: CFTypeRef) callconv(.c) void;
+
+extern "c" fn SecItemAdd(attributes: CFDictionaryRef, result: ?*CFTypeRef) callconv(.c) OSStatus;
+extern "c" fn SecItemCopyMatching(query: CFDictionaryRef, result: ?*CFTypeRef) callconv(.c) OSStatus;
+extern "c" fn SecItemUpdate(query: CFDictionaryRef, attributesToUpdate: CFDictionaryRef) callconv(.c) OSStatus;
+extern "c" fn SecItemDelete(query: CFDictionaryRef) callconv(.c) OSStatus;
 
 pub const Error = error{
-    /// A Keychain call failed with an unexpected `OSStatus`.
+    /// A Keychain call failed with an unexpected `OSStatus`, or a CoreFoundation
+    /// object could not be created.
     KeychainFailure,
-    /// A secret's byte length exceeds what the Keychain C API can address (u32).
-    SecretTooLarge,
 };
 
-fn castLen(len: usize) !u32 {
-    return std.math.cast(u32, len) orelse Error.SecretTooLarge;
+/// Build a UTF-8 `CFString` from a byte slice. Caller owns the result and must
+/// `CFRelease` it (or hand it to a dictionary that retains it).
+fn cfString(bytes: []const u8) Error!CFStringRef {
+    // `isExternalRepresentation = 0`: the bytes are interpreted in the given
+    // encoding, not as a BOM-prefixed external form.
+    return CFStringCreateWithBytes(kCFAllocatorDefault, bytes.ptr, @intCast(bytes.len), kCFStringEncodingUTF8, 0) orelse
+        Error.KeychainFailure;
+}
+
+/// Wrap secret bytes in a `CFData`. CoreFoundation copies the bytes into its own
+/// buffer; the caller's `bytes` slice is never mutated and never reaches argv (it
+/// travels only through this in-memory CF object). Caller owns the result and
+/// must `CFRelease` it.
+fn cfData(bytes: []const u8) Error!CFDataRef {
+    return CFDataCreate(kCFAllocatorDefault, bytes.ptr, @intCast(bytes.len)) orelse
+        Error.KeychainFailure;
+}
+
+/// Create a fresh mutable CF dictionary that retains/releases its CF-object keys
+/// and values. Caller owns it and must `CFRelease` it.
+fn newDict() Error!CFMutableDictionaryRef {
+    return CFDictionaryCreateMutable(
+        kCFAllocatorDefault,
+        0,
+        &kCFTypeDictionaryKeyCallBacks,
+        &kCFTypeDictionaryValueCallBacks,
+    ) orelse Error.KeychainFailure;
+}
+
+/// Build the base query dictionary that identifies a single generic-password
+/// item by `(service, account)`. Caller owns the returned dictionary and must
+/// `CFRelease` it. The dictionary retains the strings, so they are released here.
+fn baseQuery(service: []const u8, name: []const u8) Error!CFMutableDictionaryRef {
+    const svc = try cfString(service);
+    defer CFRelease(svc);
+    const acc = try cfString(name);
+    defer CFRelease(acc);
+
+    const dict = try newDict();
+    errdefer CFRelease(dict);
+    CFDictionaryAddValue(dict, kSecClass, kSecClassGenericPassword);
+    CFDictionaryAddValue(dict, kSecAttrService, svc);
+    CFDictionaryAddValue(dict, kSecAttrAccount, acc);
+    return dict;
 }
 
 /// Retrieve a secret. Returns `null` if no item exists for this service+account.
-/// The returned bytes are owned by `allocator` (copied out of the Keychain's
-/// own buffer, which is freed before returning).
+/// The returned bytes are owned by `allocator` (copied out of the CoreFoundation
+/// `CFData`, which is released before returning).
 ///
 /// `io` and `environ` are part of the uniform backend interface (the Linux
 /// backend shells out and needs them); the Keychain FFI does not, so they are
 /// ignored here.
 pub fn get(allocator: std.mem.Allocator, _: std.Io, _: *const std.process.Environ.Map, service: []const u8, name: []const u8) !?[]const u8 {
-    var password_len: u32 = 0;
-    var password_data: ?*anyopaque = null;
+    const query = try baseQuery(service, name);
+    defer CFRelease(query);
+    // Ask for the raw secret bytes back, and cap the match to a single item.
+    CFDictionaryAddValue(query, kSecReturnData, kCFBooleanTrue);
+    CFDictionaryAddValue(query, kSecMatchLimit, kSecMatchLimitOne);
 
-    const status = SecKeychainFindGenericPassword(
-        null,
-        try castLen(service.len),
-        service.ptr,
-        try castLen(name.len),
-        name.ptr,
-        &password_len,
-        &password_data,
-        null,
-    );
+    var result: CFTypeRef = null;
+    const status = SecItemCopyMatching(query, &result);
     if (status == errSecItemNotFound) return null;
     if (status != errSecSuccess) return keychainFailure(status);
 
-    defer _ = SecKeychainItemFreeContent(null, password_data);
-    // A success with no data pointer is not a documented outcome, but guard it
-    // rather than dereference null: treat it as an empty secret.
-    const data = password_data orelse return try allocator.dupe(u8, "");
-    const src: [*]const u8 = @ptrCast(data);
-    return try allocator.dupe(u8, src[0..password_len]);
+    // Success with `kSecReturnData` yields a `CFData`. A success with no object
+    // is not a documented outcome, but guard it rather than dereference null:
+    // treat it as an empty secret.
+    const data: CFDataRef = result orelse return try allocator.dupe(u8, "");
+    defer CFRelease(data);
+
+    const len: usize = @intCast(CFDataGetLength(data));
+    if (len == 0) return try allocator.dupe(u8, "");
+    const ptr = CFDataGetBytePtr(data) orelse return try allocator.dupe(u8, "");
+    return try allocator.dupe(u8, ptr[0..len]);
 }
 
 /// Store (or overwrite) a secret. If an item already exists it is updated in
 /// place; otherwise a new item is added. The `allocator` is unused here (the
-/// Keychain C API is length-based); it is in the signature so every native
-/// backend shares one interface.
+/// secret bytes are handed to CoreFoundation directly); it is in the signature so
+/// every native backend shares one interface.
 pub fn set(_: std.mem.Allocator, _: std.Io, _: *const std.process.Environ.Map, service: []const u8, name: []const u8, value: []const u8) !void {
-    const value_len = try castLen(value.len);
-    const service_len = try castLen(service.len);
-    const name_len = try castLen(name.len);
-
-    // Add → (on duplicate) Find → Modify is a read-modify-write with *two* TOCTOU
-    // windows against a concurrent `delete`: the item can vanish between our Add
-    // and our Find (Find → `errSecItemNotFound`), or between our Find and our
-    // Modify (Modify → `errSecItemNotFound`). In both cases the item genuinely no
-    // longer exists, so the correct action is simply to Add again, not to fail.
+    // Add → (on duplicate) Update is a read-modify-write racing a concurrent
+    // `delete`, and both `SecItem*` calls can surface that race as
+    // `errSecItemNotFound`:
     //
-    // Retry the whole Add/Find/Modify cycle on those benign not-found races. Each
-    // pass makes forward progress (a fresh Add), and a race only recurs if another
-    // writer deletes in our window *again* — independent events, so the loop
-    // converges in practice within one or two passes. `max_attempts` is only a
-    // livelock backstop against a pathological adversary that manages to delete in
-    // our window on every consecutive pass; it is set well above any realistic
-    // contention (two CLIs each doing a single op collide at most once) so a benign
-    // race never exhausts it and surfaces as a spurious failure.
+    //   - our Add races a Delete on the same item and securityd returns
+    //     `errSecItemNotFound` instead of adding (an Add is never *legitimately*
+    //     "not found" — it just means the store was mid-mutation, so try again);
+    //   - the item vanishes between an `errSecDuplicateItem` Add and our Update,
+    //     so the Update reports `errSecItemNotFound`.
+    //
+    // In every case the item genuinely does not exist at that instant, so the
+    // correct action is to Add again, not to fail. Retry the whole Add/Update
+    // cycle on those benign not-found races. Each pass makes forward progress (a
+    // fresh Add), and a race only recurs if another writer mutates in our window
+    // *again* — independent events, so the loop converges in practice within one
+    // or two passes. `max_attempts` is only a livelock backstop against a
+    // pathological adversary that manages to delete in our window on every
+    // consecutive pass; it is set well above any realistic contention (two CLIs
+    // each doing a single op collide at most once) so a benign race never exhausts
+    // it and surfaces as a spurious failure.
     const max_attempts = 16;
     var attempts: u8 = 0;
     while (true) : (attempts += 1) {
-        const status = SecKeychainAddGenericPassword(
-            null,
-            service_len,
-            service.ptr,
-            name_len,
-            name.ptr,
-            value_len,
-            value.ptr,
-            null,
-        );
+        // Attempt to add a brand-new item carrying the secret value.
+        const add_query = try baseQuery(service, name);
+        defer CFRelease(add_query);
+        const add_value = try cfData(value);
+        defer CFRelease(add_value);
+        CFDictionaryAddValue(add_query, kSecValueData, add_value);
+
+        const status = SecItemAdd(add_query, null);
         if (status == errSecSuccess) return;
+        // Add lost a race with a concurrent delete — loop to re-Add.
+        if (status == errSecItemNotFound and attempts < max_attempts) continue;
         if (status != errSecDuplicateItem) return keychainFailure(status);
 
-        // Item exists — find it and modify its data in place.
-        var item: SecKeychainItemRef = null;
-        const find = SecKeychainFindGenericPassword(
-            null,
-            service_len,
-            service.ptr,
-            name_len,
-            name.ptr,
-            null,
-            null,
-            &item,
-        );
-        // The item was deleted out from under us between Add and Find; loop to
-        // re-Add rather than surface an opaque failure for a benign race.
-        if (find == errSecItemNotFound) {
-            if (attempts < max_attempts) continue;
-            return keychainFailure(find);
+        // Item exists. An *empty* value cannot be written with SecItemUpdate:
+        // macOS silently ignores a zero-length `kSecValueData` and leaves the
+        // stored value unchanged (returning errSecSuccess). A zero-length value
+        // *does* store correctly via SecItemAdd, so the only way to overwrite an
+        // existing item with an empty value is to delete it and re-Add — which the
+        // loop does by removing the item here and looping back to the Add above.
+        if (value.len == 0) {
+            if (attempts >= max_attempts) return keychainFailure(status);
+            const del_query = try baseQuery(service, name);
+            defer CFRelease(del_query);
+            const del = SecItemDelete(del_query);
+            // Deleted, or a concurrent delete already removed it — either way the
+            // next Add can proceed. Any other status is a real failure.
+            if (del != errSecSuccess and del != errSecItemNotFound) return keychainFailure(del);
+            continue;
         }
-        if (find != errSecSuccess) return keychainFailure(find);
-        defer CFRelease(item);
 
-        const modify = SecKeychainItemModifyAttributesAndData(item, null, value_len, value.ptr);
-        if (modify == errSecSuccess) return;
-        // Same benign race, one window later: the item was deleted between our
-        // Find and this Modify. Loop to re-Add rather than fail. (`item` is still
-        // released by the `defer` above as this iteration's scope exits.)
-        if (modify == errSecItemNotFound and attempts < max_attempts) continue;
-        return keychainFailure(modify);
+        // Non-empty value — update its data in place. The query matches by
+        // service+account; the attributes-to-update carry only the new value.
+        const update_query = try baseQuery(service, name);
+        defer CFRelease(update_query);
+        const attrs = try newDict();
+        defer CFRelease(attrs);
+        const update_value = try cfData(value);
+        defer CFRelease(update_value);
+        CFDictionaryAddValue(attrs, kSecValueData, update_value);
+
+        const update = SecItemUpdate(update_query, attrs);
+        if (update == errSecSuccess) return;
+        // Benign race: the item was deleted between our Add and this Update. Loop
+        // to re-Add rather than surface an opaque failure.
+        if (update == errSecItemNotFound and attempts < max_attempts) continue;
+        return keychainFailure(update);
     }
 }
 
 /// Remove a secret. Succeeds (no-op) if no item exists. `allocator` is unused
 /// (see `set`), present for interface parity across native backends.
 pub fn delete(_: std.mem.Allocator, _: std.Io, _: *const std.process.Environ.Map, service: []const u8, name: []const u8) !void {
-    var item: SecKeychainItemRef = null;
-    const find = SecKeychainFindGenericPassword(
-        null,
-        try castLen(service.len),
-        service.ptr,
-        try castLen(name.len),
-        name.ptr,
-        null,
-        null,
-        &item,
-    );
-    if (find == errSecItemNotFound) return;
-    if (find != errSecSuccess) return keychainFailure(find);
-    defer CFRelease(item);
+    const query = try baseQuery(service, name);
+    defer CFRelease(query);
 
-    const status = SecKeychainItemDelete(item);
+    const status = SecItemDelete(query);
     if (status == errSecSuccess) return;
-    // Find→Delete has the mirror of `set`'s TOCTOU: the item can be removed
-    // (by a concurrent `delete`, or a `set` that re-Added over it) between our
-    // Find and this Delete, so Delete returns `errSecItemNotFound`. The caller
-    // asked for the item to be gone and it is — that is success, not a failure.
+    // The caller asked for the item to be gone; if it was already absent (or was
+    // removed by a concurrent `delete`/`set` between a prior read and now) that is
+    // success, not a failure.
     if (status == errSecItemNotFound) return;
     return keychainFailure(status);
 }

--- a/packages/core/src/plugins/zcli_secrets/secrets_live_test.zig
+++ b/packages/core/src/plugins/zcli_secrets/secrets_live_test.zig
@@ -201,29 +201,24 @@ test "public API round-trips set / get / overwrite / delete via ContextData" {
 // ---------------------------------------------------------------------------
 //
 // This exercises the macOS Keychain `set` retry (PR #234): its store path is
-// Add → (on duplicate) Find → Modify, which has *two* TOCTOU windows — a
-// concurrent `delete` landing between our Add and our Find, or between our Find
-// and our Modify, makes the later call return `errSecItemNotFound`; the bounded
-// retry re-Adds rather than surfacing an opaque `KeychainFailure`. Nothing raced
-// `set` against `delete` before, so that retry had never actually run. This drives
-// it live: one worker hammers `set` with distinct values while two others hammer
-// `delete`, all against the same key.
+// Add → (on duplicate) Update, which has a TOCTOU window — a concurrent `delete`
+// landing between our Add and our Update makes the Update return
+// `errSecItemNotFound`; the bounded retry re-Adds rather than surfacing an opaque
+// `KeychainFailure`. Nothing raced `set` against `delete` before, so that retry
+// had never actually run. This drives it live: one worker hammers `set` with
+// distinct values while two others hammer `delete`, all against the same key.
 //
 // ## Why the racers are separate *processes*, not threads
 //
 // The realistic scenario the retry defends against is two CLI *invocations*
 // racing (a `login` writing a token while a `logout` deletes it) — separate
 // processes contending on the shared OS store, which is exactly what a keychain /
-// Secret Service is built to serialize. It is NOT two threads in one process:
-// macOS's legacy `SecKeychain*GenericPassword` API (what `keychain_macos.zig`
-// uses) is not safe for concurrent same-process mutation of one item — two threads
-// doing Add/Modify vs Delete deadlock inside Security.framework's own
-// `securityd`-side mutex (observed via `sample`: both threads blocked in
-// `_pthread_mutex_firstfit_lock_wait` under `SecKeychainItemDelete` /
-// `SecKeychainItemModifyAttributesAndData`). That deadlock is an Apple-API
-// limitation, not a zcli bug, and a CLI is single-threaded anyway — so racing with
-// threads would only manufacture a hang that no product code path can hit. Racing
-// with processes models the real contention and lets the OS store arbitrate it.
+// Secret Service is built to serialize. It is NOT two threads in one process: a
+// CLI is single-threaded, so racing one item's mutation from two threads of a
+// single process is a shape no product code path can hit (and the legacy
+// `SecKeychain*GenericPassword` API this backend used before the SecItem
+// migration would even deadlock in `securityd` under it). Racing with processes
+// models the real contention and lets the OS store arbitrate it.
 //
 // The test re-exec's *itself*: `std.process.executablePath` gives this test
 // binary's path, and each child is spawned with `ZCLI_SECRETS_RACE_ROLE` set to


### PR DESCRIPTION
## Summary

Migrates the macOS `zcli_secrets` backend (`keychain_macos.zig`) off the deprecated `SecKeychain*GenericPassword` C API (deprecated since macOS 12) to the modern **SecItem** / CFDictionary API: `SecItemAdd` / `SecItemCopyMatching` / `SecItemUpdate` / `SecItemDelete` over `kSecClassGenericPassword`.

The item attributes map 1:1 onto the prior key scheme (`kSecAttrService` = app name, `kSecAttrAccount` = secret name), so **secrets stored by an older zcli build remain readable** after the migration. `Security` + `CoreFoundation` were already linked by the plugin's build wiring, so no build changes were needed.

### Preserved
- Length-based value handling — secret bytes travel only through an in-memory `CFData`, never argv.
- Add → (on duplicate) → Update overwrite semantics and the bounded TOCTOU retry loop.
- Careful CoreFoundation memory management (every created/copied ref is `CFRelease`d; `kCFAllocatorDefault`; retaining dictionaries release their inserted strings/data).

### Two SecItem behaviors the live keychain round-trip test surfaced

Both were caught by exercising the real backend on macOS and are handled explicitly:

1. **Empty value:** `SecItemUpdate` silently ignores a zero-length `kSecValueData` (leaves the stored value unchanged, returns `errSecSuccess`). `SecItemAdd` stores empty data fine, so an empty overwrite is done by delete-then-re-Add.
2. **Concurrent-delete race:** under a concurrent delete, `SecItemAdd` can transiently return `errSecItemNotFound` (the legacy Add never did). That is a benign race, so the loop re-Adds rather than surfacing an opaque `BackendFailure`.

## Testing

- `zig build` and `zig build test` (repo root) — pass.
- `zig build test-secrets` (compile/link against Security.framework) — pass.
- `zig build test-secrets-live` (real login-keychain round-trip + concurrency race, from `packages/core`) — pass. The concurrency test went from ~4/20 flaky failures during development to **0 failures across 30 consecutive runs** after the `errSecItemNotFound`-on-Add fix.

Fixes #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)