### PR TITLE
Testing/CI hygiene: cross-OS example links, settle-consistent delay, dead runInProcess

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -277,7 +277,7 @@ command-test stub only wires the shared modules you hand it, so a command that
 imports one won't compile under `zig build test` otherwise:
 
 ```zig
-_ = zcli.addCommandTests(b, zcli_dep, .{
+_ = zcli.addCommandTests(b, exe, zcli_dep, .{
     .commands_dir = "src/commands",
     .target = target,
     .optimize = optimize,
@@ -299,9 +299,15 @@ compiles each as its own in-process test binary, so a command's `test` blocks
 (typically using `zcli-testing`'s `runCommand`) actually run — without pulling
 in the whole generated app.
 
+`exe` is the project's real executable (the same one passed to `generate()`);
+the returned `test` step depends on it so `zig build test` also proves the
+real registry/main.zig link — on every OS the test job runs on, not just
+wherever someone happens to run `zig build build-examples`/install the exe.
+
 ```zig
 pub fn addCommandTests(
     b: *std.Build,
+    exe: *std.Build.Step.Compile,
     zcli_dep: *std.Build.Dependency,
     config: zcli.CommandTestsConfig,
 ) *std.Build.Step
@@ -330,7 +336,7 @@ registry — a command's tests must not require the whole app to compile.
 
 ```zig
 // build.zig
-_ = zcli.addCommandTests(b, zcli_dep, .{
+_ = zcli.addCommandTests(b, exe, zcli_dep, .{
     .commands_dir = "src/commands",
     .target = target,
     .optimize = optimize,

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -29,7 +29,7 @@ test "deploy command" {
 ```
 
 Unit tests only run under `zig build test` if `build.zig` wires
-`zcli.addCommandTests(b, zcli_dep, .{ .commands_dir = "src/commands", ... })` —
+`zcli.addCommandTests(b, exe, zcli_dep, .{ .commands_dir = "src/commands", ... })` —
 a scaffolded project (`zcli init`) already does this. See
 [BUILD.md](BUILD.md#command-unit-tests-addcommandtests) for the full config
 and how commands are compiled for testing.

--- a/examples/ext-plugin/build.zig
+++ b/examples/ext-plugin/build.zig
@@ -49,7 +49,7 @@ pub fn build(b: *std.Build) !void {
     const run_step = b.step("run", "Run the application");
     run_step.dependOn(&run_cmd.step);
 
-    _ = zcli.addCommandTests(b, zcli_dep, .{
+    _ = zcli.addCommandTests(b, exe, zcli_dep, .{
         .commands_dir = "src/commands",
         .target = target,
         .optimize = optimize,

--- a/examples/ghauth/build.zig
+++ b/examples/ghauth/build.zig
@@ -45,7 +45,7 @@ pub fn build(b: *std.Build) !void {
 
     // Per-command unit tests (the scaffolded-project idiom): compiles each
     // command file as its own test root so its `test` blocks run.
-    _ = zcli.addCommandTests(b, zcli_dep, .{
+    _ = zcli.addCommandTests(b, exe, zcli_dep, .{
         .commands_dir = "src/commands",
         .target = target,
         .optimize = optimize,

--- a/examples/notes/build.zig
+++ b/examples/notes/build.zig
@@ -55,7 +55,7 @@ pub fn build(b: *std.Build) !void {
     const run_step = b.step("run", "Run the application");
     run_step.dependOn(&run_cmd.step);
 
-    _ = zcli.addCommandTests(b, zcli_dep, .{
+    _ = zcli.addCommandTests(b, exe, zcli_dep, .{
         .commands_dir = "src/commands",
         .target = target,
         .optimize = optimize,

--- a/examples/oauth-device/build.zig
+++ b/examples/oauth-device/build.zig
@@ -45,7 +45,7 @@ pub fn build(b: *std.Build) !void {
 
     // Per-command unit tests (the scaffolded-project idiom): compiles each
     // command file as its own test root so its `test` blocks run.
-    _ = zcli.addCommandTests(b, zcli_dep, .{
+    _ = zcli.addCommandTests(b, exe, zcli_dep, .{
         .commands_dir = "src/commands",
         .target = target,
         .optimize = optimize,

--- a/examples/options-features/build.zig
+++ b/examples/options-features/build.zig
@@ -41,7 +41,7 @@ pub fn build(b: *std.Build) !void {
 
     // Per-command unit tests (the scaffolded-project idiom): compiles each
     // command file as its own test root so its `test` blocks run.
-    _ = zcli.addCommandTests(b, zcli_dep, .{
+    _ = zcli.addCommandTests(b, exe, zcli_dep, .{
         .commands_dir = "src/commands",
         .target = target,
         .optimize = optimize,

--- a/examples/prompts-features/build.zig
+++ b/examples/prompts-features/build.zig
@@ -41,7 +41,7 @@ pub fn build(b: *std.Build) !void {
 
     // Per-command unit tests (the scaffolded-project idiom): compiles each
     // command file as its own test root so its `test` blocks run.
-    _ = zcli.addCommandTests(b, zcli_dep, .{
+    _ = zcli.addCommandTests(b, exe, zcli_dep, .{
         .commands_dir = "src/commands",
         .target = target,
         .optimize = optimize,

--- a/examples/repostat/build.zig
+++ b/examples/repostat/build.zig
@@ -40,7 +40,7 @@ pub fn build(b: *std.Build) !void {
 
     // Per-command unit tests (the scaffolded-project idiom): compiles each
     // command file as its own test root so its `test` blocks run.
-    _ = zcli.addCommandTests(b, zcli_dep, .{
+    _ = zcli.addCommandTests(b, exe, zcli_dep, .{
         .commands_dir = "src/commands",
         .target = target,
         .optimize = optimize,

--- a/examples/tasks/build.zig
+++ b/examples/tasks/build.zig
@@ -64,7 +64,7 @@ pub fn build(b: *std.Build) !void {
 
     // Per-command unit tests (the scaffolded-project idiom): compiles each
     // command file as its own test root so its `test` blocks run.
-    _ = zcli.addCommandTests(b, zcli_dep, .{
+    _ = zcli.addCommandTests(b, exe, zcli_dep, .{
         .commands_dir = "src/commands",
         .target = target,
         .optimize = optimize,

--- a/examples/testing-demo/build.zig
+++ b/examples/testing-demo/build.zig
@@ -43,7 +43,7 @@ pub fn build(b: *std.Build) !void {
     // command file as its own test root, with `zcli-testing` (the unit tier,
     // `runCommand`) wired in — see `src/commands/greet.zig`'s own `test`
     // blocks. Returns the `test` step so more tiers can attach to it below.
-    const test_step = zcli.addCommandTests(b, zcli_dep, .{
+    const test_step = zcli.addCommandTests(b, exe, zcli_dep, .{
         .commands_dir = "src/commands",
         .target = target,
         .optimize = optimize,

--- a/examples/upgrade-demo/build.zig
+++ b/examples/upgrade-demo/build.zig
@@ -63,7 +63,7 @@ pub fn build(b: *std.Build) !void {
 
     // Per-command unit tests (the scaffolded-project idiom): compiles each
     // command file as its own test root so its `test` blocks run.
-    _ = zcli.addCommandTests(b, zcli_dep, .{
+    _ = zcli.addCommandTests(b, exe, zcli_dep, .{
         .commands_dir = "src/commands",
         .target = target,
         .optimize = optimize,

--- a/examples/vault/build.zig
+++ b/examples/vault/build.zig
@@ -64,7 +64,7 @@ pub fn build(b: *std.Build) !void {
 
     // Per-command unit tests (the scaffolded-project idiom): compiles each
     // command file as its own test root so its `test` blocks run.
-    _ = zcli.addCommandTests(b, zcli_dep, .{
+    _ = zcli.addCommandTests(b, exe, zcli_dep, .{
         .commands_dir = "src/commands",
         .target = target,
         .optimize = optimize,

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -22,7 +22,7 @@ Re-exported through the zcli package root — `const zcli = @import("zcli");`:
 
 - `generate(b, exe, zcli_dep, config: GenerateConfig) !*Module` — discover commands, generate the registry
 - `generateDocs(b, registry, zcli_dep, config: DocsConfig)` — markdown/man/html docs on every build
-- `addCommandTests(b, zcli_dep, config: CommandTestsConfig)` — per-command unit-test wiring
+- `addCommandTests(b, exe, zcli_dep, config: CommandTestsConfig)` — per-command unit-test wiring
 - `builtin(tag, config)` — register a shipped plugin by tag
 - Types: `GenerateConfig`, `DocsConfig`, `CommandTestsConfig`, `PluginConfig`, `SharedModule`
 

--- a/packages/core/src/build_utils/command_tests.zig
+++ b/packages/core/src/build_utils/command_tests.zig
@@ -30,14 +30,23 @@ const PluginInfo = types.PluginInfo;
 ///     tests are in-process; the subprocess/PTY tiers live in separate modules.)
 ///   - any `shared_modules` the commands were generated with.
 ///
+/// `exe` is the project's real executable (the one built by `generate()`). The
+/// `test` step depends on it so that `zig build test` — which CI runs on all
+/// three OSes — also proves the real registry/main.zig link on every OS. The
+/// per-command stub tests alone don't compile the app; without this, a
+/// Windows- or macOS-only link break could stay green until someone happens
+/// to run `zig build build-examples`/`b.installArtifact` there.
+///
 /// Returns the created `test` step so the caller can attach more to it.
 pub fn addCommandTests(
     b: *std.Build,
+    exe: *std.Build.Step.Compile,
     zcli_dep: *std.Build.Dependency,
     config: types.CommandTestsConfig,
 ) *std.Build.Step {
     const zcli_module = zcli_dep.module("zcli");
     const test_step = b.step("test", "Run command unit tests");
+    test_step.dependOn(&exe.step);
 
     const shared_modules = config.shared_modules;
 

--- a/packages/testing/src/runner.zig
+++ b/packages/testing/src/runner.zig
@@ -13,34 +13,6 @@ pub const Result = struct {
     }
 };
 
-/// Run a command using the actual compiled binary
-///
-/// This function runs the actual CLI binary as a subprocess, ensuring we test
-/// the real implementation rather than mocks or stubs. This is the most reliable
-/// way to test CLI applications as it tests the full stack including argument
-/// parsing, command routing, and output generation.
-///
-/// The RegistryType parameter is kept for API compatibility but isn't used
-/// since we're running the actual binary rather than calling registry methods.
-pub fn runInProcess(allocator: std.mem.Allocator, io: std.Io, comptime RegistryType: type, args: []const []const u8) !Result {
-    _ = RegistryType; // Not used in subprocess approach
-
-    // Determine the binary path based on the registry type
-    // For now, we'll use a hardcoded path, but this could be made configurable
-    const exe_path = "./zig-out/bin/example-cli";
-
-    // Check if the binary exists
-    std.Io.Dir.cwd().access(io, exe_path, .{}) catch |err| {
-        // If binary doesn't exist, return a helpful error
-        std.debug.print("Error: CLI binary not found at '{s}'\n", .{exe_path});
-        std.debug.print("Please run 'zig build' first to compile the CLI\n", .{});
-        return err;
-    };
-
-    // Run the actual binary
-    return runSubprocess(allocator, io, exe_path, args);
-}
-
 const max_output = 10 * 1024 * 1024;
 
 /// Serializes access to a child allocator behind a mutex.

--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -321,7 +321,7 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         \\    // blocks use `zcli-testing`'s runCommand (bundled with the zcli
         \\    // dependency, so no extra dependency is needed). `zcli add command`
         \\    // scaffolds a starting test alongside each new command.
-        \\    _ = zcli.addCommandTests(b, zcli_dep, .{{
+        \\    _ = zcli.addCommandTests(b, exe, zcli_dep, .{{
         \\        .commands_dir = "src/commands",
         \\        .target = target,
         \\        .optimize = optimize,

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -716,6 +716,29 @@ test "release --dry-run previews without creating a tag" {
 /// working tree, preserving everything else `init` wrote. Zig requires path
 /// dependencies to be relative to the package root, so we compute the relative
 /// path from `proj_abs` to the repo root.
+/// Splice `zcli.builtin(.<tag>, .{})` into the generated build.zig's
+/// `.plugins = &.{` list, right after the opening brace. Used by tests that
+/// hand-write a command using a builtin plugin `init` didn't preselect — the
+/// real exe (now part of the `test` step per #531) must actually have the
+/// plugin registered to compile, same as any real app would need.
+fn addBuiltinPlugin(proj: std.Io.Dir, tag: []const u8) !void {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const orig = try readFile(proj, a, "build.zig");
+    const marker = ".plugins = &.{";
+    const idx = std.mem.indexOf(u8, orig, marker) orelse return error.NoPluginsBlock;
+    const insert_at = idx + marker.len;
+
+    const rewritten = try std.fmt.allocPrint(
+        a,
+        "{s}\n            zcli.builtin(.{s}, .{{}}),{s}",
+        .{ orig[0..insert_at], tag, orig[insert_at..] },
+    );
+    try proj.writeFile(io, .{ .sub_path = "build.zig", .data = rewritten });
+}
+
 fn pointDependencyAtLocalTree(proj: std.Io.Dir, proj_abs: []const u8) !void {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -1738,12 +1761,19 @@ test "a command that uses zcli_secrets is runCommand-testable without the keycha
     const proj_abs = try tmpSubdirAbs(arena.allocator(), tmp, "app");
     try pointDependencyAtLocalTree(proj, proj_abs);
 
+    // `init`'s non-interactive default plugin set doesn't include secrets;
+    // register it explicitly so the *real* exe (part of the `test` step, not
+    // just the command-test stub) has `context.plugins.zcli_secrets` too — a
+    // command using a plugin's context data must have that plugin wired for
+    // the real app to compile, same as it would for any user's project.
+    try addBuiltinPlugin(proj, "secrets");
+
     // A command that reads a secret via the *builtin* zcli_secrets plugin, with
     // a co-located test. addCommandTests wires an in-memory zcli_secrets into the
-    // test stub, so this compiles and its runCommand test runs without the real
-    // OS keychain (and without a native link) — even though secrets is a builtin,
-    // not a local src/plugins/ plugin. Before that, `context.plugins.zcli_secrets`
-    // didn't exist in the stub and the test wouldn't compile.
+    // test stub, so the runCommand test below runs without the real OS keychain
+    // (and without a native link) even though the real exe links the real
+    // plugin. Before that, `context.plugins.zcli_secrets` didn't exist in the
+    // stub and the test wouldn't compile.
     try proj.writeFile(io, .{
         .sub_path = "src/commands/reveal.zig",
         .data =
@@ -1886,11 +1916,15 @@ test "interactive: a SIGTERM mid-prompt restores the terminal from raw mode" {
 
     // Drive the wizard to its first prompt (a raw-mode `text` prompt), let raw
     // mode engage (the same settle rationale as the wizard test above), then
-    // kill it with SIGTERM instead of answering.
+    // kill it with SIGTERM instead of answering. Named `settle_ms` (matching
+    // the idiom used throughout this file) rather than a bare literal, so the
+    // wait reads as the same settle window every other interactive test
+    // documents, not an unexplained magic number.
+    const settle_ms = 500;
     var script = harness.InteractiveScript.init(testing.allocator);
     defer script.deinit();
     _ = script
-        .expect("Command path:").delay(500)
+        .expect("Command path:").delay(settle_ms)
         .sendSignal(.SIGTERM);
 
     var result = harness.runInteractive(


### PR DESCRIPTION
## Summary

- **#531** — example CLIs' real executables were only proven to link on Linux (the ubuntu-only `examples` job); the root `test_projects` loop in `build.zig` shells out to `zig build test` in every example dir on all 3 OSes, but `addCommandTests`'s `test` step only depended on per-command stub test roots, never the exe itself, so a Windows/macOS-only link break could stay green. Fixed by giving `addCommandTests` the project's `exe` (mirroring `generate(b, exe, zcli_dep, config)`'s signature) and adding `test_step.dependOn(&exe.step)` — cross-OS example-link coverage for free through the existing 3-OS `test` job, no new CI job/matrix. Updated all 11 example `build.zig` callers, the `zcli init` build.zig template, and the docs describing the signature (`docs/BUILD.md`, `docs/TESTING.md`, `packages/core/README.md`).

  This surfaced a real gap of exactly the kind #531 was meant to catch: an e2e test scaffolded a `reveal` command using the builtin `zcli_secrets` plugin without registering it in the generated project's `build.zig` — it only "worked" because the command-test stub context is more permissive (always includes an in-memory secrets stand-in) than the real registry. With the real exe now part of `test`, that command correctly failed to compile until the plugin was wired, so the test (`projects/zcli/test/e2e.zig`) now registers `zcli.builtin(.secrets, .{})`, matching what a real app would need.

- **#532** — `projects/zcli/test/e2e.zig`'s SIGTERM-mid-prompt interactive test used a bare `.delay(500)` literal to let raw mode engage before sending the signal, unlike every other interactive test in the file which names the same wait `settle_ms`. Replaced the literal with a named `settle_ms` local so the wait reads as an intentional, documented window (consistent with the rest of the suite) rather than an unexplained magic number.

- **#533** — removed `runInProcess` from `packages/testing/src/runner.zig`: dead code (zero callers repo-wide, confirmed by `grep -rn runInProcess .`) that despite its name spawned a subprocess at a hardcoded, nonexistent `./zig-out/bin/example-cli` path. `runSubprocess` is the real, documented entry point (per the package's Quick Start).

## Test plan
- [x] `zig build` (repo root) — clean
- [x] `zig build test` (repo root) — all packages + all 11 examples pass, including the newly exe-linked `test` steps on this OS
- [x] `zig build e2e` (from `projects/zcli`) — full suite green, including the two touched tests (`a command that uses zcli_secrets is runCommand-testable without the keychain`, `a SIGTERM mid-prompt restores the terminal from raw mode`) run individually via `-De2e-filter`
- [x] `grep -rn runInProcess .` — no hits outside history
- [ ] CI (ubuntu/macos/windows `test` matrix) — will confirm cross-OS example linking now actually runs there

🤖 Generated with [Claude Code](https://claude.com/claude-code)