### PR TITLE
grade9: validate scaffold input in the meta-CLI (#506, #507)

### DIFF
--- a/projects/zcli/src/commands/add/_generate.zig
+++ b/projects/zcli/src/commands/add/_generate.zig
@@ -193,6 +193,13 @@ pub fn writeCommandFile(
     file_path: []const u8,
     content: []const u8,
 ) ![]const NewGroup {
+    // Guard before touching the filesystem: a user-supplied custom type or
+    // default is spliced verbatim into the source, so a typo (e.g. `u3 2`) or an
+    // otherwise malformed snippet would produce a command file that won't parse.
+    // Refuse it here — writing nothing — rather than report success and leave a
+    // broken scaffold to surface as a confusing compile error later (#506).
+    if (!try scaffold.splice.parses(arena, content)) return error.GeneratedSourceInvalid;
+
     const cwd = std.Io.Dir.cwd();
     var new_groups = std.ArrayList(NewGroup).empty;
 
@@ -279,6 +286,40 @@ test "generateSource: multiple is independent of element type" {
     try expectContains(src, "tags: [][]const u8 = &.{},"); // multiple string option
     try expectContains(src, "\"users create <email> [age] names...\"");
 }
+test "writeCommandFile refuses source that would not parse, writing nothing (#506)" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // A malformed custom option type is spliced verbatim, yielding the Options
+    // field `bad: ?u3 2 = null,` — which does not parse. The write path must
+    // reject it up front (before any filesystem work) rather than scaffold a
+    // command file that won't compile.
+    const parts = try parsePath(a, "broken");
+    const opts_list = [_]OptSpec{
+        .{ .name = "bad", .elem_type = "u3 2", .multiple = false, .nullable = true, .default_expr = null, .description = "" },
+    };
+    const src = try generateSource(a, parts, "Broken", &.{}, &opts_list);
+    // parts.len == 1, so this returns on the parse guard before touching the fs.
+    try testing.expectError(error.GeneratedSourceInvalid, writeCommandFile(a, testing.io, parts, "src/commands/broken.zig", src));
+}
+
+test "a well-formed generated command passes the parse guard" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const parts = try parsePath(a, "users/create");
+    const args_list = [_]ArgSpec{
+        .{ .name = "email", .elem_type = "[]const u8", .multiple = false, .nullable = false, .description = "Email" },
+    };
+    const opts_list = [_]OptSpec{
+        .{ .name = "format", .elem_type = "enum { json, yaml }", .multiple = false, .nullable = false, .default_expr = ".yaml", .description = "Format" },
+    };
+    const src = try generateSource(a, parts, "Create a user", &args_list, &opts_list);
+    try testing.expect(try scaffold.splice.parses(a, src));
+}
+
 fn expectContains(haystack: []const u8, needle: []const u8) !void {
     if (std.mem.indexOf(u8, haystack, needle) == null) {
         std.debug.print("\nexpected to find:\n  {s}\nin:\n{s}\n", .{ needle, haystack });

--- a/projects/zcli/src/commands/add/_wizard.zig
+++ b/projects/zcli/src/commands/add/_wizard.zig
@@ -107,7 +107,20 @@ fn runWizardOnce(
         switch (action) {
             0 => {
                 const content = try generate.generateSource(arena, path.parts, description, args_list.items, opts_list.items);
-                const new_groups = try generate.writeCommandFile(arena, io, path.parts, file_path, content);
+                const new_groups = generate.writeCommandFile(arena, io, path.parts, file_path, content) catch |err| switch (err) {
+                    // A custom type/default that isn't valid Zig would scaffold a
+                    // command file that won't compile; the write path refuses it
+                    // (#506). Report cleanly and keep the review loop open so the
+                    // user can start over and re-enter it — nothing was written.
+                    error.GeneratedSourceInvalid => {
+                        try w.writeAll("\r\n");
+                        try warn(w, theme, "  A custom type or default you entered isn't valid Zig \u{2014} nothing was written.");
+                        try warn(w, theme, "  Choose \"Start over\" to re-enter it.");
+                        try w.writeAll("\r\n");
+                        continue;
+                    },
+                    else => return err,
+                };
                 try finish(w, theme, path.parts, file_path, new_groups);
                 return .created;
             },
@@ -548,8 +561,28 @@ fn promptOptionDefault(
         .integer => try std.fmt.allocPrint(arena, "{d}", .{try p.number(.{ .message = "  Default value:", .default = 0, .interrupt_keys = back_keys })}),
         .decimal => try std.fmt.allocPrint(arena, "{d}", .{try readFloat(p, "  Default value:", 0)}),
         .choice => try std.fmt.allocPrint(arena, ".{s}", .{choices[try p.select(.{ .message = "  Default:", .choices = choices, .interrupt_keys = back_keys })]}),
-        .custom => try arena.dupe(u8, std.mem.trim(u8, try p.text(.{ .message = "  Default (Zig expression):", .interrupt_keys = back_keys }), " \t\r\n")),
+        .custom => try readCustomDefault(arena, p),
     };
+}
+
+/// Prompt for a custom default expression, re-prompting until it parses as valid
+/// Zig — a malformed expression is spliced verbatim and would otherwise scaffold
+/// a command file that won't compile (#506).
+fn readCustomDefault(arena: std.mem.Allocator, p: Prompts) ![]const u8 {
+    const w = p.writer;
+    const theme = &p.theme;
+    while (true) {
+        const v = std.mem.trim(u8, try p.text(.{ .message = "  Default (Zig expression):", .interrupt_keys = back_keys }), " \t\r\n");
+        if (v.len == 0) {
+            try warn(w, theme, "  Default cannot be empty (e.g. 42, \"hi\", .some_tag).");
+            continue;
+        }
+        if (!snippetParses(arena, v)) {
+            try warn(w, theme, "  That isn't a valid Zig expression.");
+            continue;
+        }
+        return try arena.dupe(u8, v);
+    }
 }
 
 fn selectOptKind(p: Prompts) !OptKind {
@@ -712,8 +745,25 @@ fn readZigType(p: Prompts) ![]const u8 {
             try warn(w, theme, "  Type cannot be empty (e.g. u8, []const u8, enum { a, b }).");
             continue;
         }
+        // Reject a syntactically broken type (e.g. `u3 2`) here, so the user gets
+        // a tight re-prompt instead of a refused write at the end (#506). A type
+        // that parses but isn't imported still fails at build time — the write
+        // guard and the compiler are the backstop.
+        if (!snippetParses(p.allocator, t)) {
+            try warn(w, theme, "  That isn't valid Zig (e.g. u8, []const u8, enum { a, b }).");
+            continue;
+        }
         return t;
     }
+}
+
+/// True if `snippet` (a type or value expression) parses as valid Zig. Wraps it
+/// in a trivial decl so a bare `[]const u8` or `enum { a, b }` is accepted while
+/// a typo like `u3 2` is rejected — the same parse-guard the write path applies.
+/// Permissive on allocation failure: the write-time guard is the real backstop.
+fn snippetParses(arena: std.mem.Allocator, snippet: []const u8) bool {
+    const wrapped = std.fmt.allocPrint(arena, "const _ = {s};", .{snippet}) catch return true;
+    return scaffold.splice.parses(arena, wrapped) catch true;
 }
 
 fn readShort(p: Prompts, used: []const u8) !u8 {
@@ -883,4 +933,29 @@ fn joinSpaced(arena: std.mem.Allocator, parts: []const []const u8) ![]const u8 {
         try buf.appendSlice(arena, p);
     }
     return buf.items;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const testing = std.testing;
+
+test "snippetParses accepts valid types/expressions and rejects malformed ones (#506)" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // Valid type and value snippets.
+    try testing.expect(snippetParses(a, "u8"));
+    try testing.expect(snippetParses(a, "[]const u8"));
+    try testing.expect(snippetParses(a, "enum { json, yaml }"));
+    try testing.expect(snippetParses(a, "42"));
+    try testing.expect(snippetParses(a, "\"hi\""));
+    try testing.expect(snippetParses(a, ".some_tag"));
+
+    // Malformed snippets — the wizard must re-prompt rather than splice these in.
+    try testing.expect(!snippetParses(a, "u3 2"));
+    try testing.expect(!snippetParses(a, "enum {"));
+    try testing.expect(!snippetParses(a, ""));
 }

--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -124,12 +124,22 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         return context.fail("Error: Invalid project name '{s}'{s}\n  '{s}' is a Zig reserved word and cannot be used as a package name", .{ project_name, name_origin, project_identifier });
     }
 
+    // The version lands verbatim in build.zig.zon's `.version` field, which Zig's
+    // manifest parser requires to be a semantic version. Validate it up front so a
+    // typo fails immediately with a clear message here, rather than surfacing later
+    // as an opaque manifest error from `zig fetch`/`zig build` in a half-set-up
+    // project (#507).
+    const version_str = options.version orelse "0.1.0";
+    if (!isValidSemanticVersion(version_str)) {
+        return context.fail("Error: Invalid version '{s}'\n  Must be a semantic version like 1.2.3 (see https://semver.org)", .{version_str});
+    }
+
     // Free-text options are embedded in generated string literals — escape so
     // `--description 'say "hi"'` scaffolds a project that still compiles
     // instead of breaking (or injecting code into) build.zig / build.zig.zon.
     const app_description = try escapeStringLiteral(allocator, options.description orelse "A CLI application built with zcli");
     defer allocator.free(app_description);
-    const app_version = try escapeStringLiteral(allocator, options.version orelse "0.1.0");
+    const app_version = try escapeStringLiteral(allocator, version_str);
     defer allocator.free(app_version);
 
     // Validate the target directory before prompting or creating anything, so we
@@ -594,6 +604,25 @@ test "renderPluginsBlock scaffolds a compiling github_upgrade config, not an emp
             "            }),\n",
         block,
     );
+}
+
+/// True if `s` is a semantic version acceptable to Zig's build.zig.zon manifest
+/// parser (which requires `.version` to be semver). `init` validates the
+/// `--version` value with this up front so a bad value fails immediately rather
+/// than as an opaque manifest error downstream (#507).
+fn isValidSemanticVersion(s: []const u8) bool {
+    _ = std.SemanticVersion.parse(s) catch return false;
+    return true;
+}
+
+test "isValidSemanticVersion accepts semver and rejects junk (#507)" {
+    try std.testing.expect(isValidSemanticVersion("0.1.0"));
+    try std.testing.expect(isValidSemanticVersion("1.2.3"));
+    try std.testing.expect(isValidSemanticVersion("1.2.3-rc.1+build5")); // prerelease + build metadata
+    try std.testing.expect(!isValidSemanticVersion("foo"));
+    try std.testing.expect(!isValidSemanticVersion("1.2")); // not full semver
+    try std.testing.expect(!isValidSemanticVersion("v1.2.3")); // leading v is not semver
+    try std.testing.expect(!isValidSemanticVersion(""));
 }
 
 fn escapeStringLiteral(allocator: std.mem.Allocator, s: []const u8) ![]u8 {

--- a/projects/zcli/src/scaffold/splice.zig
+++ b/projects/zcli/src/scaffold/splice.zig
@@ -58,9 +58,17 @@ pub fn insertArg(arena: std.mem.Allocator, source: [:0]const u8, a: spec.ArgSpec
 /// message. `insertStructField`/`insertMetaEntry` are safe to reuse directly in
 /// chained splices — they re-parse each intermediate result themselves.
 fn ensureParses(arena: std.mem.Allocator, result: []u8) ![]u8 {
-    const ast = try Ast.parse(arena, try arena.dupeZ(u8, result), .zig);
-    if (ast.errors.len != 0) return SpliceError.ResultDoesNotParse;
+    if (!try parses(arena, result)) return SpliceError.ResultDoesNotParse;
     return result;
+}
+
+/// True if `source` parses as valid Zig (no AST errors). The scaffold write path
+/// (`zcli add command`) reuses this as its pre-write guard so a user-supplied
+/// custom type/default that doesn't compile is caught before a file is created,
+/// exactly as `insertArg`/`insertOption` guard their verbatim `--type` splices.
+pub fn parses(arena: std.mem.Allocator, source: []const u8) !bool {
+    const ast = try Ast.parse(arena, try arena.dupeZ(u8, source), .zig);
+    return ast.errors.len == 0;
 }
 
 /// The existing field names of a command's `Args`/`Options` struct, in source

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -310,6 +310,13 @@ test "init rejects a Zig reserved word as the project name" {
     try testing.expect(!fileExists(tmp.dir, "error"));
 }
 
+// Note (#507): init's `version` option is validated as semver in-process (see
+// init.zig `isValidSemanticVersion` + its unit test). It has no CLI e2e here
+// because the zcli tool's global `--version`/`-V` flag (zcli_version plugin)
+// shadows the command option: `zcli init app --version foo` is consumed by the
+// global flag before routing, so the option is only reachable via a config-file
+// default, not argv. The validation is covered by the unit test.
+
 test "init . scaffolds into the current directory" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();


### PR DESCRIPTION
Fixes #506
Fixes #507

Two input-validation gaps in the zcli meta-CLI (`projects/zcli`).

## #506 — `add command` wizard wrote custom types/defaults verbatim
The interactive wizard spliced user-supplied custom Zig types and default expressions straight into the generated command file with no parse-guard, so a typo like `u3 2` (or otherwise malformed input) produced a command file that won't compile while the wizard reported success — surfacing only at the next `zig build` with a confusing error in scaffolded code.

- **Write-time guard**: `writeCommandFile` now runs the fully-assembled source through the same parse-guard `add arg`/`add option` already use, exposed as `scaffold.splice.parses`. On a parse error it returns `error.GeneratedSourceInvalid` **before touching the filesystem** — nothing is written.
- **Prompt-time validation**: the wizard validates custom types (`readZigType`) and custom default expressions at entry, re-prompting immediately on a syntactically invalid snippet (tight loop) instead of failing at the very end.
- **Clean surfacing**: if an invalid snippet still reaches the write, the wizard reports it and keeps the review loop open (nothing written) rather than crashing.

Note: like the existing `add arg`/`add option` guard, this catches *syntactic* errors (e.g. `u3 2`); an unimported-but-well-formed type still fails at compile time — that is inherently a compiler concern, not a parse concern.

## #507 — `init --version` accepted non-semver
`init` passed `--version` verbatim into `build.zig.zon`'s `.version` field, which Zig's manifest parser requires to be a semantic version. A bad value failed later at `zig fetch`/`zig build` with an opaque manifest error in a half-set-up project.

- Validate `options.version` (defaulting to `0.1.0`) with `std.SemanticVersion.parse` up front, before any filesystem work, and fail with a clear message consistent with the existing project-name validation style: `Invalid version 'foo': must be a semantic version like 1.2.3`.

Scoping note: the zcli tool's own global `--version`/`-V` flag (zcli_version plugin) is consumed pre-routing, so it shadows `init`'s command option — `zcli init app --version foo` triggers the version banner and never reaches `init`. The `version` option is still real (shown in `--help`, feedable via the config plugin), so the validation is the correct defensive guard; it is covered by a unit test rather than a CLI e2e (which the global shadow makes impossible).

## Tests
- Unit: `writeCommandFile` refuses non-parsing source (writes nothing); a well-formed command passes the guard; `snippetParses` accepts valid types/exprs and rejects `u3 2`/`enum {`/empty; `isValidSemanticVersion` accepts semver (incl. `1.2.3-rc.1+build5`) and rejects `foo`/`1.2`/`v1.2.3`/empty.
- `zig build`, `zig build test`, and `zig build e2e` all pass from repo root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)