### PR TITLE
init: rename --version to --app-version to escape the global flag shadow

### DIFF
--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -46,6 +46,7 @@ pub const meta = .{
     .examples = &.{
         "init my-app",
         "init my-app --description \"My awesome CLI\"",
+        "init my-app --app-version 1.0.0",
         "init . --description \"Initialize in current directory\"",
     },
     .args = .{
@@ -53,7 +54,11 @@ pub const meta = .{
     },
     .options = .{
         .description = .{ .description = "Description of your CLI application" },
-        .version = .{ .description = "Initial version number" },
+        // Named app_version (--app-version), not version: the zcli_version
+        // plugin's global --version/-V flag is consumed before command routing,
+        // so a command option spelled --version would be unreachable from the
+        // CLI (#565).
+        .app_version = .{ .description = "Initial version number" },
     },
 };
 
@@ -63,7 +68,7 @@ pub const Args = struct {
 
 pub const Options = struct {
     description: ?[]const u8 = null,
-    version: ?[]const u8 = null,
+    app_version: ?[]const u8 = null,
 };
 
 pub fn execute(args: Args, options: Options, context: *Context) !void {
@@ -129,7 +134,7 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
     // typo fails immediately with a clear message here, rather than surfacing later
     // as an opaque manifest error from `zig fetch`/`zig build` in a half-set-up
     // project (#507).
-    const version_str = options.version orelse "0.1.0";
+    const version_str = options.app_version orelse "0.1.0";
     if (!isValidSemanticVersion(version_str)) {
         return context.fail("Error: Invalid version '{s}'\n  Must be a semantic version like 1.2.3 (see https://semver.org)", .{version_str});
     }
@@ -615,8 +620,8 @@ test "renderPluginsBlock scaffolds a compiling github_upgrade config, not an emp
 
 /// True if `s` is a semantic version acceptable to Zig's build.zig.zon manifest
 /// parser (which requires `.version` to be semver). `init` validates the
-/// `--version` value with this up front so a bad value fails immediately rather
-/// than as an opaque manifest error downstream (#507).
+/// `--app-version` value with this up front so a bad value fails immediately
+/// rather than as an opaque manifest error downstream (#507).
 fn isValidSemanticVersion(s: []const u8) bool {
     _ = std.SemanticVersion.parse(s) catch return false;
     return true;

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -310,12 +310,38 @@ test "init rejects a Zig reserved word as the project name" {
     try testing.expect(!fileExists(tmp.dir, "error"));
 }
 
-// Note (#507): init's `version` option is validated as semver in-process (see
-// init.zig `isValidSemanticVersion` + its unit test). It has no CLI e2e here
-// because the zcli tool's global `--version`/`-V` flag (zcli_version plugin)
-// shadows the command option: `zcli init app --version foo` is consumed by the
-// global flag before routing, so the option is only reachable via a config-file
-// default, not argv. The validation is covered by the unit test.
+test "init --app-version lands in build.zig.zon (#565)" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // The option is spelled --app-version, not --version: the tool's global
+    // --version/-V flag (zcli_version plugin) is consumed before routing and
+    // would shadow a same-named command option (#565).
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--app-version", "2.3.4" });
+    defer r.deinit();
+    try expectOk(r);
+
+    var proj = try tmp.dir.openDir(io, "myapp", .{});
+    defer proj.close(io);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const zon = try readFile(proj, a, "build.zig.zon");
+    try expectContains(zon, ".version = \"2.3.4\"");
+}
+
+test "init rejects a non-semver --app-version before touching the filesystem (#507)" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--app-version", "foo" });
+    defer r.deinit();
+    try testing.expect(r.exit_code != 0);
+    try expectContains(r.stderr, "Invalid version");
+    try testing.expect(!fileExists(tmp.dir, "myapp"));
+}
 
 test "init . scaffolds into the current directory" {
     var tmp = testing.tmpDir(.{});

--- a/website/content/docs/cli.smd
+++ b/website/content/docs/cli.smd
@@ -31,7 +31,7 @@ zcli init myapp --description "My awesome CLI"
 zcli init .    # initialize the current directory
 ```
 
-Scaffolds a complete, buildable project — `build.zig.zon`, a `build.zig` wired with [`zcli.generate`]($link.page('docs/build')), `src/main.zig`, an example command — and fetches dependencies so `zig build` works immediately. Options: `-d/--description`, `--version` (initial version, default `0.1.0`).
+Scaffolds a complete, buildable project — `build.zig.zon`, a `build.zig` wired with [`zcli.generate`]($link.page('docs/build')), `src/main.zig`, an example command — and fetches dependencies so `zig build` works immediately. Options: `-d/--description`, `--app-version` (initial version, default `0.1.0`).
 
 On a TTY it asks which built-in plugins to enable (help, version, not-found, and completions are the defaults). It also scaffolds an `AGENTS.md` with a marker-delimited zcli section pointing coding agents at `zcli guide` — re-running `init` refreshes just that section, never clobbering the rest of the file. See [AI agents]($link.page('ai')).
 

--- a/website/layouts/getting-started.shtml
+++ b/website/layouts/getting-started.shtml
@@ -190,7 +190,7 @@ zcli <span :text="$site.asset('site-data.json').ziggy().get('version')"></span>
         <pre><span class="pr">$</span> zcli init myapp <span class="fl">--description</span> "My awesome CLI"</pre>
         <button onclick="cp(this,'zcli init myapp --description &quot;My awesome CLI&quot;')">copy</button>
       </div>
-      <p class="note">Pass <code>.</code> instead of a name to initialize in the current directory (it must be empty). <code>--version</code> sets the starting version; both options are optional.</p>
+      <p class="note">Pass <code>.</code> instead of a name to initialize in the current directory (it must be empty). <code>--app-version</code> sets the starting version; both options are optional.</p>
     </div>
 
     <div class="duo" style="margin-top:26px;">


### PR DESCRIPTION
## Summary

Fixes #565: the zcli_version plugin's global `--version`/`-V` flag is consumed by `parseGlobalOptions` before command routing, so `init`'s own `version` option was unreachable from the CLI — `zcli init app --version 1.0.0` printed the version banner instead of scaffolding.

## Why option (a) — rename — over (b) — framework yield

Making global parsing yield to a same-named command option post-routing would change framework semantics for every app built on zcli (a global flag's meaning would depend on which command follows it, and value-taking globals would parse differently per command). The docker/git convention — globals win, commands avoid colliding names — is the least surprising contract, so the local rename is the right fix.

## Changes

- `projects/zcli/src/commands/init.zig`: `Options.version` → `Options.app_version` (`--app-version`), with a comment explaining the shadow; example added to `meta.examples`; #507 doc comment updated.
- `projects/zcli/test/e2e.zig`: replaced the "untestable via CLI" note from #564 with the two now-possible e2e tests — `--app-version 2.3.4` lands as `.version = "2.3.4"` in build.zig.zon, and a non-semver value fails cleanly with nothing left on disk.
- Website source refs updated (`content/docs/cli.smd`, `layouts/getting-started.shtml`); generated `public/` files regenerate on the next zine build.

## Verification

`zig build`, `zig build test`, and `zig build e2e` all pass locally (e2e includes the two new tests). Plain `zcli --version` still prints the banner (unchanged path, covered by existing tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
