### PR TITLE
ci: add CI OK gate job as the single required check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -551,3 +551,51 @@ jobs:
         env:
           ZCLI_REQUIRE_INTERACTIVE: "1"
         run: zig build e2e
+
+  # The single required status check for branch protection — the ruleset
+  # requires ONLY this job (plus nothing else), never the per-job or per-leg
+  # names. Two reasons:
+  #
+  #   1. Skipped MATRIX jobs break per-leg required checks: when a job with a
+  #      strategy matrix is skipped by its job-level `if:`, GitHub never
+  #      expands the matrix — it reports one skipped check run with the
+  #      literal, un-substituted name (observed: "zcli_secrets backend
+  #      (${{ matrix.os }})"), so required contexts like "zcli_secrets
+  #      backend (ubuntu-latest)" are never created and sit at "Expected"
+  #      forever. A gate that is itself never skipped sidesteps this.
+  #   2. It fails when `changes` fails. Downstream jobs skipped because a
+  #      needed job FAILED still read as satisfied to branch protection — so
+  #      without this, a broken path filter could merge a PR with zero tests
+  #      run. Here a failed `changes` surfaces as this job failing.
+  #
+  # `if: always()` so it reports even when everything upstream was skipped;
+  # skipped is an acceptable result (that's the path-gating working as
+  # designed), failure and cancellation are not. Adding or removing jobs or
+  # matrix legs needs no ruleset edit — only membership in `needs` below.
+  ci-ok:
+    name: CI OK
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: always()
+    needs:
+      - changes
+      - fmt
+      - version-sync
+      - test
+      - windows-release-build
+      - linux-musl-release-build
+      - secrets
+      - examples
+      - e2e
+    steps:
+      - name: Fail if any needed job failed or was cancelled
+        env:
+          RESULTS: ${{ toJSON(needs) }}
+        run: |
+          echo "$RESULTS" | jq -r 'to_entries[] | "\(.key): \(.value.result)"'
+          bad=$(echo "$RESULTS" | jq -r '[to_entries[] | select(.value.result == "failure" or .value.result == "cancelled") | .key] | join(", ")')
+          if [ -n "$bad" ]; then
+            echo "::error::jobs failed or were cancelled: $bad"
+            exit 1
+          fi
+          echo "all jobs succeeded or were legitimately skipped"


### PR DESCRIPTION
## Problem

On PR #567, the three `zcli_secrets backend (<os>)` required checks sat at **Expected** forever. The check-runs API shows why:

```
zcli_secrets backend (${{ matrix.os }}) | completed | skipped
```

When a **matrix** job is skipped by its job-level `if:`, GitHub never expands the matrix — it reports a single skipped check run with the literal, un-substituted name. The per-leg contexts the ruleset requires (`zcli_secrets backend (ubuntu-latest)`, …) are never created, so branch protection waits on them indefinitely. Non-matrix gated jobs (e.g. `canonical examples compile`) skip and satisfy their required check fine; only skipped matrices break.

## Fix

Add a `CI OK` aggregate gate: `needs:` every other job, `if: always()` so it always reports, and fails iff any needed job **failed or was cancelled** — skipped is acceptable (that's the path gating working as designed).

The ruleset should then require **only `CI OK`** instead of the 15 per-job/per-leg names. This also:

- makes a failing `changes` job block the merge (jobs skipped because a needed job *failed* otherwise read as satisfied — a broken path filter could have merged a PR with zero tests run), and
- means adding/removing jobs or matrix legs never requires a ruleset edit again — only membership in the gate's `needs` list.

## Rollout

1. Merge this PR.
2. Update ruleset 18284157 ("Main Protection") to require only `CI OK`.
3. Re-run / rebase #567 so its merge commit picks up the gate job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)