### PR TITLE
ci: deploy docs on release publish instead of push to main

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,14 +1,21 @@
 name: Deploy Documentation
 
+# The website deploys when a RELEASE is published, not on pushes to main:
+# docs merged between releases describe features nobody can install yet, so
+# they accumulate on main and ship the moment the version does. The
+# `published` event fires when sign-release.sh flips the drafted zcli-v*
+# release public (ADR-0023's offline-signing ceremony) — so the human
+# approval that used to live on a docs-deploy environment is now implicit in
+# signing the release. On this event checkout resolves to the release tag's
+# commit, so the site is built from exactly the released tree even if main
+# has moved on.
+#
+# workflow_dispatch is the manual override for out-of-band deploys (typo
+# fixes, broken page): it builds whatever ref it's dispatched on — main by
+# default, which may be ahead of the released version.
 on:
-  push:
-    branches: [main]
-    paths:
-      - "website/**"
-      - "CHANGELOG.md"
-      - "install.sh"
-      - "install.ps1"
-      - "build.zig.zon"
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:
@@ -22,17 +29,18 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # Deliberately ungated (2026-07-16): this job used to sit behind the
-    # "docs-deploy" environment with a required reviewer (grade6 #293/#397)
-    # because every deploy republishes install.sh/install.ps1 — the curl|sh
-    # trust root. In practice the approval stalled every docs deploy (a
-    # waiting run also holds the cloudflare-pages concurrency group, so
-    # follow-up deploys queued and were superseded) and the human review
-    # rubber-stamped content that had already passed PR review. The trust
-    # model is now: main is protected (PR + required "CI OK" check), the
-    # install scripts only change via reviewed PRs, and the release ceremony
-    # keeps its own required-reviewer gate (release.yml's `finalize` job via
-    # the "release" environment) — approval is spent on releases, not docs.
+    # Both zcli-v* (CLI) and v* (library) releases publish at the same
+    # lockstep version, but only the CLI release goes through the offline
+    # signing ceremony that makes "published" mean "a human shipped this" —
+    # deploy on that one, skip the library tag (deploying twice per release
+    # would be harmless but pointless).
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'zcli-v')
+    # No environment gate (2026-07-16): the required-reviewer approval that
+    # used to live on a "docs-deploy" environment (grade6 #293/#397) stalled
+    # deploys — a waiting run holds the cloudflare-pages concurrency group —
+    # and is redundant under the release trigger above: publishing the signed
+    # release IS the approval. install.sh/install.ps1 (the curl|sh trust
+    # root) still only change via reviewed PRs on protected main.
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -22,27 +22,18 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # Every deploy republishes install.sh/install.ps1 — the curl|sh trust root —
-    # so the job is gated behind a protected environment with required reviewers
-    # (grade6 #293). Inert until the "docs-deploy" environment is created in
-    # repo settings; create it with at least one required reviewer.
-    environment: docs-deploy
+    # Deliberately ungated (2026-07-16): this job used to sit behind the
+    # "docs-deploy" environment with a required reviewer (grade6 #293/#397)
+    # because every deploy republishes install.sh/install.ps1 — the curl|sh
+    # trust root. In practice the approval stalled every docs deploy (a
+    # waiting run also holds the cloudflare-pages concurrency group, so
+    # follow-up deploys queued and were superseded) and the human review
+    # rubber-stamped content that had already passed PR review. The trust
+    # model is now: main is protected (PR + required "CI OK" check), the
+    # install scripts only change via reviewed PRs, and the release ceremony
+    # keeps its own required-reviewer gate (release.yml's `finalize` job via
+    # the "release" environment) — approval is spent on releases, not docs.
     steps:
-      # Environment gating is a repo-settings fact this YAML cannot see: if
-      # the environment loses its required-reviewers rule, the gate is
-      # silently inert (#397). An unprotected environment starts this job
-      # immediately — and this step then refuses to deploy. Fail-closed.
-      - name: Assert the docs-deploy environment is protected
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          rules=$(gh api "repos/$GITHUB_REPOSITORY/environments/docs-deploy" --jq '[.protection_rules[].type]') || {
-            echo "::error::cannot read the 'docs-deploy' environment — it must exist with a required-reviewers rule (Settings → Environments)"; exit 1; }
-          echo "protection rules: $rules"
-          echo "$rules" | grep -q required_reviewers || {
-            echo "::error::the 'docs-deploy' environment has NO required-reviewers rule — the approval gate is inert (#397); refusing to deploy"; exit 1; }
-
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 


### PR DESCRIPTION
## Summary

Reworks the website deploy trigger and removes the approval gate. (Revised from the original version of this PR, which kept the push trigger — deploying docs on every main push ships documentation for features nobody can install yet.)

- **Trigger**: `release: types: [published]` instead of `push: branches: [main]`. This event fires when `sign-release.sh` flips the drafted `zcli-v*` release public — so docs ship at the exact moment a version does, and the offline signing ceremony *is* the deploy approval. Library (`v*`) releases are skipped via a job-level `if` (same lockstep version, no signing ceremony).
- **Built from the released tree**: on the release event, checkout resolves to the tag's commit, so the deployed site matches the released version even when main has moved ahead with unreleased work.
- **`workflow_dispatch` stays** as the out-of-band override (typo fix, broken page) — it builds whatever ref it's dispatched on.
- **`docs-deploy` environment gate removed**: it stalled deploys (a waiting-for-approval run holds the `cloudflare-pages` concurrency group; the site silently stopped updating July 14–16), and under the release trigger it's redundant — publishing the signed release is the human sign-off. `install.sh`/`install.ps1` still only change via reviewed PRs on protected main.

## Follow-ups after merge

- Delete the now-unused `docs-deploy` environment in Settings → Environments.
- Reject the stale waiting run [29434173643](https://github.com/ryanhair/zcli/actions/runs/29434173643) (pinned to the old workflow snapshot; still holding the concurrency group).
- The site's last successful deploy was July 14 — it will next update on the first signed release (or a manual dispatch if you want it current sooner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)