### PR TITLE
fix(core): fall through non-trailing defaulted positional on parse failure

### DIFF
--- a/packages/core/src/args.zig
+++ b/packages/core/src/args.zig
@@ -165,20 +165,35 @@ fn parseArgsInternal(comptime ArgsType: type, args: []const []const u8, diag: ?*
             // Field with default value - optional in parsing
             const next_positional: ?usize = if (arg_index < args.len) arg_index else null;
             if (next_positional) |pos| {
-                @field(result, field.name) = parseValue(field_type, args[pos]) catch |err| {
-                    if (err == ZcliError.ArgumentInvalidValue) {
-                        if (diag) |d| d.* = .{ .ArgumentInvalidValue = .{
-                            .field_name = field.name,
-                            .position = field_index,
-                            .provided_value = args[pos],
-                            .expected_type = diagnostic_errors.expectedTypeName(field_type),
-                            .suggestion = diagnostic_errors.nearestEnumValue(field_type, args[pos]),
-                            .reason = custom_type.describeError(field_type, args[pos]),
-                        } };
+                const is_last = comptime (field_index == struct_info.fields.len - 1);
+                if (parseValue(field_type, args[pos])) |value| {
+                    @field(result, field.name) = value;
+                    arg_index = pos + 1;
+                } else |err| {
+                    // Mirror the typed-optional branch above: a NON-TRAILING
+                    // defaulted field whose token fails to parse falls through,
+                    // keeping its default and NOT consuming the token, so a later
+                    // positional can claim it (e.g. `{ count: u32 = 5, name }`
+                    // invoked as `alice` yields count=5, name="alice" instead of
+                    // hard-erroring on `alice`). A TRAILING defaulted field keeps
+                    // the strict error — there is no later field the token could
+                    // belong to.
+                    if (err == ZcliError.ArgumentInvalidValue and !is_last) {
+                        // Leave the default in place; don't consume the token.
+                    } else {
+                        if (err == ZcliError.ArgumentInvalidValue) {
+                            if (diag) |d| d.* = .{ .ArgumentInvalidValue = .{
+                                .field_name = field.name,
+                                .position = field_index,
+                                .provided_value = args[pos],
+                                .expected_type = diagnostic_errors.expectedTypeName(field_type),
+                                .suggestion = diagnostic_errors.nearestEnumValue(field_type, args[pos]),
+                                .reason = custom_type.describeError(field_type, args[pos]),
+                            } };
+                        }
+                        return err;
                     }
-                    return err;
-                };
-                arg_index = pos + 1;
+                }
             }
             // If no argument provided, default value is already set by struct initialization
         } else {
@@ -876,6 +891,41 @@ test "parseArgs trailing typed optional keeps the strict invalid-value error" {
     const TestArgs = struct {
         name: []const u8,
         level: ?u32 = null,
+    };
+
+    const args = [_][]const u8{ "svc", "notnum" };
+    try std.testing.expectError(ZcliError.ArgumentInvalidValue, parseArgs(TestArgs, &args, null));
+}
+
+test "parseArgs non-trailing defaulted field falls through to a required field" {
+    const TestArgs = struct {
+        count: u32 = 5,
+        name: []const u8,
+    };
+
+    // `alice`: doesn't parse as u32 → count keeps its default, name="alice".
+    {
+        const args = [_][]const u8{"alice"};
+        const parsed = try parseArgs(TestArgs, &args, null);
+        try std.testing.expectEqual(@as(u32, 5), parsed.count);
+        try std.testing.expectEqualStrings("alice", parsed.name);
+    }
+
+    // `10 alice`: count parses → count=10, name="alice".
+    {
+        const args = [_][]const u8{ "10", "alice" };
+        const parsed = try parseArgs(TestArgs, &args, null);
+        try std.testing.expectEqual(@as(u32, 10), parsed.count);
+        try std.testing.expectEqualStrings("alice", parsed.name);
+    }
+}
+
+test "parseArgs trailing defaulted field keeps the strict invalid-value error" {
+    // When the defaulted field IS the last field there is no later positional to
+    // hand the token to, so a non-parsing value is a genuine error.
+    const TestArgs = struct {
+        name: []const u8,
+        count: u32 = 5,
     };
 
     const args = [_][]const u8{ "svc", "notnum" };

--- a/packages/core/src/security_test.zig
+++ b/packages/core/src/security_test.zig
@@ -166,16 +166,20 @@ test "security: malicious input handling - buffer overflows" {
 
 test "security: malicious input handling - integer overflows" {
     for (MaliciousInputs.integer_overflows) |overflow_input| {
-        // Test integer parsing with overflow values
+        // Test integer parsing with overflow values. `count` (u32 = 0) is a
+        // non-trailing defaulted field, so an unparseable token falls through
+        // to the later `file` positional instead of hard-erroring. The security
+        // property is that the integer field is NEVER poisoned with an
+        // out-of-range value: on fall-through it keeps its default (0).
         const args = [_][]const u8{ "test", overflow_input };
 
         if (args_parser.parseArgs(TestArgs, &args, null)) |parsed| {
-            // If it somehow parsed an obviously invalid number, that's concerning
-            if (std.mem.eql(u8, overflow_input, "999999999999999999999999999999999999")) {
-                // This should have been rejected
-                try testing.expect(false);
+            // The overflow token must not have been accepted into the u32 field.
+            // It either parsed as a valid in-range u32 or fell through to `file`.
+            if (parsed.count != 0) {
+                // A non-default value means the token genuinely parsed in range.
+                try testing.expect(std.fmt.parseInt(u32, overflow_input, 10) catch 0 == parsed.count);
             }
-            _ = parsed; // Use the result
         } else |err| {
             // Should gracefully handle overflows
             try testing.expect(err == zcli.ZcliError.ArgumentInvalidValue);


### PR DESCRIPTION
## Summary

`packages/core/src/args.zig` handled a non-trailing typed optional that fails `parseValue` by falling through — leaving it at its default and not consuming the token, so a later positional could claim it. The defaulted-field branch used the same `next_positional` probe but hard-returned the error instead of falling through.

As a result, `struct { count: u32 = 5, name: []const u8 }` invoked as `myapp alice` failed with `ArgumentInvalidValue` (`count` rejected "alice"), making `name` unreachable unless `count` was also supplied.

## Fix

The defaulted branch now mirrors the typed-optional branch:

- A **non-trailing** defaulted field whose token fails to parse keeps its default and does **not** consume the token, letting a later positional claim it.
- A **trailing** defaulted field keeps the strict invalid-value error (no later field the token could belong to).

Comptime rejection of "defaulted-before-required" was considered but rejected: the codebase already deliberately supports non-trailing optional fall-through (with a regression test), and a rejection rule general enough to catch this case would also outlaw the supported optional-before-required layout. Fall-through is the consistent choice.

## Tests

- Added `parseArgs non-trailing defaulted field falls through to a required field` and `parseArgs trailing defaulted field keeps the strict invalid-value error` in `args.zig`.
- Updated `security: malicious input handling - integer overflows` in `security_test.zig`: the overflow token now falls through the defaulted `count: u32 = 0` (kept at default, never poisoned) to the trailing optional string field, so the test asserts the real security property.

`zig build` and `zig build test` both pass.

Fixes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)