### PR TITLE
fix(build): stop stamping wall-clock build_date into the generated registry

### DIFF
--- a/packages/core/src/build_utils/code_generation.zig
+++ b/packages/core/src/build_utils/code_generation.zig
@@ -151,8 +151,6 @@ fn generateSimpleRegistry(writer: anytype, commands: DiscoveredCommands, config:
     defer allocator.free(app_version);
     const app_description = try escapeStringLiteral(allocator, config.app_description);
     defer allocator.free(app_description);
-    const build_date = try escapeStringLiteral(allocator, config.build_date);
-    defer allocator.free(build_date);
 
     // Generate the registry type (private)
     try writer.print(
@@ -180,13 +178,12 @@ fn generateSimpleRegistry(writer: anytype, commands: DiscoveredCommands, config:
         \\pub const app_name = "{s}";
         \\pub const app_version = "{s}";
         \\pub const app_description = "{s}";
-        \\pub const build_date = "{s}";
         \\
         \\pub fn init() RegistryType {{
         \\    return RegistryType.init();
         \\}}
         \\
-    , .{ app_name, app_version, app_description, build_date });
+    , .{ app_name, app_version, app_description });
 }
 
 /// Generate metadata for pure command groups

--- a/packages/core/src/build_utils/main.zig
+++ b/packages/core/src/build_utils/main.zig
@@ -41,11 +41,12 @@ pub const linkSecretsBackend = types.linkSecretsBackend;
 // VERSION MANAGEMENT - Read version from build.zig.zon
 // ============================================================================
 
-/// Compute the build date (`YYYY-MM-DD`) stamped into the registry for the man
-/// page `.TH` field. Honors `SOURCE_DATE_EPOCH` (the reproducible-builds
-/// convention) when set, otherwise stamps the current build time. Either way
-/// the date is fixed at build time, so `zig build docs` is reproducible across
-/// runs of the same build.
+/// Compute the build date (`YYYY-MM-DD`) used for the man page `.TH` field.
+/// Honors `SOURCE_DATE_EPOCH` (the reproducible-builds convention) when set,
+/// otherwise stamps the current build time. This is injected only into the
+/// on-demand doc generator (via a build option), never into the command
+/// registry — baking the wall-clock date into the registry source would bust
+/// the compile cache once per calendar day for every consuming project.
 fn computeBuildDate(b: *std.Build) []const u8 {
     const epoch_secs: u64 = blk: {
         if (b.graph.environ_map.get("SOURCE_DATE_EPOCH")) |raw| {
@@ -257,7 +258,6 @@ fn generatePluginRegistry(
 pub fn generate(b: *std.Build, exe: *std.Build.Step.Compile, zcli_dep: *std.Build.Dependency, config: GenerateConfig) GenerateError!*std.Build.Module {
     const zcli_module = zcli_dep.module("zcli");
     const app_version = readVersionFromZon(b);
-    const build_date = computeBuildDate(b);
 
     // Convert plugin configs to PluginInfo array. Each explicit plugin is
     // registered one of two ways (see PluginConfig): a built-in whose source
@@ -337,7 +337,6 @@ pub fn generate(b: *std.Build, exe: *std.Build.Step.Compile, zcli_dep: *std.Buil
         .app_name = config.app_name,
         .app_version = app_version,
         .app_description = config.app_description,
-        .build_date = build_date,
     };
 
     return buildWithPlugins(b, exe, zcli_dep, zcli_module, build_config);
@@ -369,6 +368,15 @@ pub fn generateDocs(b: *std.Build, registry_module: *std.Build.Module, zcli_dep:
     });
     doc_exe.root_module.addImport("command_registry", registry_module);
     doc_exe.root_module.addImport("zcli", zcli_module);
+
+    // The man page `.TH` date is injected here, into the doc generator only —
+    // never into the command registry — so the wall-clock date can't bust the
+    // registry/exe compile cache once per calendar day. The doc generator is
+    // built on demand (`zig build docs`), so stamping it here is free for
+    // ordinary builds.
+    const doc_options = b.addOptions();
+    doc_options.addOption([]const u8, "build_date", computeBuildDate(b));
+    doc_exe.root_module.addOptions("build_options", doc_options);
 
     const run = b.addRunArtifact(doc_exe);
     run.addArg(config.output_dir);

--- a/packages/core/src/build_utils/types.zig
+++ b/packages/core/src/build_utils/types.zig
@@ -92,11 +92,6 @@ pub const BuildConfig = struct {
     app_name: []const u8,
     app_version: []const u8,
     app_description: []const u8,
-    /// Build date stamped into the registry as `YYYY-MM-DD`, used for the man
-    /// page `.TH` date. Fixed at build time (honoring `SOURCE_DATE_EPOCH`) so
-    /// regenerating docs is reproducible. Empty only for internal test
-    /// fixtures, which never run the doc generator.
-    build_date: []const u8 = "",
 };
 
 /// The native libraries a plugin's backend needs, expressed as a hook the

--- a/packages/core/src/doc_gen_main.zig
+++ b/packages/core/src/doc_gen_main.zig
@@ -9,6 +9,7 @@
 
 const std = @import("std");
 const registry = @import("command_registry");
+const build_options = @import("build_options");
 const zcli = @import("zcli");
 const esc = @import("doc_escape.zig");
 
@@ -212,9 +213,10 @@ fn writeCommandMarkdown(allocator: std.mem.Allocator, io: std.Io, output_dir: []
 // ============================================================================
 
 fn writeManPages(allocator: std.mem.Allocator, io: std.Io, output_dir: []const u8, commands: []const CommandInfo, global_opts: []const OptionInfo) !void {
-    // The `.TH` date field (mandoc warns when it is empty). Stamped into the
-    // registry at build time, so it is stable across doc regenerations.
-    const date = registry.build_date;
+    // The `.TH` date field (mandoc warns when it is empty). Injected as a build
+    // option by `generateDocs`, so it stays out of the registry source (which
+    // must not carry a wall-clock date — see computeBuildDate).
+    const date = build_options.build_date;
     for (commands) |cmd| {
         if (cmd.hidden) continue;
         try writeCommandManPage(allocator, io, output_dir, cmd, global_opts, date);


### PR DESCRIPTION
## Problem

`computeBuildDate` stamped the man-page date into the generated registry source as `pub const build_date = "YYYY-MM-DD";` (`code_generation.zig`). With `SOURCE_DATE_EPOCH` unset it used the current wall-clock date, so the registry module's input hash changed every calendar day. The first `zig build` of a new day regenerated and recompiled the registry and relinked the exe with **zero source changes**, and made output non-reproducible for every zcli consumer.

## Fix

`build_date` is only consumed by the on-demand doc generator (`doc_gen_main.zig`, man-page `.TH` field). So:

- Removed `build_date` from the generated registry source, from `BuildConfig` (`types.zig`), and from the `generate()` path.
- Moved `computeBuildDate` into `generateDocs()`, injecting the date into the doc-gen executable via a `build_options` module (`b.addOptions`). `doc_gen_main.zig` now reads `build_options.build_date`.

The command registry no longer carries any date, so ordinary builds are reproducible and cache-stable. The date still lands in man pages, which are built only via `zig build docs` (an explicit, on-demand step).

## Verification

- `zig build` — pass
- `zig build test` — pass (all packages + examples)
- `projects/zcli` `zig build` — pass
- `zig build docs` — pass; man pages still carry the date (`.TH ZCLI 1 "2026-07-16" "zcli 0.20.0"`)

Fixes #575

🤖 Generated with [Claude Code](https://claude.com/claude-code)