### PR TITLE
fix(vterm): sync virtual_cursor_y on clear() so post-clear writes land on the top row

### DIFF
--- a/packages/vterm/src/tests/parser_test.zig
+++ b/packages/vterm/src/tests/parser_test.zig
@@ -126,6 +126,29 @@ test "clear screen" {
     }
 }
 
+test "ESC[2J then write lands on top viewport row" {
+    // Regression for #571: ESC[2J resets the cursor to (0,0) but must also
+    // re-sync virtual_cursor_y (the write path's line), otherwise text written
+    // after a bare clear lands on the pre-clear bottom line.
+    var term = try VTerm.init(testing.allocator, 10, 3);
+    defer term.deinit();
+
+    term.write("L0\nL1\nL2\nL3\nL4\n");
+    term.write("\x1b[2J");
+    term.write("HELLO");
+
+    // "HELLO" must render on the top viewport row (row 0).
+    const expected = "HELLO";
+    for (expected, 0..) |ch, x| {
+        try testing.expectEqual(@as(u21, ch), term.getCell(@intCast(x), 0).char);
+    }
+    // Rows 1 and 2 stay empty.
+    for (0..10) |x| {
+        try testing.expect(term.getCell(@intCast(x), 1).isEmpty());
+        try testing.expect(term.getCell(@intCast(x), 2).isEmpty());
+    }
+}
+
 test "clear line" {
     var term = try VTerm.init(testing.allocator, 5, 3);
     defer term.deinit();

--- a/packages/vterm/src/vterm.zig
+++ b/packages/vterm/src/vterm.zig
@@ -427,6 +427,10 @@ pub const VTerm = struct {
     pub fn clear(self: *VTerm) void {
         @memset(self.cells, Cell.empty());
         self.cursor = Position.init(0, 0);
+        // Keep the write position (virtual_cursor_y) in sync with the reset
+        // cursor, as CUP/moveCursor does — otherwise post-clear writes key off a
+        // stale virtual_cursor_y and land on the pre-clear bottom line (#571).
+        self.virtual_cursor_y = self.viewportToLogicalLine(self.cursor.y);
     }
 
     // Resize Support


### PR DESCRIPTION
## Problem

`clear()` (and the ED `ESC[2J` path that calls it) reset `self.cursor` to `(0,0)` but left `virtual_cursor_y` stale. The write path addresses cells by `virtual_cursor_y` (`setCellDirect(self.cursor.x, self.virtual_cursor_y, cell)`), so after a **bare** clear the next output landed on the pre-clear bottom viewport line instead of the top.

Repro (10x3 term): `write("L0\nL1\nL2\nL3\nL4\n")` → `write("\x1b[2J")` → `write("HELLO")` rendered `HELLO` on row 2 with rows 0-1 empty. Programs pairing `ESC[2J` with `ESC[H` were fine (CUP re-syncs), but bare `ESC[2J` — and the public `term.clear()` used by the testing package — was affected.

## Fix

`clear()` now re-derives `virtual_cursor_y` from the reset cursor row via `viewportToLogicalLine(self.cursor.y)`, exactly as `moveCursor`/CUP already do. One line, no behavior change for the `ESC[2J` + `ESC[H` case.

## Tests

Added a regression test in `packages/vterm/src/tests/parser_test.zig` asserting post-`ESC[2J` writes land on the top viewport row (verified it fails without the fix). `zig build` and `zig build test` pass from the repo root.

Fixes #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)