### PR TITLE
fix(core): accept attached short value for value-taking global options

### DIFF
--- a/packages/core/src/registry/compiled.zig
+++ b/packages/core/src/registry/compiled.zig
@@ -931,29 +931,71 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
                         }
                     }
                 } else if (!options_ended and std.mem.startsWith(u8, arg, "-") and arg.len > 2) {
-                    // Bundled shorts (-abc): consumed as globals only when
-                    // EVERY char is a boolean global — a partial match would
-                    // silently drop the other chars, and a value-taking short
-                    // can't get a value inside a bundle. Anything else stays
-                    // in `remaining` for the command's own option parser.
+                    // Mixed short bundle (GNU getopt), mirroring the command-option
+                    // parser (options/parser.zig): consume leading boolean globals
+                    // one at a time; the first value-taking global short claims the
+                    // rest of the token as an attached value (`-cval` == `-c val`),
+                    // or the next argument when it ends the token (`-vc val`). The
+                    // whole token is consumed only when it resolves entirely to
+                    // globals — a non-global leading char aborts (the token layer
+                    // can't partially consume), leaving the token in `remaining`
+                    // for the command's own option parser.
                     const short_opts = arg[1..];
-                    var all_boolean_globals = true;
+
+                    // First pass: decide whether the token is consumable without
+                    // mutating any state. Every char up to (and including) the first
+                    // value-taking global must resolve to a global; a value-taking
+                    // global ends the scan since the remainder is its value.
+                    var consumable = true;
                     for (short_opts) |short_char| {
-                        var char_is_boolean_global = false;
+                        var is_bool_global = false;
+                        var is_value_global = false;
                         inline for (global_options) |global_opt| {
-                            if (global_opt.short == short_char and global_opt.type == bool) {
-                                char_is_boolean_global = true;
+                            if (global_opt.short == short_char) {
+                                if (global_opt.type == bool) {
+                                    is_bool_global = true;
+                                } else {
+                                    is_value_global = true;
+                                }
                             }
                         }
-                        if (!char_is_boolean_global) all_boolean_globals = false;
+                        if (is_value_global) break; // rest of token is this option's value
+                        if (!is_bool_global) {
+                            consumable = false;
+                            break;
+                        }
                     }
 
-                    if (all_boolean_globals) {
+                    if (consumable) {
                         try consumed.append(context.allocator, i);
-                        for (short_opts) |short_char| {
+                        var ci: usize = 0;
+                        dispatch: while (ci < short_opts.len) : (ci += 1) {
+                            const short_char = short_opts[ci];
                             inline for (global_options) |global_opt| {
                                 if (global_opt.short == short_char) {
-                                    try dispatchGlobalOption(context, global_opt, "true", true);
+                                    if (global_opt.type == bool) {
+                                        try dispatchGlobalOption(context, global_opt, "true", true);
+                                    } else {
+                                        const attached = short_opts[ci + 1 ..];
+                                        var value: []const u8 = attached;
+                                        if (attached.len == 0) {
+                                            if (i + 1 < args.len and option_utils.isValueToken(args[i + 1])) {
+                                                i += 1;
+                                                value = args[i];
+                                                try consumed.append(context.allocator, i);
+                                            } else {
+                                                context.diagnostic = .{ .OptionMissingValue = .{
+                                                    .option_name = global_opt.name,
+                                                    .is_short = true,
+                                                    .expected_type = zcli.expectedTypeName(global_opt.type),
+                                                } };
+                                                return zcli.ZcliError.OptionMissingValue;
+                                            }
+                                        }
+                                        try dispatchGlobalOption(context, global_opt, value, true);
+                                        break :dispatch; // value claimed the rest of the token
+                                    }
+                                    break;
                                 }
                             }
                         }

--- a/packages/core/src/registry/tests.zig
+++ b/packages/core/src/registry/tests.zig
@@ -1712,6 +1712,112 @@ test "commands inherit global options" {
     try testing.expect(LocalCmd.local_seen);
 }
 
+// Test the attached short form for a value-taking global option: `-cval` must be
+// parsed identically to `-c val` and `--config=val` (issue #573). The value-taking
+// short falls into the >2-char bundle branch, which used to require every char to
+// be a boolean global and so passed `-cval` through to the command parser (which
+// has no such field) as OptionUnknown.
+test "global options: attached short value -cval and mixed bundle" {
+    const GlobalAttachedPlugin = struct {
+        var config_seen: ?[]const u8 = null;
+        var verbose_seen: ?bool = null;
+
+        pub const global_options = [_]zcli.GlobalOption{
+            zcli.option("config", []const u8, .{ .short = 'c', .default = "~/.config", .description = "Config file path" }),
+            zcli.option("verbose", bool, .{ .short = 'v', .default = false, .description = "Verbose output" }),
+        };
+
+        pub fn handleGlobalOption(_: anytype, name: []const u8, value: anytype) !void {
+            if (std.mem.eql(u8, name, "config")) {
+                if (@TypeOf(value) == []const u8) config_seen = value;
+            } else if (std.mem.eql(u8, name, "verbose")) {
+                if (@TypeOf(value) == bool) verbose_seen = value;
+            }
+        }
+    };
+
+    const TestCommand = struct {
+        pub const Args = struct {};
+        pub const Options = struct {};
+        pub fn execute(_: Args, _: Options, _: anytype) !void {}
+    };
+
+    const TestRegistry = Registry.init(.{
+        .app_name = "test-app",
+        .app_version = "1.0.0",
+        .app_description = "Test application",
+    })
+        .registerPlugin(GlobalAttachedPlugin)
+        .register("global-test", TestCommand)
+        .build();
+
+    // Case 1: bare attached short `-c/custom/path`.
+    {
+        GlobalAttachedPlugin.config_seen = null;
+        GlobalAttachedPlugin.verbose_seen = null;
+
+        var app = TestRegistry.init();
+        var stdio: zcli.Stdio = undefined;
+        stdio.init(std.testing.io);
+        var out_aw = std.Io.Writer.Allocating.init(testing.allocator);
+        defer out_aw.deinit();
+        var err_aw = std.Io.Writer.Allocating.init(testing.allocator);
+        defer err_aw.deinit();
+        stdio.stdout_override = &out_aw.writer;
+        stdio.stderr_override = &err_aw.writer;
+        const args = [_][]const u8{ "-c/custom/path", "global-test" };
+        try app.executeWithStdio(testing.allocator, std.testing.io, &(std.process.Environ.Map.init(testing.allocator)), &args, &stdio);
+
+        try testing.expect(GlobalAttachedPlugin.config_seen != null);
+        try testing.expectEqualStrings("/custom/path", GlobalAttachedPlugin.config_seen.?);
+    }
+
+    // Case 2: leading boolean global then attached value `-vc/custom/path`
+    // (GNU getopt mixed bundle: -v consumed, -c takes the rest as its value).
+    {
+        GlobalAttachedPlugin.config_seen = null;
+        GlobalAttachedPlugin.verbose_seen = null;
+
+        var app = TestRegistry.init();
+        var stdio: zcli.Stdio = undefined;
+        stdio.init(std.testing.io);
+        var out_aw = std.Io.Writer.Allocating.init(testing.allocator);
+        defer out_aw.deinit();
+        var err_aw = std.Io.Writer.Allocating.init(testing.allocator);
+        defer err_aw.deinit();
+        stdio.stdout_override = &out_aw.writer;
+        stdio.stderr_override = &err_aw.writer;
+        const args = [_][]const u8{ "-vc/custom/path", "global-test" };
+        try app.executeWithStdio(testing.allocator, std.testing.io, &(std.process.Environ.Map.init(testing.allocator)), &args, &stdio);
+
+        try testing.expectEqual(@as(?bool, true), GlobalAttachedPlugin.verbose_seen);
+        try testing.expect(GlobalAttachedPlugin.config_seen != null);
+        try testing.expectEqualStrings("/custom/path", GlobalAttachedPlugin.config_seen.?);
+    }
+
+    // Case 3: value-taking short ends the token, value in the next arg `-vc val`.
+    {
+        GlobalAttachedPlugin.config_seen = null;
+        GlobalAttachedPlugin.verbose_seen = null;
+
+        var app = TestRegistry.init();
+        var stdio: zcli.Stdio = undefined;
+        stdio.init(std.testing.io);
+        var out_aw = std.Io.Writer.Allocating.init(testing.allocator);
+        defer out_aw.deinit();
+        var err_aw = std.Io.Writer.Allocating.init(testing.allocator);
+        defer err_aw.deinit();
+        stdio.stdout_override = &out_aw.writer;
+        stdio.stderr_override = &err_aw.writer;
+        const args = [_][]const u8{ "-vc", "next-value", "global-test" };
+        try app.executeWithStdio(testing.allocator, std.testing.io, &(std.process.Environ.Map.init(testing.allocator)), &args, &stdio);
+
+        try testing.expectEqual(@as(?bool, true), GlobalAttachedPlugin.verbose_seen);
+        try testing.expect(GlobalAttachedPlugin.config_seen != null);
+        try testing.expectEqualStrings("next-value", GlobalAttachedPlugin.config_seen.?);
+    }
+}
+
 // Test global option defaults: when options are omitted the pipeline accepts
 // them silently (defaults are not errors), and the handler is not invoked for
 // absent options — only explicitly supplied values flow through the handler.


### PR DESCRIPTION
## Summary

Value-taking global short options accepted the spaced form `-c val` and the long forms `--config val` / `--config=val`, but rejected the attached short form `-cval`. The attached form fell into the `>2`-char bundle branch of `parseGlobalOptions` (`packages/core/src/registry/compiled.zig`), which required *every* char to be a boolean global. `-cval` failed that test, so `handled` stayed false and the token flowed through to the command parser, which errored with `OptionUnknown`.

This was inconsistent with both the long path (which splits `--config=v`) and the command-option parser (`options/parser.zig`), which already accepts attached values in its mixed-bundle path.

## Fix

Rework the `>2`-char branch to mirror the command parser's GNU getopt mixed-bundle semantics:

- A first, side-effect-free pass classifies the leading chars and decides whether the whole token resolves to globals (a value-taking global ends the scan since the remainder is its value; a non-global leading char aborts, leaving the token for the command parser — the token layer can't partially consume).
- The dispatch pass consumes leading boolean globals one at a time and lets the first value-taking global short claim the rest of the token as an attached value (`-cval` == `-c val`, `-vc/path` == `-v -c /path`), or the next argument when it ends the token (`-vc val`), reusing the existing `OptionMissingValue` diagnostic path.

## Tests

Added `global options: attached short value -cval and mixed bundle` in `packages/core/src/registry/tests.zig` covering the bare attached form, the leading-boolean mixed bundle, and the value-in-next-arg case. `zig build` and `zig build test` pass (core: all green).

Fixes #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)