### PR TITLE
fix(secrets): zero Windows credential plaintext blob before CredFree

### DIFF
--- a/packages/core/src/plugins/zcli_secrets/credential_manager_windows.zig
+++ b/packages/core/src/plugins/zcli_secrets/credential_manager_windows.zig
@@ -105,7 +105,14 @@ pub fn get(allocator: std.mem.Allocator, _: std.Io, _: *const std.process.Enviro
     defer CredFree(c);
 
     const blob = c.CredentialBlob orelse return try allocator.dupe(u8, "");
-    return try allocator.dupe(u8, blob[0..c.CredentialBlobSize]);
+    const plaintext = blob[0..c.CredentialBlobSize];
+    // Wipe the OS-heap plaintext before CredFree hands the buffer back to the
+    // heap — otherwise a copy of the secret lingers in freed memory (recoverable
+    // via core dump, attached debugger, or heap reuse). `secureZero` uses
+    // volatile writes so the compiler cannot elide it. Registered after the
+    // `CredFree` defer so it runs first (LIFO): wipe, then free.
+    defer std.crypto.secureZero(u8, plaintext);
+    return try allocator.dupe(u8, plaintext);
 }
 
 /// Store (or overwrite) a secret. `CredWriteW` overwrites an existing


### PR DESCRIPTION
## Summary

`CredReadW` in the `zcli_secrets` Windows Credential Manager backend returns an OS-heap buffer containing the plaintext secret. `get()` duped the bytes out for the caller but then let `CredFree` release the buffer **without wiping it**, leaving a plaintext copy of the secret in freed heap memory — recoverable via a core dump, an attached debugger, or heap reuse.

This is defense-in-depth heap hygiene (P3), and it was inconsistent with the plugin's own bar: the subprocess/Linux backends already `secureZero` every secret buffer before freeing it.

## Fix

Zero `blob[0..CredentialBlobSize]` with `std.crypto.secureZero` (volatile writes, so the compiler cannot elide it) before `CredFree` runs. The wipe `defer` is registered *after* the `CredFree` defer, so LIFO ordering guarantees wipe-then-free.

## Verification

Windows-only code, so it cannot execute on macOS, but:
- `zig test -fno-emit-bin -target x86_64-windows` on the backend file — analyzes and type-checks the Windows path clean.
- `zig build` and `zig build test` from the repo root both pass.

Fixes #579

🤖 Generated with [Claude Code](https://claude.com/claude-code)