### PR TITLE
fix(terminal): recompute Windows ResizeWatcher wait budget from a monotonic clock

### DIFF
--- a/packages/terminal/src/backend_windows.zig
+++ b/packages/terminal/src/backend_windows.zig
@@ -78,6 +78,10 @@ extern "kernel32" fn ReadConsoleInputW(hConsoleInput: HANDLE, lpBuffer: [*]INPUT
 // against 0 like the other kernel32 externs here.
 extern "kernel32" fn GetConsoleOutputCP() callconv(.winapi) UINT;
 extern "kernel32" fn SetConsoleOutputCP(wCodePageID: UINT) callconv(.winapi) c_int;
+// Monotonic millisecond clock (milliseconds since boot), for computing wait
+// deadlines that don't drift when `WaitForSingleObject` returns early on a
+// non-key console record. Libc-free, matching the rest of this backend.
+extern "kernel32" fn GetTickCount64() callconv(.winapi) u64;
 
 /// Saved console state for restoring after raw mode. Raw mode touches both the
 /// input handle (to stop line buffering/echo and turn on VT input) and the
@@ -230,12 +234,20 @@ pub const ResizeWatcher = struct {
     /// returns `.timeout`). A finite timeout lets a full-screen loop repaint
     /// on a tick with no input; the size poll runs at most one
     /// `resize_poll_ms` interval past the deadline.
+    ///
+    /// The remaining budget is recomputed from a monotonic clock rather than by
+    /// subtracting the nominal wait, so a `WaitForSingleObject` that returns
+    /// early on a non-key console record (focus/menu/buffer-size events that
+    /// `drainedToRealInput` discards) doesn't over-charge the timeout and expire
+    /// it early under a storm of such records.
     pub fn waitTimeout(self: *ResizeWatcher, handle: Handle, timeout_ms: ?u32) WaitResult {
-        var remaining: ?u32 = timeout_ms;
+        const deadline_ms: ?u64 = if (timeout_ms) |t| GetTickCount64() + t else null;
         while (true) {
-            const wait_ms: DWORD = if (remaining) |r| blk: {
-                if (r == 0) return .timeout;
-                break :blk @intCast(@min(r, @as(u32, @intCast(resize_poll_ms))));
+            const wait_ms: DWORD = if (deadline_ms) |deadline| blk: {
+                const now = GetTickCount64();
+                if (now >= deadline) return .timeout;
+                const remaining: u64 = deadline - now;
+                break :blk @intCast(@min(remaining, @as(u64, @intCast(resize_poll_ms))));
             } else @intCast(resize_poll_ms);
 
             const ready = WaitForSingleObject(handle, wait_ms) == WAIT_OBJECT_0;
@@ -245,7 +257,6 @@ pub const ResizeWatcher = struct {
                 return .resize;
             }
             if (ready and drainedToRealInput(handle)) return .input;
-            if (remaining) |*r| r.* -|= wait_ms;
         }
     }
 };


### PR DESCRIPTION
## Summary

`ResizeWatcher.waitTimeout` in the Windows terminal backend charged the full nominal `wait_ms` against the remaining deadline on every iteration, even when `WaitForSingleObject` returned early because of a non-key console record that `drainedToRealInput` discards (focus, menu, or window-buffer-size events). Under a storm of such records, a finite deadline expired noticeably early.

This ports the POSIX backend's fix (`backend_posix.zig`): the deadline is now tracked against a monotonic clock (`GetTickCount64`, libc-free like the rest of this backend) and the remaining budget is recomputed each iteration rather than decremented by the nominal wait.

## Changes

- Added a `GetTickCount64` kernel32 extern.
- `waitTimeout` computes an absolute `deadline_ms` up front and derives `wait_ms` from `deadline - now` each loop, returning `.timeout` when the deadline is reached. Dropped the now-unused `remaining -|= wait_ms` decrement.

Windows-only code; behavior on the happy path is unchanged.

## Verification

- `zig build` — passes (RC 0)
- `zig build test` — passes (RC 0)
- `zig build test -Dtarget=x86_64-windows` in `packages/terminal` — the Windows path compiles cleanly (the only failure is the macOS host being unable to *execute* the produced Windows binary, which is expected on cross-compilation).

Fixes #582

🤖 Generated with [Claude Code](https://claude.com/claude-code)