### PR TITLE
fix(vterm): map findPattern byte offsets to cell positions

### DIFF
--- a/packages/vterm/src/tests/pattern_test.zig
+++ b/packages/vterm/src/tests/pattern_test.zig
@@ -49,6 +49,52 @@ test "findPattern returns position of match" {
     try testing.expectEqual(@as(u16, 1), positions[0].y); // Line 2
 }
 
+test "findPattern reports cell position after wide (CJK) characters" {
+    var term = try VTerm.init(testing.allocator, 20, 3);
+    defer term.deinit();
+
+    // 你 and 好 each occupy 2 cells, so X lands at column 4, not byte offset 6.
+    term.write("你好X");
+
+    const positions = try term.findPattern(testing.allocator, "X");
+    defer testing.allocator.free(positions);
+
+    try testing.expectEqual(@as(usize, 1), positions.len);
+    try testing.expectEqual(@as(u16, 4), positions[0].x);
+    try testing.expectEqual(@as(u16, 0), positions[0].y);
+}
+
+test "findPattern reports cell position after multibyte (narrow) characters" {
+    var term = try VTerm.init(testing.allocator, 20, 3);
+    defer term.deinit();
+
+    // é is one cell wide but two UTF-8 bytes; the byte offset of X would be 4,
+    // while its cell column is 3.
+    term.write("café X");
+
+    const positions = try term.findPattern(testing.allocator, "X");
+    defer testing.allocator.free(positions);
+
+    try testing.expectEqual(@as(usize, 1), positions.len);
+    try testing.expectEqual(@as(u16, 5), positions[0].x); // c a f é <space> X
+    try testing.expectEqual(@as(u16, 0), positions[0].y);
+}
+
+test "findPattern maps wide content across rows to correct cell" {
+    var term = try VTerm.init(testing.allocator, 10, 3);
+    defer term.deinit();
+
+    term.write("你好\n");
+    term.write("abZcd");
+
+    const positions = try term.findPattern(testing.allocator, "Z");
+    defer testing.allocator.free(positions);
+
+    try testing.expectEqual(@as(usize, 1), positions.len);
+    try testing.expectEqual(@as(u16, 2), positions[0].x);
+    try testing.expectEqual(@as(u16, 1), positions[0].y);
+}
+
 test "containsTextIgnoreCase finds text case-insensitively" {
     var term = try VTerm.init(testing.allocator, 40, 5);
     defer term.deinit();

--- a/packages/vterm/src/vterm.zig
+++ b/packages/vterm/src/vterm.zig
@@ -1291,13 +1291,43 @@ pub const VTerm = struct {
         }
 
         if (std.mem.indexOf(u8, text, search_pattern)) |index| {
-            // Convert linear index to x,y position
-            const y = @as(u16, @intCast(index / self.width));
-            const x = @as(u16, @intCast(index % self.width));
-            try positions.append(allocator, Position{ .x = x, .y = y });
+            // `index` is a byte offset into getAllText()'s output, which UTF-8
+            // encodes multibyte glyphs and skips wide-continuation cells. Walk
+            // the grid the same way to map the byte offset back to a cell.
+            try positions.append(allocator, self.byteOffsetToPosition(index));
         }
 
         return positions.toOwnedSlice(allocator);
+    }
+
+    /// Map a byte offset in getAllText()'s output back to the terminal cell
+    /// that produced it. Mirrors getAllText()'s per-cell byte accounting so
+    /// positions stay cell-accurate for wide (CJK/emoji) and multibyte content.
+    fn byteOffsetToPosition(self: *VTerm, target: usize) Position {
+        var offset: usize = 0;
+        for (0..self.height) |y| {
+            for (0..self.width) |x| {
+                const cell = self.getCell(@intCast(x), @intCast(y));
+                if (cell.wide_continuation) {
+                    // Skipped by getAllText — consumes no bytes.
+                    continue;
+                }
+                const byte_len: usize = if (cell.char == 0 or cell.char < 128)
+                    1
+                else
+                    std.unicode.utf8CodepointSequenceLength(cell.char) catch 1;
+
+                if (target < offset + byte_len) {
+                    return Position{ .x = @intCast(x), .y = @intCast(y) };
+                }
+                offset += byte_len;
+            }
+        }
+        // Offset past the end: report the last cell.
+        return Position{
+            .x = if (self.width > 0) self.width - 1 else 0,
+            .y = if (self.height > 0) self.height - 1 else 0,
+        };
     }
 
     pub fn containsTextIgnoreCase(self: *VTerm, text: []const u8) bool {


### PR DESCRIPTION
Fixes #583

## Problem

`VTerm.findPattern` converted the match index into an `(x, y)` cell position with `index / self.width` and `index % self.width`. But that index is a **byte** offset into `getAllText()`'s output, which UTF-8-encodes multibyte glyphs (multiple bytes per cell) and skips wide-continuation cells. Dividing a byte offset by cell width gives wrong coordinates for any non-ASCII content.

Repro: `write("你好X")` on a 20-wide term → `findPattern("X")` reported `x=6` (byte offset) instead of `x=4` (你/好 are 2 cells each). Existing tests were ASCII-only, where byte index == column by luck.

## Fix

Added `byteOffsetToPosition`, which walks the grid mirroring `getAllText()`'s per-cell byte accounting (skip wide-continuation cells; 1 byte for NUL/ASCII, otherwise the codepoint's UTF-8 sequence length) to recover the exact cell that produced a byte offset. `findPattern` now uses it, so positions are cell-accurate for wide (CJK, emoji) and multibyte (accented Latin) content.

## Tests

Added three `pattern_test.zig` cases covering wide CJK, narrow multibyte (`é`), and wide content spanning rows. `zig build` and `zig build test` pass from the repo root (vterm: 137/137; full suite green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)