### PR TITLE
fix(completions): align option spec lookup with global-first precedence

### DIFF
--- a/packages/core/src/plugin_completions_test.zig
+++ b/packages/core/src/plugin_completions_test.zig
@@ -208,6 +208,55 @@ test "resolve - a positional field with no .complete yields nothing" {
     try expectNoResolve(&.{ "tasks", "list", "" }, 2);
 }
 
+// A command option colliding with a global on long name AND short char, differing
+// in both `takes_value` and `complete`. The resolver's arity walk and its spec
+// lookup must agree on precedence; the runtime parser extracts globals first, so
+// the collision resolves to the GLOBAL definition (issue #577). Two distinct
+// hooks let the test tell which definition won.
+fn globalHook(_: *zcli.completion.Request) anyerror!zcli.completion.Result {
+    return .{};
+}
+fn commandHook(_: *zcli.completion.Request) anyerror!zcli.completion.Result {
+    return .{};
+}
+
+test "resolve - option name collision resolves to the global (arity + spec agree)" {
+    // Global `--out`/`-o` takes a value and has globalHook; command `gen`'s
+    // `--out`/`-o` is a valueless boolean with commandHook. Completing the token
+    // after `--out` must (a) treat it as the option's value, not a positional
+    // (global-first arity), and (b) complete with the global's hook (global-first
+    // spec). A command-first order would classify `--out` as boolean and shift the
+    // slot, completing against the wrong definition.
+    const collide_globals = [_]zcli.OptionInfo{
+        .{ .name = "out", .short = 'o', .takes_value = true, .complete = .{ .hook = globalHook } },
+    };
+    const gen_opts = [_]zcli.OptionInfo{
+        .{ .name = "out", .short = 'o', .takes_value = false, .complete = .{ .hook = commandHook } },
+    };
+    const gen_args = [_]zcli.ArgInfo{.{ .name = "target", .complete = hook_spec }};
+    const collide_commands = [_]zcli.CommandInfo{
+        .{ .path = &.{"gen"}, .options = &gen_opts, .args = &gen_args },
+    };
+
+    // Long form: `tasks gen --out <TAB>`.
+    {
+        const m = (try resolve.resolve(std.testing.allocator, &collide_commands, &collide_globals, &.{ "tasks", "gen", "--out", "" }, 3)) orelse return error.NoMatch;
+        defer std.testing.allocator.free(m.positionals);
+        try std.testing.expectEqual(@as(usize, 0), m.positionals.len);
+        try std.testing.expect(m.spec == .hook);
+        try std.testing.expectEqual(&globalHook, m.spec.hook);
+    }
+
+    // Short form: `tasks gen -o <TAB>`.
+    {
+        const m = (try resolve.resolve(std.testing.allocator, &collide_commands, &collide_globals, &.{ "tasks", "gen", "-o", "" }, 3)) orelse return error.NoMatch;
+        defer std.testing.allocator.free(m.positionals);
+        try std.testing.expectEqual(@as(usize, 0), m.positionals.len);
+        try std.testing.expect(m.spec == .hook);
+        try std.testing.expectEqual(&globalHook, m.spec.hook);
+    }
+}
+
 test "resolve - cursor on the command name is not dynamic" {
     try expectNoResolve(&.{ "tasks", "ed" }, 1);
 }

--- a/packages/core/src/plugins/zcli_completions/resolve.zig
+++ b/packages/core/src/plugins/zcli_completions/resolve.zig
@@ -134,8 +134,13 @@ pub fn resolve(
 }
 
 /// The completion `Spec` of the option named by `tok` (a `--long` or `-x` flag,
-/// optionally with a trailing `=`), looked up in the command's options then the
-/// globals, or null when unknown / no completion declared.
+/// optionally with a trailing `=`), or null when unknown / no completion
+/// declared. Globals are consulted before command options — the same
+/// global-first precedence `optionTakesSeparateValue` uses, matching the runtime
+/// parser, which extracts global options from argv before command routing so a
+/// name/short collision resolves to the global. The two lookups must agree or the
+/// cursor walk can miscount positional slots (arity) while completing against the
+/// other definition (spec).
 fn optionSpecFor(
     tok: []const u8,
     global_options: []const zcli.OptionInfo,
@@ -143,14 +148,14 @@ fn optionSpecFor(
 ) ?zcli.completion.Spec {
     if (std.mem.startsWith(u8, tok, "--")) {
         const name = tok[2..];
-        if (lookupLong(cmd_options, name)) |o| return o.complete;
         if (lookupLong(global_options, name)) |o| return o.complete;
+        if (lookupLong(cmd_options, name)) |o| return o.complete;
         return null;
     }
     if (tok.len == 2 and tok[0] == '-') {
         const ch = tok[1];
-        if (lookupShort(cmd_options, ch)) |o| return o.complete;
         if (lookupShort(global_options, ch)) |o| return o.complete;
+        if (lookupShort(cmd_options, ch)) |o| return o.complete;
     }
     return null;
 }


### PR DESCRIPTION
## Problem

The dynamic completion resolver (`zcli_completions/resolve.zig`) disagreed with itself on global-vs-command option precedence:

- `optionTakesSeparateValue` (arity) resolved **global-first**
- `optionSpecFor` (spec) resolved **command-first**

Both run in the same `resolve()` cursor walk. When a command option collides with a global option on long name (or short char) and they differ in `takes_value`/`complete`, the walk could miscount positional slots while completing against the *other* definition — producing wrong dynamic completions.

## Root cause & fix

The runtime parser (`registry/compiled.zig` `parseGlobalOptions`) extracts global options from the entire argv **before** command routing, so on a name/short collision the global option wins. That makes **global-first** the runtime-correct precedence, so the arity lookup was already right and the spec lookup was the inconsistent one.

This flips `optionSpecFor` to consult globals before command options (both long and short forms), so the two lookups share one consistent order that matches actual parsing. Added a resolver test covering a long+short collision differing in both arity and completion hook.

## Verification

`zig build` and `zig build test` pass from the repo root.

Fixes #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)