### PR TITLE
fix(completions/bash): skip command-scoped value-option values in the command path

### DIFF
--- a/packages/core/src/plugin_completions_test.zig
+++ b/packages/core/src/plugin_completions_test.zig
@@ -868,8 +868,16 @@ const gopt_globals = [_]zcli.OptionInfo{
     .{ .name = "config", .short = 'c', .description = "Config file", .takes_value = true },
 };
 
+// A command set with NO value-taking options anywhere (so the look-ahead patterns
+// come only from the globals). `sprint create` is a nested pure-group leaf; `list`
+// declares an enum positional but no options.
+const no_value_opt_commands = [_]zcli.CommandInfo{
+    .{ .path = &.{"list"}, .description = "List tasks", .args = &list_args },
+    .{ .path = &.{ "sprint", "create" }, .description = "Create a sprint" },
+};
+
 test "bash gen - value-taking global option skips its value in the command path" {
-    const script = try bash.generate(std.testing.allocator, app_name, &commands, &gopt_globals);
+    const script = try bash.generate(std.testing.allocator, app_name, &no_value_opt_commands, &gopt_globals);
     defer std.testing.allocator.free(script);
 
     // The look-ahead skip machinery is emitted...
@@ -880,11 +888,109 @@ test "bash gen - value-taking global option skips its value in the command path"
     try std.testing.expect(!contains(script, "'--verbose'"));
 }
 
-test "bash gen - no skip machinery when no global option takes a value" {
-    // The default `global_options` fixture is all-boolean → no look-ahead case.
-    const script = try bash.generate(std.testing.allocator, app_name, &commands, &global_options);
+test "bash gen - no skip machinery when no option takes a value" {
+    // Both the `global_options` fixture and `no_value_opt_commands` are value-free
+    // → no look-ahead case at all.
+    const script = try bash.generate(std.testing.allocator, app_name, &no_value_opt_commands, &global_options);
     defer std.testing.allocator.free(script);
     try std.testing.expect(!contains(script, "skip_val=1"));
+}
+
+// ============================================================================
+// Layer 3b': value-taking COMMAND-scoped option before a positional (issue #578).
+// A command-scoped `--target prod` must have its VALUE skipped too, or `prod`
+// pollutes the command path and the command's static positional completions die.
+// ============================================================================
+
+const scoped_envs = [_][]const u8{ "staging", "production" };
+// `deploy` has a value-taking option (`--target`) AND a static enum positional.
+const scoped_deploy_opts = [_]zcli.OptionInfo{
+    .{ .name = "target", .short = 't', .description = "Deploy target", .takes_value = true },
+};
+const scoped_deploy_args = [_]zcli.ArgInfo{
+    .{ .name = "env", .description = "Environment", .enum_values = &scoped_envs },
+};
+const scoped_commands = [_]zcli.CommandInfo{
+    .{ .path = &.{"deploy"}, .description = "Deploy", .options = &scoped_deploy_opts, .args = &scoped_deploy_args },
+};
+
+test "bash gen - value-taking command option skips its value in the command path (issue #578)" {
+    const script = try bash.generate(std.testing.allocator, app_name, &scoped_commands, &global_options);
+    defer std.testing.allocator.free(script);
+
+    // The command-scoped value option's long AND short forms are recognised by the
+    // command-path look-ahead — even though `--target` is not a GLOBAL option.
+    try std.testing.expect(contains(script, "'--target'|'-t') skip_val=1"));
+}
+
+test "functional bash - value-taking command option preserves static positional completion (issue #578)" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const sh = findShell("bash") orelse return error.SkipZigTest;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const script = try bash.generate(a, app_name, &scoped_commands, &global_options);
+    const script_path = try writeTemp(a, tmp.dir, "zcli_scoped_completion.bash", script);
+
+    // Drive completion with a command-scoped value option (`--target h1`) before the
+    // positional. The value `h1` must be skipped so the command path resolves to
+    // `deploy` (not `deploy h1`) and the enum positional's choices are offered.
+    // The separate-word (`--target h1` / `-t h1`) and `=`-joined forms must all work.
+    const harness = try std.fmt.allocPrint(a,
+        \\source "{s}"
+        \\
+        \\run() {{
+        \\    COMP_WORDS=("$@")
+        \\    COMP_CWORD=$(( ${{#COMP_WORDS[@]}} - 1 ))
+        \\    COMPREPLY=()
+        \\    _tasks_completions
+        \\    echo "${{COMPREPLY[@]}}"
+        \\}}
+        \\
+        \\echo "LONG:$(run tasks deploy --target h1 '')"
+        \\echo "SHORT:$(run tasks deploy -t h1 '')"
+        \\echo "EQ:$(run tasks deploy --target=h1 '')"
+        \\echo "PLAIN:$(run tasks deploy '')"
+        \\
+    , .{script_path});
+    const harness_path = try writeTemp(a, tmp.dir, "zcli_scoped_harness.bash", harness);
+
+    const result = try std.process.run(a, io, .{
+        .argv = &.{ sh, harness_path },
+    });
+    const out = result.stdout;
+
+    var long_line: ?[]const u8 = null;
+    var short_line: ?[]const u8 = null;
+    var eq_line: ?[]const u8 = null;
+    var plain_line: ?[]const u8 = null;
+    var lines = std.mem.splitScalar(u8, out, '\n');
+    while (lines.next()) |line| {
+        if (std.mem.startsWith(u8, line, "LONG:")) long_line = line["LONG:".len..];
+        if (std.mem.startsWith(u8, line, "SHORT:")) short_line = line["SHORT:".len..];
+        if (std.mem.startsWith(u8, line, "EQ:")) eq_line = line["EQ:".len..];
+        if (std.mem.startsWith(u8, line, "PLAIN:")) plain_line = line["PLAIN:".len..];
+    }
+
+    try std.testing.expect(long_line != null);
+    try std.testing.expect(short_line != null);
+    try std.testing.expect(eq_line != null);
+    try std.testing.expect(plain_line != null);
+
+    // Every form keys to `deploy` and offers the enum positional's choices — the
+    // #578 bug keyed to `deploy h1`, matched no positional case, and offered none.
+    try std.testing.expect(contains(long_line.?, "staging"));
+    try std.testing.expect(contains(long_line.?, "production"));
+    try std.testing.expect(contains(short_line.?, "staging"));
+    try std.testing.expect(contains(short_line.?, "production"));
+    try std.testing.expect(contains(eq_line.?, "staging"));
+    try std.testing.expect(contains(eq_line.?, "production"));
+    // Sanity: with no option at all the positional still completes.
+    try std.testing.expect(contains(plain_line.?, "staging"));
 }
 
 test "powershell gen - value-taking global option skips its value in the command path" {

--- a/packages/core/src/plugins/zcli_completions/bash.zig
+++ b/packages/core/src/plugins/zcli_completions/bash.zig
@@ -50,21 +50,26 @@ pub fn generate(
     try writer.writeAll("    fi\n\n");
 
     // Build the command path key: non-option words between app name and cursor.
-    // A value-taking global option (e.g. `--config x.json`) is followed by its
-    // VALUE, which is NOT a command word — skip it so the value never becomes
-    // the key. The `--opt=value` form carries its value in the same token (which
-    // is already skipped as an option word), so only the separate-word form
-    // needs the look-ahead.
+    // A value-taking option (e.g. a global `--config x.json` or a command-scoped
+    // `--target prod`) is followed by its VALUE, which is NOT a command word —
+    // skip it so the value never becomes the key. The `--opt=value` form carries
+    // its value in the same token (which is already skipped as an option word),
+    // so only the separate-word form needs the look-ahead. The loop runs before
+    // the command is known, so the patterns cover EVERY value-taking option —
+    // global AND command-scoped, anywhere in the tree — matching the same
+    // pragmatic "keyed regardless of command path" simplification used by the
+    // `$prev` option-value cases below (option names rarely collide).
+    const value_opts = try collectValueTakingOptions(arena, root, global_options);
     try writer.writeAll("    local cmd_path=()\n");
     try writer.writeAll("    local i skip_val=0\n");
     try writer.writeAll("    for ((i=1; i<cword; i++)); do\n");
     try writer.writeAll("        if [[ $skip_val == 1 ]]; then skip_val=0; continue; fi\n");
     try writer.writeAll("        if [[ \"${words[i]}\" == -* ]]; then\n");
-    if (anyValueTakingOption(global_options)) {
+    if (value_opts.len > 0) {
         // A bare value-taking option word consumes the NEXT word as its value.
         try writer.writeAll("            case \"${words[i]}\" in\n");
         try writer.writeAll("                ");
-        try writeValueOptionPatterns(arena, writer, global_options);
+        try writeValueOptionPatterns(arena, writer, value_opts);
         try writer.writeAll(") skip_val=1 ;;\n");
         try writer.writeAll("            esac\n");
     }
@@ -148,12 +153,43 @@ pub fn generate(
     return al.toOwnedSlice(allocator);
 }
 
-/// True if any option in the set takes a value (so a bare `--opt <value>` on the
-/// command line consumes the following word — which must not be mistaken for a
-/// command word when reconstructing the command path).
-fn anyValueTakingOption(options: []const zcli.OptionInfo) bool {
-    for (options) |opt| if (opt.takes_value) return true;
-    return false;
+/// Collect every value-taking option — the global options plus every command's
+/// options anywhere in the tree — into one list, deduplicated by long name. The
+/// command-path loop consumes a value-taking option's separate-word value before
+/// it knows which command it is in, so it must recognise ALL of them (not just
+/// the globals); otherwise a command-scoped `--target prod` leaks `prod` into the
+/// command path and kills that command's static positional completions.
+fn collectValueTakingOptions(
+    arena: std.mem.Allocator,
+    node: *const tree.CommandNode,
+    global_options: []const zcli.OptionInfo,
+) ![]const zcli.OptionInfo {
+    var out = std.ArrayList(zcli.OptionInfo).empty;
+    try addValueTakingOptions(arena, &out, global_options);
+    try addValueTakingOptionsRec(arena, &out, node);
+    return out.items;
+}
+
+fn addValueTakingOptionsRec(
+    arena: std.mem.Allocator,
+    out: *std.ArrayList(zcli.OptionInfo),
+    node: *const tree.CommandNode,
+) !void {
+    try addValueTakingOptions(arena, out, node.options);
+    for (node.children) |child| try addValueTakingOptionsRec(arena, out, child);
+}
+
+fn addValueTakingOptions(
+    arena: std.mem.Allocator,
+    out: *std.ArrayList(zcli.OptionInfo),
+    options: []const zcli.OptionInfo,
+) !void {
+    for (options) |opt| {
+        if (!opt.takes_value) continue;
+        for (out.items) |existing| {
+            if (std.mem.eql(u8, existing.name, opt.name)) break;
+        } else try out.append(arena, opt);
+    }
 }
 
 /// Emit `'--name'|'-s'` case patterns (joined with `|`) for every value-taking


### PR DESCRIPTION
Fixes #578

## Root cause

The generated bash completion function reconstructs the command-path `$key` by
walking the words before the cursor and skipping option words. A value-taking
option's *separate-word value* (`--target prod` → `prod`) is not a command word,
so it must also be skipped. The look-ahead that did this was only emitted for
**global** value-taking options (`anyValueTakingOption(global_options)` /
`writeValueOptionPatterns(..., global_options)`).

A **command-scoped** value-taking option was skipped as an option word, but its
value fell through to `cmd_path+=("${words[i]}")`. So `app deploy --target prod <TAB>`
built `key="deploy prod"`, which matched no `case "$key"` positional case, and the
command's static enum/`.file`/`.dir` positional completions were silently lost. The
dynamic `__complete` path was unaffected (it re-parses full argv in `resolve.zig`),
which is why the blast radius was limited to static positionals behind a
command-scoped value option (P3).

## Fix

Collect every value-taking option — the global options **plus every command's
options anywhere in the tree**, deduplicated by long name — and emit the
command-path look-ahead patterns for all of them. The loop runs before the command
is known, so recognising all value-taking option names is the correct behavior;
this mirrors the existing "keyed regardless of command path" pragmatic
simplification already used by the `$prev` static-option-value cases. Only bash was
affected (issue is bash-scoped); zsh/fish/powershell generators are untouched.

## Tests

- New structural test: a command-scoped `--target`/`-t` now appears in the
  `skip_val=1` look-ahead patterns.
- New functional bash test: `deploy --target h1 <TAB>` / `-t h1` / `--target=h1`
  all key to `deploy` and still offer the enum positional's choices.
- Updated the two existing skip-machinery tests to use value-free fixtures so they
  assert exactly what they intend (a value-taking command option in the default
  fixture now — correctly — produces skip machinery).

`zig build` and `zig build test` pass from the repo root (full suite green,
including the real-shell functional bash tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)