### PR TITLE
fix(zcli): reject duplicate names in batch rm arg/option

### DIFF
--- a/projects/zcli/src/commands/rm/arg.zig
+++ b/projects/zcli/src/commands/rm/arg.zig
@@ -58,6 +58,19 @@ pub fn execute(args: Args, _: Options, context: *Context) !void {
         };
     }
 
+    // Reject duplicates up front: the removal loop strips each field once, so a
+    // repeated name would remove it on the first pass and fail on the second.
+    const dups = try splice.duplicateFields(arena, names);
+    if (dups.len > 0) {
+        var msg = std.Io.Writer.Allocating.init(arena);
+        try msg.writer.print("Error: argument name listed more than once: ", .{});
+        for (dups, 0..) |d, i| {
+            if (i > 0) try msg.writer.print(", ", .{});
+            try msg.writer.print("'{s}'", .{d});
+        }
+        return context.fail("{s}", .{msg.written()});
+    }
+
     const raw = std.Io.Dir.cwd().readFileAlloc(io, file_path, arena, .limited(max_source_bytes)) catch {
         return context.fail("Error: Command not found: {s}", .{file_path});
     };

--- a/projects/zcli/src/commands/rm/option.zig
+++ b/projects/zcli/src/commands/rm/option.zig
@@ -58,6 +58,19 @@ pub fn execute(args: Args, _: Options, context: *Context) !void {
         };
     }
 
+    // Reject duplicates up front: the removal loop strips each field once, so a
+    // repeated name would remove it on the first pass and fail on the second.
+    const dups = try splice.duplicateFields(arena, names);
+    if (dups.len > 0) {
+        var msg = std.Io.Writer.Allocating.init(arena);
+        try msg.writer.print("Error: option name listed more than once: ", .{});
+        for (dups, 0..) |d, i| {
+            if (i > 0) try msg.writer.print(", ", .{});
+            try msg.writer.print("'{s}'", .{d});
+        }
+        return context.fail("{s}", .{msg.written()});
+    }
+
     const raw = std.Io.Dir.cwd().readFileAlloc(io, file_path, arena, .limited(max_source_bytes)) catch {
         return context.fail("Error: Command not found: {s}", .{file_path});
     };

--- a/projects/zcli/src/scaffold/splice.zig
+++ b/projects/zcli/src/scaffold/splice.zig
@@ -111,6 +111,31 @@ pub fn missingFields(arena: std.mem.Allocator, source: [:0]const u8, container: 
     return missing.items;
 }
 
+/// The `targets` that appear more than once, each reported a single time in the
+/// order of its first repeat. Lets a bulk `rm` reject a batch that would
+/// otherwise strip a field on the first pass and hit `FieldNotFound` on the
+/// second.
+pub fn duplicateFields(arena: std.mem.Allocator, targets: []const []const u8) ![]const []const u8 {
+    var dups = std.ArrayList([]const u8).empty;
+    for (targets, 0..) |t, i| {
+        var already = false;
+        for (dups.items) |d| {
+            if (std.mem.eql(u8, d, t)) {
+                already = true;
+                break;
+            }
+        }
+        if (already) continue;
+        for (targets[i + 1 ..]) |other| {
+            if (std.mem.eql(u8, other, t)) {
+                try dups.append(arena, t);
+                break;
+            }
+        }
+    }
+    return dups.items;
+}
+
 /// The ordering-relevant shape of an existing `Args`/`Options` field.
 pub const FieldShape = struct {
     name: []const u8,
@@ -561,6 +586,23 @@ test "removing an absent field errors" {
     defer arena.deinit();
     const a = arena.allocator();
     try testing.expectError(SpliceError.FieldNotFound, removeOption(a, shell, "ghost"));
+}
+
+test "duplicateFields reports each repeated name once, in first-repeat order" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    try testing.expectEqual(@as(usize, 0), (try duplicateFields(a, &.{ "a", "b", "c" })).len);
+
+    const dups = try duplicateFields(a, &.{ "region", "retries", "region", "region" });
+    try testing.expectEqual(@as(usize, 1), dups.len);
+    try testing.expectEqualStrings("region", dups[0]);
+
+    const many = try duplicateFields(a, &.{ "x", "y", "x", "y", "z" });
+    try testing.expectEqual(@as(usize, 2), many.len);
+    try testing.expectEqualStrings("x", many[0]);
+    try testing.expectEqualStrings("y", many[1]);
 }
 
 test "duplicate field is rejected" {


### PR DESCRIPTION
## Problem

`missingFields` validates that every requested name exists but does not dedupe the batch. The removal loop `try`s `splice.removeOption`/`removeArg` per entry, so a duplicated name (`zcli rm option deploy region region`) removes the field on the first pass and hits `SpliceError.FieldNotFound` on the second — which propagated uncaught out of `execute`, printing `error: FieldNotFound` plus a raw Zig stack trace. Verified live for both `rm option` and `rm arg`.

## Fix

- Add `splice.duplicateFields(arena, targets)` — returns each repeated name once, in first-repeat order.
- In both `rm/option.zig` and `rm/arg.zig`, check the *normalized* batch for duplicates right after normalization and, if any exist, exit cleanly via `context.fail` with a friendly diagnostic — consistent with every other validation path in these commands.

No data was ever at risk (the raw error fired before `writeFileAtomic`); this only replaces the crash with a clean message.

## Tests

- New `duplicateFields` unit test in `splice.zig` (empty case, single repeat reported once, multiple repeats in order).
- `zig build` + `zig build test` pass at the repo root and in `projects/zcli`.

Fixes #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)