### PR TITLE
fix(ui): align TextInput caret when scroll splits a wide grapheme

### DIFF
--- a/packages/ui/src/input_helpers.zig
+++ b/packages/ui/src/input_helpers.zig
@@ -43,9 +43,16 @@ pub fn utf8Count(s: []const u8) usize {
     return n;
 }
 
-/// The byte offset in `text` at which the cumulative display width first
-/// reaches `target_col` — the left edge of a horizontally scrolled field.
-pub fn byteAtColumn(text: []const u8, target_col: u16) usize {
+/// The left edge of a horizontally scrolled field: the byte offset in `text` at
+/// which the cumulative display width first reaches `target_col`, paired with the
+/// actual column that offset lands on. Graphemes are never split, so when a
+/// wide-cell grapheme straddles `target_col` the whole grapheme is stepped over
+/// and `col` overshoots to the first column *past* it (`col >= target_col`).
+/// Callers must anchor their caret math on `col`, not `target_col`, to stay
+/// aligned with what is painted.
+pub const ColumnStart = struct { byte: usize, col: u16 };
+
+pub fn byteAtColumn(text: []const u8, target_col: u16) ColumnStart {
     var col: u16 = 0;
     var i: usize = 0;
     while (i < text.len and col < target_col) {
@@ -53,7 +60,7 @@ pub fn byteAtColumn(text: []const u8, target_col: u16) usize {
         col += @intCast(terminal.displayWidth(text[i..end]));
         i = end;
     }
-    return i;
+    return .{ .byte = i, .col = col };
 }
 
 // ============================================================================

--- a/packages/ui/src/input_test.zig
+++ b/packages/ui/src/input_test.zig
@@ -1183,6 +1183,28 @@ test "TextInput caret reports the scrolled column" {
     try testing.expectEqual(@as(u16, 3), caret.?.x);
 }
 
+test "TextInput caret stays aligned when scroll splits a wide grapheme" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var buf: [32]u8 = undefined;
+    var ti = TextInput{ .buffer = &buf };
+    // "a世界": 'a' at col 0, '世' at cols 1-2, '界' at cols 3-4 → cursor_col 5.
+    for ([_]u21{ 'a', '世', '界' }) |c| _ = ti.handle(.{ .char = c });
+
+    var caret: ?ui.Point = null;
+    var s = try ui.Surface.init(testing.allocator, 4, 1); // width 4 → scroll 2
+    defer s.deinit();
+    try renderNode(a, try ti.view(a, .{ .focused = true, .cursor_out = &caret }), &s);
+
+    // scroll 2 falls inside '世' (cols 1-2); it is stepped over whole, so the
+    // painted left edge is '界' at actual column 3. The caret (cursor_col 5)
+    // must anchor on that edge → column 2, in line with the drawn '界'.
+    try testing.expectEqual(@as(u16, 2), caret.?.x);
+    try testing.expectEqualStrings("界  ", try rowString(a, &s, 0));
+}
+
 test "unfocused TextInput reports no caret" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();

--- a/packages/ui/src/text_input.zig
+++ b/packages/ui/src/text_input.zig
@@ -175,11 +175,14 @@ const FieldView = struct {
         // Scroll horizontally so the caret stays in view (right-anchored once
         // the text outgrows the field).
         const scroll: u16 = if (self.cursor_col < w) 0 else self.cursor_col - w + 1;
-        const start = byteAtColumn(self.text, scroll);
-        _ = try region.writeText(0, 0, self.text[start..], self.text_style);
+        // A wide grapheme straddling `scroll` is stepped over whole, so the
+        // painted left edge (`edge.col`) can sit past `scroll`; anchor the caret
+        // on that actual column so it lines up with what was drawn.
+        const edge = byteAtColumn(self.text, scroll);
+        _ = try region.writeText(0, 0, self.text[edge.byte..], self.text_style);
         if (!self.focused) return;
 
-        const vis_col = self.cursor_col - scroll;
+        const vis_col = self.cursor_col - edge.col;
         if (self.cursor_out) |out| {
             // Report the caret's absolute cell for a real terminal cursor; no
             // block (the App draws the cursor there instead).


### PR DESCRIPTION
Fixes #584

## Problem

`FieldView.renderFn` computes the caret's visible column as `cursor_col - scroll`, where `scroll` is the *desired* left-edge column. But `byteAtColumn` never splits a grapheme — when `scroll` falls inside a 2-cell CJK/emoji grapheme (its first cell at `scroll - 1`), the whole grapheme is stepped over and the painted left edge lands one column *past* `scroll`. The caret math then disagrees with what was drawn, misplacing the reverse-video caret by one column when typing wide characters into a field narrower than its content.

## Fix

`byteAtColumn` now returns a `ColumnStart { byte, col }` reporting the actual column its byte offset lands on. The renderer anchors `vis_col` on `edge.col` instead of `scroll`, so the caret lines up with the painted content. Because a grapheme is at most 2 cells wide and the cursor is always on a grapheme boundary, `edge.col` never overshoots `cursor_col`, so `vis_col` stays in `[0, w)`.

## Tests

Added `TextInput caret stays aligned when scroll splits a wide grapheme` covering the CJK boundary case (previously only ASCII scroll was tested). `zig build`, `zig build test` (root), and `zig build e2e` (projects/zcli) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)