### PR TITLE
fix(ui): paint orphan continuation cells so the cursor stays in lockstep

### DIFF
--- a/packages/ui/src/diff.zig
+++ b/packages/ui/src/diff.zig
@@ -182,18 +182,17 @@ const EmitState = struct {
         self.cur_style = style;
     }
 
-    /// Emit the cells first..=last of `row`, skipping continuations (their
-    /// head's grapheme paints both columns).
+    /// Emit the cells first..=last of `row`. A wide grapheme's head advances
+    /// `x` by 2, stepping over its continuation cell so both columns are
+    /// painted by the head's write. An orphan continuation — reachable only
+    /// when a span begins mid-character during a full repaint of a
+    /// blank-headed row — falls through to the general path below, which
+    /// paints it as a styled space (`text_len == 0`) and advances one column
+    /// (`@max(c.width, 1)`), keeping `cur_col` in lockstep with the model.
     fn emitCells(self: *EmitState, s: *const Surface, row: u16, first: u16, last: u16) !void {
         var x = first;
         while (x <= last) {
             const c = s.cell(x, row);
-            if (c.isContinuation()) {
-                // Only reachable when a span begins mid-character during a
-                // full repaint of a blank-headed row; paint it as a space.
-                x += 1;
-                continue;
-            }
             try self.setStyle(c.style);
             if (c.text_len == 0) {
                 try self.writer.writeByte(' ');
@@ -283,6 +282,26 @@ test "diff never extends a span past the surface edge on a torn wide head" {
     const out = try paintToString(testing.allocator, .{ .capability = .ansi_16, .sync = false }, &prev, &next);
     defer testing.allocator.free(out);
     try testing.expect(out.len > 0);
+}
+
+test "span starting on an orphan continuation paints a space so the cursor stays in lockstep" {
+    var prev = try Surface.init(testing.allocator, 4, 1);
+    defer prev.deinit();
+    var next = try Surface.init(testing.allocator, 4, 1);
+    defer next.deinit();
+    // Synthesize an orphan continuation at column 0: a width-0 cell with no
+    // head to its left. `paintRowDiff` cannot back `first` off column 0
+    // (the `first > 0` guard), so `emitCells` begins the span on the
+    // continuation itself. It must paint a space and advance `cur_col`, or the
+    // following real cell would be written one column too far left.
+    next.cells[0] = .{ .width = 0 };
+    _ = try next.root().writeText(1, 0, "X", .{});
+
+    const out = try paintToString(testing.allocator, .{ .capability = .no_color, .sync = false }, &prev, &next);
+    defer testing.allocator.free(out);
+    // The continuation renders as a space, immediately followed by the head of
+    // the next cell — no shift.
+    try testing.expect(std.mem.indexOf(u8, out, " X") != null);
 }
 
 test "no_color paints text but never SGR" {


### PR DESCRIPTION
## Summary

`EmitState.emitCells` in `packages/ui/src/diff.zig` had a continuation branch that contradicted its own comment. The comment said "paint it as a space", but the code did `x += 1; continue;` — painting nothing and, crucially, never advancing `self.cur_col` (contrast the normal path's `self.cur_col += @max(c.width, 1)`). If a span ever began on an orphan continuation cell, the terminal cursor would lag the model by one column and shift the rest of the row's span.

## Root cause

A wide grapheme's head (width 2) writes its grapheme and advances `x` by 2, stepping over its continuation cell — so in normal flow a continuation is never visited. The `isContinuation()` branch was only reachable when a span *starts* on an orphan continuation (e.g. a width-0 cell at column 0, which `paintRowDiff` cannot back `first` off of because of its `first > 0` guard). In that defensive case the branch emitted no space and left `cur_col` stale.

## Fix

Drop the dead special-case and let the general path handle it. A continuation cell always has `text_len == 0` (so the general path writes a styled space) and `@max(c.width, 1) == 1` (so it advances exactly one column) — precisely the behavior the comment described. In-span continuations are still never double-painted, since the head steps `x` past its own continuation.

Added a regression test (`span starting on an orphan continuation paints a space so the cursor stays in lockstep`) that synthesizes an orphan continuation at column 0 and asserts the emitted bytes contain the space immediately followed by the next cell's head (no shift).

## Testing

- `zig build` (repo root) — passes
- `zig build test` (repo root) — passes
- `zig build e2e` (projects/zcli) — passes

Fixes #585

🤖 Generated with [Claude Code](https://claude.com/claude-code)