### PR TITLE
fix(ui): hit-test Table.rowAt against the scroll actually rendered

### DIFF
--- a/packages/ui/src/input_test.zig
+++ b/packages/ui/src/input_test.zig
@@ -393,6 +393,40 @@ test "Table rowAt maps a click through the header offset and scroll window" {
     try testing.expectEqual(@as(?usize, null), t.rowAt(rect, 4)); // still the header
 }
 
+test "Table rowAt hit-tests against the scroll view derived (not the stale one)" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // 30 rows, one column. Enough to scroll a small window well down the list.
+    const grid = try a.alloc([]const []const u8, 30);
+    for (grid, 0..) |*row, i| {
+        const cell = try std.fmt.allocPrint(a, "{d}", .{i});
+        row.* = try a.dupe([]const u8, &.{cell});
+    }
+    const cols = [_]Table.Column{.{ .header = "N" }};
+
+    // The documented case `view`'s re-derive exists for: a caller sets `highlighted`
+    // directly (here row 25), leaving the persistent `scroll` at its stale 0. Before
+    // the fix, `rowAt` mapped the first body click through scroll=0 → row 0, while the
+    // frame actually painted rows 18-25 (scrollFor(0, 25, 8, 30) == 18).
+    var t = Table{};
+    t.highlighted = 25;
+
+    var s = try ui.Surface.init(testing.allocator, 4, 10);
+    defer s.deinit();
+    // Rendering derives the window and writes it back to `self.scroll`.
+    try renderNode(a, try t.view(a, .{ .focused = true, .columns = &cols, .rows = grid, .height = 8 }), &s);
+    try testing.expectEqual(@as(usize, 18), t.scroll);
+
+    // The table rect matches what was painted: 1 header + 8 body rows at y=4.
+    const rect = ui.Rect{ .x = 0, .y = 4, .w = 4, .h = 1 + 8 };
+    // The first body click now maps to the window top (18), not the stale 0.
+    try testing.expectEqual(@as(?usize, 18), t.rowAt(rect, 5));
+    // ...and the highlighted row (25) sits at the bottom of the painted window.
+    try testing.expectEqual(@as(?usize, 25), t.rowAt(rect, 12));
+}
+
 // ---- handle: Button --------------------------------------------------------
 
 test "Button activates on Enter and Space, ignores other keys" {

--- a/packages/ui/src/table.zig
+++ b/packages/ui/src/table.zig
@@ -108,13 +108,17 @@ pub const Table = struct {
     /// is into the caller's full row slice. It does not bound against the row
     /// count — the caller clamps (a click below the last populated row is theirs to
     /// reject); it only rejects the header and rows past the rendered rect.
+    ///
+    /// `scroll` is the window `view` last painted: `view` writes its derived scroll
+    /// back to `self.scroll`, so a click hit-tests the same window on screen even
+    /// when the caller set `highlighted` directly and never called `handle`.
     pub fn rowAt(self: *const Table, rect: Rect, y: u16) ?usize {
         if (y < rect.y + header_rows) return null; // header or above
         if (y >= rect.y + rect.h) return null; // below the table
         return self.scroll + (y - rect.y - header_rows);
     }
 
-    pub fn view(self: *const Table, a: std.mem.Allocator, opts: ViewOpts) !Node {
+    pub fn view(self: *Table, a: std.mem.Allocator, opts: ViewOpts) !Node {
         const th = opts.theme;
         const cols = opts.columns;
         const count = opts.rows.len;
@@ -141,8 +145,12 @@ pub const Table = struct {
         const hi = if (count == 0) 0 else @min(self.highlighted, count - 1);
         const visible = @min(@max(@as(usize, opts.height), 1), count);
         // Persistent scroll, re-derived so the selection stays in view even if the
-        // caller set `highlighted` directly, bypassing `handle`.
+        // caller set `highlighted` directly, bypassing `handle`. Written back to
+        // `self.scroll` so `rowAt` hit-tests a click against the same window this
+        // frame actually paints — otherwise a caller that set `highlighted` and
+        // clicked before any `handle` would map the click through the stale scroll.
         const scroll = if (count == 0) 0 else scrollFor(self.scroll, hi, @intCast(visible), count);
+        self.scroll = scroll;
 
         const more_above = scroll > 0;
         const more_below = scroll + visible < count;


### PR DESCRIPTION
Fixes #586

## Problem

`Table.view` derives its scroll window with `scrollFor(self.scroll, hi, visible, count)` but never persists it, while `Table.rowAt` maps clicks through the stale persistent `self.scroll`. In the normal key-driven flow the two agree (because `handle` writes the derived scroll back), but when a caller sets `highlighted` directly — the documented case the re-derive in `view` exists for — and the user clicks before any `handle` call, `rowAt` hit-tests against a window that was never rendered. Example: `scroll=0, highlighted=50, visible=8` paints rows 43-50 on screen, yet `rowAt` maps the first body click to row 0. It self-corrects on the next keypress.

## Fix

`view` now writes its derived scroll back to `self.scroll` (making it the single source of truth, exactly as `handle` already does), so `rowAt` always hit-tests the same window the frame actually painted. Adds a regression test that sets `highlighted` directly, renders, and asserts the click maps through the derived window (18) rather than the stale one (0).

## Testing

- `zig build` — clean
- `zig build test` — 179/179 ui tests pass (plus full workspace suite)
- `zig build e2e` (projects/zcli) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)