### PR TITLE
fix(theme): key color detection off the target stream, not always stdout

### DIFF
--- a/packages/core/src/plugins/zcli_help/app_help.zig
+++ b/packages/core/src/plugins/zcli_help/app_help.zig
@@ -24,7 +24,7 @@ const app_palette = format.app_palette;
 /// pollute a piped stdout.
 pub fn showApp(context: anytype, to_stdout: bool) !void {
     var writer = if (to_stdout) context.stdout() else context.stderr();
-    var fmt = md.formatterWithPalette(writer, context.theme.capability(), app_palette);
+    var fmt = md.formatterWithPalette(writer, context.theme.capabilityFor(context.io, writer), app_palette);
     const app_name = context.app_name;
     const app_version = context.app_version;
     const app_description = context.app_description;
@@ -55,7 +55,8 @@ pub fn showApp(context: anytype, to_stdout: bool) !void {
 /// arguments, options, and examples (the root command can be invoked directly).
 pub fn showRoot(context: anytype, to_stdout: bool) !void {
     var writer = if (to_stdout) context.stdout() else context.stderr();
-    var fmt = md.formatterWithPalette(writer, context.theme.capability(), app_palette);
+    const capability = context.theme.capabilityFor(context.io, writer);
+    var fmt = md.formatterWithPalette(writer, capability, app_palette);
     const app_name = context.app_name;
     const app_version = context.app_version;
     const app_description = context.app_description;
@@ -84,7 +85,7 @@ pub fn showRoot(context: anytype, to_stdout: bool) !void {
     // Root command's own options, before the navigation list below.
     if (context.command_module_info) |module_info| {
         if (module_info.has_options) {
-            if (format.generateOptionsHelp(module_info, context) catch null) |options_help| {
+            if (format.generateOptionsHelp(module_info, context, capability) catch null) |options_help| {
                 defer context.allocator.free(options_help);
                 try fmt.write("<header>OPTIONS:</header>\n", .{});
                 try writer.writeAll(options_help);

--- a/packages/core/src/plugins/zcli_help/command_help.zig
+++ b/packages/core/src/plugins/zcli_help/command_help.zig
@@ -17,7 +17,8 @@ const app_palette = format.app_palette;
 /// explicit-vs-error stream rule as the app-level renderers.
 pub fn showCommand(context: anytype, to_stdout: bool) !void {
     var writer = if (to_stdout) context.stdout() else context.stderr();
-    var fmt = md.formatterWithPalette(writer, context.theme.capability(), app_palette);
+    const capability = context.theme.capabilityFor(context.io, writer);
+    var fmt = md.formatterWithPalette(writer, capability, app_palette);
     const app_name = context.app_name;
 
     // Lead with the description (like the root help), then USAGE below. No
@@ -30,7 +31,7 @@ pub fn showCommand(context: anytype, to_stdout: bool) !void {
 
     // Usage
     try fmt.write("<header>USAGE:</header>\n", .{});
-    const usage_string = try generateUsage(context);
+    const usage_string = try generateUsage(context, capability);
     defer context.allocator.free(usage_string);
     try writer.print("    {s}\n\n", .{usage_string});
 
@@ -43,7 +44,7 @@ pub fn showCommand(context: anytype, to_stdout: bool) !void {
     try fmt.write("<header>OPTIONS:</header>\n", .{});
     if (context.command_module_info) |module_info| {
         if (module_info.has_options) {
-            if (format.generateOptionsHelp(module_info, context) catch null) |options_help| {
+            if (format.generateOptionsHelp(module_info, context, capability) catch null) |options_help| {
                 defer context.allocator.free(options_help);
                 try writer.writeAll(options_help);
             }
@@ -72,12 +73,12 @@ pub fn showCommand(context: anytype, to_stdout: bool) !void {
 /// Generate the command's synopsis string. Required options are spelled out
 /// (e.g. `--region <value>`); optional ones fold into `[OPTIONS]`. The
 /// positional pattern comes from the shared arg-token convention.
-fn generateUsage(context: anytype) ![]const u8 {
+fn generateUsage(context: anytype, capability: md.TerminalCapability) ![]const u8 {
     // Build a markdown-formatted usage string using the formatter
     var aw: std.Io.Writer.Allocating = .init(context.allocator);
     errdefer aw.deinit();
     const buf_writer = &aw.writer;
-    var fmt = md.formatterWithPalette(buf_writer, context.theme.capability(), app_palette);
+    var fmt = md.formatterWithPalette(buf_writer, capability, app_palette);
 
     // Start with app name and command path
     try fmt.write("<command>{s}</command>", .{context.app_name});
@@ -456,7 +457,7 @@ test "generateUsage: folds optional options, shows required ones explicitly" {
         },
     };
 
-    const usage = try generateUsage(&ctx);
+    const usage = try generateUsage(&ctx, ctx.theme.capability());
     defer allocator.free(usage);
 
     // Required option is spelled out (dash-converted); the rest fold into
@@ -485,7 +486,7 @@ test "generateUsage: a command with subcommands shows COMMAND, not its options" 
     };
     ctx.command_module_info = .{ .has_options = false, .has_args = false };
 
-    const usage = try generateUsage(&ctx);
+    const usage = try generateUsage(&ctx, ctx.theme.capability());
     defer allocator.free(usage);
 
     try std.testing.expect(std.mem.indexOf(u8, usage, "remote") != null);
@@ -510,7 +511,7 @@ test "generateUsage: an empty Args struct renders no [ARGS...] placeholder" {
     // regression: this used to fall through to a bogus `[ARGS...]`.
     ctx.command_module_info = .{ .has_args = true, .has_options = false };
 
-    const usage = try generateUsage(&ctx);
+    const usage = try generateUsage(&ctx, ctx.theme.capability());
     defer allocator.free(usage);
 
     // Exact line: no positionals, no [ARGS...] tail.
@@ -540,7 +541,7 @@ test "generateUsage: a command with real args renders their names in the shared 
         .has_options = false,
     };
 
-    const usage = try generateUsage(&ctx);
+    const usage = try generateUsage(&ctx, ctx.theme.capability());
     defer allocator.free(usage);
 
     // Exact line: real, uppercased arg names in the shared clap-style

--- a/packages/core/src/plugins/zcli_help/format.zig
+++ b/packages/core/src/plugins/zcli_help/format.zig
@@ -55,13 +55,13 @@ pub fn generateArgsPattern(module_info: zcli.CommandModuleInfo, context: anytype
 
 /// Generate args help text (the ARGUMENTS table body) from command module info.
 /// Returns null if there are no args to display.
-pub fn generateArgsHelp(module_info: zcli.CommandModuleInfo, context: anytype) !?[]u8 {
+pub fn generateArgsHelp(module_info: zcli.CommandModuleInfo, context: anytype, capability: md.TerminalCapability) !?[]u8 {
     if (!module_info.has_args or module_info.args_fields.len == 0) return null;
 
     var aw: std.Io.Writer.Allocating = .init(context.allocator);
     errdefer aw.deinit();
     const buf_writer = &aw.writer;
-    var buf_fmt = md.formatterWithPalette(buf_writer, context.theme.capability(), app_palette);
+    var buf_fmt = md.formatterWithPalette(buf_writer, capability, app_palette);
 
     // Each row: name column, then the description (from meta.args), then the
     // valid choices for an enum-typed arg — `one of: dev, staging, prod`. When a
@@ -106,13 +106,13 @@ fn writeChoices(fmt: anytype, values: []const []const u8, leading_space: bool) !
 
 /// Generate options help text (the OPTIONS table body) from command module info.
 /// Returns null if there are no options to display.
-pub fn generateOptionsHelp(module_info: zcli.CommandModuleInfo, context: anytype) !?[]u8 {
+pub fn generateOptionsHelp(module_info: zcli.CommandModuleInfo, context: anytype, capability: md.TerminalCapability) !?[]u8 {
     if (!module_info.has_options or module_info.options_fields.len == 0) return null;
 
     var aw: std.Io.Writer.Allocating = .init(context.allocator);
     errdefer aw.deinit();
     const buf_writer = &aw.writer;
-    var buf_fmt = md.formatterWithPalette(buf_writer, context.theme.capability(), app_palette);
+    var buf_fmt = md.formatterWithPalette(buf_writer, capability, app_palette);
 
     // Generate help from field info with metadata
     for (module_info.options_fields) |field_info| {
@@ -237,7 +237,7 @@ fn writeDashedFlag(buf_fmt: anytype, field_name: []const u8) !void {
 pub fn writeArgumentsSection(writer: *std.Io.Writer, fmt: anytype, context: anytype) !void {
     if (context.command_module_info) |module_info| {
         if (module_info.has_args) {
-            if (generateArgsHelp(module_info, context) catch null) |args_help| {
+            if (generateArgsHelp(module_info, context, fmt.capability) catch null) |args_help| {
                 defer context.allocator.free(args_help);
                 try fmt.write("<header>ARGUMENTS:</header>\n", .{});
                 try writer.writeAll(args_help);
@@ -322,7 +322,7 @@ test "help never renders auto-generated --no- negation flags" {
         },
     };
 
-    const help = (try generateOptionsHelp(module_info, &ctx)).?;
+    const help = (try generateOptionsHelp(module_info, &ctx, ctx.theme.capability())).?;
     defer allocator.free(help);
 
     // default-false bool: positive shown, negation hidden.
@@ -354,7 +354,7 @@ test "help renders requires markers and mutually-exclusive sets" {
         .exclusive = &.{&.{ "json", "yaml" }},
     };
 
-    const help = (try generateOptionsHelp(module_info, &ctx)).?;
+    const help = (try generateOptionsHelp(module_info, &ctx, ctx.theme.capability())).?;
     defer allocator.free(help);
 
     // The dependent option shows its requirement (dash-converted).
@@ -387,7 +387,7 @@ test "help renders each argument row on its own line" {
         },
     };
 
-    const help = (try generateArgsHelp(module_info, &ctx)).?;
+    const help = (try generateArgsHelp(module_info, &ctx, ctx.theme.capability())).?;
     defer allocator.free(help);
 
     try std.testing.expect(std.mem.endsWith(u8, help, "\n"));
@@ -429,7 +429,7 @@ test "help renders each option row on its own line" {
         },
     };
 
-    const help = (try generateOptionsHelp(module_info, &ctx)).?;
+    const help = (try generateOptionsHelp(module_info, &ctx, ctx.theme.capability())).?;
     defer allocator.free(help);
 
     // Two options → two rows, each ending in its own newline. The block ends
@@ -484,7 +484,7 @@ test "help marks array options as repeatable but not scalars" {
         },
     };
 
-    const help = (try generateOptionsHelp(module_info, &ctx)).?;
+    const help = (try generateOptionsHelp(module_info, &ctx, ctx.theme.capability())).?;
     defer allocator.free(help);
 
     // The array option carries the marker; the scalar option does not (there is
@@ -516,7 +516,7 @@ test "help option rendering does not overflow on a >64-char field name" {
         },
     };
 
-    const help = (try generateOptionsHelp(module_info, &ctx)).?;
+    const help = (try generateOptionsHelp(module_info, &ctx, ctx.theme.capability())).?;
     defer allocator.free(help);
 
     // The truncated (64-char, underscores→dashes) prefix is present; the render

--- a/packages/theme/src/definition.zig
+++ b/packages/theme/src/definition.zig
@@ -176,6 +176,14 @@ pub const ThemeContext = struct {
     pub fn capability(self: ThemeContext) TerminalCapability {
         return self.caps.getCapability();
     }
+
+    /// The effective capability for output written to `writer` (issue #588):
+    /// keyed off that writer's own stream, so themed output on a redirected
+    /// stderr picks up (or drops) color independently of stdout. Prefer this
+    /// over `capability()` wherever the destination stream is known.
+    pub fn capabilityFor(self: ThemeContext, io: std.Io, writer: *std.Io.Writer) TerminalCapability {
+        return self.caps.capabilityFor(io, writer);
+    }
 };
 
 const testing = std.testing;

--- a/packages/theme/src/detection/capability.zig
+++ b/packages/theme/src/detection/capability.zig
@@ -99,10 +99,13 @@ pub const Capabilities = struct {
     is_tty: bool,
     color_enabled: bool,
 
-    /// Initialize theme context with automatic detection
+    /// Initialize theme context with automatic detection. `is_tty` /
+    /// `color_enabled` describe the *default* output stream (stdout); use
+    /// `capabilityFor` to gate color on whichever stream is actually being
+    /// styled (issue #588).
     pub fn init(env: *const std.process.Environ.Map, io: std.Io) Capabilities {
         const capability = TerminalCapability.detect(env);
-        const is_tty = detectTTY(io);
+        const is_tty = detectTTY(io, std.Io.File.stdout());
 
         return .{
             .capability = capability,
@@ -113,7 +116,7 @@ pub const Capabilities = struct {
 
     /// Initialize with explicit capability (for testing or forced modes)
     pub fn initWithCapability(capability: TerminalCapability, io: std.Io) Capabilities {
-        const is_tty = detectTTY(io);
+        const is_tty = detectTTY(io, std.Io.File.stdout());
         return .{
             .capability = capability,
             .is_tty = is_tty,
@@ -124,13 +127,26 @@ pub const Capabilities = struct {
     /// Initialize with forced color setting (override TTY detection)
     pub fn initForced(env: *const std.process.Environ.Map, io: std.Io, force_color: bool) Capabilities {
         const capability = TerminalCapability.detect(env);
-        const is_tty = detectTTY(io);
+        const is_tty = detectTTY(io, std.Io.File.stdout());
 
         return .{
             .capability = capability,
             .is_tty = is_tty,
             .color_enabled = if (force_color) capability != .no_color else capability != .no_color and is_tty,
         };
+    }
+
+    /// The effective capability for output written to `writer`, keyed off that
+    /// writer's own stream rather than a single global assumption: a redirected
+    /// stderr disables color there even when stdout is a TTY, and vice-versa
+    /// (issue #588). The terminal's color depth still comes from the environment
+    /// (`self.capability`); this only gates it on the destination being a TTY.
+    /// Foreign writers whose OS handle can't be recovered (in-memory buffers,
+    /// test overrides) fall back to the detected default (`self.is_tty`).
+    pub fn capabilityFor(self: *const Capabilities, io: std.Io, writer: *std.Io.Writer) TerminalCapability {
+        if (self.capability == .no_color) return .no_color;
+        const tty = if (writerFile(writer)) |file| detectTTY(io, file) else self.is_tty;
+        return if (tty) self.capability else .no_color;
     }
 
     /// Get the effective capability (accounting for color_enabled)
@@ -165,9 +181,19 @@ pub const Capabilities = struct {
     }
 };
 
-/// Detect if output is to a TTY (terminal)
-fn detectTTY(io: std.Io) bool {
-    return std.Io.File.stdout().isTty(io) catch false;
+/// Detect if `file` is connected to a TTY (terminal).
+fn detectTTY(io: std.Io, file: std.Io.File) bool {
+    return file.isTty(io) catch false;
+}
+
+/// Recover the OS file behind `writer` when it is a `std.Io.File.Writer`
+/// interface (the common case: stdout/stderr streams). Discriminates by vtable
+/// so it never `@fieldParentPtr`s a foreign writer (`Allocating`, `fixed`, a
+/// test override). Mirrors the writer-handle recovery in `progress`.
+fn writerFile(writer: *std.Io.Writer) ?std.Io.File {
+    if (writer.vtable.drain != std.Io.File.Writer.drain) return null;
+    const file_writer: *const std.Io.File.Writer = @fieldParentPtr("interface", writer);
+    return file_writer.file;
 }
 
 test "NO_COLOR: empty string does not disable color" {
@@ -236,7 +262,7 @@ test "TTY detection" {
     const testing = std.testing;
 
     // Test TTY detection doesn't crash
-    const is_tty = detectTTY(std.testing.io);
+    const is_tty = detectTTY(std.testing.io, std.Io.File.stdout());
     try testing.expect(@TypeOf(is_tty) == bool);
 
     // Test theme includes TTY info
@@ -327,4 +353,27 @@ test "Capabilities capability hierarchy" {
         try testing.expect(ansi256.supports256Color());
         try testing.expect(ansi256.supportsColor());
     }
+}
+
+test "capabilityFor: gates color on the target stream, not a global assumption" {
+    const testing = std.testing;
+    const io = std.testing.io;
+
+    // An in-memory (foreign) writer can't expose an OS handle, so detection
+    // falls back to the stored `is_tty` — modelling the default stream.
+    var buf: [64]u8 = undefined;
+    var sink: std.Io.Writer = .fixed(&buf);
+
+    // NO_COLOR from the environment wins regardless of the destination stream.
+    const forced_off = Capabilities{ .capability = .no_color, .is_tty = true, .color_enabled = false };
+    try testing.expect(forced_off.capabilityFor(io, &sink) == .no_color);
+
+    // A supported terminal keeps its color depth when the fallback stream is a TTY…
+    const on = Capabilities{ .capability = .true_color, .is_tty = true, .color_enabled = true };
+    try testing.expect(on.capabilityFor(io, &sink) == .true_color);
+
+    // …and drops to no_color when the target stream is not a TTY, even though the
+    // terminal itself is capable — this is the redirected-stderr case (#588).
+    const redirected = Capabilities{ .capability = .true_color, .is_tty = false, .color_enabled = false };
+    try testing.expect(redirected.capabilityFor(io, &sink) == .no_color);
 }


### PR DESCRIPTION
## Summary

`theme.Capabilities.init` derived both `is_tty` and `color_enabled` from a hardcoded `std.Io.File.stdout().isTty(io)`, so the single global `theme.caps` used **stdout's** TTY-ness to gate color on **every** stream. Because zcli renders themed help to **stderr** on the error path, `myapp | tee` (stdout piped, stderr a TTY) dropped color from stderr help, and the inverse redirection over-enabled it.

## Fix

- Added `Capabilities.capabilityFor(io, writer)` (plus a `ThemeContext.capabilityFor` shim) that recovers the writer's own OS handle by vtable discrimination — mirroring the writer-handle recovery already used in `packages/progress` — and gates the environment-derived color depth on **that** stream's TTY-ness. Foreign writers whose handle can't be recovered (in-memory buffers, test overrides) fall back to the detected default.
- `detectTTY` is now parameterized by the target `std.Io.File` instead of assuming stdout; `init`/`initWithCapability`/`initForced` pass stdout explicitly for the stored default.
- The `zcli_help` renderers (`showApp`, `showRoot`, `showCommand`) now resolve capability from the stream they actually write to and thread it through the buffered sub-generators (`generateUsage`, `generateArgsHelp`, `generateOptionsHelp`) so a single render is uniformly colored (or not).

## Tests

- New unit test in `capability.zig` covering `capabilityFor`: NO_COLOR always wins, a supported terminal keeps its depth when the target stream is a TTY, and it drops to `no_color` when the target stream is not (the redirected-stderr case).
- `zig build`, `zig build test`, and `zig build e2e` (in `projects/zcli`) all pass.

Fixes #588

🤖 Generated with [Claude Code](https://claude.com/claude-code)