### PR TITLE
ci: add top-level least-privilege permissions to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
   push:
     branches: [main]
 
+# Least-privilege default: every job here checks out, builds, and tests — none
+# needs to write anything. The `changes` job further narrows its own token
+# (adds `pull-requests: read` for the paths-filter API call); no other job
+# needs elevation above this default.
+permissions:
+  contents: read
+
 jobs:
   # Classifies the diff so the expensive jobs below only run when paths they
   # actually cover changed. Deliberately job-level `if:` gating (each job


### PR DESCRIPTION
## Summary
- Adds a workflow-level `permissions: contents: read` block to `.github/workflows/ci.yml`, so every job (fmt, version-sync, the cross-OS test matrix, windows/linux release builds, secrets, examples, e2e, ci-ok) runs with a least-privilege `GITHUB_TOKEN` by default instead of inheriting the repo-default scope.
- No job in this workflow needs write access — they only checkout, build, and test. The `changes` job already narrows further (adds `pull-requests: read` for the paths-filter API call), which is unaffected by this change.
- Other workflows were checked and are out of scope per the issue text, which calls out `ci.yml` specifically.

Fixes #592

## Test plan
- [x] `git diff` reviewed — only the new `permissions:` block added, no other changes
- [x] `actionlint .github/workflows/ci.yml` run — no new findings (pre-existing shellcheck warnings on unrelated lines 448/475 confirmed unchanged by this diff)
- [x] Workflow YAML validated (actionlint parses it successfully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)