### PR TITLE
docs: remove fictional REPL and subcommand inheritance from DESIGN.md

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -882,20 +882,10 @@ zcli ships seven built-in plugins — `zcli_help`, `zcli_version`, `zcli_not_fou
 
 ## 12. Advanced Features
 
-**Subcommand Inheritance:**
-
-- Commands can inherit options from parent commands
-- Shared validation and preprocessing
-
 **Command Aliases:**
 
 - Define aliases in command metadata
 - Multiple paths to same handler
-
-**Interactive Mode:**
-
-- Optional REPL for command exploration
-- Tab completion using comptime-generated data
 
 **Type-Safe Context Extensions:**
 


### PR DESCRIPTION
## Summary
- DESIGN.md §12 ("Advanced Features") documented an "Interactive Mode" REPL with tab completion, and "Subcommand Inheritance" of options from parent commands — neither exists anywhere in `packages/core/src/`.
- Removed both fictional subsections. Kept "Command Aliases", which is real (`meta.aliases`, verified in `packages/core/src/zcli.zig`).

Fixes #594

## Test plan
- [x] Verified no REPL/interactive-mode code exists (`grep -rniE "repl|interactive mode" packages/core/src/`)
- [x] Verified no per-command option inheritance mechanism exists (only global-option inheritance, which is a different, already-documented feature)
- [x] Verified `meta.aliases` is real and implemented in `packages/core/src/zcli.zig`
- [x] Docs-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)