### PR TITLE
docs: fix README/website drift (doc-gen wording, ui package row, pinned install example)

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ try app.frame(try ui.column(app.arena(), .{ .border = .rounded }, &.{
 
 Boxes, wrapped text, spacers, and custom leaves; `fit`/`len`/`fill` sizing; viewport-clamped, resize-aware (the live region re-lays-out and the visible scrollback tail reflows), and piped output degrades to plain lines.
 
-When you want the whole terminal — a `top`-style dashboard, an interactive form — the same node tree, layout, and diff run in **full-screen mode**: `context.uiFullScreen(.{})` switches to the alternate screen and hands the `frame → event → update` loop to `app.run`. It comes with focusable widgets (`TextInput`, `Select`, `Checkbox`, `Button` — each a plain struct in your state, routed by a single `handle`-returns-`bool` contract), overlays via a `stack` of z-layers, scrollable viewports, mouse/focus/paste events, and anchored popups that flip and clamp to stay on screen. On exit the shell comes back exactly as it was. Walkthrough at [zcli.sh/ui](https://zcli.sh/ui/); design in [ADR-0013](docs/adr/0013-terminal-native-layout-engine.md) (full-screen and widgets in [ADRs 0015–0020](docs/adr/)), API in [packages/ui](packages/ui/).
+When you want the whole terminal — a `top`-style dashboard, an interactive form — the same node tree, layout, and diff run in **full-screen mode**: `context.uiFullScreen(.{})` switches to the alternate screen and hands the `frame → event → update` loop to `app.run`. It comes with focusable widgets (`TextInput`, `Select`, `Checkbox`, `Button` — each a plain struct in your state, routed by a single `handle`-returns-`bool` contract), overlays via a `stack` of z-layers, scrollable viewports, mouse/focus/paste events, and anchored popups that flip and clamp to stay on screen. On exit the shell comes back exactly as it was. Walkthrough at [zcli.sh/ui](https://zcli.sh/ui/); design in [ADR-0013](docs/adr/0013-terminal-native-layout-engine.md) (full-screen and widgets in [ADRs 0015–0021](docs/adr/)), API in [packages/ui](packages/ui/).
 
 ## Theming
 
@@ -316,7 +316,7 @@ test "deploy command" {
 
 ## Documentation generation
 
-Generate markdown, man pages, or HTML documentation from your command metadata — automatically on every build:
+Generate markdown, man pages, or HTML documentation from your command metadata, on demand via `zig build docs`:
 
 ```zig
 // In build.zig, after generate():
@@ -360,6 +360,7 @@ Building something with zcli? Open a PR to add it here.
 | Package | Description |
 |---------|-------------|
 | [**core**](packages/core/) | Command discovery, argument parsing, plugin system, registry |
+| [**ui**](packages/ui/) | Terminal-native layout engine (CLI/TUI hybrid, focusable widgets, full-screen mode) |
 | [**prompts**](packages/prompts/) | Interactive prompts (text, confirm, select, password, search, number, editor) |
 | [**progress**](packages/progress/) | Spinners and progress bars |
 | [**theme**](packages/theme/) | Terminal theming with semantic colors and capability detection |

--- a/website/layouts/install.shtml
+++ b/website/layouts/install.shtml
@@ -65,16 +65,17 @@
       <!-- PKG -->
       <div class="panel" id="p-pkg">
         <h3>Add as a Zig package</h3>
-        <p>The usual path: add zcli to <code class="mono" style="color:var(--accent)">build.zig.zon</code> and import the module in <code class="mono" style="color:var(--accent)">build.zig</code>.</p>
+        <p>The usual path: add zcli to <code class="mono" style="color:var(--accent)">build.zig.zon</code> and import the module in <code class="mono" style="color:var(--accent)">build.zig</code>. Pin a tagged release for an immutable hash:</p>
         <div class="cmdbox">
           <pre>.dependencies = .{
     .zcli = .{
-        <span class="pr">.url</span> = "https://github.com/ryanhair/zcli/archive/refs/heads/main.tar.gz",
+        <span class="pr">.url</span> = "https://github.com/ryanhair/zcli/archive/refs/tags/v0.20.0.tar.gz",
         <span class="pr">.hash</span> = "...", // zig build prints the correct hash
     },
 },</pre>
-          <button onclick="cp(this,'.zcli = .{ .url = &quot;https://github.com/ryanhair/zcli/archive/refs/heads/main.tar.gz&quot;, .hash = &quot;...&quot; },')">copy</button>
+          <button onclick="cp(this,'.zcli = .{ .url = &quot;https://github.com/ryanhair/zcli/archive/refs/tags/v0.20.0.tar.gz&quot;, .hash = &quot;...&quot; },')">copy</button>
         </div>
+        <p style="font-size:13.5px;">To track the development branch instead, fetch <code class="mono" style="color:var(--accent)">.../archive/refs/heads/main.tar.gz</code> — its hash changes with every commit, so re-run <code class="mono">zig fetch --save</code> to update.</p>
         <p style="font-size:13.5px;">Then follow steps 2 & 3 in the <a href="$site.page('docs').link().suffix('#quick-start')">docs</a> to wire up <code class="mono">zcli.generate</code>.</p>
       </div>
 


### PR DESCRIPTION
## Summary
- README.md:319 claimed docs generate "automatically on every build" — reworded to describe the actual on-demand `zig build docs` flow (per `packages/core/src/build_utils/main.zig:348,379`).
- README.md package table was missing a row for `packages/ui` — added, consistent with the other package rows.
- README.md:249 cited ADRs 0015–0020 for widgets — extended to 0015–0021 to include the widget-catalog ADR (addresses the README nit from #646; the rest of that issue is handled elsewhere).
- website/layouts/install.shtml now leads with a pinned `refs/tags/v0.20.0.tar.gz` example instead of the unpinned `refs/heads/main.tar.gz`, matching README's pin-a-release guidance, with a follow-up note for tracking `main` instead.

## Test plan
- [x] Diffed each change against the cited source/README lines to confirm the drift and the fix
- [x] website/ builds via Zine, not `zig build` — no build verification needed; edits preserve the existing SuperHTML tab/panel structure

Fixes #634

🤖 Generated with [Claude Code](https://claude.com/claude-code)