### PR TITLE
test(zcli): unit-test the 7 untested meta-CLI command files

### DIFF
--- a/projects/zcli/build.zig
+++ b/projects/zcli/build.zig
@@ -154,8 +154,15 @@ pub fn build(b: *std.Build) !void {
         "src/commands/add/plugin.zig",
         "src/commands/rm/option.zig",
         "src/commands/rm/arg.zig",
+        "src/commands/rm/command.zig",
+        "src/commands/rm/index.zig",
         "src/commands/init.zig",
         "src/commands/release.zig",
+        "src/commands/mv.zig",
+        "src/commands/guide.zig",
+        "src/commands/add/index.zig",
+        "src/commands/gh/index.zig",
+        "src/commands/gh/add/workflow/release.zig",
     };
     for (command_test_files) |path| {
         const mod = b.addModule(b.fmt("test-{s}", .{path}), .{
@@ -167,6 +174,7 @@ pub fn build(b: *std.Build) !void {
         mod.addImport("nightwatch", nightwatch_module);
         mod.addImport("scaffold", scaffold_module);
         mod.addImport("command_registry", command_registry_stub);
+        mod.addImport("guide_examples", guide_examples_module);
         const cmd_tests = b.addTest(.{ .root_module = mod });
         test_step.dependOn(&b.addRunArtifact(cmd_tests).step);
     }

--- a/projects/zcli/src/commands/add/index.zig
+++ b/projects/zcli/src/commands/add/index.zig
@@ -1,3 +1,12 @@
+const std = @import("std");
+
 pub const meta = .{
     .description = "Add commands and plugins to your zcli project",
 };
+
+test "meta.description names what this group adds" {
+    try std.testing.expect(meta.description.len > 0);
+    try std.testing.expect(std.mem.startsWith(u8, meta.description, "Add"));
+    try std.testing.expect(std.mem.indexOf(u8, meta.description, "commands") != null);
+    try std.testing.expect(std.mem.indexOf(u8, meta.description, "plugins") != null);
+}

--- a/projects/zcli/src/commands/gh/add/workflow/release.zig
+++ b/projects/zcli/src/commands/gh/add/workflow/release.zig
@@ -17,163 +17,16 @@ pub const Options = struct {};
 // don't need that testability use `*Context` for the compile-time contract.
 pub fn execute(_: Args, _: Options, context: anytype) !void {
     var stdout = context.stdout();
-
-    // Verify we're in a zcli project
-    const cwd = std.Io.Dir.cwd();
     const io = context.io;
-    cwd.access(io, "src/commands", .{}) catch {
-        return context.fail("Error: Not in a zcli project directory\nRun this command from the root of your zcli project (where build.zig is)", .{});
-    };
 
-    // Create .github/workflows directory
-    cwd.createDir(io, ".github", .default_dir) catch |err| switch (err) {
-        error.PathAlreadyExists => {},
-        else => return err,
-    };
-
-    cwd.createDir(io, ".github/workflows", .default_dir) catch |err| switch (err) {
-        error.PathAlreadyExists => {},
-        else => return err,
-    };
-
-    // Check if workflow already exists
-    if (cwd.access(io, ".github/workflows/release.yml", .{})) {
-        return context.fail("Error: .github/workflows/release.yml already exists\nRemove it first if you want to regenerate it", .{});
-    } else |err| switch (err) {
-        error.FileNotFound => {}, // Good, safe to create
-        else => return err,
+    const outcome = try writeReleaseWorkflow(std.Io.Dir.cwd(), io);
+    switch (outcome) {
+        .not_a_project => return context.fail("Error: Not in a zcli project directory\nRun this command from the root of your zcli project (where build.zig is)", .{}),
+        .already_exists => return context.fail("Error: .github/workflows/release.yml already exists\nRemove it first if you want to regenerate it", .{}),
+        .created => {},
     }
 
     try stdout.print("Creating GitHub Actions release workflow...\n", .{});
-
-    // Generate workflow content
-    const workflow_content =
-        \\name: Release
-        \\
-        \\# Actions are pinned to full commit SHAs (with the version as a comment)
-        \\# so a moved or compromised tag can't change what runs in this workflow.
-        \\# When upgrading an action, update the SHA and the comment together.
-        \\
-        \\on:
-        \\  push:
-        \\    tags:
-        \\      - '*-v*'
-        \\
-        \\jobs:
-        \\  build:
-        \\    name: Build ${{ matrix.target }}
-        \\    runs-on: ${{ matrix.os }}
-        \\    strategy:
-        \\      matrix:
-        \\        include:
-        \\          - os: ubuntu-latest
-        \\            target: x86_64-linux
-        \\            zig_target: x86_64-linux-musl
-        \\          - os: ubuntu-latest
-        \\            target: aarch64-linux
-        \\            zig_target: aarch64-linux-musl
-        \\          - os: macos-latest
-        \\            target: x86_64-macos
-        \\            zig_target: x86_64-macos
-        \\          - os: macos-latest
-        \\            target: aarch64-macos
-        \\            zig_target: aarch64-macos
-        \\
-        \\    steps:
-        \\      - name: Checkout code
-        \\        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        \\
-        \\      - name: Setup Zig
-        \\        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
-        \\        with:
-        \\          version: 0.16.0
-        \\
-        \\      - name: Build binary
-        \\        # ReleaseSafe keeps runtime safety checks (bounds/overflow) in a
-        \\        # binary that parses untrusted input; -Dstrip=true drops debug info,
-        \\        # which dominates size. If your build.zig predates the `strip`
-        \\        # option, add: b.option(bool, "strip", "...") and `.strip = strip`
-        \\        # on the exe module.
-        \\        run: zig build -Doptimize=ReleaseSafe -Dstrip=true -Dtarget=${{ matrix.zig_target }}
-        \\
-        \\      - name: Get app name from build.zig.zon
-        \\        id: appname
-        \\        run: |
-        \\          # Extract .name from build.zig.zon (handles both quoted strings and identifiers)
-        \\          NAME_LINE=$(grep -m1 '\.name = ' build.zig.zon)
-        \\          if [[ "$NAME_LINE" =~ \.name\ =\ \"([^\"]+)\" ]]; then
-        \\            APP_NAME="${BASH_REMATCH[1]}"
-        \\          elif [[ "$NAME_LINE" =~ \.name\ =\ \.([^,}\ ]+) ]]; then
-        \\            APP_NAME="${BASH_REMATCH[1]}"
-        \\          else
-        \\            echo "Error: Could not parse .name from build.zig.zon"
-        \\            exit 1
-        \\          fi
-        \\          echo "name=$APP_NAME" >> $GITHUB_OUTPUT
-        \\
-        \\      - name: Package binary
-        \\        run: |
-        \\          mkdir -p dist
-        \\          cp zig-out/bin/${{ steps.appname.outputs.name }} dist/${{ steps.appname.outputs.name }}-${{ matrix.target }}
-        \\          chmod +x dist/${{ steps.appname.outputs.name }}-${{ matrix.target }}
-        \\
-        \\      - name: Generate checksum
-        \\        run: |
-        \\          cd dist
-        \\          shasum -a 256 ${{ steps.appname.outputs.name }}-${{ matrix.target }} > ${{ steps.appname.outputs.name }}-${{ matrix.target }}.sha256
-        \\
-        \\      - name: Upload artifact
-        \\        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        \\        with:
-        \\          name: ${{ steps.appname.outputs.name }}-${{ matrix.target }}
-        \\          path: |
-        \\            dist/${{ steps.appname.outputs.name }}-${{ matrix.target }}
-        \\            dist/${{ steps.appname.outputs.name }}-${{ matrix.target }}.sha256
-        \\
-        \\  release:
-        \\    name: Create Release
-        \\    needs: build
-        \\    runs-on: ubuntu-latest
-        \\    permissions:
-        \\      contents: write
-        \\
-        \\    steps:
-        \\      - name: Checkout code
-        \\        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        \\
-        \\      - name: Download all artifacts
-        \\        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        \\        with:
-        \\          path: dist
-        \\
-        \\      - name: Flatten artifact structure
-        \\        run: |
-        \\          mkdir -p release
-        \\          find dist -type f \( -name '*-x86_64-*' -o -name '*-aarch64-*' \) -exec cp {} release/ \;
-        \\          ls -la release/
-        \\
-        \\      - name: Create checksums file
-        \\        run: |
-        \\          cd release
-        \\          cat *.sha256 > checksums.txt
-        \\          rm *.sha256
-        \\
-        \\      - name: Create Release
-        \\        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
-        \\        with:
-        \\          files: release/*
-        \\          generate_release_notes: true
-        \\          draft: false
-        \\          prerelease: false
-        \\        env:
-        \\          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        \\
-    ;
-
-    var workflow_file = try cwd.createFile(io, ".github/workflows/release.yml", .{});
-    defer workflow_file.close(io);
-    try workflow_file.writeStreamingAll(io, workflow_content);
-
     try stdout.print("✓ Created .github/workflows/release.yml\n\n", .{});
     try stdout.print("Next steps:\n", .{});
     try stdout.print("  1. Commit and push the workflow file:\n", .{});
@@ -188,4 +41,215 @@ pub fn execute(_: Args, _: Options, context: anytype) !void {
     try stdout.print("     zcli release major   # 0.1.0 → 1.0.0\n\n", .{});
     try stdout.print("  3. Monitor builds at:\n", .{});
     try stdout.print("     https://github.com/YOUR_USERNAME/YOUR_REPO/actions\n\n", .{});
+}
+
+const WorkflowOutcome = enum { created, not_a_project, already_exists };
+
+/// Writes the release workflow into `dir`. Takes `dir` explicitly (rather
+/// than hardcoding `std.Io.Dir.cwd()`) so it can be exercised against a
+/// scratch directory in tests without touching the real repo.
+fn writeReleaseWorkflow(dir: std.Io.Dir, io: std.Io) !WorkflowOutcome {
+    dir.access(io, "src/commands", .{}) catch return .not_a_project;
+
+    dir.createDir(io, ".github", .default_dir) catch |err| switch (err) {
+        error.PathAlreadyExists => {},
+        else => return err,
+    };
+
+    dir.createDir(io, ".github/workflows", .default_dir) catch |err| switch (err) {
+        error.PathAlreadyExists => {},
+        else => return err,
+    };
+
+    if (dir.access(io, ".github/workflows/release.yml", .{})) {
+        return .already_exists;
+    } else |err| switch (err) {
+        error.FileNotFound => {}, // Good, safe to create
+        else => return err,
+    }
+
+    var workflow_file = try dir.createFile(io, ".github/workflows/release.yml", .{});
+    defer workflow_file.close(io);
+    try workflow_file.writeStreamingAll(io, workflow_content);
+
+    return .created;
+}
+
+// Generate workflow content
+const workflow_content =
+    \\name: Release
+    \\
+    \\# Actions are pinned to full commit SHAs (with the version as a comment)
+    \\# so a moved or compromised tag can't change what runs in this workflow.
+    \\# When upgrading an action, update the SHA and the comment together.
+    \\
+    \\on:
+    \\  push:
+    \\    tags:
+    \\      - '*-v*'
+    \\
+    \\jobs:
+    \\  build:
+    \\    name: Build ${{ matrix.target }}
+    \\    runs-on: ${{ matrix.os }}
+    \\    strategy:
+    \\      matrix:
+    \\        include:
+    \\          - os: ubuntu-latest
+    \\            target: x86_64-linux
+    \\            zig_target: x86_64-linux-musl
+    \\          - os: ubuntu-latest
+    \\            target: aarch64-linux
+    \\            zig_target: aarch64-linux-musl
+    \\          - os: macos-latest
+    \\            target: x86_64-macos
+    \\            zig_target: x86_64-macos
+    \\          - os: macos-latest
+    \\            target: aarch64-macos
+    \\            zig_target: aarch64-macos
+    \\
+    \\    steps:
+    \\      - name: Checkout code
+    \\        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    \\
+    \\      - name: Setup Zig
+    \\        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+    \\        with:
+    \\          version: 0.16.0
+    \\
+    \\      - name: Build binary
+    \\        # ReleaseSafe keeps runtime safety checks (bounds/overflow) in a
+    \\        # binary that parses untrusted input; -Dstrip=true drops debug info,
+    \\        # which dominates size. If your build.zig predates the `strip`
+    \\        # option, add: b.option(bool, "strip", "...") and `.strip = strip`
+    \\        # on the exe module.
+    \\        run: zig build -Doptimize=ReleaseSafe -Dstrip=true -Dtarget=${{ matrix.zig_target }}
+    \\
+    \\      - name: Get app name from build.zig.zon
+    \\        id: appname
+    \\        run: |
+    \\          # Extract .name from build.zig.zon (handles both quoted strings and identifiers)
+    \\          NAME_LINE=$(grep -m1 '\.name = ' build.zig.zon)
+    \\          if [[ "$NAME_LINE" =~ \.name\ =\ \"([^\"]+)\" ]]; then
+    \\            APP_NAME="${BASH_REMATCH[1]}"
+    \\          elif [[ "$NAME_LINE" =~ \.name\ =\ \.([^,}\ ]+) ]]; then
+    \\            APP_NAME="${BASH_REMATCH[1]}"
+    \\          else
+    \\            echo "Error: Could not parse .name from build.zig.zon"
+    \\            exit 1
+    \\          fi
+    \\          echo "name=$APP_NAME" >> $GITHUB_OUTPUT
+    \\
+    \\      - name: Package binary
+    \\        run: |
+    \\          mkdir -p dist
+    \\          cp zig-out/bin/${{ steps.appname.outputs.name }} dist/${{ steps.appname.outputs.name }}-${{ matrix.target }}
+    \\          chmod +x dist/${{ steps.appname.outputs.name }}-${{ matrix.target }}
+    \\
+    \\      - name: Generate checksum
+    \\        run: |
+    \\          cd dist
+    \\          shasum -a 256 ${{ steps.appname.outputs.name }}-${{ matrix.target }} > ${{ steps.appname.outputs.name }}-${{ matrix.target }}.sha256
+    \\
+    \\      - name: Upload artifact
+    \\        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+    \\        with:
+    \\          name: ${{ steps.appname.outputs.name }}-${{ matrix.target }}
+    \\          path: |
+    \\            dist/${{ steps.appname.outputs.name }}-${{ matrix.target }}
+    \\            dist/${{ steps.appname.outputs.name }}-${{ matrix.target }}.sha256
+    \\
+    \\  release:
+    \\    name: Create Release
+    \\    needs: build
+    \\    runs-on: ubuntu-latest
+    \\    permissions:
+    \\      contents: write
+    \\
+    \\    steps:
+    \\      - name: Checkout code
+    \\        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    \\
+    \\      - name: Download all artifacts
+    \\        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+    \\        with:
+    \\          path: dist
+    \\
+    \\      - name: Flatten artifact structure
+    \\        run: |
+    \\          mkdir -p release
+    \\          find dist -type f \( -name '*-x86_64-*' -o -name '*-aarch64-*' \) -exec cp {} release/ \;
+    \\          ls -la release/
+    \\
+    \\      - name: Create checksums file
+    \\        run: |
+    \\          cd release
+    \\          cat *.sha256 > checksums.txt
+    \\          rm *.sha256
+    \\
+    \\      - name: Create Release
+    \\        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
+    \\        with:
+    \\          files: release/*
+    \\          generate_release_notes: true
+    \\          draft: false
+    \\          prerelease: false
+    \\        env:
+    \\          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    \\
+;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const testing = std.testing;
+
+test "writeReleaseWorkflow fails outside a zcli project" {
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const outcome = try writeReleaseWorkflow(tmp.dir, io);
+    try testing.expectEqual(WorkflowOutcome.not_a_project, outcome);
+}
+
+test "writeReleaseWorkflow creates a pinned, version-matched workflow" {
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDir(io, "src", .default_dir);
+    try tmp.dir.createDir(io, "src/commands", .default_dir);
+
+    const outcome = try writeReleaseWorkflow(tmp.dir, io);
+    try testing.expectEqual(WorkflowOutcome.created, outcome);
+
+    const content = try tmp.dir.readFileAlloc(io, ".github/workflows/release.yml", testing.allocator, .limited(1 << 20));
+    defer testing.allocator.free(content);
+
+    try testing.expect(std.mem.indexOf(u8, content, "name: Release") != null);
+    // Every `uses:` action must be pinned to a full commit SHA (with the
+    // version as a trailing comment), never a mutable tag.
+    try testing.expect(std.mem.indexOf(u8, content, "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1") != null);
+    try testing.expect(std.mem.indexOf(u8, content, "mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1") != null);
+    try testing.expect(std.mem.indexOf(u8, content, "version: 0.16.0") != null);
+    try testing.expect(std.mem.indexOf(u8, content, "-Dstrip=true") != null);
+}
+
+test "writeReleaseWorkflow refuses to overwrite an existing workflow" {
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDir(io, "src", .default_dir);
+    try tmp.dir.createDir(io, "src/commands", .default_dir);
+    try tmp.dir.createDir(io, ".github", .default_dir);
+    try tmp.dir.createDir(io, ".github/workflows", .default_dir);
+    try tmp.dir.writeFile(io, .{ .sub_path = ".github/workflows/release.yml", .data = "custom content\n" });
+
+    const outcome = try writeReleaseWorkflow(tmp.dir, io);
+    try testing.expectEqual(WorkflowOutcome.already_exists, outcome);
+
+    const content = try tmp.dir.readFileAlloc(io, ".github/workflows/release.yml", testing.allocator, .limited(4096));
+    defer testing.allocator.free(content);
+    try testing.expectEqualStrings("custom content\n", content);
 }

--- a/projects/zcli/src/commands/gh/index.zig
+++ b/projects/zcli/src/commands/gh/index.zig
@@ -1,3 +1,11 @@
+const std = @import("std");
+
 pub const meta = .{
     .description = "Add GitHub-related features and workflows",
 };
+
+test "meta.description names what this group covers" {
+    try std.testing.expect(meta.description.len > 0);
+    try std.testing.expect(std.mem.indexOf(u8, meta.description, "GitHub") != null);
+    try std.testing.expect(std.mem.indexOf(u8, meta.description, "workflows") != null);
+}

--- a/projects/zcli/src/commands/guide.zig
+++ b/projects/zcli/src/commands/guide.zig
@@ -31,11 +31,9 @@ pub fn execute(args: Args, _: Options, context: *Context) !void {
         return;
     };
 
-    for (topics) |t| {
-        if (std.mem.eql(u8, t.name, requested)) {
-            try stdout.writeAll(t.body);
-            return;
-        }
+    if (findTopic(requested)) |t| {
+        try stdout.writeAll(t.body);
+        return;
     }
 
     const stderr = context.stderr();
@@ -44,6 +42,15 @@ pub fn execute(args: Args, _: Options, context: *Context) !void {
     // We've already printed the full topic list as guidance, so exit non-zero
     // cleanly here rather than returning an error on top of that help.
     context.exit(1);
+}
+
+/// Looks up a topic by name. Extracted from `execute` so the dispatch logic
+/// is testable without a real `Context`.
+fn findTopic(name: []const u8) ?Topic {
+    for (topics) |t| {
+        if (std.mem.eql(u8, t.name, name)) return t;
+    }
+    return null;
 }
 
 fn printOverview(w: *std.Io.Writer) !void {
@@ -461,3 +468,56 @@ const topics = [_]Topic{
         ,
     },
 };
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const testing = std.testing;
+
+test "findTopic finds a known topic by name" {
+    const t = findTopic("arena") orelse return error.TestUnexpectedResult;
+    try testing.expectEqualStrings("arena", t.name);
+    try testing.expect(std.mem.startsWith(u8, t.body, "arena — the per-command allocator"));
+}
+
+test "findTopic returns null for an unknown topic" {
+    try testing.expectEqual(@as(?Topic, null), findTopic("does-not-exist"));
+}
+
+test "every topic name is unique and non-empty" {
+    for (topics, 0..) |t, i| {
+        try testing.expect(t.name.len > 0);
+        try testing.expect(t.summary.len > 0);
+        try testing.expect(t.body.len > 0);
+        for (topics[i + 1 ..]) |other| {
+            try testing.expect(!std.mem.eql(u8, t.name, other.name));
+        }
+    }
+}
+
+test "printTopicList lists every topic name and summary" {
+    var out: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer out.deinit();
+
+    try printTopicList(&out.writer);
+    const rendered = out.written();
+
+    try testing.expect(std.mem.startsWith(u8, rendered, "Topics (zcli guide <topic>):\n"));
+    for (topics) |t| {
+        try testing.expect(std.mem.indexOf(u8, rendered, t.name) != null);
+        try testing.expect(std.mem.indexOf(u8, rendered, t.summary) != null);
+    }
+}
+
+test "printOverview explains the loop and includes the topic list" {
+    var out: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer out.deinit();
+
+    try printOverview(&out.writer);
+    const rendered = out.written();
+
+    try testing.expect(std.mem.indexOf(u8, rendered, "zcli guide") != null);
+    try testing.expect(std.mem.indexOf(u8, rendered, "Topics (zcli guide <topic>):") != null);
+    try testing.expect(std.mem.indexOf(u8, rendered, "structure") != null);
+}

--- a/projects/zcli/src/commands/mv.zig
+++ b/projects/zcli/src/commands/mv.zig
@@ -33,54 +33,79 @@ pub fn execute(args: Args, _: Options, context: *Context) !void {
     defer arena_state.deinit();
     const arena = arena_state.allocator();
 
-    const io = context.io;
-    const cwd = std.Io.Dir.cwd();
+    const outcome = try performMove(std.Io.Dir.cwd(), context.io, arena, args.from, args.to);
+    switch (outcome) {
+        .ok => |r| try finish(context.stdout(), &context.theme, r.from_file, r.to_file),
+        .not_a_project => return context.fail("Error: Not in a zcli project directory\nRun this command from the root of your zcli project (where build.zig is)", .{}),
+        .invalid_from_path => return context.fail("Error: Invalid command path: '{s}'", .{args.from}),
+        .invalid_to_path => return context.fail("Error: Invalid command path: '{s}'", .{args.to}),
+        .from_is_group => return context.fail("Error: '{s}' is a command group; move its subcommands individually", .{args.from}),
+        .from_not_found => |file_path| return context.fail("Error: Command not found: {s}", .{file_path}),
+        .to_exists => |file_path| return context.fail("Error: Destination already exists: {s}", .{file_path}),
+        .to_is_group => return context.fail("Error: Destination is a command group: {s}", .{args.to}),
+    }
+}
 
-    cwd.access(io, "src/commands", .{}) catch {
-        return context.fail("Error: Not in a zcli project directory\nRun this command from the root of your zcli project (where build.zig is)", .{});
-    };
+/// Result of `performMove`. A tagged union (rather than an error set) because
+/// several failure modes need to carry the resolved file path back to the
+/// caller for the user-facing message.
+const MoveOutcome = union(enum) {
+    ok: struct { from_file: []const u8, to_file: []const u8 },
+    not_a_project,
+    invalid_from_path,
+    invalid_to_path,
+    from_is_group,
+    from_not_found: []const u8,
+    to_exists: []const u8,
+    to_is_group,
+};
 
-    const from_parts = spec.parsePath(arena, args.from) catch {
-        return context.fail("Error: Invalid command path: '{s}'", .{args.from});
-    };
-    const to_parts = spec.parsePath(arena, args.to) catch {
-        return context.fail("Error: Invalid command path: '{s}'", .{args.to});
-    };
+/// The actual move: validates both paths, checks for destination conflicts,
+/// creates any parent group directories the destination needs, renames the
+/// file, tidies up any group the source left empty, and rewrites the moved
+/// file's self-referential path mentions. Takes `dir` explicitly (rather than
+/// hardcoding `std.Io.Dir.cwd()`) so it can be exercised against a scratch
+/// directory in tests.
+fn performMove(dir: std.Io.Dir, io: std.Io, arena: std.mem.Allocator, from: []const u8, to: []const u8) !MoveOutcome {
+    dir.access(io, "src/commands", .{}) catch return .not_a_project;
+
+    const from_parts = spec.parsePath(arena, from) catch return .invalid_from_path;
+    const to_parts = spec.parsePath(arena, to) catch return .invalid_to_path;
 
     const from_file = try spec.buildFilePath(arena, from_parts);
-    if (!exists(io, from_file)) {
-        if (exists(io, try fs.groupPath(arena, from_parts))) {
-            return context.fail("Error: '{s}' is a command group; move its subcommands individually", .{args.from});
+    if (!exists(dir, io, from_file)) {
+        if (exists(dir, io, try fs.groupPath(arena, from_parts))) {
+            return .from_is_group;
         }
-        return context.fail("Error: Command not found: {s}", .{from_file});
+        return .{ .from_not_found = from_file };
     }
 
     const to_file = try spec.buildFilePath(arena, to_parts);
-    if (exists(io, to_file)) {
-        return context.fail("Error: Destination already exists: {s}", .{to_file});
+    if (exists(dir, io, to_file)) {
+        return .{ .to_exists = to_file };
     }
-    if (exists(io, try fs.groupPath(arena, to_parts))) {
-        return context.fail("Error: Destination is a command group: {s}", .{args.to});
+    if (exists(dir, io, try fs.groupPath(arena, to_parts))) {
+        return .to_is_group;
     }
 
     // Create any parent group directories the destination needs.
     if (to_parts.len > 1) {
-        var dir = std.ArrayList(u8).empty;
-        try dir.appendSlice(arena, "src/commands");
+        var dirbuf = std.ArrayList(u8).empty;
+        try dirbuf.appendSlice(arena, "src/commands");
         for (to_parts[0 .. to_parts.len - 1]) |segment| {
-            try dir.append(arena, '/');
-            try dir.appendSlice(arena, segment);
-            cwd.createDir(io, dir.items, .default_dir) catch |err| switch (err) {
+            try dirbuf.append(arena, '/');
+            try dirbuf.appendSlice(arena, segment);
+            dir.createDir(io, dirbuf.items, .default_dir) catch |err| switch (err) {
                 error.PathAlreadyExists => {},
                 else => return err,
             };
         }
     }
 
-    try cwd.rename(from_file, cwd, to_file, io);
+    try dir.rename(from_file, dir, to_file, io);
     // Tidy up any group the source left empty (its co-located `execute` and
     // any in-file tests travel with the file).
-    try fs.removeEmptyParents(cwd, io, arena, from_parts);
+    try fs.removeEmptyParents(dir, io, arena, from_parts);
 
     // The scaffolder embeds the old path in three self-referential spots
     // (leading meta.examples entry, the execute TODO print, and the
@@ -88,13 +113,13 @@ pub fn execute(args: Args, _: Options, context: *Context) !void {
     // pointing at its old address (#591).
     const old_path = try std.mem.join(arena, " ", from_parts);
     const new_path = try std.mem.join(arena, " ", to_parts);
-    const content = try cwd.readFileAlloc(io, to_file, arena, .limited(1024 * 1024));
+    const content = try dir.readFileAlloc(io, to_file, arena, .limited(1024 * 1024));
     const rewritten = try fs.rewriteCommandPathReferences(arena, content, old_path, new_path);
     if (!std.mem.eql(u8, content, rewritten)) {
-        try fs.writeFileAtomic(cwd, io, arena, to_file, rewritten);
+        try fs.writeFileAtomic(dir, io, arena, to_file, rewritten);
     }
 
-    try finish(context.stdout(), &context.theme, from_file, to_file);
+    return .{ .ok = .{ .from_file = from_file, .to_file = to_file } };
 }
 
 fn finish(w: *std.Io.Writer, theme: *const ThemeContext, from_file: []const u8, to_file: []const u8) !void {
@@ -105,7 +130,133 @@ fn finish(w: *std.Io.Writer, theme: *const ThemeContext, from_file: []const u8, 
     try w.writeAll("\n\n  Note: any other mentions of the old path in comments or hand-written description text were left as-is.\n");
 }
 
-fn exists(io: std.Io, path: []const u8) bool {
-    std.Io.Dir.cwd().access(io, path, .{}) catch return false;
+fn exists(dir: std.Io.Dir, io: std.Io, path: []const u8) bool {
+    dir.access(io, path, .{}) catch return false;
     return true;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const testing = std.testing;
+
+fn makeProject(dir: std.Io.Dir, io: std.Io) !void {
+    try dir.createDir(io, "src", .default_dir);
+    try dir.createDir(io, "src/commands", .default_dir);
+}
+
+test "performMove fails outside a zcli project" {
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const outcome = try performMove(tmp.dir, io, arena.allocator(), "deploy", "release");
+    try testing.expectEqual(MoveOutcome.not_a_project, outcome);
+}
+
+test "performMove rejects invalid from/to paths" {
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try makeProject(tmp.dir, io);
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    try testing.expectEqual(MoveOutcome.invalid_from_path, try performMove(tmp.dir, io, a, "not valid!", "release"));
+    try testing.expectEqual(MoveOutcome.invalid_to_path, try performMove(tmp.dir, io, a, "deploy", "not valid!"));
+}
+
+test "performMove reports a missing source command" {
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try makeProject(tmp.dir, io);
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const outcome = try performMove(tmp.dir, io, arena.allocator(), "deploy", "release");
+    try testing.expectEqualStrings("src/commands/deploy.zig", outcome.from_not_found);
+}
+
+test "performMove refuses to move a command group" {
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try makeProject(tmp.dir, io);
+    try tmp.dir.createDir(io, "src/commands/users", .default_dir);
+    try tmp.dir.writeFile(io, .{ .sub_path = "src/commands/users/create.zig", .data = "pub const meta = .{};\n" });
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const outcome = try performMove(tmp.dir, io, arena.allocator(), "users", "admin");
+    try testing.expectEqual(MoveOutcome.from_is_group, outcome);
+}
+
+test "performMove refuses an existing destination file or group" {
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try makeProject(tmp.dir, io);
+    try tmp.dir.writeFile(io, .{ .sub_path = "src/commands/deploy.zig", .data = "pub const meta = .{};\n" });
+    try tmp.dir.writeFile(io, .{ .sub_path = "src/commands/release.zig", .data = "pub const meta = .{};\n" });
+    try tmp.dir.createDir(io, "src/commands/admin", .default_dir);
+    try tmp.dir.writeFile(io, .{ .sub_path = "src/commands/admin/create.zig", .data = "pub const meta = .{};\n" });
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const to_file = try performMove(tmp.dir, io, a, "deploy", "release");
+    try testing.expectEqualStrings("src/commands/release.zig", to_file.to_exists);
+
+    const to_group = try performMove(tmp.dir, io, a, "deploy", "admin");
+    try testing.expectEqual(MoveOutcome.to_is_group, to_group);
+}
+
+test "performMove renames the file, creates parent groups, and rewrites self-references" {
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try makeProject(tmp.dir, io);
+    try tmp.dir.writeFile(io, .{ .sub_path = "src/commands/deploy.zig", .data =
+        \\pub const meta = .{
+        \\    .examples = &.{"deploy --env prod"},
+        \\};
+        \\
+        \\test "deploy: works" {}
+        \\
+    });
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const outcome = try performMove(tmp.dir, io, arena.allocator(), "deploy", "release/deploy");
+
+    try testing.expectEqualStrings("src/commands/deploy.zig", outcome.ok.from_file);
+    try testing.expectEqualStrings("src/commands/release/deploy.zig", outcome.ok.to_file);
+    try testing.expect(!exists(tmp.dir, io, "src/commands/deploy.zig"));
+    try testing.expect(exists(tmp.dir, io, "src/commands/release/deploy.zig"));
+
+    const moved = try tmp.dir.readFileAlloc(io, "src/commands/release/deploy.zig", testing.allocator, .limited(4096));
+    defer testing.allocator.free(moved);
+    try testing.expect(std.mem.indexOf(u8, moved, "release deploy --env prod") != null);
+    try testing.expect(std.mem.indexOf(u8, moved, "\"release deploy: works\"") != null);
+}
+
+test "performMove cascades removeEmptyParents when the source group is left empty" {
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try makeProject(tmp.dir, io);
+    try tmp.dir.createDir(io, "src/commands/users", .default_dir);
+    try tmp.dir.writeFile(io, .{ .sub_path = "src/commands/users/create.zig", .data = "pub const meta = .{};\n" });
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    _ = try performMove(tmp.dir, io, arena.allocator(), "users/create", "register");
+
+    try testing.expect(!exists(tmp.dir, io, "src/commands/users"));
+    try testing.expect(exists(tmp.dir, io, "src/commands/register.zig"));
 }

--- a/projects/zcli/src/commands/rm/command.zig
+++ b/projects/zcli/src/commands/rm/command.zig
@@ -30,31 +30,50 @@ pub fn execute(args: Args, _: Options, context: *Context) !void {
     defer arena_state.deinit();
     const arena = arena_state.allocator();
 
-    const io = context.io;
-    const cwd = std.Io.Dir.cwd();
+    const outcome = try performRemove(std.Io.Dir.cwd(), context.io, arena, args.path);
+    switch (outcome) {
+        .ok => |file_path| try finish(context.stdout(), &context.theme, file_path),
+        .not_a_project => return context.fail("Error: Not in a zcli project directory\nRun this command from the root of your zcli project (where build.zig is)", .{}),
+        .invalid_path => return context.fail("Error: Invalid command path: '{s}'", .{args.path}),
+        .is_group => return context.fail("Error: '{s}' is a command group; remove its subcommands first", .{args.path}),
+        .not_found => |file_path| return context.fail("Error: Command not found: {s}", .{file_path}),
+    }
+}
 
-    cwd.access(io, "src/commands", .{}) catch {
-        return context.fail("Error: Not in a zcli project directory\nRun this command from the root of your zcli project (where build.zig is)", .{});
-    };
+/// Result of `performRemove`. A tagged union (rather than an error set)
+/// because a couple of failure modes need to carry the resolved file path
+/// back to the caller for the user-facing message.
+const RemoveOutcome = union(enum) {
+    ok: []const u8,
+    not_a_project,
+    invalid_path,
+    is_group,
+    not_found: []const u8,
+};
 
-    const parts = spec.parsePath(arena, args.path) catch {
-        return context.fail("Error: Invalid command path: '{s}'", .{args.path});
-    };
+/// The actual removal: validates the path, refuses to delete a whole command
+/// group, deletes the file, and tidies up any group left empty behind it.
+/// Takes `dir` explicitly (rather than hardcoding `std.Io.Dir.cwd()`) so it
+/// can be exercised against a scratch directory in tests.
+fn performRemove(dir: std.Io.Dir, io: std.Io, arena: std.mem.Allocator, path: []const u8) !RemoveOutcome {
+    dir.access(io, "src/commands", .{}) catch return .not_a_project;
+
+    const parts = spec.parsePath(arena, path) catch return .invalid_path;
 
     const file_path = try spec.buildFilePath(arena, parts);
-    if (!exists(io, file_path)) {
+    if (!exists(dir, io, file_path)) {
         // A group directory is not removed here — that would delete its
         // subcommands (and any index.zig) wholesale. Ask for the leaf files.
-        if (exists(io, try fs.groupPath(arena, parts))) {
-            return context.fail("Error: '{s}' is a command group; remove its subcommands first", .{args.path});
+        if (exists(dir, io, try fs.groupPath(arena, parts))) {
+            return .is_group;
         }
-        return context.fail("Error: Command not found: {s}", .{file_path});
+        return .{ .not_found = file_path };
     }
 
-    try cwd.deleteFile(io, file_path);
-    try fs.removeEmptyParents(cwd, io, arena, parts);
+    try dir.deleteFile(io, file_path);
+    try fs.removeEmptyParents(dir, io, arena, parts);
 
-    try finish(context.stdout(), &context.theme, file_path);
+    return .{ .ok = file_path };
 }
 
 fn finish(w: *std.Io.Writer, theme: *const ThemeContext, file_path: []const u8) !void {
@@ -65,7 +84,102 @@ fn finish(w: *std.Io.Writer, theme: *const ThemeContext, file_path: []const u8) 
     try w.writeAll("\n");
 }
 
-fn exists(io: std.Io, path: []const u8) bool {
-    std.Io.Dir.cwd().access(io, path, .{}) catch return false;
+fn exists(dir: std.Io.Dir, io: std.Io, path: []const u8) bool {
+    dir.access(io, path, .{}) catch return false;
     return true;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const testing = std.testing;
+
+fn makeProject(dir: std.Io.Dir, io: std.Io) !void {
+    try dir.createDir(io, "src", .default_dir);
+    try dir.createDir(io, "src/commands", .default_dir);
+}
+
+test "performRemove fails outside a zcli project" {
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const outcome = try performRemove(tmp.dir, io, arena.allocator(), "deploy");
+    try testing.expectEqual(RemoveOutcome.not_a_project, outcome);
+}
+
+test "performRemove rejects an invalid path" {
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try makeProject(tmp.dir, io);
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const outcome = try performRemove(tmp.dir, io, arena.allocator(), "not valid!");
+    try testing.expectEqual(RemoveOutcome.invalid_path, outcome);
+}
+
+test "performRemove reports a missing command" {
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try makeProject(tmp.dir, io);
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const outcome = try performRemove(tmp.dir, io, arena.allocator(), "deploy");
+    try testing.expectEqualStrings("src/commands/deploy.zig", outcome.not_found);
+}
+
+test "performRemove refuses to remove a whole command group" {
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try makeProject(tmp.dir, io);
+    try tmp.dir.createDir(io, "src/commands/users", .default_dir);
+    try tmp.dir.writeFile(io, .{ .sub_path = "src/commands/users/create.zig", .data = "pub const meta = .{};\n" });
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const outcome = try performRemove(tmp.dir, io, arena.allocator(), "users");
+    try testing.expectEqual(RemoveOutcome.is_group, outcome);
+}
+
+test "performRemove deletes the file and cascades removeEmptyParents" {
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try makeProject(tmp.dir, io);
+    try tmp.dir.createDir(io, "src/commands/users", .default_dir);
+    try tmp.dir.writeFile(io, .{ .sub_path = "src/commands/users/create.zig", .data = "pub const meta = .{};\n" });
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const outcome = try performRemove(tmp.dir, io, arena.allocator(), "users/create");
+
+    try testing.expectEqualStrings("src/commands/users/create.zig", outcome.ok);
+    try testing.expect(!exists(tmp.dir, io, "src/commands/users/create.zig"));
+    try testing.expect(!exists(tmp.dir, io, "src/commands/users"));
+    try testing.expect(exists(tmp.dir, io, "src/commands"));
+}
+
+test "performRemove leaves a non-empty group behind" {
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try makeProject(tmp.dir, io);
+    try tmp.dir.createDir(io, "src/commands/users", .default_dir);
+    try tmp.dir.writeFile(io, .{ .sub_path = "src/commands/users/create.zig", .data = "pub const meta = .{};\n" });
+    try tmp.dir.writeFile(io, .{ .sub_path = "src/commands/users/delete.zig", .data = "pub const meta = .{};\n" });
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    _ = try performRemove(tmp.dir, io, arena.allocator(), "users/create");
+
+    try testing.expect(exists(tmp.dir, io, "src/commands/users"));
+    try testing.expect(exists(tmp.dir, io, "src/commands/users/delete.zig"));
 }

--- a/projects/zcli/src/commands/rm/index.zig
+++ b/projects/zcli/src/commands/rm/index.zig
@@ -1,3 +1,12 @@
+const std = @import("std");
+
 pub const meta = .{
     .description = "Remove args and options from an existing command",
 };
+
+test "meta.description names what this group removes" {
+    try std.testing.expect(meta.description.len > 0);
+    try std.testing.expect(std.mem.startsWith(u8, meta.description, "Remove"));
+    try std.testing.expect(std.mem.indexOf(u8, meta.description, "args") != null);
+    try std.testing.expect(std.mem.indexOf(u8, meta.description, "options") != null);
+}


### PR DESCRIPTION
## Summary
- Fixes #635: `command_test_files` in `projects/zcli/build.zig` omitted `mv.zig`, `guide.zig`, `rm/command.zig`, `rm/index.zig`, `add/index.zig`, `gh/index.zig`, and `gh/add/workflow/release.zig`, and none of them had `test` blocks.
- `mv.zig`, `rm/command.zig`, and `gh/add/workflow/release.zig` hardcoded `std.Io.Dir.cwd()` inside `execute`, so their core logic (path validation, group/conflict checks, the actual filesystem move/remove/write) is extracted into a `dir`-parameterized helper that returns a tagged outcome — `execute` just translates the outcome into `context.fail(...)` messages. This makes the logic exercisable against a scratch `std.testing.tmpDir` instead of the real repo.
- `guide.zig`'s topic lookup is pulled into a pure `findTopic()` helper; `printOverview`/`printTopicList` are tested directly against a `std.Io.Writer.Allocating`.
- The three metadata-only `index.zig` groups (`rm`, `add`, `gh`) get a content-checking test on `meta.description` (catches an empty/typo'd description, not just "it compiles").
- All seven files are wired into `command_test_files`.

## Test plan
- [x] `cd projects/zcli && zig build test` — green (new tests + existing suite)
- [x] `cd projects/zcli && zig build` — the real `*Context`-typed `execute()` paths still compile
- [x] `zig fmt --check` clean on all touched files
- [x] Root `zig build test` — the `zcli` package tests pass within the full aggregate run (verified via `✓ zcli tests passed`); the remaining example packages are unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)