### PR TITLE
fix: multi-param DEC modes and codepoint-safe spinner truncation

### DIFF
--- a/packages/progress/src/Progress.zig
+++ b/packages/progress/src/Progress.zig
@@ -237,7 +237,14 @@ pub const Spinner = struct {
     /// the animation task never reads the caller's slice. Callers holding the
     /// mutex (or before the animate task spawns) may invoke this safely.
     fn storeMessage(self: *Spinner, msg: []const u8) void {
-        const n = @min(msg.len, self.message_buf.len);
+        var n = @min(msg.len, self.message_buf.len);
+        if (n < msg.len) {
+            // A hard byte-count truncation can land mid-codepoint. Back off
+            // over UTF-8 continuation bytes (0b10xxxxxx) until `n` sits on a
+            // codepoint boundary, so ui.text never receives a truncated
+            // multibyte sequence.
+            while (n > 0 and (msg[n] & 0xC0) == 0x80) : (n -= 1) {}
+        }
         @memcpy(self.message_buf[0..n], msg[0..n]);
         self.message_len = n;
     }
@@ -1044,6 +1051,35 @@ test "spinner copies its message so a reused caller buffer is safe" {
     const written = writer.buffered();
     try testing.expect(std.mem.indexOf(u8, written, "loading data") != null);
     try testing.expect(std.mem.indexOf(u8, written, "XXXX") == null);
+}
+
+test "spinner message truncation never splits a UTF-8 codepoint" {
+    // Regression (#643): storeMessage hard-cuts at 256 bytes. Build a
+    // message whose 256-byte cut point lands inside a 4-byte codepoint
+    // (a padding prefix of 253 ASCII bytes followed by 😀, which starts
+    // at byte 253 and spans bytes 253-256) and confirm the stored
+    // message backs off to a codepoint boundary instead of emitting
+    // invalid UTF-8.
+    var output: [8192]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&output);
+
+    var s = try Spinner.init(testing.allocator, &writer, testing.io, .fallback, .{});
+
+    var msg_buf: [512]u8 = undefined;
+    @memset(msg_buf[0..253], 'a');
+    const emoji = "\u{1F600}"; // 😀, 4 UTF-8 bytes
+    @memcpy(msg_buf[253..257], emoji);
+    const msg = msg_buf[0..257];
+
+    s.storeMessage(msg);
+    const stored = s.messageSlice();
+
+    try testing.expect(stored.len <= 256);
+    try testing.expect(std.unicode.utf8ValidateSlice(stored));
+    // The emoji doesn't fully fit within 256 bytes, so it must be dropped
+    // entirely rather than truncated mid-sequence.
+    try testing.expectEqual(@as(usize, 253), stored.len);
+    try testing.expect(std.mem.indexOf(u8, stored, "\u{1F600}") == null);
 }
 
 test "spinner double start does not spawn a second animation" {

--- a/packages/vterm/src/tests/parser_test.zig
+++ b/packages/vterm/src/tests/parser_test.zig
@@ -256,6 +256,24 @@ test "alternate screen" {
     try testing.expect(!term.alt_screen);
 }
 
+test "multi-param DEC private mode sequence applies all modes" {
+    var term = try VTerm.init(testing.allocator, 10, 5);
+    defer term.deinit();
+
+    try testing.expect(term.cursor_visible);
+    try testing.expect(!term.alt_screen);
+
+    // A combined sequence like `CSI ? 25 ; 1049 h` must apply BOTH modes,
+    // not just the first param.
+    term.write("\x1b[?25;1049h");
+    try testing.expect(term.cursor_visible);
+    try testing.expect(term.alt_screen);
+
+    term.write("\x1b[?25;1049l");
+    try testing.expect(!term.cursor_visible);
+    try testing.expect(!term.alt_screen);
+}
+
 test "parameter defaults and edge cases" {
     var term = try VTerm.init(testing.allocator, 10, 10);
     defer term.deinit();

--- a/packages/vterm/src/vterm.zig
+++ b/packages/vterm/src/vterm.zig
@@ -885,12 +885,18 @@ pub const VTerm = struct {
 
     // Private mode handling (DEC sequences)
     fn handlePrivateMode(self: *VTerm, enable: bool) void {
-        const mode = self.getParam(0, 0);
-        switch (mode) {
-            7 => self.autowrap = enable, // DECAWM auto-wrap
-            25 => self.cursor_visible = enable, // Cursor visibility
-            1049 => self.alt_screen = enable, // Alternate screen buffer
-            else => {}, // Ignore other modes
+        // A combined sequence like `CSI ? 7;25;1049 h` carries multiple
+        // modes in one escape; apply every param, not just the first
+        // (mirrors the loop in handleSGR).
+        var i: usize = 0;
+        while (i <= self.param_count) : (i += 1) {
+            const mode = self.params[i];
+            switch (mode) {
+                7 => self.autowrap = enable, // DECAWM auto-wrap
+                25 => self.cursor_visible = enable, // Cursor visibility
+                1049 => self.alt_screen = enable, // Alternate screen buffer
+                else => {}, // Ignore other modes
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- `packages/vterm`: `handlePrivateMode` only read `getParam(0, 0)`, so a combined DEC private-mode sequence like `CSI ?25;1049 h` applied mode 25 and silently dropped 1049. Now loops over every param (`0..=param_count`), matching the existing pattern in `handleSGR`.
- `packages/progress` (module `progress`): `Spinner.storeMessage` hard-truncated messages at 256 bytes with `@memcpy(...@min(msg.len, 256)...)`, which could split a UTF-8 codepoint mid-sequence. It now backs off over continuation bytes (`msg[n] & 0xC0 == 0x80`) to land on a codepoint boundary before copying.

Fixes #642
Fixes #643

## Test plan
- [x] Added `multi-param DEC private mode sequence applies all modes` in `packages/vterm/src/tests/parser_test.zig` — sends `CSI ?25;1049 h`/`l` and asserts both `cursor_visible` and `alt_screen` toggle together.
- [x] Added `spinner message truncation never splits a UTF-8 codepoint` in `packages/progress/src/Progress.zig` — a 257-byte message with a 4-byte emoji straddling the 256-byte cut point; asserts the stored message stays valid UTF-8 and drops the incomplete codepoint entirely.
- [x] `zig build test` passes from repo root (also verified `packages/vterm` and `packages/progress` standalone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)