### PR TITLE
fix(markdown): escape literal braces, fix header underline width

### DIFF
--- a/packages/markdown/src/inline_parser.zig
+++ b/packages/markdown/src/inline_parser.zig
@@ -66,11 +66,25 @@ pub fn parseInline(comptime markdown: []const u8, comptime palette: semantic.Pal
                 continue;
             }
 
-            // Check for format specifiers - preserve them exactly
-            if (markdown[i] == '{' and i + 2 < markdown.len and markdown[i + 2] == '}') {
-                result = result ++ markdown[i .. i + 3];
-                i += 3;
-                continue;
+            // Check for format specifiers - preserve them exactly for runtime
+            // interpolation. Recognized as either a single-character
+            // specifier ({s}, {d}, {}...) or one carrying fill/alignment/
+            // width/precision directives, which always contain a ':' (e.g.
+            // {s:<16}). Anything else between literal braces (e.g.
+            // "{threshold}" in prose) is ordinary text, not a specifier, and
+            // falls through to be brace-escaped below.
+            if (markdown[i] == '{') {
+                var j = i + 1;
+                var has_colon = false;
+                const search_limit = @min(markdown.len, i + 1 + 32);
+                while (j < search_limit and markdown[j] != '}' and markdown[j] != '{') : (j += 1) {
+                    if (markdown[j] == ':') has_colon = true;
+                }
+                if (j < search_limit and markdown[j] == '}' and (j <= i + 2 or has_colon)) {
+                    result = result ++ markdown[i .. j + 1];
+                    i = j + 1;
+                    continue;
+                }
             }
 
             // Check for inline code (`code`)
@@ -239,13 +253,64 @@ pub fn parseInline(comptime markdown: []const u8, comptime palette: semantic.Pal
                 continue;
             }
 
-            // Regular character
-            result = result ++ &[_]u8{markdown[i]};
+            // Regular character. Literal braces that aren't a recognized
+            // format specifier (handled above) must be escaped, since the
+            // final rendered string is used as a std.fmt format string by
+            // callers of `Formatter.print` (see main.zig).
+            if (markdown[i] == '{' or markdown[i] == '}') {
+                result = result ++ &[_]u8{ markdown[i], markdown[i] };
+            } else {
+                result = result ++ &[_]u8{markdown[i]};
+            }
             i += 1;
         }
 
         return result;
     }
+}
+
+/// Display width of already-parsed, ANSI-free plain text (e.g. the output of
+/// `parseInline(content, palette, .no_color)`). UTF-8 codepoint aware, and
+/// treats common East Asian wide ranges as occupying two terminal columns so
+/// headings underline to the correct visible width instead of the raw byte
+/// count.
+pub fn visibleWidth(comptime text: []const u8) usize {
+    comptime {
+        var width: usize = 0;
+        var i: usize = 0;
+        while (i < text.len) {
+            const seq_len = std.unicode.utf8ByteSequenceLength(text[i]) catch 1;
+            const len = @min(seq_len, text.len - i);
+            const codepoint: u21 = if (len > 1)
+                std.unicode.utf8Decode(text[i .. i + len]) catch 0
+            else
+                text[i];
+            width += if (isWideCodepoint(codepoint)) 2 else 1;
+            i += len;
+        }
+        return width;
+    }
+}
+
+/// Best-effort East Asian Wide/Fullwidth check (not a full Unicode Annex #11
+/// table, but covers the common CJK/Hangul/fullwidth ranges).
+fn isWideCodepoint(cp: u21) bool {
+    return switch (cp) {
+        0x1100...0x115F, // Hangul Jamo
+        0x2E80...0x303E, // CJK Radicals Supplement .. CJK Symbols/Punctuation
+        0x3041...0x33FF, // Hiragana .. CJK Compatibility
+        0x3400...0x4DBF, // CJK Unified Ideographs Extension A
+        0x4E00...0x9FFF, // CJK Unified Ideographs
+        0xA000...0xA4CF, // Yi Syllables/Radicals
+        0xAC00...0xD7A3, // Hangul Syllables
+        0xF900...0xFAFF, // CJK Compatibility Ideographs
+        0xFF00...0xFF60, // Fullwidth Forms
+        0xFFE0...0xFFE6, // Fullwidth Signs
+        0x20000...0x2FFFD, // CJK Unified Ideographs Extension B+ / Compat Supplement
+        0x30000...0x3FFFD, // CJK Unified Ideographs Extension G+
+        => true,
+        else => false,
+    };
 }
 
 /// Parse a markdown link [text](url)
@@ -359,6 +424,35 @@ test "no color mode strips all ANSI" {
     const palette = semantic.Palette{};
     const result = comptime parseInline("**bold** and `code`", palette, .no_color);
     try std.testing.expectEqualStrings("bold and code", result);
+}
+
+test "literal braces in prose are escaped" {
+    // Regression: `{threshold}` isn't a recognized single-char format
+    // specifier like `{s}`/`{d}`, so it must be escaped to `{{threshold}}`
+    // rather than passed through raw - otherwise the final rendered string
+    // (used as a std.fmt format string by callers) fails to compile/parse.
+    const palette = semantic.Palette{};
+    const result = comptime parseInline("Set {threshold} high", palette, .no_color);
+    try std.testing.expectEqualStrings("Set {{threshold}} high", result);
+
+    // Actual format specifiers must still be preserved for interpolation.
+    const with_spec = comptime parseInline("Value: {s}", palette, .no_color);
+    try std.testing.expectEqualStrings("Value: {s}", with_spec);
+
+    // The escaped output must itself be a valid format string (with no args).
+    var buf: [64]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buf);
+    try writer.print(result, .{});
+    try std.testing.expectEqualStrings("Set {threshold} high", writer.buffered());
+}
+
+test "visibleWidth counts ASCII as one column each" {
+    try std.testing.expectEqual(@as(usize, 11), comptime visibleWidth("Hello World"));
+}
+
+test "visibleWidth treats CJK codepoints as double width" {
+    // "日本語" is 3 codepoints (9 UTF-8 bytes), each rendering 2 columns wide.
+    try std.testing.expectEqual(@as(usize, 6), comptime visibleWidth("日本語"));
 }
 
 test {

--- a/packages/markdown/src/renderers.zig
+++ b/packages/markdown/src/renderers.zig
@@ -27,11 +27,12 @@ pub fn renderHeader(comptime level: usize, comptime content: []const u8, comptim
                 // H1: Bold + underline with ═
                 const header_line = color_code ++ parsed_content ++ ANSI_RESET;
 
-                // Calculate visible width (approximate - count non-ANSI characters)
-                var visible_width: usize = 0;
-                for (content) |c| {
-                    if (c != '\x1b') visible_width += 1;
-                }
+                // Measure the parsed, marker-stripped text (markdown syntax
+                // like `**` removed, no ANSI codes) at display width, so
+                // multi-byte / wide characters underline correctly instead
+                // of using the raw pre-parse byte count.
+                const plain_content = inline_parser.parseInline(content, palette, .no_color);
+                const visible_width = inline_parser.visibleWidth(plain_content);
 
                 // Create underline
                 var underline: []const u8 = "\n" ++ color_code;
@@ -47,10 +48,8 @@ pub fn renderHeader(comptime level: usize, comptime content: []const u8, comptim
                 // H2: Bold + underline with ─
                 const header_line = color_code ++ parsed_content ++ ANSI_RESET;
 
-                var visible_width: usize = 0;
-                for (content) |c| {
-                    if (c != '\x1b') visible_width += 1;
-                }
+                const plain_content = inline_parser.parseInline(content, palette, .no_color);
+                const visible_width = inline_parser.visibleWidth(plain_content);
 
                 var underline: []const u8 = "\n" ++ color_code;
                 var i: usize = 0;
@@ -86,6 +85,17 @@ pub fn renderCodeBlock(comptime language: []const u8, comptime content: []const 
                 escaped_content = escaped_content ++ &[_]u8{ c, c }; // {{ or }}
             } else {
                 escaped_content = escaped_content ++ &[_]u8{c};
+            }
+        }
+
+        // Escape braces in the language tag too - it's spliced into the same
+        // result string, which callers use as a std.fmt format string.
+        var escaped_language: []const u8 = "";
+        for (language) |c| {
+            if (c == '{' or c == '}') {
+                escaped_language = escaped_language ++ &[_]u8{ c, c }; // {{ or }}
+            } else {
+                escaped_language = escaped_language ++ &[_]u8{c};
             }
         }
 
@@ -141,7 +151,7 @@ pub fn renderCodeBlock(comptime language: []const u8, comptime content: []const 
         var result: []const u8 = "\n" ++ color_code;
         result = result ++ "┌";
         if (language.len > 0) {
-            result = result ++ "─ " ++ language ++ " ";
+            result = result ++ "─ " ++ escaped_language ++ " ";
             const remaining = box_width - language.len - 3;
             var j: usize = 0;
             while (j < remaining) : (j += 1) {
@@ -288,6 +298,54 @@ test "render code block with long language tag and short content" {
     try std.testing.expect(std.mem.indexOf(u8, result, "x") != null);
     try std.testing.expect(std.mem.indexOf(u8, result, "┌") != null);
     try std.testing.expect(std.mem.indexOf(u8, result, "└") != null);
+}
+
+test "render code block with braces in language tag" {
+    // Regression: the language tag is spliced into the same result string as
+    // the (brace-escaped) content, and callers use that result as a
+    // std.fmt format string - so an unescaped tag like "{s}" broke print().
+    const palette = semantic.Palette{};
+    const result = comptime renderCodeBlock("{s}", "x", palette, .true_color);
+    try std.testing.expect(std.mem.indexOf(u8, result, "{{s}}") != null);
+
+    var buf: [256]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buf);
+    try writer.print(result, .{});
+}
+
+test "render header with non-ascii text underlines to display width" {
+    // Regression: the underline used to count raw pre-parse bytes, so a
+    // 3-codepoint / 9-byte CJK heading drew a 9-wide underline instead of
+    // the correct 6 display columns (each codepoint is double-width).
+    const palette = semantic.Palette{};
+    const result = comptime renderHeader(1, "日本語", palette, .no_color);
+
+    var underline_len: usize = 0;
+    var it = std.mem.splitScalar(u8, result, '\n');
+    while (it.next()) |line| {
+        if (std.mem.indexOf(u8, line, "═") != null) {
+            underline_len = std.mem.count(u8, line, "═");
+        }
+    }
+    try std.testing.expectEqual(@as(usize, 6), underline_len);
+}
+
+test "render header with markdown markers underlines to visible width, not byte count" {
+    // Regression: the underline used to count the raw content bytes,
+    // including markdown syntax markers (e.g. "**"), producing an
+    // underline wider than the actual rendered text.
+    const palette = semantic.Palette{};
+    const result = comptime renderHeader(1, "Hello **World**", palette, .no_color);
+
+    var underline_len: usize = 0;
+    var it = std.mem.splitScalar(u8, result, '\n');
+    while (it.next()) |line| {
+        if (std.mem.indexOf(u8, line, "═") != null) {
+            underline_len = std.mem.count(u8, line, "═");
+        }
+    }
+    // Visible text is "Hello World" (11 chars).
+    try std.testing.expectEqual(@as(usize, 11), underline_len);
 }
 
 test "render horizontal rule" {


### PR DESCRIPTION
## Summary

- **#628**: The code-fence language tag was spliced into the rendered result unescaped, even though content already goes through a brace-escape loop. Since the final rendered markdown string is used as a `std.fmt` format string by callers (`main.zig`'s `Formatter.print`), a language tag like `{s}` broke `writer.print`. Fixed by running `language` through the same `{{`/`}}` escape loop as `content`. (The box-width underflow half of #628 was already fixed in a prior commit; this closes the remaining brace-escaping gap called out in the issue.)
- **#641** (part 1): H1/H2 heading underlines counted raw pre-parse bytes — including markdown syntax markers (`**`) and multi-byte UTF-8 sequences — instead of the parsed, marker-stripped display width. Fixed by measuring `parseInline(content, palette, .no_color)` (marker-stripped, ANSI-free plain text) with a new codepoint-aware `visibleWidth` helper that treats common CJK/Hangul/fullwidth ranges as double-width.
- **#641** (part 2): Ordinary prose braces (e.g. `Set {threshold} high`) passed through unescaped, since only exact single-character specifiers (`{s}`, `{d}`) were recognized and preserved for runtime interpolation. Broadened the specifier detector to also recognize specifiers with fill/alignment/width/precision directives (which always contain a `:`, e.g. `{s:<16}`, used by `zcli_help`'s help-table formatting) — anything else between braces is now escaped to `{{...}}` rather than passed through raw.

## Test plan

- [x] Added unit tests in `packages/markdown/src/inline_parser.zig`: literal-brace escaping in prose (`{threshold}` → `{{threshold}}`, verified round-trips through `std.Io.Writer.print` with no args), preserved format specifiers, `visibleWidth` for ASCII and CJK text.
- [x] Added unit tests in `packages/markdown/src/renderers.zig`: code block with a brace-containing language tag (`{s}`, round-tripped through `print`), header underline width for a non-ASCII (CJK) heading, header underline width for text containing markdown markers.
- [x] `zig build test` passes from the repo root (all packages + examples).
- [x] `zig build test` from `packages/markdown/` — 82/82 tests passed.

Fixes #628
Fixes #641

🤖 Generated with [Claude Code](https://claude.com/claude-code)