### PR TITLE
fix(core): enforce Options-parity comptime rule for optional Args defaults (#622)

### DIFF
--- a/packages/core/src/args.zig
+++ b/packages/core/src/args.zig
@@ -932,6 +932,22 @@ test "parseArgs trailing defaulted field keeps the strict invalid-value error" {
     try std.testing.expectError(ZcliError.ArgumentInvalidValue, parseArgs(TestArgs, &args, null));
 }
 
+test "parseArgs defaulted leading positional falls through to varargs (#626)" {
+    const TestArgs = struct {
+        count: u32 = 5,
+        rest: [][]const u8,
+    };
+
+    // `foo bar`: `foo` doesn't parse as u32 → count keeps its default and the
+    // token falls through to the varargs field instead of hard-erroring.
+    const args = [_][]const u8{ "foo", "bar" };
+    const parsed = try parseArgs(TestArgs, &args, null);
+    try std.testing.expectEqual(@as(u32, 5), parsed.count);
+    try std.testing.expectEqual(@as(usize, 2), parsed.rest.len);
+    try std.testing.expectEqualStrings("foo", parsed.rest[0]);
+    try std.testing.expectEqualStrings("bar", parsed.rest[1]);
+}
+
 test "parseArgs unicode strings" {
     const TestArgs = struct {
         text: []const u8,

--- a/packages/core/src/zcli.zig
+++ b/packages/core/src/zcli.zig
@@ -451,6 +451,26 @@ pub fn validateCommand(comptime path: []const u8, comptime Module: type) void {
             "`. Example: `pub const Options = struct { verbose: bool = false };`");
     }
 
+    // Args field shapes. An optional positional carries a `null` "absent"
+    // state, and the parser initializes optionals to `null` when the positional
+    // is not supplied — a non-null default would be silently discarded. Forbid
+    // it, mirroring the same rule for options: `?T = null` is the only valid
+    // optional spelling; for a guaranteed value use a non-optional field with a
+    // default.
+    if (@typeInfo(ArgsType) == .@"struct") {
+        inline for (@typeInfo(ArgsType).@"struct".fields) |field| {
+            if (@typeInfo(field.type) == .optional and field.default_value_ptr != null) {
+                const dv: *const field.type = @ptrCast(@alignCast(field.default_value_ptr.?));
+                if (dv.* != null) {
+                    @compileError(loc ++ "optional argument '" ++ field.name ++ "' has a non-null default. " ++
+                        "Optionals default to `null` when the positional is absent. " ++
+                        "Drop the `?` and declare it non-optional (`" ++ field.name ++ ": " ++
+                        @typeName(@typeInfo(field.type).optional.child) ++ " = …`) for a guaranteed value.");
+                }
+            }
+        }
+    }
+
     // Options field shapes. A field with no absent-flag value — not bool,
     // optional, accumulating array, or defaulted — is a REQUIRED option: its
     // type says a value must be supplied, and the parser enforces that at


### PR DESCRIPTION
## Summary

Two argument/option parsing-semantics bugs in `packages/core`. Reworked per design discussion on issue #622.

### #622 — optional field with a non-null default silently parsed to null when absent

An `Args` field like `level: ?u32 = 5` yielded `null` (not `5`) when the positional was absent, because the parser initializes optionals to `null` when the token is missing — the declared default is discarded.

The framework **already** comptime-rejects the identical shape for `Options` (`validateMeta` in `zcli.zig`: *"optional option '<name>' has a non-null default"*). `Args` never got the parallel guard. The correct fix is to make the invalid shape **unrepresentable**, not to teach the parser to honor a forbidden default.

**Fix:** `zcli.zig` (`validateCommand`) now mirrors the Options check for Args. An optional `Args` field with a non-null default fails compilation with a message parallel to the Options one:

```
command 'badshape': optional argument 'level' has a non-null default. Optionals default to `null` when the positional is absent. Drop the `?` and declare it non-optional (`level: u32 = …`) for a guaranteed value.
```

`?T = null` is the only valid optional spelling; a guaranteed value is a non-optional field with a default.

### #626 — defaulted (non-optional) leading positional falls through to varargs

`Args = struct { count: u32 = 5, rest: [][]const u8 }` invoked as `foo bar` correctly keeps `count = 5` and lets the tokens flow to `rest` (this behavior already exists on `main`). This PR adds a regression test for the exact issue shape to lock it in.

## Tests / verification
- `args.zig`: regression test — defaulted leading positional falls through to a trailing varargs field.
- Valid optional shapes (`?T = null` stays null when absent; `T = default` keeps default) remain covered by existing tests.
- A `?u32 = 5` `Args` field is a compile error and cannot be unit-tested directly (verified manually — message above).
- `zig build test` (repo root) passes: 151/151 steps, 2651/2653 tests (2 skipped). `zig build` in `projects/zcli` passes.

Fixes #622
Fixes #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)