### PR TITLE
fix(dev): close reaper track/kill race around the app child

### DIFF
--- a/projects/zcli/src/commands/dev.zig
+++ b/projects/zcli/src/commands/dev.zig
@@ -237,11 +237,14 @@ fn doCycle(
     app_child: *?std.process.Child,
 ) !void {
     // Stop the previous run before rebuilding (restart-on-change). kill() blocks
-    // until the child is reaped and is idempotent.
+    // until the child is reaped and is idempotent. Untrack *before* reaping: the
+    // pid stays live (and can even be reused by an unrelated process) until the
+    // reap completes, so clearing the tracked target first ensures a signal
+    // arriving mid-kill can never end up targeting a stale/reused pid.
     if (app_child.*) |*child| {
+        reaper.track(null);
         child.kill(io);
         app_child.* = null;
-        reaper.track(null);
     }
 
     try paint(status, theme, "▸ rebuilding…", .info);
@@ -252,7 +255,6 @@ fn doCycle(
 
     if (command.len > 0) {
         app_child.* = try startApp(io, arena, status, theme, app_name, command);
-        reaper.track(app_child.*);
     }
 }
 
@@ -302,12 +304,18 @@ fn startApp(
     try status.writeByte('\n');
     try status.flush();
 
-    return try std.process.spawn(io, .{
+    const child = try std.process.spawn(io, .{
         .argv = try appArgv(arena, binary, command),
         .stdin = .inherit,
         .stdout = .inherit,
         .stderr = .inherit,
     });
+    // Record it for the signal handlers immediately — before any other work
+    // (including returning to the caller) — so the window in which a SIGTERM
+    // could reach dev without the reaper knowing about the just-spawned child
+    // is as small as possible.
+    reaper.track(child);
+    return child;
 }
 
 /// Picks the executable in zig-out/bin to run. A scaffolded project produces


### PR DESCRIPTION
## Summary
- `zcli dev`'s reaper tracked the spawned app child only *after* `startApp` returned to `doCycle`, and cleared tracking only *after* `child.kill(io)` finished reaping it — leaving two narrow windows where an external signal (SIGTERM/SIGHUP/Ctrl-C via the console handler) could either miss the just-spawned child (orphaning it) or, on restart, still be pointed at a pid that had just been reaped and could be reused by an unrelated process.
- `reaper.track(child)` now happens inside `startApp`, immediately after `std.process.spawn` returns, before any other work (including returning to the caller) — shrinking the spawn-side window as much as possible without true atomicity.
- `doCycle` now calls `reaper.track(null)` *before* `child.kill(io)` instead of after, so the tracked target is cleared before the reap begins, closing the kill-side window where a stale/reused pid could be signalled.

Per the issue, terminate is already documented as best-effort, so this narrows the race rather than claiming full atomicity (Zig's `spawn` and a separate atomic store can't be made truly atomic).

## Test plan
- [x] `zig build test` (root) — full run completed with all packages (`zcli`, examples, etc.) reporting `✓ ... tests passed`, including `projects/zcli`'s `dev.zig` unit tests (`reaper.track`/`reaper.kill` tests).
- [x] `zig build` in `projects/zcli` succeeds.

Fixes #645

🤖 Generated with [Claude Code](https://claude.com/claude-code)