### PR TITLE
fix(theme): downconvert 256-color indices to nearest ansi16 at runtime

### DIFF
--- a/packages/theme/src/core/color.zig
+++ b/packages/theme/src/core/color.zig
@@ -116,8 +116,9 @@ fn rgbToAnsi256(r: u8, g: u8, b: u8) u8 {
     return 16 + (r_idx * 36) + (g_idx * 6) + b_idx;
 }
 
-/// Convert 256-color palette index to closest 16-color ANSI equivalent
-fn approximateToAnsi16(idx: u8) u8 {
+/// Convert 256-color palette index to closest 16-color ANSI equivalent.
+/// Pure integer math, so it is safe on both the comptime and runtime paths.
+pub fn approximateToAnsi16(idx: u8) u8 {
     // First 16 colors map directly
     if (idx < 16) return idx;
 

--- a/packages/theme/src/core/style.zig
+++ b/packages/theme/src/core/style.zig
@@ -9,6 +9,7 @@ const toAnsi16 = @import("color.zig").toAnsi16;
 const toAnsi256 = @import("color.zig").toAnsi256;
 const parseHex = @import("color.zig").parseHex;
 const approximateRgbToAnsi16 = @import("color.zig").approximateRgbToAnsi16;
+const approximateToAnsi16 = @import("color.zig").approximateToAnsi16;
 const TerminalCapability = @import("../detection/capability.zig").TerminalCapability;
 
 // Runtime version of toAnsi16 (color.zig's version requires comptime for hex parsing)
@@ -30,7 +31,7 @@ fn toAnsi16Runtime(color: Color) u8 {
         .bright_magenta => 13,
         .bright_cyan => 14,
         .bright_white => 15,
-        .indexed => |idx| if (idx < 16) idx else 7,
+        .indexed => |idx| approximateToAnsi16(idx),
         .rgb => |rgb| approximateRgbToAnsi16(rgb.r, rgb.g, rgb.b),
         .hex => |hex_str| {
             const rgb = parseHex(hex_str);
@@ -403,6 +404,42 @@ test "hex colors render as exact RGB in true color mode" {
 
     const comptime_seq = comptime (Style{ .foreground = Color{ .hex = "#FF8040" } }).sequenceComptime(.true_color);
     try testing.expectEqualStrings("\x1B[38;2;255;128;64m", comptime_seq);
+}
+
+test "runtime indexed→ansi16 downconversion picks nearest color" {
+    const testing = std.testing;
+
+    // First 16 palette entries pass straight through.
+    try testing.expectEqual(@as(u8, 9), toAnsi16Runtime(Color{ .indexed = 9 }));
+
+    // 216-color cube entries map to the nearest ANSI-16 color instead of
+    // collapsing to white (7). Regression: idx 196 is pure red, not white.
+    try testing.expectEqual(@as(u8, 9), toAnsi16Runtime(Color{ .indexed = 196 })); // bright red
+    try testing.expectEqual(@as(u8, 1), toAnsi16Runtime(Color{ .indexed = 88 })); // dim red
+    try testing.expectEqual(@as(u8, 12), toAnsi16Runtime(Color{ .indexed = 21 })); // bright blue
+    try testing.expectEqual(@as(u8, 13), toAnsi16Runtime(Color{ .indexed = 201 })); // bright magenta
+    try testing.expectEqual(@as(u8, 14), toAnsi16Runtime(Color{ .indexed = 123 })); // bright cyan
+
+    // Grayscale ramp (232-255) spans black → gray → bright white.
+    try testing.expectEqual(@as(u8, 0), toAnsi16Runtime(Color{ .indexed = 232 })); // black
+    try testing.expectEqual(@as(u8, 8), toAnsi16Runtime(Color{ .indexed = 244 })); // gray
+    try testing.expectEqual(@as(u8, 15), toAnsi16Runtime(Color{ .indexed = 255 })); // bright white
+}
+
+test "indexed colors render as nearest ANSI-16 sequence" {
+    const testing = std.testing;
+    var buf: [64]u8 = undefined;
+
+    // Regression test: the runtime fallback used to emit bright white (97) for
+    // every index ≥ 16, so pure-red 196 rendered white on a 16-color terminal.
+    const red_style = Style{ .foreground = Color{ .indexed = 196 } };
+    try testing.expectEqualStrings("\x1B[91m", try sequenceToBuf(red_style, .ansi_16, &buf));
+
+    const blue_bg = Style{ .background = Color{ .indexed = 21 } };
+    try testing.expectEqualStrings("\x1B[104m", try sequenceToBuf(blue_bg, .ansi_16, &buf));
+
+    const gray_style = Style{ .foreground = Color{ .indexed = 244 } };
+    try testing.expectEqualStrings("\x1B[90m", try sequenceToBuf(gray_style, .ansi_16, &buf));
 }
 
 test "multiple text decorations" {


### PR DESCRIPTION
## Problem

The runtime `indexed → ansi16` fallback in `toAnsi16Runtime` (`packages/theme/src/core/style.zig`) collapsed **every** 256-color palette index ≥ 16 to `7` (white):

```zig
.indexed => |idx| if (idx < 16) idx else 7,
```

So `color256(196)` (pure red) rendered as white on a 16-color terminal — and the runtime path is the common one. The comptime twin in `color.zig` already downconverted correctly via `approximateToAnsi16`.

## Fix

- Made `approximateToAnsi16` `pub` in `color.zig`. It is pure integer math (no comptime requirement), so it is safe on both paths.
- Call it from `toAnsi16Runtime` for all indices, replacing the `else 7` collapse.

The mapping decodes the palette index back to RGB and reuses the existing `approximateRgbToAnsi16` nearest-color logic:
- **16–231** (6×6×6 cube): reconstruct RGB from the cube coordinates (`0–5 → 0/51/102/…/255`), then approximate.
- **232–255** (grayscale ramp): reconstruct the gray level (`(idx-232)*10+8`), then approximate — spanning black → gray → bright white.

## Tests

Added two runtime-path tests in `style.zig` covering representative indices: cube colors (196→bright red, 88→dim red, 21→bright blue, 201→magenta, 123→cyan), the grayscale ramp (232→black, 244→gray, 255→bright white), and a passthrough (idx 9), plus a rendering test asserting the emitted ANSI sequences.

Fixes #625

🤖 Generated with [Claude Code](https://claude.com/claude-code)