### PR TITLE
fix: exit 141 (not 0) when a broken pipe hits the final buffered flush

### DIFF
--- a/packages/core/src/registry/compiled.zig
+++ b/packages/core/src/registry/compiled.zig
@@ -805,6 +805,20 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
                 }
                 return err;
             };
+
+            // The command completed without erroring, but the writers may still
+            // have hit a broken pipe on the *final* buffered flush — the one
+            // `executeWithStdio`'s `defer stdio.flush()` runs on its way out,
+            // which swallows the write error (`catch {}`) rather than surfacing
+            // it as `error.WriteFailed`. A whole-output-fits-in-one-buffer
+            // command (`yourcli cmd | head -c0`) never sees a mid-command write
+            // failure, so without this check it would exit 0 instead of the
+            // conventional SIGPIPE status. Check the recorded writer error the
+            // same way the error path above does.
+            if (wroteToBrokenPipe(&stdio)) {
+                console.restore();
+                std.process.exit(broken_pipe_status);
+            }
         }
 
         /// Convert `value` and hand it to the plugin that declared

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -151,6 +151,52 @@ fn runIntoHeadViaShell(a: std.mem.Allocator, cwd: std.Io.Dir, bin: []const u8, c
     return readFile(cwd, a, err_name);
 }
 
+/// Run `bin cmd | head -c0` through a shell: `head -c0` closes its read end
+/// immediately, without reading anything, before the CLI ever writes. Unlike
+/// `runIntoHeadViaShell`'s `flood` scenario — where the pipe fills mid-command
+/// and a *write inside `execute()`* fails — a small command's whole output
+/// fits in the framework's 4096-byte stdout buffer, so nothing hits the wire
+/// until the deferred final flush after `execute()` returns successfully.
+/// That is exactly the gap #630 covers: the mid-command broken-pipe path
+/// never fires, so the framework must still notice the flush-time EPIPE and
+/// exit 141 rather than 0. The subshell's own exit status is captured to
+/// `exit_file` (not stdout, so it doesn't confuse `head`) so the caller can
+/// assert on the CLI's real exit code rather than the pipeline's.
+fn runIntoHeadC0ViaShell(a: std.mem.Allocator, cwd: std.Io.Dir, bin: []const u8, cmd: []const u8, exit_file: []const u8) !u8 {
+    const argv: []const []const u8 = if (builtin.os.tag == .windows) blk: {
+        const trimmed = if (std.mem.startsWith(u8, bin, "./")) bin[2..] else bin;
+        const win_bin = try a.dupe(u8, trimmed);
+        std.mem.replaceScalar(u8, win_bin, '/', '\\');
+        // `Select-Object -First 0` closes the pipe without reading any input,
+        // mirroring `head -c0` on POSIX.
+        break :blk &.{ "cmd", "/c", try std.fmt.allocPrint(
+            a,
+            "(cmd /c \"{s} {s} & echo %errorlevel% > {s}\") | powershell -NoProfile -Command \"$input | Select-Object -First 0\" > NUL",
+            .{ win_bin, cmd, exit_file },
+        ) };
+    } else &.{ "sh", "-c", try std.fmt.allocPrint(
+        a,
+        // `echo $? > file` writes to a file, not to the piped stdout stream,
+        // so it can't confuse `head`. This avoids relying on bash-only
+        // `PIPESTATUS`, which plain POSIX `sh` (e.g. dash) doesn't have.
+        "('{s}' {s}; echo $? > {s}) | head -c0",
+        .{ bin, cmd, exit_file },
+    ) };
+
+    var child = try std.process.spawn(io, .{
+        .argv = argv,
+        .cwd = .{ .dir = cwd },
+        .stdin = .ignore,
+        .stdout = .ignore,
+        .stderr = .ignore,
+    });
+    _ = try child.wait(io);
+
+    const contents = try readFile(cwd, a, exit_file);
+    const trimmed = std.mem.trim(u8, contents, " \r\n\t");
+    return std.fmt.parseInt(u8, trimmed, 10);
+}
+
 fn fileExists(dir: std.Io.Dir, path: []const u8) bool {
     // Windows rejects these characters in a path at the syscall layer with
     // OBJECT_NAME_INVALID, which Zig surfaces as an unrecoverable panic rather
@@ -904,6 +950,18 @@ test "scaffolded project builds, runs, and round-trips add command" {
             std.debug.print("broken-pipe leaked a trace to stderr:\n----\n{s}\n----\n", .{cli_stderr});
             return error.BrokenPipeLeakedTrace;
         }
+    }
+
+    // Regression (#630): a command whose *entire* output fits in the
+    // framework's 4096-byte stdout buffer, piped to a reader that closes
+    // without reading anything (`demo hello World | head -c0`), never
+    // triggers the mid-command broken-pipe path — the EPIPE only surfaces on
+    // the deferred final flush after `execute()` has already returned
+    // successfully. The framework must still notice it and exit with the
+    // conventional SIGPIPE status (141), not 0.
+    {
+        const exit_code = try runIntoHeadC0ViaShell(arena.allocator(), proj, demo_bin, "hello World", "hello.exit");
+        try testing.expectEqual(@as(u8, 141), exit_code);
     }
 
     // Help lists the discovered command. Explicitly-requested help goes to

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -162,26 +162,22 @@ fn runIntoHeadViaShell(a: std.mem.Allocator, cwd: std.Io.Dir, bin: []const u8, c
 /// exit 141 rather than 0. The subshell's own exit status is captured to
 /// `exit_file` (not stdout, so it doesn't confuse `head`) so the caller can
 /// assert on the CLI's real exit code rather than the pipeline's.
+///
+/// POSIX-only: exit code 141 is the SIGPIPE convention (128 + 13), which has
+/// no meaning on Windows (no SIGPIPE at all), so callers must gate on
+/// `builtin.os.tag == .windows` and skip rather than call this.
 fn runIntoHeadC0ViaShell(a: std.mem.Allocator, cwd: std.Io.Dir, bin: []const u8, cmd: []const u8, exit_file: []const u8) !u8 {
-    const argv: []const []const u8 = if (builtin.os.tag == .windows) blk: {
-        const trimmed = if (std.mem.startsWith(u8, bin, "./")) bin[2..] else bin;
-        const win_bin = try a.dupe(u8, trimmed);
-        std.mem.replaceScalar(u8, win_bin, '/', '\\');
-        // `Select-Object -First 0` closes the pipe without reading any input,
-        // mirroring `head -c0` on POSIX.
-        break :blk &.{ "cmd", "/c", try std.fmt.allocPrint(
+    const argv: []const []const u8 = &.{
+        "sh", "-c",
+        try std.fmt.allocPrint(
             a,
-            "(cmd /c \"{s} {s} & echo %errorlevel% > {s}\") | powershell -NoProfile -Command \"$input | Select-Object -First 0\" > NUL",
-            .{ win_bin, cmd, exit_file },
-        ) };
-    } else &.{ "sh", "-c", try std.fmt.allocPrint(
-        a,
-        // `echo $? > file` writes to a file, not to the piped stdout stream,
-        // so it can't confuse `head`. This avoids relying on bash-only
-        // `PIPESTATUS`, which plain POSIX `sh` (e.g. dash) doesn't have.
-        "('{s}' {s}; echo $? > {s}) | head -c0",
-        .{ bin, cmd, exit_file },
-    ) };
+            // `echo $? > file` writes to a file, not to the piped stdout stream,
+            // so it can't confuse `head`. This avoids relying on bash-only
+            // `PIPESTATUS`, which plain POSIX `sh` (e.g. dash) doesn't have.
+            "('{s}' {s}; echo $? > {s}) | head -c0",
+            .{ bin, cmd, exit_file },
+        ),
+    };
 
     var child = try std.process.spawn(io, .{
         .argv = argv,
@@ -959,7 +955,10 @@ test "scaffolded project builds, runs, and round-trips add command" {
     // the deferred final flush after `execute()` has already returned
     // successfully. The framework must still notice it and exit with the
     // conventional SIGPIPE status (141), not 0.
-    {
+    //
+    // POSIX-only: 141 (128 + SIGPIPE) is a POSIX convention with no Windows
+    // analogue (no SIGPIPE at all), and `sh -c` piping isn't portable either.
+    if (builtin.os.tag != .windows) {
         const exit_code = try runIntoHeadC0ViaShell(arena.allocator(), proj, demo_bin, "hello World", "hello.exit");
         try testing.expectEqual(@as(u8, 141), exit_code);
     }


### PR DESCRIPTION
## Summary
- `wroteToBrokenPipe(&stdio)` was only checked on `run()`'s error path (when `execute()` itself returns `error.WriteFailed`). A command whose entire output fits inside the framework's 4096-byte stdout buffer never returns that error — the write is deferred until `stdio.flush()` runs after `executeWithStdio` returns successfully, and that flush swallows the write error with `catch {}`.
- `run()` now also checks `wroteToBrokenPipe(&stdio)` on the success path and exits with the conventional SIGPIPE status (141) when the deferred flush recorded `error.BrokenPipe`, matching the behavior already in place for larger outputs.
- Added an e2e regression test (`projects/zcli/test/e2e.zig`) that pipes a small command's output (`demo hello World`) into `head -c0`, which closes its read end without reading anything — exactly the flush-time-only EPIPE scenario the mid-command path doesn't cover.

Fixes #630

## Test plan
- [x] `zig build test` (root) passes
- [x] `zig build e2e` (projects/zcli) passes, including the new regression test
- [x] Manual check: `./zig-out/bin/zcli guide | head -c0; echo ${pipestatus[1]}` → prints `141` (was `0` before the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)