### PR TITLE
fix(ui): grapheme-cluster-granular text editing (#640)

### DIFF
--- a/packages/terminal/src/terminal.zig
+++ b/packages/terminal/src/terminal.zig
@@ -37,6 +37,7 @@ pub const wrapToWidth = wrap.wrapToWidth;
 pub const wrapForEach = wrap.wrapForEach;
 pub const wrapCount = wrap.wrapCount;
 pub const trailingGraphemeLen = wrap.trailingGraphemeLen;
+pub const leadingGraphemeLen = wrap.leadingGraphemeLen;
 pub const graphemeCount = wrap.graphemeCount;
 
 // ============================================================================

--- a/packages/terminal/src/wrap.zig
+++ b/packages/terminal/src/wrap.zig
@@ -76,6 +76,15 @@ pub fn trailingGraphemeLen(text: []const u8) usize {
     return last;
 }
 
+/// Byte length of the leading grapheme cluster of `text` (0 for empty text).
+/// The mirror of `trailingGraphemeLen`: line editors use it to step the cursor
+/// forward, or delete-forward one *visible* character, so multibyte chars,
+/// combining marks, and ZWJ emoji sequences move as a single unit.
+pub fn leadingGraphemeLen(text: []const u8) usize {
+    var it = Graphemes.iterator(text);
+    return if (it.next()) |g| g.len else 0;
+}
+
 /// Number of grapheme clusters in `text` (what a user perceives as characters).
 pub fn graphemeCount(text: []const u8) usize {
     var n: usize = 0;
@@ -278,6 +287,18 @@ test "trailingGraphemeLen: ascii, CJK, combining, ZWJ emoji" {
     // Family ZWJ sequence is a single cluster.
     const family = "👨\u{200D}👩\u{200D}👧";
     try testing.expectEqual(family.len, trailingGraphemeLen("x" ++ family));
+}
+
+test "leadingGraphemeLen: ascii, CJK, combining, ZWJ emoji" {
+    try testing.expectEqual(@as(usize, 0), leadingGraphemeLen(""));
+    try testing.expectEqual(@as(usize, 1), leadingGraphemeLen("abc"));
+    // 你 is 3 bytes.
+    try testing.expectEqual(@as(usize, 3), leadingGraphemeLen("你a"));
+    // 'e' + combining acute = one 3-byte cluster at the front.
+    try testing.expectEqual(@as(usize, 3), leadingGraphemeLen("e\u{0301}fg"));
+    // Family ZWJ sequence is a single leading cluster.
+    const family = "👨\u{200D}👩\u{200D}👧";
+    try testing.expectEqual(family.len, leadingGraphemeLen(family ++ "x"));
 }
 
 test "graphemeCount counts clusters, not bytes" {

--- a/packages/ui/src/input_helpers.zig
+++ b/packages/ui/src/input_helpers.zig
@@ -18,29 +18,24 @@ const Region = surface_mod.Region;
 const Theme = theme_mod.Theme;
 
 // ============================================================================
-// UTF-8 helpers (codepoint boundaries; editing is codepoint-granular)
+// Grapheme helpers (editing is grapheme-cluster-granular)
 // ============================================================================
+//
+// Cursor movement and deletion step whole grapheme clusters, never codepoints:
+// backspacing `café` (base + combining U+0301) drops the whole `é`, and a ZWJ
+// emoji family moves as one unit instead of tearing into fragments. Boundaries
+// are derived from `terminal`'s zg-backed segmenter — the same source the
+// prompts package uses — so caret cells and byte cursors stay in lockstep.
 
+/// Byte offset of the grapheme boundary immediately before `i`.
 pub fn prevBoundary(s: []const u8, i: usize) usize {
-    var j = i;
-    while (j > 0) {
-        j -= 1;
-        if (s[j] & 0xc0 != 0x80) break; // not a UTF-8 continuation byte
-    }
-    return j;
+    return i - terminal.trailingGraphemeLen(s[0..i]);
 }
 
+/// Byte offset of the grapheme boundary immediately after `i`.
 pub fn nextBoundary(s: []const u8, i: usize) usize {
     if (i >= s.len) return s.len;
-    const n = std.unicode.utf8ByteSequenceLength(s[i]) catch 1;
-    return @min(i + n, s.len);
-}
-
-pub fn utf8Count(s: []const u8) usize {
-    var n: usize = 0;
-    var i: usize = 0;
-    while (i < s.len) : (n += 1) i = nextBoundary(s, i);
-    return n;
+    return i + terminal.leadingGraphemeLen(s[i..]);
 }
 
 /// The left edge of a horizontally scrolled field: the byte offset in `text` at

--- a/packages/ui/src/input_test.zig
+++ b/packages/ui/src/input_test.zig
@@ -61,6 +61,49 @@ test "TextInput edits multibyte codepoints whole" {
     try testing.expectEqual(@as(usize, 2), ti.cursor);
 }
 
+test "TextInput edits grapheme clusters whole (combining mark)" {
+    var buf: [64]u8 = undefined;
+    var ti = TextInput{ .buffer = &buf };
+    // "e" + combining acute U+0301 render as one grapheme (é).
+    _ = ti.handle(.{ .char = 'e' });
+    _ = ti.handle(.{ .char = '\u{0301}' });
+    try testing.expectEqualStrings("e\u{0301}", ti.value());
+    try testing.expectEqual(@as(usize, 3), ti.len); // 1 + 2 bytes
+    // Arrow keys step over the whole cluster, not the combining mark alone.
+    _ = ti.handle(.left);
+    try testing.expectEqual(@as(usize, 0), ti.cursor);
+    _ = ti.handle(.right);
+    try testing.expectEqual(@as(usize, 3), ti.cursor);
+    // Backspace deletes base + mark together, never stripping the accent only.
+    _ = ti.handle(.backspace);
+    try testing.expectEqualStrings("", ti.value());
+    try testing.expectEqual(@as(usize, 0), ti.cursor);
+}
+
+test "TextInput backspace deletes a ZWJ emoji family as one unit" {
+    var buf: [64]u8 = undefined;
+    var ti = TextInput{ .buffer = &buf };
+    // 👨‍👩‍👧 = man ZWJ woman ZWJ girl — one grapheme, 18 bytes.
+    for ([_]u21{ 0x1F468, 0x200D, 0x1F469, 0x200D, 0x1F467 }) |cp|
+        _ = ti.handle(.{ .char = cp });
+    try testing.expectEqual(@as(usize, 18), ti.len);
+    _ = ti.handle(.backspace); // the whole family, not just the last child
+    try testing.expectEqualStrings("", ti.value());
+    try testing.expectEqual(@as(usize, 0), ti.cursor);
+}
+
+test "TextInput delete removes the whole grapheme ahead of the cursor" {
+    var buf: [64]u8 = undefined;
+    var ti = TextInput{ .buffer = &buf };
+    _ = ti.handle(.{ .char = 'e' });
+    _ = ti.handle(.{ .char = '\u{0301}' }); // é
+    _ = ti.handle(.{ .char = 'x' });
+    _ = ti.handle(.home); // cursor at 0
+    _ = ti.handle(.delete); // removes é as a unit, leaving "x"
+    try testing.expectEqualStrings("x", ti.value());
+    try testing.expectEqual(@as(usize, 0), ti.cursor);
+}
+
 test "TextInput drops a keystroke when the buffer is full" {
     var buf: [2]u8 = undefined;
     var ti = TextInput{ .buffer = &buf };
@@ -110,6 +153,22 @@ test "TextArea edits multibyte codepoints whole" {
     try testing.expectEqual(@as(usize, 5), ta.len);
     _ = ta.handle(.backspace, ta_w, ta_h); // removes 中 whole
     try testing.expectEqualStrings("é", ta.value());
+}
+
+test "TextArea edits grapheme clusters whole (combining mark + ZWJ emoji)" {
+    var buf: [64]u8 = undefined;
+    var ta = TextArea{ .buffer = &buf };
+    _ = ta.handle(.{ .char = 'e' }, ta_w, ta_h);
+    _ = ta.handle(.{ .char = '\u{0301}' }, ta_w, ta_h); // é (base + combining)
+    // 👨‍👩‍👧 = man ZWJ woman ZWJ girl — one grapheme.
+    for ([_]u21{ 0x1F468, 0x200D, 0x1F469, 0x200D, 0x1F467 }) |cp|
+        _ = ta.handle(.{ .char = cp }, ta_w, ta_h);
+    // Backspace removes the whole emoji family, then é as a unit.
+    _ = ta.handle(.backspace, ta_w, ta_h);
+    try testing.expectEqualStrings("e\u{0301}", ta.value());
+    _ = ta.handle(.backspace, ta_w, ta_h);
+    try testing.expectEqualStrings("", ta.value());
+    try testing.expectEqual(@as(usize, 0), ta.cursor);
 }
 
 test "TextArea left/right cross the newline boundary" {

--- a/packages/ui/src/text_input.zig
+++ b/packages/ui/src/text_input.zig
@@ -19,7 +19,6 @@ const Theme = theme_mod.Theme;
 
 const prevBoundary = helpers.prevBoundary;
 const nextBoundary = helpers.nextBoundary;
-const utf8Count = helpers.utf8Count;
 const byteAtColumn = helpers.byteAtColumn;
 
 /// A single-line text field over a caller-owned buffer (capacity is the
@@ -141,9 +140,9 @@ pub const TextInput = struct {
     }
 };
 
-/// One mask glyph per codepoint of `s`.
+/// One mask glyph per visible character (grapheme cluster) of `s`.
 fn maskOf(a: std.mem.Allocator, s: []const u8, m: u8) ![]const u8 {
-    const out = try a.alloc(u8, utf8Count(s));
+    const out = try a.alloc(u8, terminal.graphemeCount(s));
     @memset(out, m);
     return out;
 }


### PR DESCRIPTION
Fixes #640.

## Part 1 — grapheme-cluster-granular editing (the fix)

`TextInput`/`TextArea` cursor movement and deletion stepped **codepoint** boundaries, tearing grapheme clusters:

- backspacing `café` (base `e` + combining U+0301) stripped only the accent;
- a ZWJ emoji family (`👨‍👩‍👧`) split into fragments on backspace/delete;
- arrowing into a cluster desynced the caret cell from the byte cursor.

`input_helpers.prevBoundary`/`nextBoundary` now step whole grapheme clusters via `terminal.trailingGraphemeLen` and a new symmetric `terminal.leadingGraphemeLen`, reusing the same zg-backed segmenter the prompts package uses (rather than hand-rolling segmentation). `byteAtColumn` walks true clusters too, so horizontal-scroll caret math stays aligned, and password masking emits one glyph per visible character (grapheme) instead of per codepoint (`utf8Count` removed).

New unit tests cover combining marks and ZWJ emoji families across both widgets, plus a `leadingGraphemeLen` test.

## Part 2 — diff continuation-skip desync (already resolved)

The latent `diff.emitCells` continuation-skip desync was already fixed on `main` by #613 (`grade10/585-emitcells-continuation`): `emitCells` advances `cur_col` by `@max(c.width, 1)` for every cell, matching its comment. No further change needed.

## Testing

- `packages/terminal` `zig build test`: pass
- `packages/ui` `zig build test`: pass (includes new grapheme tests)
- `zig build e2e` (from repo root): pass
- Root `zig build test`: all package/example tests pass; the one flaky wrapper step was an environmental `SIGTERM` under parallel-build load (`examples/ext-plugin` passes cleanly in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)