### PR TITLE
test: attribute & silence assertion self-test noise in zig build test

### DIFF
--- a/packages/testing/src/assertions.zig
+++ b/packages/testing/src/assertions.zig
@@ -1,13 +1,26 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const runner = @import("runner.zig");
 const testing = std.testing;
+
+// These helpers print a human-facing diagnostic on the failure path before
+// returning their error, which is the right default for a real consumer test
+// debugging a failed assertion. Under this package's *own* test runner, though,
+// the negative-path self-tests below deliberately drive those failure paths and
+// assert the returned error — so the diagnostics are pure noise. Worse, writing
+// to stderr in an otherwise-passing run makes Zig's build runner echo a
+// misleading `failed command: …` even though every test passed (the same reason
+// `snapshot.zig`/`e2e.zig` gate their diagnostics). Guard each print with
+// `!builtin.is_test` so a passing run stays quiet.
 
 /// Assert that the exit code matches expected value
 pub fn expectExitCode(result: runner.Result, expected: u8) !void {
     if (result.exit_code != expected) {
-        std.debug.print("\nExpected exit code {d}, but got {d}\n", .{ expected, result.exit_code });
-        if (result.stderr.len > 0) {
-            std.debug.print("stderr: {s}\n", .{result.stderr});
+        if (!builtin.is_test) {
+            std.debug.print("\nExpected exit code {d}, but got {d}\n", .{ expected, result.exit_code });
+            if (result.stderr.len > 0) {
+                std.debug.print("stderr: {s}\n", .{result.stderr});
+            }
         }
         return error.ExitCodeMismatch;
     }
@@ -16,7 +29,7 @@ pub fn expectExitCode(result: runner.Result, expected: u8) !void {
 /// Assert that the exit code does not match a value
 pub fn expectExitCodeNot(result: runner.Result, not_expected: u8) !void {
     if (result.exit_code == not_expected) {
-        std.debug.print("\nExpected exit code to not be {d}, but it was\n", .{not_expected});
+        if (!builtin.is_test) std.debug.print("\nExpected exit code to not be {d}, but it was\n", .{not_expected});
         return error.UnexpectedExitCode;
     }
 }
@@ -24,7 +37,7 @@ pub fn expectExitCodeNot(result: runner.Result, not_expected: u8) !void {
 /// Assert that stdout is empty
 pub fn expectStdoutEmpty(result: runner.Result) !void {
     if (result.stdout.len > 0) {
-        std.debug.print("\nExpected stdout to be empty, but got:\n{s}\n", .{result.stdout});
+        if (!builtin.is_test) std.debug.print("\nExpected stdout to be empty, but got:\n{s}\n", .{result.stdout});
         return error.StdoutNotEmpty;
     }
 }
@@ -32,7 +45,7 @@ pub fn expectStdoutEmpty(result: runner.Result) !void {
 /// Assert that stderr is empty
 pub fn expectStderrEmpty(result: runner.Result) !void {
     if (result.stderr.len > 0) {
-        std.debug.print("\nExpected stderr to be empty, but got:\n{s}\n", .{result.stderr});
+        if (!builtin.is_test) std.debug.print("\nExpected stderr to be empty, but got:\n{s}\n", .{result.stderr});
         return error.StderrNotEmpty;
     }
 }
@@ -40,7 +53,7 @@ pub fn expectStderrEmpty(result: runner.Result) !void {
 /// Assert that output contains a substring
 pub fn expectContains(output: []const u8, needle: []const u8) !void {
     if (std.mem.indexOf(u8, output, needle) == null) {
-        std.debug.print("\nExpected output to contain:\n  '{s}'\n\nActual output:\n{s}\n", .{ needle, output });
+        if (!builtin.is_test) std.debug.print("\nExpected output to contain:\n  '{s}'\n\nActual output:\n{s}\n", .{ needle, output });
         return error.SubstringNotFound;
     }
 }
@@ -48,7 +61,7 @@ pub fn expectContains(output: []const u8, needle: []const u8) !void {
 /// Assert that output does not contain a substring
 pub fn expectNotContains(output: []const u8, needle: []const u8) !void {
     if (std.mem.indexOf(u8, output, needle) != null) {
-        std.debug.print("\nExpected output to NOT contain:\n  '{s}'\n\nActual output:\n{s}\n", .{ needle, output });
+        if (!builtin.is_test) std.debug.print("\nExpected output to NOT contain:\n  '{s}'\n\nActual output:\n{s}\n", .{ needle, output });
         return error.UnexpectedSubstring;
     }
 }
@@ -56,7 +69,7 @@ pub fn expectNotContains(output: []const u8, needle: []const u8) !void {
 /// Assert that two strings are equal
 pub fn expectEqualStrings(expected: []const u8, actual: []const u8) !void {
     if (!std.mem.eql(u8, expected, actual)) {
-        std.debug.print("\nStrings not equal!\n\nExpected:\n{s}\n\nActual:\n{s}\n", .{ expected, actual });
+        if (!builtin.is_test) std.debug.print("\nStrings not equal!\n\nExpected:\n{s}\n\nActual:\n{s}\n", .{ expected, actual });
         return error.StringMismatch;
     }
 }
@@ -64,7 +77,7 @@ pub fn expectEqualStrings(expected: []const u8, actual: []const u8) !void {
 /// Assert that output is valid JSON
 pub fn expectValidJson(allocator: std.mem.Allocator, output: []const u8) !void {
     const parsed = std.json.parseFromSlice(std.json.Value, allocator, output, .{}) catch |err| {
-        std.debug.print("\nExpected valid JSON but got error: {}\n\nOutput:\n{s}\n", .{ err, output });
+        if (!builtin.is_test) std.debug.print("\nExpected valid JSON but got error: {}\n\nOutput:\n{s}\n", .{ err, output });
         return error.InvalidJson;
     };
     defer parsed.deinit();


### PR DESCRIPTION
## Attribution (resolves the investigation in #692)

The "1 failed build step" the Grade 12 audit saw at b91f3f2 is **not a regression** — it's noise from intentional negative-path self-tests.

- **Step**: the `testing` package's own test run (`test-testing` -> `run test`, root `main.zig` test binary).
- **File / mechanism**: `packages/testing/src/assertions.zig`. Its self-tests (`test "expectExitCode"`, `test "expectContains"`, `test "expectValidJson"`, `test "expectContains with edge cases"`, etc.) deliberately drive each assertion's failure path via `std.testing.expectError(...)` to lock in the returned error. On that failure path every helper wrote a human-facing diagnostic to stderr **unconditionally**, so a fully-passing run printed lines like `Expected output to contain: 'hello'` and the exit-code/JSON mismatches.
- **Why it looked like a failing step**: writing to stderr in an otherwise-passing test run makes Zig's build runner echo a misleading `failed command: ... --listen=-`, even though every test passes and the build exits 0.

All 67 tests pass; root `zig build test` exits 0 both before and after — the "failure" was purely cosmetic/unattributed output.

## Fix

`snapshot.zig` and `e2e.zig` already gate their diagnostics for exactly this reason (see their in-file comments about the misleading `failed command: ...`). `assertions.zig` was the lone file that missed the convention. This guards every diagnostic `std.debug.print` with `if (!builtin.is_test)`, so a passing test run stays quiet while non-test callers still get the diagnostics. Consumer projects exercise these helpers inside their own `is_test` binaries (same gate), matching how the rest of the package already behaves.

## Verification

- `zig build test` (root): exit 0, zero `failed command` / `Expected ...` noise lines, all 12 project test groups pass.
- `zig build test` (packages/testing): exit 0, output now empty of diagnostics.

Fixes #692

🤖 Generated with [Claude Code](https://claude.com/claude-code)
