### PR TITLE
fix(add plugin): reject newlines in --description to close build-time code injection

### DIFF
--- a/projects/zcli/src/commands/add/plugin.zig
+++ b/projects/zcli/src/commands/add/plugin.zig
@@ -61,7 +61,16 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
     };
 
     const description = options.description orelse "TODO: describe this plugin";
-    const content = try generatePlugin(arena, name, description);
+    const content = generatePlugin(arena, name, description) catch |err| switch (err) {
+        // `description` lands on a `///` line, so a newline would end the doc
+        // comment and splice the remainder in as live top-level Zig (build-time
+        // code injection). Reject multi-line input rather than escape it — a doc
+        // comment has no escape for a line break.
+        error.DescriptionNotSingleLine => return context.fail("Error: --description must be a single line (no newlines)", .{}),
+        // Defense-in-depth: never write a plugin file that doesn't parse.
+        error.GeneratedSourceInvalid => return context.fail("Error: generated plugin source did not parse (unexpected --description content)", .{}),
+        else => return err,
+    };
 
     var file = try cwd.createFile(io, file_path, .{});
     defer file.close(io);
@@ -76,6 +85,11 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
 /// needs neither (hooks are `@hasDecl`-gated; `plugin_id` is only required
 /// alongside `ContextData`).
 fn generatePlugin(arena: std.mem.Allocator, name: []const u8, description: []const u8) ![]u8 {
+    // `description` is spliced verbatim into a `///` doc-comment line; a newline
+    // would terminate the comment and turn the rest into live top-level code.
+    // There is no in-comment escape for a line break, so reject it outright.
+    if (std.mem.indexOfAny(u8, description, "\r\n") != null) return error.DescriptionNotSingleLine;
+
     var aw = std.Io.Writer.Allocating.init(arena);
     const w = &aw.writer;
 
@@ -175,7 +189,11 @@ fn generatePlugin(arena: std.mem.Allocator, name: []const u8, description: []con
         \\
     );
 
-    return aw.written();
+    // Defense-in-depth: match `add command`'s pre-write guard — never hand back
+    // source that doesn't parse, even if some future interpolation slips through.
+    const source = aw.written();
+    if (!try scaffold.splice.parses(arena, source)) return error.GeneratedSourceInvalid;
+    return source;
 }
 
 /// Whether build.zig already sets `plugins_dir` (best-effort; on any read error
@@ -243,6 +261,31 @@ test "generatePlugin: only the working hook is uncommented" {
         if (std.mem.startsWith(u8, t, "pub fn ")) count += 1;
     }
     try testing.expectEqual(@as(usize, 1), count);
+}
+
+test "generatePlugin: rejects a newline in the description (code injection)" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // Repro from issue #664: an embedded newline would end the `///` doc comment
+    // and land the next line as live top-level Zig.
+    const payload = "x\npub fn pwned() void {}\n///";
+    try testing.expectError(error.DescriptionNotSingleLine, generatePlugin(a, "foo", payload));
+
+    // A bare carriage return is rejected too (can act as a line ending).
+    try testing.expectError(error.DescriptionNotSingleLine, generatePlugin(a, "foo", "x\rpub fn pwned() void {}"));
+}
+
+test "generatePlugin: a single-line description with quotes is accepted verbatim" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // Quotes and other single-line punctuation are harmless on a `///` line.
+    const src = try generatePlugin(a, "auth", "attach a \"bearer\" token");
+    try testing.expect(std.mem.indexOf(u8, src, "The `auth` plugin — attach a \"bearer\" token") != null);
+    try expectParses(a, src);
 }
 
 fn expectParses(arena: std.mem.Allocator, source: []const u8) !void {


### PR DESCRIPTION
## Problem

`zcli add plugin` spliced the user-supplied `--description` **verbatim** into a `///` doc-comment line of the generated plugin (`projects/zcli/src/commands/add/plugin.zig`). An embedded newline ends the doc comment and lands the remainder as live top-level Zig. Because `plugins_dir`-discovered files are imported into the generated registry and their hooks execute, this is genuine **build-time code injection**.

Repro:
```
zcli add plugin foo --description $'x\npub fn pwned() void { ... }\n///'
```

Most plausible trigger: an AI-agent scaffolding workflow piping untrusted text (issue body, ticket description) into `--description`.

## Fix

- `generatePlugin` now rejects any `\r`/`\n` in the description (`error.DescriptionNotSingleLine`). A `///` comment has no escape for a line break, so rejection — not escaping — is the correct response.
- Defense-in-depth: `generatePlugin` verifies the result parses (`scaffold.splice.parses`) before returning, matching `add command`'s pre-write guard.
- `execute()` maps both errors to a clean `context.fail` message.

## Siblings spot-checked (not affected)

`add/arg`, `add/option`, `add/group`, and `add/command` all splice descriptions into **string literals** via `writeEscaped` (`std.zig.stringEscape`) and/or through `parses`-guarded splices (`insertOption`/`insertArg`/`writeCommandFile`). Newlines become escaped `\n` inside a literal — no break-out. Only `add/plugin` used the raw `///` sink.

## Tests

Added unit tests from the issue repro: newline and bare-CR payloads are rejected; a single-line description with quotes is still accepted verbatim and parses. `zig build test` green. Manually verified against the built CLI: malicious newline description exits 1 with the error; benign description scaffolds normally.

Fixes #664

🤖 Generated with [Claude Code](https://claude.com/claude-code)