### PR TITLE
registry: comptime-detect command options shadowed by plugin globals

### DIFF
--- a/packages/core/src/registry/compiled.zig
+++ b/packages/core/src/registry/compiled.zig
@@ -400,6 +400,45 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
             }
         }
 
+        // Validate no command option is silently shadowed by a plugin global
+        // option. parseGlobalOptions() scans the entire argv and consumes any
+        // token matching a global option's long name or short flag *before*
+        // routing, so a command field that collides with a global would never
+        // receive its own flag — the global handler eats it and the field keeps
+        // its default (see issue #663). Catch it here with a message naming the
+        // command, the field, and the owning plugin.
+        comptime {
+            for (new_plugins) |Plugin| {
+                if (!plugin_types.hasGlobalOptions(Plugin)) continue;
+                for (Plugin.global_options) |gopt| {
+                    for (cmd_entries) |cmd| {
+                        if (!@hasDecl(cmd.module, "Options")) continue;
+                        const meta = if (@hasDecl(cmd.module, "meta")) cmd.module.meta else null;
+                        for (std.meta.fields(cmd.module.Options)) |field| {
+                            const long = option_utils.effectiveLongName(meta, field.name);
+                            if (std.mem.eql(u8, long, gopt.name)) {
+                                @compileError("Command '" ++ comptimeJoinPath(cmd.path) ++
+                                    "' option --" ++ long ++ " (field '" ++ field.name ++
+                                    "') collides with global option --" ++ gopt.name ++
+                                    " provided by plugin '" ++ @typeName(Plugin) ++
+                                    "'. The global handler consumes this flag before the command runs, so the command would never see it. Rename the command's option (e.g. `meta.options." ++
+                                    field.name ++ ".name`) or remove the conflicting global option.");
+                            }
+                            const short = option_utils.shortCharForField(meta, field.name);
+                            if (short != null and gopt.short != null and short.? == gopt.short.?) {
+                                @compileError("Command '" ++ comptimeJoinPath(cmd.path) ++
+                                    "' option -" ++ &[_]u8{short.?} ++ " (field '" ++ field.name ++
+                                    "') collides with global short flag -" ++ &[_]u8{gopt.short.?} ++
+                                    " (--" ++ gopt.name ++ ") provided by plugin '" ++ @typeName(Plugin) ++
+                                    "'. The global handler consumes this flag before the command runs, so the command would never see it. Rename the command's short (`meta.options." ++
+                                    field.name ++ ".short`) or remove the conflicting global option.");
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         // Discover all plugin command entries (including nested)
         const plugin_command_entries = blk: {
             var entries: []const CommandEntry = &.{};


### PR DESCRIPTION
## Problem

`parseGlobalOptions()` in `packages/core/src/registry/compiled.zig` scans the entire argv before routing and consumes any token matching a plugin **global option**'s long name or short flag. A command declaring an option that collides with a global (e.g. a command `--version` against `zcli_version`'s global `--version`, or `--config`/`--help`) never sees its own flag — the global handler eats it and the command's field silently keeps its default. No error, no warning.

`CompiledRegistry` already validated command-path duplicates and global-vs-global collisions at comptime, but never global-vs-command-option — even though both `cmd_entries[i].module.Options` and `global_options` are available at comptime.

This is not hypothetical: bundled plugins claim `--help/-h`, `--version/-V`, `--config`, and #565 (`zcli init --version`) was exactly this bug, worked around by renaming the command's option (2a272a1) rather than fixing the framework. Every downstream app author would rediscover it the same way.

## Fix

Add a comptime pass in `CompiledRegistry` comparing each command's effective long names (via `option_utils.effectiveLongName`) and declared shorts (via `option_utils.shortCharForField`) against the flattened `global_options` list. On collision, `@compileError` naming the command, the field, and the owning plugin, with guidance to rename the command's option or drop the global.

Example error (reproduced by temporarily re-adding a `version` option to `init`):

```
error: Command 'init' option --version (field 'version') collides with global
option --version provided by plugin 'plugin'. The global handler consumes this
flag before the command runs, so the command would never see it. Rename the
command's option (e.g. `meta.options.version.name`) or remove the conflicting
global option.
```

## Testing

- `zig build test` from repo root: exit 0 (the "failed command: .../test --listen=-" line and JSON self-test noise are the known pre-existing packages/testing output, fixed separately in #693).
- `projects/zcli` builds clean — no bundled command trips the new check (init's option was already `--app-version`).
- Verified the check fires by temporarily adding a colliding `version: bool` to `init` — compile error above; reverted.

Fixes #663

🤖 Generated with [Claude Code](https://claude.com/claude-code)