### PR TITLE
docs: reconcile plugin hook contract to 9 hooks, fix stale generate()/postExecute snippets

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -139,11 +139,13 @@ Plugins can implement any of these lifecycle hooks:
 
 1. **`onStartup`** - Called once per invocation, after plugin data is captured but before argument parsing/routing (for one-time work like update checks)
 2. **`preParse`** - Called before argument parsing
-3. **`postParse`** - Called after parsing, before command execution  
-4. **`preExecute`** - Called right before command execution (can cancel)
-5. **`postExecute`** - Called after command execution
-6. **`onError`** - Called when an error occurs
-7. **`handleGlobalOption`** - Called when global options are processed
+3. **`transformArgs`** - Called after `preParse`, can rewrite/short-circuit the raw argv before parsing
+4. **`handleGlobalOption`** - Called when global options are processed
+5. **`postParse`** - Called after parsing, before command execution
+6. **`applyConfigDefaults`** - Called during option parsing to fill fields from a lower-precedence source (e.g. a config file), after CLI + env but before required/dependency/exclusive validation
+7. **`preExecute`** - Called right before command execution (can cancel)
+8. **`postExecute`** - Called after command execution, with the command's success/failure outcome
+9. **`onError`** - Called when an error occurs
 
 ### Plugin Integration
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -798,12 +798,13 @@ pub const global_options = [_]zcli.GlobalOption{
 
 // Lifecycle hooks (all optional). Plugins are compiled independently of the
 // host app, so hooks take `context: anytype` rather than a named Context type.
+pub fn onStartup(context: anytype) !void { }
 pub fn handleGlobalOption(context: anytype, name: []const u8, value: anytype) !void { }
 pub fn preParse(context: anytype, args: []const []const u8) ![]const []const u8 { }
 pub fn transformArgs(context: anytype, args: []const []const u8) !zcli.TransformResult { }
 pub fn postParse(context: anytype, args: zcli.ParsedArgs) !?zcli.ParsedArgs { }
 pub fn preExecute(context: anytype, args: zcli.ParsedArgs) !?zcli.ParsedArgs { }
-pub fn postExecute(context: anytype, result: anytype) !void { }
+pub fn postExecute(context: anytype, success: bool) !void { }
 pub fn onError(context: anytype, err: anyerror) !bool { }
 
 // Fill option fields from a lower-precedence source (e.g. a config file) after

--- a/packages/core/src/plugin_types.zig
+++ b/packages/core/src/plugin_types.zig
@@ -206,7 +206,7 @@ pub fn getPriority(comptime T: type) i32 {
 ///   preParse(context, args: []const []const u8) ![]const []const u8
 ///   postParse(context, args: zcli.ParsedArgs) !?zcli.ParsedArgs
 ///   preExecute(context, args: zcli.ParsedArgs) !?zcli.ParsedArgs
-///   postExecute(context, result: anytype) !void
+///   postExecute(context, success: bool) !void
 ///   onError(context, err: anyerror) !bool
 ///
 ///   applyConfigDefaults(context, comptime OptionsType: type,

--- a/website/layouts/plugins.shtml
+++ b/website/layouts/plugins.shtml
@@ -119,7 +119,7 @@
           </div>
           <div class="code">
             <div class="code-head"><span class="fname">build.zig — all three together</span><span class="lang">zig</span></div>
-<pre><span class="kw">const</span> cmd_registry = zcli.<span class="fn">generate</span>(b, exe, zcli_dep, zcli_module, .{
+<pre><span class="kw">const</span> cmd_registry = <span class="kw">try</span> zcli.<span class="fn">generate</span>(b, exe, zcli_dep, .{
     .commands_dir = <span class="str">"src/commands"</span>,
 
     <span class="cm">// Auto-discover everything in your own plugins folder</span>
@@ -205,9 +205,13 @@
           <table class="hooks">
             <tbody>
               <tr><td class="h">onStartup</td><td class="d">Runs once before routing — set up shared state.</td></tr>
+              <tr><td class="h">preParse</td><td class="d">Runs before argument parsing; can rewrite the raw argv.</td></tr>
+              <tr><td class="h">transformArgs</td><td class="d">Runs after <code>preParse</code>; can rewrite or short-circuit the raw argv before parsing.</td></tr>
               <tr><td class="h">handleGlobalOption</td><td class="d">Called for each global option your plugin declared; stash the value in your context data.</td></tr>
+              <tr><td class="h">postParse</td><td class="d">Runs after parsing, before command execution.</td></tr>
+              <tr><td class="h">applyConfigDefaults</td><td class="d">Fills option fields from a lower-precedence source (e.g. a config file), after CLI + env parsing but before required/dependency validation.</td></tr>
               <tr><td class="h">preExecute</td><td class="d">Runs before the matched command. Return <code>null</code> to halt execution, or the (possibly transformed) args to continue.</td></tr>
-              <tr><td class="h">postExecute</td><td class="d">Runs after the command succeeds — flush, report, clean up.</td></tr>
+              <tr><td class="h">postExecute</td><td class="d">Runs after the command finishes, with a <code>success: bool</code> outcome — flush, report, clean up.</td></tr>
               <tr><td class="h">onError</td><td class="d">Handle an error. Return <code>true</code> if you handled it.</td></tr>
             </tbody>
           </table>
@@ -226,7 +230,8 @@
     <span class="kw">return</span> args;
 }
 
-<span class="kw">pub fn</span> <span class="fn">postExecute</span>(context: <span class="kw">anytype</span>) !<span class="kw">void</span> {
+<span class="kw">pub fn</span> <span class="fn">postExecute</span>(context: <span class="kw">anytype</span>, success: <span class="fn">bool</span>) !<span class="kw">void</span> {
+    _ = success;
     <span class="kw">const</span> start = context.plugins.timing.started_ns;
     <span class="kw">if</span> (start != <span class="num">0</span>) {
         <span class="kw">const</span> ms = <span class="at">@divTrunc</span>(std.time.<span class="fn">nanoTimestamp</span>() - start, <span class="num">1_000_000</span>);


### PR DESCRIPTION
## Summary
- Root cause (#666): a stale doc-comment at `packages/core/src/plugin_types.zig:209` claimed `postExecute(context, result: anytype)`. The registry actually calls `Plugin.postExecute(context, success: bool)` (`packages/core/src/registry/compiled.zig:1346`). That wrong signature had propagated into `docs/BUILD.md`'s hook list (7 hooks — missing `transformArgs` and `applyConfigDefaults`), `docs/DESIGN.md`'s example (right hook count claim but wrong `postExecute` signature and missing `onStartup`), and the live website's plugin-authoring guide.
- Fixed the doc-comment, then reconciled `docs/BUILD.md`, `docs/DESIGN.md`, and `website/layouts/plugins.shtml` to the authoritative 9-hook contract from `plugin_types.zig`'s `hook_names`: `onStartup`, `preParse`, `transformArgs`, `handleGlobalOption`, `postParse`, `applyConfigDefaults`, `preExecute`, `postExecute`, `onError`.
- Fixes #665: the website's `generate()` build.zig snippet used a stale 5-arg form (`zcli.generate(b, exe, zcli_dep, zcli_module, .{...})`, no `try`). Current signature is `generate(b, exe, zcli_dep, config) GenerateError!*std.Build.Module` (4 args, error union) — snippet now matches the working pattern in `projects/zcli/src/commands/init.zig`.

## Test plan
- [x] `zig build test` from repo root — exit 0 (pre-existing "Expected output to contain..." noise from `packages/testing` example self-tests is unrelated, tracked for PR #693)
- [x] `cd website && zig build release` — succeeds; verified rendered `public/docs/plugins/index.html` shows the corrected `generate()` call and `postExecute(context: anytype, success: bool)` signature

Fixes #665, Fixes #666

🤖 Generated with [Claude Code](https://claude.com/claude-code)