### PR TITLE
fix(args): guard misplaced varargs (SEGV) + optional-before-required token steal

### DIFF
--- a/packages/core/src/args.zig
+++ b/packages/core/src/args.zig
@@ -125,8 +125,16 @@ fn parseArgsInternal(comptime ArgsType: type, args: []const []const u8, diag: ?*
             }
             break;
         } else if (comptime @typeInfo(field_type) == .optional) {
-            // Optional field - consume the next argument if present
-            const next_positional: ?usize = if (arg_index < args.len) arg_index else null;
+            // Optional field - consume the next argument only if doing so still
+            // leaves enough tokens for the required fields behind it. Without
+            // this lookahead an always-parsing optional (e.g. `?[]const u8`)
+            // greedily steals the last token and starves a later required field
+            // (#675). A typed optional whose token fails to parse still falls
+            // through below; this guard additionally rescues optionals whose
+            // token WOULD parse but is needed downstream.
+            const required_after = comptime countRequiredArgsAfter(ArgsType, field_index);
+            const has_room = (args.len - arg_index) > required_after;
+            const next_positional: ?usize = if (arg_index < args.len and has_room) arg_index else null;
             if (next_positional) |pos| {
                 const is_last = comptime (field_index == struct_info.fields.len - 1);
                 if (parseValue(field_type, args[pos])) |value| {
@@ -324,16 +332,38 @@ fn hasVarArgs(comptime T: type) bool {
     return false;
 }
 
-/// Count the number of required arguments (non-optional, non-varargs)
+/// A field is "required" as a positional when it has no way to be absent: not
+/// varargs (may be empty), not optional (defaults to null), and not defaulted
+/// (a value is already supplied). Counting defaulted fields as required
+/// overstated the `ArgumentTooMany` diagnostic's `min_count` (#675).
+fn isRequiredArg(comptime T: type, comptime field: std.builtin.Type.StructField) bool {
+    return !isVarArgs(field.type) and
+        @typeInfo(field.type) != .optional and
+        !type_utils.hasDefaultValue(T, field.name);
+}
+
+/// Count the number of required arguments (see `isRequiredArg`).
 fn getRequiredArgCount(comptime T: type) usize {
     const type_info = @typeInfo(T);
     if (type_info != .@"struct") return 0;
 
     var count: usize = 0;
     inline for (type_info.@"struct".fields) |field| {
-        if (!isVarArgs(field.type) and @typeInfo(field.type) != .optional) {
-            count += 1;
-        }
+        if (isRequiredArg(T, field)) count += 1;
+    }
+    return count;
+}
+
+/// Count required args (see `isRequiredArg`) strictly after `field_index`. Used
+/// as parse-time lookahead so an optional field only consumes a token when the
+/// required fields behind it can still be satisfied (#675).
+fn countRequiredArgsAfter(comptime T: type, comptime field_index: usize) usize {
+    const type_info = @typeInfo(T);
+    if (type_info != .@"struct") return 0;
+
+    var count: usize = 0;
+    inline for (type_info.@"struct".fields, 0..) |field, i| {
+        if (i > field_index and isRequiredArg(T, field)) count += 1;
     }
     return count;
 }
@@ -946,6 +976,49 @@ test "parseArgs defaulted leading positional falls through to varargs (#626)" {
     try std.testing.expectEqual(@as(usize, 2), parsed.rest.len);
     try std.testing.expectEqualStrings("foo", parsed.rest[0]);
     try std.testing.expectEqualStrings("bar", parsed.rest[1]);
+}
+
+test "parseArgs optional string before required does not steal the token (#675)" {
+    // A string optional always parses, so it used to greedily consume the only
+    // token and starve the required field (ArgumentMissingRequired). With
+    // lookahead it declines the token when a required field behind it would go
+    // unfilled.
+    const TestArgs = struct {
+        maybe: ?[]const u8 = null,
+        required: []const u8,
+    };
+
+    // One token: it must satisfy `required`, not get stolen by `maybe`.
+    {
+        const args = [_][]const u8{"only"};
+        const parsed = try parseArgs(TestArgs, &args, null);
+        try std.testing.expectEqual(@as(?[]const u8, null), parsed.maybe);
+        try std.testing.expectEqualStrings("only", parsed.required);
+    }
+
+    // Two tokens: optional fills first, required second.
+    {
+        const args = [_][]const u8{ "a", "b" };
+        const parsed = try parseArgs(TestArgs, &args, null);
+        try std.testing.expectEqualStrings("a", parsed.maybe.?);
+        try std.testing.expectEqualStrings("b", parsed.required);
+    }
+}
+
+test "parseArgs too-many min_count excludes defaulted fields (#675)" {
+    // A non-optional field with a default is NOT required — the ArgumentTooMany
+    // diagnostic's min_count must not count it.
+    const TestArgs = struct {
+        name: []const u8,
+        tag: []const u8 = "latest",
+    };
+
+    var diag: ?ZcliDiagnostic = null;
+    const args = [_][]const u8{ "a", "b", "c" };
+    try std.testing.expectError(ZcliError.ArgumentTooMany, parseArgs(TestArgs, &args, &diag));
+    // Only `name` is truly required; `tag` is defaulted, so min is 1, not 2.
+    try std.testing.expectEqual(@as(usize, 1), diag.?.ArgumentTooMany.min_count);
+    try std.testing.expectEqual(@as(usize, 2), diag.?.ArgumentTooMany.max_count);
 }
 
 test "parseArgs unicode strings" {

--- a/packages/core/src/zcli.zig
+++ b/packages/core/src/zcli.zig
@@ -451,6 +451,23 @@ pub fn validateCommand(comptime path: []const u8, comptime Module: type) void {
             "`. Example: `pub const Options = struct { verbose: bool = false };`");
     }
 
+    // A varargs field (`[][]const u8` / `[]const []const u8`) captures ALL
+    // remaining positionals, so any `Args` field after it can never receive a
+    // value: the parser leaves it `undefined` and command_parser frees the
+    // backing slice out from under the varargs slice (a verified use-after-free
+    // SEGV, #662). Reject it at build time so the author fixes the field order
+    // instead of shipping a crash.
+    if (@typeInfo(ArgsType) == .@"struct") {
+        const arg_fields = @typeInfo(ArgsType).@"struct".fields;
+        inline for (arg_fields, 0..) |field, i| {
+            if (args_parser.isVarArgs(field.type) and i != arg_fields.len - 1) {
+                @compileError(loc ++ "varargs arg '" ++ field.name ++ "' (`" ++ @typeName(field.type) ++
+                    "`) must be the LAST `Args` field — it captures every remaining positional, so `" ++
+                    arg_fields[i + 1].name ++ "` after it could never be filled. Move it to the end.");
+            }
+        }
+    }
+
     // Args field shapes. An optional positional carries a `null` "absent"
     // state, and the parser initializes optionals to `null` when the positional
     // is not supplied — a non-null default would be silently discarded. Forbid


### PR DESCRIPTION
Fixes #662, Fixes #675

Two Args-shape defects from the Grade 12 whole-repo review.

## #662 (P1) — misplaced varargs reads undefined memory + use-after-free (verified SEGV)

A varargs `Args` field not in last position (`files: []const []const u8` before `dest: []const u8`) left every later field `undefined`: the parse loop in `args.zig` `break`s at the first varargs field, and `command_parser.hasVarargsFields` only inspects the *last* field, so it freed the positional slice while the varargs slice still pointed into it.

Fix: a `@compileError` in `validateCommand` (`zcli.zig`) rejects any non-last varargs `Args` field, so the natural cp-style command (`copy <files...> <dest>`) fails the build with an actionable message instead of shipping a crash. This also resolves the noted `isVarArgs` classifier drift — with non-last varargs impossible, the "any field" and "last field only" classifiers agree for every valid struct.

Verified manually via a scratch build (comptime `@compileError` can't be unit-tested):

```
error: command 'copy': varargs arg 'files' (`[]const []const u8`) must be the LAST `Args` field — it captures every remaining positional, so `dest` after it could never be filled. Move it to the end.
```

## #675 — optional positional before a required one steals the token; min_count overstated

- An always-parsing optional (e.g. `?[]const u8`) before a required field greedily consumed the only token and starved the required field (`ArgumentMissingRequired`). Added parse-time lookahead: an optional consumes a token only when enough tokens remain to satisfy the required fields behind it. The existing typed-optional parse-failure fall-through is preserved.
- Fixed `getRequiredArgCount`, which counted defaulted non-optional fields as required and overstated the `ArgumentTooMany` diagnostic's `min_count`.

Both covered by new unit tests in `args.zig`.

## Verification

- `zig build test` from repo root: exit 0 (pre-existing testing-package self-test noise unchanged; fixed separately in #693).
- New `args.zig` tests fail before / pass after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)