### PR TITLE
zcli.zig: remove dead CommandModuleInfo.raw_meta_ptr field

### DIFF
--- a/packages/core/src/registry/compiled.zig
+++ b/packages/core/src/registry/compiled.zig
@@ -1215,7 +1215,6 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
             return .{
                 .has_args = @hasDecl(Module, "Args"),
                 .has_options = @hasDecl(Module, "Options"),
-                .raw_meta_ptr = if (@hasDecl(Module, "meta")) &Module.meta else null,
                 .args_fields = if (@hasDecl(Module, "Args")) buildFieldInfoList(Module.Args, args_meta, false) else &.{},
                 .options_fields = if (@hasDecl(Module, "Options")) buildFieldInfoList(Module.Options, options_meta, true) else &.{},
                 .exclusive = option_utils.exclusiveSets(if (@hasDecl(Module, "meta")) Module.meta else null),

--- a/packages/core/src/zcli.zig
+++ b/packages/core/src/zcli.zig
@@ -244,7 +244,6 @@ pub const FieldInfo = struct {
 pub const CommandModuleInfo = struct {
     has_args: bool = false,
     has_options: bool = false,
-    raw_meta_ptr: ?*const anyopaque = null, // Points to cmd.module.meta
     args_fields: []const FieldInfo = &.{}, // Runtime-safe field info
     options_fields: []const FieldInfo = &.{}, // Runtime-safe field info
     /// The command's `meta.exclusive` mutually-exclusive sets — each a list of


### PR DESCRIPTION
## Summary
- Removes `CommandModuleInfo.raw_meta_ptr` from `packages/core/src/zcli.zig` — a type-erased `?*const anyopaque` pointer to a comptime anonymous struct that's unusable without knowing the concrete type anyway.
- Removes the corresponding writer in `packages/core/src/registry/compiled.zig` (`.raw_meta_ptr = if (@hasDecl(Module, "meta")) &Module.meta else null`).
- Repo-wide grep confirmed zero readers of the field before removal.

## Test plan
- [x] `zig build test` from repo root — exit 0 (one pre-existing "failed command"/testing-demo self-test noise line, unrelated to this change and tracked separately in PR #693)
- [x] `projects/zcli` builds cleanly (`zig build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #676