### PR TITLE
options: reject non-empty defaults on accumulating array options at comptime

### DIFF
--- a/packages/core/src/zcli.zig
+++ b/packages/core/src/zcli.zig
@@ -505,6 +505,21 @@ pub fn validateCommand(comptime path: []const u8, comptime Module: type) void {
                         "Drop the default, or use a non-optional field with a default for a guaranteed value.");
                 }
             }
+
+            // An accumulating-array option collects repeated flags, so the parser
+            // always initializes it to the empty slice *before* any declared
+            // default is read (the overwrite is required — `cleanupOptions` would
+            // otherwise `free` a static literal). A non-empty default is therefore
+            // silently discarded. Forbid it, mirroring the optional-default rule:
+            // arrays default to empty; supply values by passing the flag.
+            if (comptime option_utils.isArrayType(field.type) and field.default_value_ptr != null) {
+                const dv: *const field.type = @ptrCast(@alignCast(field.default_value_ptr.?));
+                if (dv.*.len != 0) {
+                    @compileError(loc ++ "array option '" ++ field.name ++ "' has a non-empty default. " ++
+                        "Accumulating arrays always default to empty (repeat the flag to add values); " ++
+                        "a non-empty default is silently discarded. Drop the default.");
+                }
+            }
         }
 
         // No two options may collide on a spelling: the parser resolves a flag by
@@ -856,6 +871,19 @@ test "validateCommand accepts a well-formed command" {
     };
     comptime validateCommand("distinct", Distinct);
 
+    // Accumulating-array options are valid with no default (implicitly empty) or
+    // an explicitly empty default. A non-empty default is a compile error (see
+    // the hand-verified negative case below).
+    const Arrays = struct {
+        pub const Args = struct {};
+        pub const Options = struct {
+            tags: []const []const u8,
+            ports: []const u16 = &.{},
+        };
+        pub fn execute(_: Args, _: Options, _: anytype) !void {}
+    };
+    comptime validateCommand("arrays", Arrays);
+
     try testing.expect(true);
 }
 
@@ -901,6 +929,16 @@ test "validateCommand accepts a well-formed command" {
 //
 //   command 'broken': options 'dry_run' and 'dry-run' both resolve to the long flag `--dry-run`. ...
 //     pub const Options = struct { @"dry-run": bool = false, dry_run: bool = false };
+//
+//   Option default shapes. Optionals default to null and accumulating arrays
+//   default to empty; a non-null/non-empty default is silently discarded, so
+//   both are rejected. Each guard below is verified by hand:
+//
+//   command 'broken': optional option 'name' has a non-null default. ...
+//     pub const Options = struct { name: ?[]const u8 = "x" };
+//
+//   command 'broken': array option 'tags' has a non-empty default. ...
+//     pub const Options = struct { tags: []const []const u8 = &.{"a"} };
 
 test "Context creation" {
     const allocator = testing.allocator;


### PR DESCRIPTION
## Summary

`packages/core/src/options/parser.zig` unconditionally initializes every accumulating-array option field to the empty slice *before* any declared default is read. So a non-empty default like `tags: []const []const u8 = &.{"alpha","beta"}` parsed to `tags.len == 0` with no flag passed — compile-clean, no warning.

The overwrite itself is *necessary*: `cleanupOptions` would otherwise `free` a static literal. So the fix is a comptime error on a non-empty array default, mirroring the existing non-null optional-default rule in `validateCommand` (`zcli.zig`).

## Change

- `validateCommand`: added a comptime guard that rejects an accumulating-array option with a non-empty default, right after the optional-default guard. Uses the existing `option_utils.isArrayType` (which already excludes `[]const u8` strings, so string defaults are unaffected).
- Positive test in `test "validateCommand accepts a well-formed command"` now includes an array option with no default and one with an explicit empty default (`&.{}`) — both valid.
- Documented the new negative case (and the pre-existing optional one) in the hand-verified compile-error comment block.

## Compile-error text

```
error: command 'arrays': array option 'ports' has a non-empty default. Accumulating arrays always default to empty (repeat the flag to add values); a non-empty default is silently discarded. Drop the default.
```

Verified via a scratch edit (non-empty default in the positive test) which failed to compile with the above; reverted.

## Test evidence

`zig build test` from repo root: **exit 0** (pre-existing packages/testing self-test "failed command"/"Expected output to contain" noise unrelated — fixed separately in #693). Empty-default and no-default array options compile and validate cleanly.

Fixes #668

🤖 Generated with [Claude Code](https://claude.com/claude-code)