### PR TITLE
perf: kill quadratic-growth appends in markdown parse + completions tree

### DIFF
--- a/packages/core/src/plugins/zcli_completions/tree.zig
+++ b/packages/core/src/plugins/zcli_completions/tree.zig
@@ -30,6 +30,10 @@ pub const CommandNode = struct {
     args: []const zcli.ArgInfo = &.{},
     /// Child commands, sorted by name for deterministic output.
     children: []const *CommandNode = &.{},
+    /// Internal: full-capacity backing store for `children`, grown by doubling as
+    /// children are appended. `children` is always `children_buf[0..children.len]`.
+    /// Not part of the public tree shape — renderers use `children`.
+    children_buf: []*CommandNode = &.{},
 
     /// A command with no children is a leaf (a runnable command); one with
     /// children is (at least) a command group.
@@ -147,10 +151,18 @@ fn childNamed(
     const child = try arena.create(CommandNode);
     child.* = .{ .name = name, .path = try arena.dupe([]const u8, path) };
 
-    const grown = try arena.alloc(*CommandNode, parent.children.len + 1);
-    @memcpy(grown[0..parent.children.len], parent.children);
-    grown[parent.children.len] = child;
-    parent.children = grown;
+    // Grow the backing store by doubling when full, so appending C children is
+    // O(C) amortized instead of O(C²) (a fresh alloc + full copy per append) and
+    // leaves only O(C) stale bytes resident in the arena rather than O(C²).
+    if (parent.children.len == parent.children_buf.len) {
+        const new_cap = if (parent.children_buf.len == 0) 4 else parent.children_buf.len * 2;
+        const grown = try arena.alloc(*CommandNode, new_cap);
+        @memcpy(grown[0..parent.children.len], parent.children);
+        parent.children_buf = grown;
+    }
+    const n = parent.children.len;
+    parent.children_buf[n] = child;
+    parent.children = parent.children_buf[0 .. n + 1];
     return child;
 }
 

--- a/packages/markdown/src/block_parser.zig
+++ b/packages/markdown/src/block_parser.zig
@@ -27,7 +27,13 @@ pub const Block = struct {
 /// Parse markdown into blocks at comptime
 pub fn parseBlocks(comptime markdown: []const u8) []const Block {
     comptime {
-        var blocks: []const Block = &[_]Block{};
+        // Every iteration of the outer loop emits exactly one block and consumes
+        // at least one byte of input, so the block count is bounded by
+        // `markdown.len`. Fill a single fixed-size buffer instead of growing a
+        // slice one element at a time (which reallocated+copied the whole array
+        // per block, making discovery O(n²) in the doc size).
+        var blocks: [markdown.len + 1]Block = undefined;
+        var count: usize = 0;
         var i: usize = 0;
 
         while (i < markdown.len) {
@@ -46,38 +52,45 @@ pub fn parseBlocks(comptime markdown: []const u8) []const Block {
 
             // Check for blank line
             if (isBlank(line)) {
-                blocks = blocks ++ &[_]Block{.{
+                blocks[count] = .{
                     .type = .blank_line,
                     .content = "",
-                }};
+                };
+                count += 1;
                 continue;
             }
 
             // Check for horizontal rule (---, ***, ___)
             if (isHorizontalRule(line)) {
-                blocks = blocks ++ &[_]Block{.{
+                blocks[count] = .{
                     .type = .horizontal_rule,
                     .content = line,
-                }};
+                };
+                count += 1;
                 continue;
             }
 
             // Check for heading (# through ######)
             if (detectHeading(line)) |heading_level| {
                 const content = std.mem.trimStart(u8, line[heading_level..], " ");
-                blocks = blocks ++ &[_]Block{.{
+                blocks[count] = .{
                     .type = .heading,
                     .content = content,
                     .level = heading_level,
-                }};
+                };
+                count += 1;
                 continue;
             }
 
             // Check for code block start (```)
             if (std.mem.startsWith(u8, line, "```")) {
                 const lang = std.mem.trim(u8, line[3..], " ");
-                var code_content: []const u8 = "";
-                var found_end = false;
+                // The code content is a contiguous run of source lines joined by
+                // '\n' — exactly the substring between the opening fence and the
+                // closing fence. Track its byte span and slice it out once,
+                // rather than concatenating line by line (which was O(n²)).
+                const content_start = i;
+                var content_end = i;
 
                 // Collect code block content
                 while (i < markdown.len) {
@@ -92,33 +105,32 @@ pub fn parseBlocks(comptime markdown: []const u8) []const Block {
 
                     // Check for closing ```
                     if (std.mem.startsWith(u8, code_line, "```")) {
-                        found_end = true;
                         break;
                     }
 
-                    // Add line to code content
-                    if (code_content.len > 0) {
-                        code_content = code_content ++ "\n" ++ code_line;
-                    } else {
-                        code_content = code_line;
-                    }
+                    // Extend the content span up to (but not including) this
+                    // line's trailing newline; the '\n' separators between kept
+                    // lines fall inside the resulting slice.
+                    content_end = code_line_end;
                 }
 
-                blocks = blocks ++ &[_]Block{.{
+                blocks[count] = .{
                     .type = .code_block,
-                    .content = code_content,
+                    .content = markdown[content_start..content_end],
                     .language = lang,
-                }};
+                };
+                count += 1;
                 continue;
             }
 
             // Check for blockquote (> text)
             if (std.mem.startsWith(u8, line, ">")) {
                 const content = std.mem.trimStart(u8, line[1..], " ");
-                blocks = blocks ++ &[_]Block{.{
+                blocks[count] = .{
                     .type = .blockquote,
                     .content = content,
-                }};
+                };
+                count += 1;
                 continue;
             }
 
@@ -126,34 +138,38 @@ pub fn parseBlocks(comptime markdown: []const u8) []const Block {
             if (line.len >= 2 and (line[0] == '-' or line[0] == '*' or line[0] == '+') and line[1] == ' ') {
                 const nesting = countLeadingSpaces(line) / 2;
                 const content = std.mem.trimStart(u8, line[2..], " ");
-                blocks = blocks ++ &[_]Block{.{
+                blocks[count] = .{
                     .type = .unordered_list_item,
                     .content = content,
                     .level = nesting,
-                }};
+                };
+                count += 1;
                 continue;
             }
 
             // Check for ordered list (1., 2., etc.)
             if (detectOrderedList(line)) |info| {
                 const nesting = countLeadingSpaces(line) / 2;
-                blocks = blocks ++ &[_]Block{.{
+                blocks[count] = .{
                     .type = .ordered_list_item,
                     .content = info.content,
                     .level = nesting,
                     .ordered_number = info.number,
-                }};
+                };
+                count += 1;
                 continue;
             }
 
             // Default: paragraph
-            blocks = blocks ++ &[_]Block{.{
+            blocks[count] = .{
                 .type = .paragraph,
                 .content = line,
-            }};
+            };
+            count += 1;
         }
 
-        return blocks;
+        const final = blocks;
+        return final[0..count];
     }
 }
 

--- a/packages/markdown/src/inline_parser.zig
+++ b/packages/markdown/src/inline_parser.zig
@@ -5,33 +5,66 @@
 const std = @import("std");
 const semantic = @import("semantic.zig");
 
+/// Comptime string builder. Appending with `result = result ++ piece` reallocates
+/// and copies the whole accumulated string per append, making a build over an
+/// N-byte doc O(N²). Instead we collect the output pieces into a fixed-capacity
+/// list (piece count is bounded by the input length) and concatenate them once.
+fn Builder(comptime cap: usize) type {
+    return struct {
+        pieces: [cap][]const u8 = undefined,
+        len: usize = 0,
+
+        fn push(comptime self: *@This(), comptime piece: []const u8) void {
+            self.pieces[self.len] = piece;
+            self.len += 1;
+        }
+
+        fn build(comptime self: *const @This()) []const u8 {
+            comptime {
+                var total: usize = 0;
+                for (self.pieces[0..self.len]) |p| total += p.len;
+
+                var out: [total]u8 = undefined;
+                var idx: usize = 0;
+                for (self.pieces[0..self.len]) |p| {
+                    @memcpy(out[idx..][0..p.len], p);
+                    idx += p.len;
+                }
+                const final = out;
+                return &final;
+            }
+        }
+    };
+}
+
 /// Re-apply formatting after reset codes to maintain outer formatting in nested contexts
 pub fn reapplyAfterResets(comptime content: []const u8, comptime format_code: []const u8, comptime ansi_reset: []const u8) []const u8 {
     comptime {
         if (ansi_reset.len == 0) return content;
 
-        var result: []const u8 = "";
+        // At most two pieces (reset + format) per input byte.
+        var result = Builder(content.len * 2 + 2){};
         var i: usize = 0;
 
         while (i < content.len) {
             // Look for ANSI_RESET
             if (i + ansi_reset.len <= content.len and std.mem.eql(u8, content[i .. i + ansi_reset.len], ansi_reset)) {
                 // Found a reset - add it and then re-apply our format
-                result = result ++ ansi_reset;
+                result.push(ansi_reset);
 
                 // Check if there's more content after reset (don't re-apply if at end)
                 if (i + ansi_reset.len < content.len) {
-                    result = result ++ format_code;
+                    result.push(format_code);
                 }
 
                 i += ansi_reset.len;
             } else {
-                result = result ++ &[_]u8{content[i]};
+                result.push(content[i .. i + 1]);
                 i += 1;
             }
         }
 
-        return result;
+        return result.build();
     }
 }
 
@@ -45,7 +78,9 @@ pub fn parseInline(comptime markdown: []const u8, comptime palette: semantic.Pal
         const strikethrough = if (capability == .no_color) "" else "\x1b[9m";
         const reset = if (capability == .no_color) "" else "\x1b[0m";
 
-        var result: []const u8 = "";
+        // Piece count is bounded by input length; collect pieces and join once
+        // instead of reallocating the whole result per append (which was O(n²)).
+        var result = Builder(markdown.len * 2 + 16){};
         var i: usize = 0;
 
         while (i < markdown.len) {
@@ -56,12 +91,12 @@ pub fn parseInline(comptime markdown: []const u8, comptime palette: semantic.Pal
                     ((markdown[i + 1] == '*' and markdown[i + 2] == '*') or
                         (markdown[i + 1] == '~' and markdown[i + 2] == '~')))
                 {
-                    result = result ++ &[_]u8{ markdown[i + 1], markdown[i + 2] };
+                    result.push(markdown[i + 1 .. i + 3]);
                     i += 3;
                     continue;
                 }
                 // Escape next character
-                result = result ++ &[_]u8{markdown[i + 1]};
+                result.push(markdown[i + 1 .. i + 2]);
                 i += 2;
                 continue;
             }
@@ -81,7 +116,7 @@ pub fn parseInline(comptime markdown: []const u8, comptime palette: semantic.Pal
                     if (markdown[j] == ':') has_colon = true;
                 }
                 if (j < search_limit and markdown[j] == '}' and (j <= i + 2 or has_colon)) {
-                    result = result ++ markdown[i .. j + 1];
+                    result.push(markdown[i .. j + 1]);
                     i = j + 1;
                     continue;
                 }
@@ -96,20 +131,19 @@ pub fn parseInline(comptime markdown: []const u8, comptime palette: semantic.Pal
                 while (i < markdown.len) {
                     if (markdown[i] == '`') {
                         const content = markdown[start..i];
-                        const code_color = palette.code;
-                        const code_ansi = code_color.sequenceComptime(capability);
+                        const code_ansi = palette.code.sequenceComptime(capability);
 
+                        result.push(code_ansi);
                         // Escape braces in code content to prevent them being treated as format specifiers
-                        var escaped_content: []const u8 = "";
-                        for (content) |c| {
+                        for (content, 0..) |c, ci| {
                             if (c == '{' or c == '}') {
-                                escaped_content = escaped_content ++ &[_]u8{ c, c }; // {{ or }}
+                                result.push(&[_]u8{ c, c }); // {{ or }}
                             } else {
-                                escaped_content = escaped_content ++ &[_]u8{c};
+                                result.push(content[ci .. ci + 1]);
                             }
                         }
+                        result.push(reset);
 
-                        result = result ++ code_ansi ++ escaped_content ++ reset;
                         i += 1;
                         found_close = true;
                         break;
@@ -118,7 +152,8 @@ pub fn parseInline(comptime markdown: []const u8, comptime palette: semantic.Pal
                 }
 
                 if (!found_close) {
-                    result = result ++ "`" ++ markdown[start..];
+                    result.push("`");
+                    result.push(markdown[start..]);
                     break;
                 }
                 continue;
@@ -136,7 +171,9 @@ pub fn parseInline(comptime markdown: []const u8, comptime palette: semantic.Pal
                         // Recursively parse content inside strikethrough for nested formatting
                         const parsed_content = parseInline(content, palette, capability);
                         const fixed_content = reapplyAfterResets(parsed_content, strikethrough, reset);
-                        result = result ++ strikethrough ++ fixed_content ++ reset;
+                        result.push(strikethrough);
+                        result.push(fixed_content);
+                        result.push(reset);
                         i += 2;
                         found_close = true;
                         break;
@@ -145,7 +182,8 @@ pub fn parseInline(comptime markdown: []const u8, comptime palette: semantic.Pal
                 }
 
                 if (!found_close) {
-                    result = result ++ "~~" ++ markdown[start..];
+                    result.push("~~");
+                    result.push(markdown[start..]);
                     break;
                 }
                 continue;
@@ -159,10 +197,14 @@ pub fn parseInline(comptime markdown: []const u8, comptime palette: semantic.Pal
 
                     if (capability == .no_color) {
                         // No OSC 8 in no_color mode
-                        result = result ++ parsed_text;
+                        result.push(parsed_text);
                     } else {
                         // OSC 8 hyperlink: \x1b]8;;URL\x1b\\TEXT\x1b]8;;\x1b\\
-                        result = result ++ "\x1b]8;;" ++ link_info.url ++ "\x1b\\" ++ parsed_text ++ "\x1b]8;;\x1b\\";
+                        result.push("\x1b]8;;");
+                        result.push(link_info.url);
+                        result.push("\x1b\\");
+                        result.push(parsed_text);
+                        result.push("\x1b]8;;\x1b\\");
                     }
                     i += link_info.consumed;
                     continue;
@@ -184,7 +226,9 @@ pub fn parseInline(comptime markdown: []const u8, comptime palette: semantic.Pal
                         // If nested content contains resets, we need to re-apply bold after each reset
                         const fixed_content = reapplyAfterResets(parsed_content, bold, reset);
 
-                        result = result ++ bold ++ fixed_content ++ reset;
+                        result.push(bold);
+                        result.push(fixed_content);
+                        result.push(reset);
                         i += 2;
                         found_close = true;
                         break;
@@ -193,7 +237,8 @@ pub fn parseInline(comptime markdown: []const u8, comptime palette: semantic.Pal
                 }
 
                 if (!found_close) {
-                    result = result ++ "**" ++ markdown[start..];
+                    result.push("**");
+                    result.push(markdown[start..]);
                     break;
                 }
                 continue;
@@ -211,7 +256,9 @@ pub fn parseInline(comptime markdown: []const u8, comptime palette: semantic.Pal
                         // Recursively parse content inside italic for nested formatting
                         const parsed_content = parseInline(content, palette, capability);
                         const fixed_content = reapplyAfterResets(parsed_content, italic, reset);
-                        result = result ++ italic ++ fixed_content ++ reset;
+                        result.push(italic);
+                        result.push(fixed_content);
+                        result.push(reset);
                         i += 1;
                         found_close = true;
                         break;
@@ -220,7 +267,8 @@ pub fn parseInline(comptime markdown: []const u8, comptime palette: semantic.Pal
                 }
 
                 if (!found_close) {
-                    result = result ++ "*" ++ markdown[start..];
+                    result.push("*");
+                    result.push(markdown[start..]);
                     break;
                 }
                 continue;
@@ -238,7 +286,9 @@ pub fn parseInline(comptime markdown: []const u8, comptime palette: semantic.Pal
                         // Recursively parse content inside dim for nested formatting
                         const parsed_content = parseInline(content, palette, capability);
                         const fixed_content = reapplyAfterResets(parsed_content, dim, reset);
-                        result = result ++ dim ++ fixed_content ++ reset;
+                        result.push(dim);
+                        result.push(fixed_content);
+                        result.push(reset);
                         i += 1;
                         found_close = true;
                         break;
@@ -247,7 +297,8 @@ pub fn parseInline(comptime markdown: []const u8, comptime palette: semantic.Pal
                 }
 
                 if (!found_close) {
-                    result = result ++ "~" ++ markdown[start..];
+                    result.push("~");
+                    result.push(markdown[start..]);
                     break;
                 }
                 continue;
@@ -258,14 +309,14 @@ pub fn parseInline(comptime markdown: []const u8, comptime palette: semantic.Pal
             // final rendered string is used as a std.fmt format string by
             // callers of `Formatter.print` (see main.zig).
             if (markdown[i] == '{' or markdown[i] == '}') {
-                result = result ++ &[_]u8{ markdown[i], markdown[i] };
+                result.push(&[_]u8{ markdown[i], markdown[i] });
             } else {
-                result = result ++ &[_]u8{markdown[i]};
+                result.push(markdown[i .. i + 1]);
             }
             i += 1;
         }
 
-        return result;
+        return result.build();
     }
 }
 


### PR DESCRIPTION
Two quadratic-growth performance fixes from the Grade 12 whole-repo review. Both are pure perf changes — output/behavior is unchanged, verified by the existing test suites.

## #673 — markdown comptime O(n²) array appends
`packages/markdown/src/{inline,block}_parser.zig` built up their results by growing a comptime slice one element at a time (`result = result ++ &[_]u8{...}`, `blocks = blocks ++ &[_]Block{...}`), which reallocated and copied the whole accumulated array per single-element append — O(N²) comptime work in the doc length, run 4x per formatted string (once per `TerminalCapability`).

- **Block parser**: the block count is bounded by the input length, so it now fills one fixed-size buffer and slices `[0..count]` at the end. Code-block content is sliced directly out of the source (`markdown[start..end]`) instead of being rebuilt line-by-line.
- **Inline parser**: a small comptime `Builder` collects output pieces into a fixed-capacity list (piece count is bounded by input length) and concatenates them once via `@memcpy`. `reapplyAfterResets` uses the same builder.

## #674 — completions childNamed O(C²) tree growth
`packages/core/src/plugins/zcli_completions/tree.zig` — `childNamed` grew `parent.children` by exactly one element per call (fresh arena alloc + full `@memcpy`), leaving O(C²) copy work and O(C²) stale bytes resident in the arena for a group of C subcommands.

It now keeps an internal `children_buf` backing store grown by **doubling** (`children` stays the exact-length public view `children_buf[0..len]`), making appends O(C) amortized with only O(C) stale arena bytes.

## Verification
- `packages/markdown/src/block_parser.zig` unit tests (std-only, standalone) — pass.
- `inline_parser.zig` and the full `main.zig` markdown pipeline tests (theme module wired) — pass.
- Completions tree doubling verified with a harness building a 138-child group (exercising doublings 4→8→…→256) plus a nested chain: children sorted, no duplicates, no stale/undefined slots, multi-level nodes intact.
- Full `zig build test` from repo root was also run (green aside from the pre-existing packages/testing self-test noise fixed separately in #693). CI is the final gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)