### PR TITLE
build_utils: flatten the command tree once (single shared codegen walk)

### DIFF
--- a/packages/core/src/build_utils/code_generation.zig
+++ b/packages/core/src/build_utils/code_generation.zig
@@ -47,63 +47,16 @@ pub fn generateComptimeRegistrySource(
 
 /// Generate command module imports
 fn generateCommandImports(writer: anytype, commands: DiscoveredCommands) !void {
-    // Emit in alphabetical order (see types.sortedByName) so the generated
-    // registry is deterministic rather than filesystem-iteration ordered.
-    const sorted = try types.sortedByName(commands.allocator, &commands.root);
-    defer commands.allocator.free(sorted);
-    for (sorted) |cmd_info| {
-        const cmd_name = cmd_info.name;
-
-        if (cmd_info.command_type != .leaf) {
-            // Generate import for optional group with index file
-            if (cmd_info.command_type == .optional_group) {
-                const module_name = try module_names.indexModuleName(commands.allocator, cmd_name);
-                defer commands.allocator.free(module_name);
-
-                try writer.print("const {s} = @import(\"{s}\");\n", .{ module_name, module_name });
-            }
-            // Generate imports for subcommands
-            try generateGroupImports(writer, cmd_name, &cmd_info);
-        } else {
-            const module_name = try module_names.leafModuleName(commands.allocator, cmd_name);
-            defer commands.allocator.free(module_name);
-
-            try writer.print("const {s} = @import(\"{s}\");\n", .{ module_name, module_name });
-        }
+    // One walk of the tree (module_names.flatten), shared with the registration
+    // pass below and with module_creation.zig, so import strings can never drift
+    // from registered module names. Ordering is pre-order + alphabetical, so the
+    // generated registry is deterministic rather than filesystem-iteration ordered.
+    const emitted = try module_names.flatten(commands.allocator, commands);
+    defer module_names.freeEmitted(commands.allocator, emitted);
+    for (emitted) |e| {
+        try writer.print("const {s} = @import(\"{s}\");\n", .{ e.module_name, e.module_name });
     }
     try writer.writeAll("\n");
-}
-
-/// Generate group command imports recursively
-fn generateGroupImports(writer: anytype, _: []const u8, group_info: *const DiscoveredCommand) !void {
-    if (group_info.subcommands) |subcommands| {
-        const sorted = try types.sortedByName(subcommands.allocator, &subcommands);
-        defer subcommands.allocator.free(sorted);
-        for (sorted) |subcmd_info| {
-            const subcmd_name = subcmd_info.name;
-
-            if (subcmd_info.command_type == .optional_group) {
-                // Generate import for optional group with index file
-                const module_name_with_index = try module_names.pathIndexModuleName(subcommands.allocator, subcmd_info.path);
-                defer subcommands.allocator.free(module_name_with_index);
-
-                try writer.print("const {s} = @import(\"{s}\");\n", .{ module_name_with_index, module_name_with_index });
-
-                // Also recurse for subcommands
-                try generateGroupImports(writer, subcmd_name, &subcmd_info);
-            } else if (subcmd_info.command_type == .pure_group) {
-                // Pure groups have no imports, just recurse
-                try generateGroupImports(writer, subcmd_name, &subcmd_info);
-            } else {
-                // Module name from the full command path — same derivation
-                // module_creation.zig uses, via module_names.
-                const module_name = try module_names.pathModuleName(subcommands.allocator, subcmd_info.path);
-                defer subcommands.allocator.free(module_name);
-
-                try writer.print("const {s} = @import(\"{s}\");\n", .{ module_name, module_name });
-            }
-        }
-    }
 }
 
 /// Generate plugin imports and initialization
@@ -223,83 +176,18 @@ fn generatePureGroupsFromMap(writer: anytype, command_map: *const std.StringHash
 
 /// Generate command registrations
 fn generateCommandRegistrations(writer: anytype, commands: DiscoveredCommands, allocator: std.mem.Allocator) !void {
-    // Registration order becomes the registry's command order (and thus the
-    // order help/completions read back), so emit alphabetically.
-    const sorted = try types.sortedByName(allocator, &commands.root);
-    defer allocator.free(sorted);
-    for (sorted) |cmd_info| {
-        const cmd_name = cmd_info.name;
+    // Same single walk as the import pass: registration order becomes the
+    // registry's command order (and thus the order help/completions read back),
+    // which flatten already emits alphabetically and pre-order.
+    const emitted = try module_names.flatten(allocator, commands);
+    defer module_names.freeEmitted(allocator, emitted);
+    for (emitted) |e| {
+        const command_path_str = try std.mem.join(allocator, " ", e.path);
+        defer allocator.free(command_path_str);
+        const command_path_lit = try escapeStringLiteral(allocator, command_path_str);
+        defer allocator.free(command_path_lit);
 
-        if (cmd_info.command_type != .leaf) {
-            // Register optional group with index file as a command
-            if (cmd_info.command_type == .optional_group) {
-                const module_name = try module_names.indexModuleName(allocator, cmd_name);
-                defer allocator.free(module_name);
-
-                const command_path_str = try std.mem.join(allocator, " ", cmd_info.path);
-                defer allocator.free(command_path_str);
-                const command_path_lit = try escapeStringLiteral(allocator, command_path_str);
-                defer allocator.free(command_path_lit);
-
-                try writer.print("\n    .register(\"{s}\", {s})", .{ command_path_lit, module_name });
-            }
-            // Register subcommands
-            try generateGroupRegistrations(writer, cmd_name, &cmd_info, allocator);
-        } else {
-            const module_name = try module_names.leafModuleName(allocator, cmd_name);
-            defer allocator.free(module_name);
-
-            // Use the actual command path from DiscoveredCommand (it's now an array)
-            const command_path_str = try std.mem.join(allocator, " ", cmd_info.path);
-            defer allocator.free(command_path_str);
-            const command_path_lit = try escapeStringLiteral(allocator, command_path_str);
-            defer allocator.free(command_path_lit);
-
-            try writer.print("\n    .register(\"{s}\", {s})", .{ command_path_lit, module_name });
-        }
-    }
-}
-
-/// Generate group command registrations recursively
-fn generateGroupRegistrations(writer: anytype, _: []const u8, group_info: *const DiscoveredCommand, allocator: std.mem.Allocator) !void {
-    if (group_info.subcommands) |subcommands| {
-        const sorted = try types.sortedByName(allocator, &subcommands);
-        defer allocator.free(sorted);
-        for (sorted) |subcmd_info| {
-            const subcmd_name = subcmd_info.name;
-
-            if (subcmd_info.command_type == .optional_group) {
-                // Register the optional group itself
-                const module_name_with_index = try module_names.pathIndexModuleName(allocator, subcmd_info.path);
-                defer allocator.free(module_name_with_index);
-
-                const command_path_str = try std.mem.join(allocator, " ", subcmd_info.path);
-                defer allocator.free(command_path_str);
-                const command_path_lit = try escapeStringLiteral(allocator, command_path_str);
-                defer allocator.free(command_path_lit);
-
-                try writer.print("\n    .register(\"{s}\", {s})", .{ command_path_lit, module_name_with_index });
-
-                // Also recurse for its subcommands
-                try generateGroupRegistrations(writer, subcmd_name, &subcmd_info, allocator);
-            } else if (subcmd_info.command_type == .pure_group) {
-                // Pure groups are not registered, just recurse
-                try generateGroupRegistrations(writer, subcmd_name, &subcmd_info, allocator);
-            } else {
-                // Module name from the full command path — same derivation
-                // module_creation.zig uses, via module_names.
-                const module_name = try module_names.pathModuleName(allocator, subcmd_info.path);
-                defer allocator.free(module_name);
-
-                // Use the actual command path from the DiscoveredCommand (it's now an array)
-                const command_path_str = try std.mem.join(allocator, " ", subcmd_info.path);
-                defer allocator.free(command_path_str);
-                const command_path_lit = try escapeStringLiteral(allocator, command_path_str);
-                defer allocator.free(command_path_lit);
-
-                try writer.print("\n    .register(\"{s}\", {s})", .{ command_path_lit, module_name });
-            }
-        }
+        try writer.print("\n    .register(\"{s}\", {s})", .{ command_path_lit, e.module_name });
     }
 }
 
@@ -363,6 +251,87 @@ const PluginTestHelper = struct {
         });
     }
 };
+
+fn tcDupePath(a: std.mem.Allocator, path: []const []const u8) ![]const []const u8 {
+    const out = try a.alloc([]const u8, path.len);
+    for (path, 0..) |p, i| out[i] = try a.dupe(u8, p);
+    return out;
+}
+
+fn tcCmd(
+    a: std.mem.Allocator,
+    name: []const u8,
+    path: []const []const u8,
+    file_path: []const u8,
+    command_type: CommandType,
+    subcommands: ?std.StringHashMap(DiscoveredCommand),
+) !DiscoveredCommand {
+    return .{
+        .name = try a.dupe(u8, name),
+        .path = try tcDupePath(a, path),
+        .file_path = try a.dupe(u8, file_path),
+        .command_type = command_type,
+        .subcommands = subcommands,
+    };
+}
+
+test "nested imports and registrations share one alphabetical pre-order walk" {
+    // Mirrors the real projects/zcli tree: a leaf, an optional group with a
+    // nested leaf, and an optional group whose descendants sit under two pure
+    // groups. The import block and the .register(...) chain must cover the same
+    // commands, name each module identically, and appear in the same order —
+    // which is exactly what routing both passes through module_names.flatten
+    // guarantees. Insert out of alphabetical order to prove the walk sorts.
+    const allocator = std.testing.allocator;
+    var commands = DiscoveredCommands.init(allocator);
+    defer commands.deinit();
+
+    // gh (optional_group) → add (pure) → workflow (pure) → release (leaf)
+    var wf_subs = std.StringHashMap(DiscoveredCommand).init(allocator);
+    try wf_subs.put(try allocator.dupe(u8, "release"), try tcCmd(allocator, "release", &.{ "gh", "add", "workflow", "release" }, "gh/add/workflow/release.zig", .leaf, null));
+    var ghadd_subs = std.StringHashMap(DiscoveredCommand).init(allocator);
+    try ghadd_subs.put(try allocator.dupe(u8, "workflow"), try tcCmd(allocator, "workflow", &.{ "gh", "add", "workflow" }, "gh/add/workflow", .pure_group, wf_subs));
+    var gh_subs = std.StringHashMap(DiscoveredCommand).init(allocator);
+    try gh_subs.put(try allocator.dupe(u8, "add"), try tcCmd(allocator, "add", &.{ "gh", "add" }, "gh/add", .pure_group, ghadd_subs));
+    try commands.root.put(try allocator.dupe(u8, "gh"), try tcCmd(allocator, "gh", &.{"gh"}, "gh/index.zig", .optional_group, gh_subs));
+
+    // init (leaf)
+    try commands.root.put(try allocator.dupe(u8, "init"), try tcCmd(allocator, "init", &.{"init"}, "init.zig", .leaf, null));
+
+    // add (optional_group) → command (leaf)
+    var add_subs = std.StringHashMap(DiscoveredCommand).init(allocator);
+    try add_subs.put(try allocator.dupe(u8, "command"), try tcCmd(allocator, "command", &.{ "add", "command" }, "add/command.zig", .leaf, null));
+    try commands.root.put(try allocator.dupe(u8, "add"), try tcCmd(allocator, "add", &.{"add"}, "add/index.zig", .optional_group, add_subs));
+
+    const config = BuildConfig{
+        .commands_dir = "src/commands",
+        .plugins_dir = null,
+        .plugins = &.{},
+        .app_name = "app",
+        .app_version = "1.0.0",
+        .app_description = "app",
+    };
+
+    const source = try generateComptimeRegistrySource(allocator, commands, config, &.{});
+    defer allocator.free(source);
+
+    const expected_imports =
+        \\const add_index = @import("add_index");
+        \\const add_command = @import("add_command");
+        \\const gh_index = @import("gh_index");
+        \\const gh_add_workflow_release = @import("gh_add_workflow_release");
+        \\const cmd_init = @import("cmd_init");
+    ;
+    try std.testing.expect(std.mem.indexOf(u8, source, expected_imports) != null);
+
+    const expected_registrations =
+        "\n    .register(\"add\", add_index)" ++
+        "\n    .register(\"add command\", add_command)" ++
+        "\n    .register(\"gh\", gh_index)" ++
+        "\n    .register(\"gh add workflow release\", gh_add_workflow_release)" ++
+        "\n    .register(\"init\", cmd_init)";
+    try std.testing.expect(std.mem.indexOf(u8, source, expected_registrations) != null);
+}
 
 test "app metadata is escaped into valid string literals" {
     const allocator = std.testing.allocator;

--- a/packages/core/src/build_utils/module_creation.zig
+++ b/packages/core/src/build_utils/module_creation.zig
@@ -5,7 +5,6 @@ const command_config_lookup = @import("command_config_lookup.zig");
 
 const PluginInfo = types.PluginInfo;
 const DiscoveredCommands = types.DiscoveredCommands;
-const DiscoveredCommand = types.DiscoveredCommand;
 
 // ============================================================================
 // MODULE CREATION - Build-time module creation and linking
@@ -37,7 +36,14 @@ fn applyCommandSpecificModules(
     }
 }
 
-/// Create modules for all discovered commands dynamically
+/// Create modules for all discovered commands dynamically.
+///
+/// Iterates the single `module_names.flatten` walk — the same list of
+/// (module_name, path, file_path) triples code_generation.zig emits imports and
+/// registrations from — so a build module is created and named for exactly the
+/// commands the generated registry imports, with no separate recursion to keep
+/// in sync. Pure groups contribute no entry (they get no module); their
+/// descendants still appear because flatten visits them.
 pub fn createDiscoveredModules(
     b: *std.Build,
     registry_module: *std.Build.Module,
@@ -47,128 +53,28 @@ pub fn createDiscoveredModules(
     shared_modules: []const types.SharedModule,
     command_configs: []const types.CommandConfig,
 ) void {
-    var it = commands.root.iterator();
-    while (it.next()) |entry| {
-        const cmd_name = entry.key_ptr.*;
-        const cmd_info = entry.value_ptr.*;
+    const emitted = module_names.flatten(b.allocator, commands) catch @panic("OOM");
+    defer module_names.freeEmitted(b.allocator, emitted);
+    for (emitted) |e| {
+        const full_path = b.fmt("{s}/{s}", .{ commands_dir, e.file_path });
+        const cmd_module = b.addModule(e.module_name, .{
+            .root_source_file = b.path(full_path),
+        });
+        cmd_module.addImport("zcli", zcli_module);
+        // Let commands optionally name the generated Context type via
+        // `@import("command_registry").Context`. The back-reference is safe:
+        // Context depends only on config + plugins, not commands.
+        cmd_module.addImport("command_registry", registry_module);
 
-        if (cmd_info.command_type != .leaf) {
-            // Create module for optional group with index file
-            if (cmd_info.command_type == .optional_group) {
-                const module_name = module_names.indexModuleName(b.allocator, cmd_name) catch @panic("OOM");
-                const full_path = b.fmt("{s}/{s}", .{ commands_dir, cmd_info.file_path });
-                const cmd_module = b.addModule(module_name, .{
-                    .root_source_file = b.path(full_path),
-                });
-                cmd_module.addImport("zcli", zcli_module);
-                // Let commands optionally name the generated Context type via
-                // `@import("command_registry").Context`. The back-reference is
-                // safe: Context depends only on config + plugins, not commands.
-                cmd_module.addImport("command_registry", registry_module);
-
-                // Add shared modules
-                for (shared_modules) |shared_mod| {
-                    cmd_module.addImport(shared_mod.name, shared_mod.module);
-                }
-
-                // Add command-specific modules
-                applyCommandSpecificModules(b, cmd_module, cmd_info.path, shared_modules, command_configs);
-
-                registry_module.addImport(module_name, cmd_module);
-            }
-            // Create modules for subcommands
-            createGroupModules(b, registry_module, zcli_module, cmd_name, &cmd_info, commands_dir, shared_modules, command_configs);
-        } else {
-            const module_name = module_names.leafModuleName(b.allocator, cmd_name) catch @panic("OOM");
-
-            const full_path = b.fmt("{s}/{s}", .{ commands_dir, cmd_info.file_path });
-            const cmd_module = b.addModule(module_name, .{
-                .root_source_file = b.path(full_path),
-            });
-            cmd_module.addImport("zcli", zcli_module);
-            cmd_module.addImport("command_registry", registry_module);
-
-            // Add shared modules
-            for (shared_modules) |shared_mod| {
-                cmd_module.addImport(shared_mod.name, shared_mod.module);
-            }
-
-            // Add command-specific modules
-            applyCommandSpecificModules(b, cmd_module, cmd_info.path, shared_modules, command_configs);
-
-            registry_module.addImport(module_name, cmd_module);
+        // Add shared modules
+        for (shared_modules) |shared_mod| {
+            cmd_module.addImport(shared_mod.name, shared_mod.module);
         }
-    }
-}
 
-/// Create modules for command groups recursively
-fn createGroupModules(
-    b: *std.Build,
-    registry_module: *std.Build.Module,
-    zcli_module: *std.Build.Module,
-    _: []const u8,
-    group_info: *const DiscoveredCommand,
-    commands_dir: []const u8,
-    shared_modules: []const types.SharedModule,
-    command_configs: []const types.CommandConfig,
-) void {
-    if (group_info.subcommands) |subcommands| {
-        var it = subcommands.iterator();
-        while (it.next()) |entry| {
-            const subcmd_name = entry.key_ptr.*;
-            const subcmd_info = entry.value_ptr.*;
+        // Add command-specific modules
+        applyCommandSpecificModules(b, cmd_module, e.path, shared_modules, command_configs);
 
-            if (subcmd_info.command_type == .optional_group) {
-                // Create module for nested optional group — same derivation
-                // code_generation.zig emits imports with, via module_names.
-                const module_name_with_index = module_names.pathIndexModuleName(b.allocator, subcmd_info.path) catch @panic("OOM");
-
-                const full_path = b.fmt("{s}/{s}", .{ commands_dir, subcmd_info.file_path });
-                const cmd_module = b.addModule(module_name_with_index, .{
-                    .root_source_file = b.path(full_path),
-                });
-                cmd_module.addImport("zcli", zcli_module);
-                cmd_module.addImport("command_registry", registry_module);
-
-                // Add shared modules
-                for (shared_modules) |shared_mod| {
-                    cmd_module.addImport(shared_mod.name, shared_mod.module);
-                }
-
-                // Add command-specific modules
-                applyCommandSpecificModules(b, cmd_module, subcmd_info.path, shared_modules, command_configs);
-
-                registry_module.addImport(module_name_with_index, cmd_module);
-
-                // Also recurse for its subcommands
-                createGroupModules(b, registry_module, zcli_module, subcmd_name, &subcmd_info, commands_dir, shared_modules, command_configs);
-            } else if (subcmd_info.command_type == .pure_group) {
-                // Pure groups have no module, just recurse
-                createGroupModules(b, registry_module, zcli_module, subcmd_name, &subcmd_info, commands_dir, shared_modules, command_configs);
-            } else {
-                // Module name from the full command path (unique even for
-                // deeply nested commands) — same derivation code_generation.zig
-                // emits imports with, via module_names.
-                const module_name = module_names.pathModuleName(b.allocator, subcmd_info.path) catch @panic("OOM");
-
-                const full_path = b.fmt("{s}/{s}", .{ commands_dir, subcmd_info.file_path });
-                const cmd_module = b.addModule(module_name, .{
-                    .root_source_file = b.path(full_path),
-                });
-                cmd_module.addImport("zcli", zcli_module);
-                cmd_module.addImport("command_registry", registry_module);
-
-                // Add shared modules
-                for (shared_modules) |shared_mod| {
-                    cmd_module.addImport(shared_mod.name, shared_mod.module);
-                }
-
-                // Add command-specific modules
-                applyCommandSpecificModules(b, cmd_module, subcmd_info.path, shared_modules, command_configs);
-
-                registry_module.addImport(module_name, cmd_module);
-            }
-        }
+        registry_module.addImport(e.module_name, cmd_module);
     }
 }
 

--- a/packages/core/src/build_utils/module_names.zig
+++ b/packages/core/src/build_utils/module_names.zig
@@ -12,6 +12,7 @@ const discovery_types = @import("discovery_types.zig");
 
 const DiscoveredCommand = discovery_types.DiscoveredCommand;
 const DiscoveredCommands = discovery_types.DiscoveredCommands;
+const CommandType = discovery_types.CommandType;
 
 /// Top-level leaf command: `cmd_<name>`. The prefix keeps top-level command
 /// modules from colliding with other module-level decls (and keeps "test"
@@ -132,6 +133,70 @@ fn findCollisionInMap(
         }
     }
     return null;
+}
+
+// --- The single tree walk -----------------------------------------------------
+
+/// One command that gets a generated module: everything the two codegen passes
+/// need and nothing they must recompute. `path` and `file_path` are borrowed
+/// from the `DiscoveredCommands` that produced them; `module_name` is owned by
+/// the caller (freed via `freeEmitted`).
+pub const EmittedCommand = struct {
+    module_name: []u8,
+    path: []const []const u8,
+    file_path: []const u8,
+    kind: CommandType,
+};
+
+/// Flatten the discovered command tree into the exact, ordered sequence of
+/// commands that get a generated module — the ONE walk shared by both codegen
+/// passes. code_generation.zig emits an `@import` + a `.register(...)` per
+/// entry; module_creation.zig builds + wires one `b.addModule` per entry. Since
+/// both iterate this same list, they can never disagree on which commands are
+/// covered or what each module is named — the drift the "Nested command groups
+/// not being registered" troubleshooting entry documents becomes impossible.
+///
+/// Order is pre-order and alphabetical at every level (via `sortedByName`),
+/// matching the generated registry's command order. Pure groups get no module
+/// (mirroring `moduleNameFor` returning null) but their descendants are still
+/// visited. Caller owns the slice and each entry's `module_name`.
+pub fn flatten(allocator: std.mem.Allocator, commands: DiscoveredCommands) ![]EmittedCommand {
+    var out = std.ArrayList(EmittedCommand).empty;
+    errdefer {
+        for (out.items) |e| allocator.free(e.module_name);
+        out.deinit(allocator);
+    }
+    try flattenMap(allocator, &out, &commands.root, true);
+    return out.toOwnedSlice(allocator);
+}
+
+fn flattenMap(
+    allocator: std.mem.Allocator,
+    out: *std.ArrayList(EmittedCommand),
+    map: *const std.StringHashMap(DiscoveredCommand),
+    is_root: bool,
+) !void {
+    const sorted = try discovery_types.sortedByName(allocator, map);
+    defer allocator.free(sorted);
+    for (sorted) |cmd| {
+        if (try moduleNameFor(allocator, &cmd, is_root)) |name| {
+            try out.append(allocator, .{
+                .module_name = name,
+                .path = cmd.path,
+                .file_path = cmd.file_path,
+                .kind = cmd.command_type,
+            });
+        }
+        if (cmd.subcommands) |*subcmds| {
+            try flattenMap(allocator, out, subcmds, false);
+        }
+    }
+}
+
+/// Free the slice returned by `flatten` and every entry's owned `module_name`.
+pub fn freeEmitted(allocator: std.mem.Allocator, emitted: []EmittedCommand) void {
+    for (emitted) |e| allocator.free(e.module_name);
+    allocator.free(emitted);
 }
 
 const testing = std.testing;


### PR DESCRIPTION
## What

`build_utils` generated the command registry through **four structurally identical tree walks** that had to agree by convention:

- `code_generation.zig` — `generateCommandImports`/`generateGroupImports` (emit `@import` lines) and `generateCommandRegistrations`/`generateGroupRegistrations` (emit `.register(...)` lines), each a root/nested split.
- `module_creation.zig` — `createDiscoveredModules`/`createGroupModules` (register build modules), same shape.

`module_names.zig` already centralized the *naming*, but not the *walk*. A new command type meant editing ~6 places in lockstep or commands silently vanished from the registry — the exact bug class the "Nested command groups not being registered" troubleshooting entry documents.

## Change

Introduce **`module_names.flatten()`** — the single pre-order, alphabetically-sorted walk (issue #679's fix sketch):

```zig
pub const EmittedCommand = struct {
    module_name: []u8,        // owned
    path: []const []const u8, // borrowed
    file_path: []const u8,    // borrowed
    kind: CommandType,
};
pub fn flatten(allocator, commands: DiscoveredCommands) ![]EmittedCommand;
```

It yields exactly the commands that get a generated module (leaf + optional_group; pure groups contribute no entry but their descendants are still visited), reusing the existing `moduleNameFor` (so names match the collision checker too) and `sortedByName`.

- `code_generation` now emits one import + one `.register(...)` per flattened entry.
- `module_creation` builds + wires one `b.addModule` per entry — its two recursive functions collapse into one loop.

The two passes iterate the same list, so they can no longer disagree on which commands are covered or how each module is named.

**Net −60 lines.**

## Byte-identical registry — the hard invariant

The change is a pure reorganization of the same emission logic:

- **Same order.** `flatten` is pre-order and `sortedByName`-alphabetical at every level, reproducing the previous root-then-recursive-descent emission order exactly (parent emitted before its children; pure groups skipped but descended into).
- **Same strings.** The `@import("{s}")` and `\n    .register("{s}", {s})` format strings, path joining, and `escapeStringLiteral` calls are unchanged; module names come from the same `module_names` helpers.

A new regression test, `nested imports and registrations share one alphabetical pre-order walk`, mirrors the real `projects/zcli` tree (a leaf, an optional group with a nested leaf, and an optional group whose descendants sit under two pure groups, inserted out of order) and asserts the **exact** import block and `.register(...)` chain — locking both order and module names across all three group types:

```
const add_index = @import("add_index");
const add_command = @import("add_command");
const gh_index = @import("gh_index");
const gh_add_workflow_release = @import("gh_add_workflow_release");
const cmd_init = @import("cmd_init");
...
    .register("add", add_index)
    .register("add command", add_command)
    .register("gh", gh_index)
    .register("gh add workflow release", gh_add_workflow_release)
    .register("init", cmd_init)
```

<!--DIFF-EVIDENCE-->

## Scope

Deliberately limited to the "four synchronized tree walks" in the issue's part 1. Two related walks are left as-is and noted for the record:

- `code_generation.generatePureGroupsFromMap` collects a different projection (pure-group path arrays for the `pure_command_groups` table), not one of the four module walks.
- `command_tests.addMapTests` selects the same command set but names modules with a distinct test-stub scheme and never touches the generated registry.

Issue #679's part 2 (extracting the `init` scaffold string templates to `@embedFile`d reference sources compiled by CI) is a separate, larger change entangled with the release/version-pinning contract and the e2e drift bridge; it does not affect the generated registry and is not included here.

Fixes #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)
