### PR TITLE
docs: fix testing doc example, surface all canonical examples, refresh stale review artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,14 @@ What a real zcli app looks like. The meta-CLI you install is one; the rest are t
 | [**oauth-device**](examples/oauth-device) | Mints a token from scratch by running GitHub's OAuth device flow (RFC 8628), then keychains it — freeform command code, not a framework feature. |
 | [**notes**](examples/notes) | A tiny note keeper: saves and loads a typed struct as a JSON file and shares one `store` module across three commands. |
 | [**repostat**](examples/repostat) | Prints stats for a public GitHub repo — the minimal `zcli.http` + typed-JSON example, with safe client defaults out of the box. |
+| [**ext-plugin**](examples/ext-plugin) | Registers a third-party plugin shipped as its own Zig package (`.dependency = greet_plugin_dep`), contrasting the local-path and built-in plugin styles used elsewhere. |
+| [**vault**](examples/vault) | A secrets-backed CLI combining `zcli_secrets` (OS keychain), `zcli_config`, dynamic completions, and password prompts in one app. |
+| [**options-features**](examples/options-features) | Exercises option-parsing edge cases: required options (flag/env/config), array options, per-field `validate` hooks, custom `parse` types, and `meta.exclusive`/`meta.options.*.requires`. |
+| [**prompts-features**](examples/prompts-features) | Covers the `password` and `multi_select` prompt types not shown elsewhere. |
+| [**testing-demo**](examples/testing-demo) | Shows the `zcli-testing` harness used directly in app code — unit-tier `runCommand` in command tests plus a subprocess/snapshot integration test against the compiled binary. |
+| [**upgrade-demo**](examples/upgrade-demo) | Wires the `github_upgrade` plugin to add a self-upgrade `upgrade` command backed by GitHub Releases. |
+
+See [`examples/README.md`](examples/README.md) for the full index, including how each example is built and tested in CI.
 
 Building something with zcli? Open a PR to add it here.
 

--- a/docs/adr/0027-plugins-are-compile-time.md
+++ b/docs/adr/0027-plugins-are-compile-time.md
@@ -57,10 +57,11 @@ Stated plainly, because it is real:
 The gap is narrower in practice than it looks, because the workflows runtime
 plugins usually serve are covered another way:
 
-- **Local plugins are convention-discovered.** A `plugins_dir` (default
-  `src/plugins`) is scanned exactly like `commands_dir`; dropping a
-  `plugins/<name>.zig` file is enough (`build_utils/plugin_system.zig`
-  `scanLocalPlugins`, ADR-0006). No `build.zig` array to splice.
+- **Local plugins are convention-discovered.** A `plugins_dir` (opt-in; `null`
+  unless the project sets it — `zcli init` scaffolds it to `src/plugins`) is
+  scanned exactly like `commands_dir`; dropping a `plugins/<name>.zig` file is
+  enough (`build_utils/plugin_system.zig` `scanLocalPlugins`, ADR-0006). No
+  `build.zig` array to splice.
 - **`zcli add plugin <name>` scaffolds one** as a guided skeleton, auto-discovered
   on the next build (ADR-0006).
 - **Rebuilds are fast**, and `zcli dev` watches and rebuilds on change — the

--- a/docs/reviews/2026-07-02T12-28-14-0600-zcli-secrets-fable-review.md
+++ b/docs/reviews/2026-07-02T12-28-14-0600-zcli-secrets-fable-review.md
@@ -2,27 +2,34 @@
 
 - **Reviewer:** Fable (independent code review), 2026-07-02
 - **PR:** #39 — `zcli_secrets` opt-in credential plugin (macOS Keychain / Linux Secret Service / Windows Credential Manager)
-- **Status of this file:** a backlog of *deferred* items. Everything Fable rated
-  blocking or cheap-and-clear was already addressed in the PR (commit `af398fc`);
-  the items below were consciously left for later, with Fable's agreement that
-  none block merge. Recorded here so they are not lost.
+- **Status of this file:** a point-in-time backlog of *deferred* items. Everything
+  Fable rated blocking or cheap-and-clear was already addressed in the PR (commit
+  `af398fc`); the items below were consciously left for later, with Fable's
+  agreement that none block merge. **Updated 2026-07-17 (Grade 12 review,
+  issue #691):** items 1, 3, and 6 have since shipped and item 2's premise no
+  longer applies (see per-item notes) — this file is now historical record, not
+  an outstanding-work list. Grep the codebase, not this file, to check current
+  status of anything below.
 
 ## Open items (not yet addressed)
 
-### 1. Double-context API wart — needs a framework-level `initContextData` hook
+### 1. Double-context API wart — needs a framework-level `initContextData` hook — **RESOLVED**
 - **Severity:** design / medium. **Where:** `plugins/zcli_secrets/plugin.zig` `ContextData`, and the plugin/registry framework (`packages/core/src/registry.zig`).
 - **Problem:** the public API is `context.plugins.zcli_secrets.get(context, name)` — the context is passed twice. `ContextData` is default-initialized (`.{}`) with no init hook, so it can't capture `allocator`/`app_name` at construction; hence every call re-threads `context`. The `context: anytype` signature also erases the contract, so misuse surfaces as an instantiation error deep in the plugin.
 - **Direction:** add an `initContextData(context)` hook to the plugin framework so a plugin's `ContextData` can capture what it needs once; then the API becomes `context.plugins.zcli_secrets.get(name)`. This is a framework change touching all plugins, not secrets-only — hence deferred.
+- **Resolution:** `initContextData(data: *ContextData, context: anytype)` is now implemented (`plugins/zcli_secrets/plugin.zig:277`) and the framework calls it before every command; `get`/`set`/`remove` no longer take `context` as a parameter.
 
-### 2. Linux libsecret: base64 wrapper vs. raw `SecretValue`
+### 2. Linux libsecret: base64 wrapper vs. raw `SecretValue` — **SUPERSEDED**
 - **Severity:** minor / polish. **Where:** `plugins/zcli_secrets/secret_service_linux.zig`.
 - **Problem:** the variadic `secret_password_*_sync` helpers are NUL-terminated, so values are base64-encoded to stay binary-safe. Side effect: a value inspected via `secret-tool` shows base64, not the raw token.
 - **Direction:** switch to `secret_service_store_sync` / `SecretValue` (length-based) to store raw bytes and preserve `secret-tool` interop. Cost is a `GHashTable`/`SecretValue` FFI surface (more glib marshalling) — a fair trade to defer while the base64 limitation is documented in the module and ADR.
+- **Resolution:** the libsecret FFI this item was about no longer exists. ADR-0010 replaced it with a shell-out design (`secret-tool`/`pass` via `subprocess.zig`, `linux_secret_service.zig`, `linux_pass.zig`) so Linux secrets don't break musl builds. Both shell-out backends are line-oriented over stdin/stdout, so they still base64-encode (ADR-0010's "Consequences" section documents this explicitly) — the original direction (raw `SecretValue` FFI) doesn't apply to a shell-out backend and won't be pursued.
 
-### 3. No secure zeroing of transient secret buffers
+### 3. No secure zeroing of transient secret buffers — **RESOLVED**
 - **Severity:** minor. **Where:** all backends — e.g. the base64 staging buffer in `secret_service_linux.zig` `set`, and the caller-owned copies returned by every `get`.
 - **Problem:** plaintext secret material lingers in freed heap pages until reused; a core dump / memory scrape could recover it. Low severity for short-lived CLI processes, but cheap credibility for a "credentials done right" module.
 - **Direction:** `std.crypto.secureZero(u8, buf)` on transient buffers before free. Returned buffers are caller-owned (arena), so scope carefully — likely only the internal staging buffers, plus a documented note that callers should zero what they free.
+- **Resolution:** `std.crypto.secureZero` is now applied to transient secret buffers in every backend (`credential_manager_windows.zig`, `linux_pass.zig`, `linux_secret_service.zig`, `subprocess.zig`).
 
 ### 4. Windows key flattening can collide across apps
 - **Severity:** minor / correctness edge. **Where:** `credential_manager_windows.zig` `makeTarget`.
@@ -34,10 +41,11 @@
 - **Problem:** values over `CRED_MAX_CREDENTIAL_BLOB_SIZE` fail with `SecretTooLarge` only on Windows; some real tokens (large JWTs, certain PATs) exceed 2.5 KB. A CLI that works on macOS/Linux can fail only on Windows.
 - **Direction:** documented for now. If it bites, chunk a large value across multiple credentials (`name`, `name#1`, …) transparently in the Windows backend.
 
-### 6. Non-UTF-8 secret names behave differently per OS
+### 6. Non-UTF-8 secret names behave differently per OS — **RESOLVED**
 - **Severity:** minor / contract. **Where:** `plugin.zig` `validateName`, `credential_manager_windows.zig`.
 - **Problem:** Windows requires a valid-UTF-8 name (it becomes a UTF-16 target); macOS/Linux accept arbitrary bytes. Names are already validated to reject NUL, but not to require UTF-8, so a non-UTF-8 name "works" on two platforms and fails on the third.
 - **Direction:** consider requiring valid, printable UTF-8 names centrally in `validateName` for a uniform cross-platform key contract. Slight tightening (names are identifiers in practice), so deferred as a deliberate contract decision.
+- **Resolution:** `validateName` (`plugin.zig:184`) now calls `std.unicode.utf8ValidateSlice(name)` and rejects invalid UTF-8 with `Error.InvalidSecretName`, uniformly across all three backends.
 
 ## Already addressed in the PR (for reference)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,27 @@
+# Examples
+
+Every directory here is a small, complete zcli app. Each depends on the root
+`zcli` package the same way an external consumer would (`.zcli = .{ .path =
+"../.." }`), so they build and test as subprocesses rather than as workspace
+members — that's also what makes them *canonical*: they exercise the exact
+path a real project takes through this package, manifest and module exports
+included (see `build.zig` at the repo root, `test_projects`).
+
+`zig build test` from the repo root compiles and runs every example below
+(`test-<name>` steps also exist individually, e.g. `zig build test-vault`).
+
+| Example | What it demonstrates |
+|---------|-----------------------|
+| [**tasks**](tasks) | The showcase app (see the demo GIF in the root README): 14 commands with nested groups and aliases, six of the eight prompt types, spinners and progress bars, themed output, JSON persistence, config files, and completions. |
+| [**ghauth**](ghauth) | GitHub device-flow companion: stashes an API token in the OS keychain via `zcli_secrets`, then uses `zcli.http` to call the API as `whoami`. |
+| [**oauth-device**](oauth-device) | Mints a token from scratch by running GitHub's OAuth device flow (RFC 8628), then keychains it — freeform command code, not a framework feature. |
+| [**notes**](notes) | A tiny note keeper: saves and loads a typed struct as a JSON file and shares one `store` module across three commands. |
+| [**repostat**](repostat) | Prints stats for a public GitHub repo — the minimal `zcli.http` + typed-JSON example, with safe client defaults out of the box. |
+| [**ext-plugin**](ext-plugin) | Registers a third-party plugin shipped as its own Zig package (`.dependency = greet_plugin_dep`), contrasting the local-path and built-in plugin styles. |
+| [**vault**](vault) | A secrets-backed CLI stitching together `zcli_secrets` (OS keychain), `zcli_config` defaults, dynamic shell completions, and password prompts. |
+| [**options-features**](options-features) | Option-parsing edge cases: required options (flag/env/config), array options, per-field `validate` hooks, custom `parse` types, and `meta.exclusive`/`meta.options.*.requires`. |
+| [**prompts-features**](prompts-features) | The `password` and `multi_select` prompt types (the other prompt types are covered in `tasks`). |
+| [**testing-demo**](testing-demo) | The `zcli-testing` harness used directly in app code: unit-tier `runCommand` inside a command's own tests, plus a subprocess/snapshot integration test against the compiled binary. |
+| [**upgrade-demo**](upgrade-demo) | Wires the `github_upgrade` plugin to add a self-upgrade `upgrade` command backed by GitHub Releases. |
+
+Building something with zcli? Open a PR to add it here.

--- a/packages/testing/src/main.zig
+++ b/packages/testing/src/main.zig
@@ -19,7 +19,7 @@
 //!
 //! // Integration test
 //! test "help flag" {
-//!     const result = try testing.integration.runSubprocess(allocator, "./myapp", &.{"--help"});
+//!     const result = try testing.integration.runSubprocess(allocator, std.testing.io, "./myapp", &.{"--help"});
 //!     try testing.expectExitCode(result, 0);
 //!     try testing.expectContains(result.stdout, "USAGE:");
 //! }


### PR DESCRIPTION
## Summary

Grade 12 docs sweep, three issues:

- **#689** — `packages/testing/src/main.zig`'s Quick Start doc comment showed
  `runSubprocess(allocator, "./myapp", &.{...})`, missing the required `io`
  param (real signature: `runSubprocess(allocator, io, exe_path, args)` in
  `runner.zig`). Fixed to `runSubprocess(allocator, std.testing.io, "./myapp", &.{"--help"})`.
  The other half of the issue — the flagship `runCommand` living in a separate
  module (`zcli_testing_unit`) unreachable from the doc comment it's attached
  to — was already addressed in a prior commit: the module doc explicitly
  explains the split and redirects to `unit.zig`.

- **#690** — 6 of the 11 CI-compiled canonical examples (`ext-plugin`, `vault`,
  `options-features`, `prompts-features`, `testing-demo`, `upgrade-demo`) were
  absent from the README's "Built with zcli" table and had no index anywhere.
  Added all six to the README table with one-line descriptions, and added
  `examples/README.md` as a full index (per the issue's suggested fix),
  covering build/test mechanics shared across all 11.

- **#691** — Two stale point-in-time docs:
  - `docs/reviews/2026-07-02T12-28-14-...secrets-fable-review.md` listed items
    1 (`initContextData`), 3 (`secureZero`), and 6 (UTF-8 name validation) as
    open; verified all three are implemented in current code and marked them
    **RESOLVED** with pointers. Item 2 (libsecret `SecretValue` vs base64) is
    marked **SUPERSEDED** — the libsecret FFI it was about no longer exists;
    ADR-0010 replaced it with a shell-out design (`secret-tool`/`pass`) that
    still base64-encodes for different reasons, so the original direction
    doesn't apply.
  - `docs/adr/0027-plugins-are-compile-time.md` claimed `plugins_dir` defaults
    to `src/plugins`; verified the actual default is `null` (opt-in) in
    `packages/core/src/build_utils/types.zig`, with `zcli init` scaffolding
    `src/plugins` explicitly. Corrected the ADR text.

## Verification

- All code changes are confined to a `//!` doc comment (cannot affect
  compilation) plus Markdown files — no runtime behavior changed.
- Cross-checked every factual claim against current source:
  `runSubprocess` signature in `runner.zig`, `initContextData`/`secureZero`/
  `utf8ValidateSlice` call sites in `zcli_secrets`, and the `plugins_dir`
  default in `types.zig`.
- Attempted a full local `zig build test` run; the dev machine had several
  concurrent agent builds in flight and the run didn't complete in a
  reasonable window. Given the diff is docs/comment-only, relying on CI for
  the compiled-example checks (README/examples table changes don't add new
  compiled code, only links/prose).

Fixes #689, Fixes #690, Fixes #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)