### PR TITLE
testing: env/stdin below the e2e tier + real signal-death exit codes

### DIFF
--- a/examples/testing-demo/src/integration_test.zig
+++ b/examples/testing-demo/src/integration_test.zig
@@ -18,7 +18,7 @@ test "greet world prints a greeting and exits 0" {
 
     // The first arg is the command name — `greeter greet world`, exactly as a
     // user would type it (runSubprocess supplies the binary as argv[0]).
-    var result = try testing.runSubprocess(allocator, io, exe_path, &.{ "greet", "world" });
+    var result = try testing.runSubprocess(allocator, io, exe_path, &.{ "greet", "world" }, .{});
     defer result.deinit();
 
     try testing.expectExitCode(result, 0);
@@ -30,7 +30,7 @@ test "greet --loud shouts" {
     const allocator = std.testing.allocator;
     const io = std.testing.io;
 
-    var result = try testing.runSubprocess(allocator, io, exe_path, &.{ "greet", "world", "--loud" });
+    var result = try testing.runSubprocess(allocator, io, exe_path, &.{ "greet", "world", "--loud" }, .{});
     defer result.deinit();
 
     try testing.expectExitCode(result, 0);
@@ -41,7 +41,7 @@ test "an unrecognized flag is reported misuse (exit code 2)" {
     const allocator = std.testing.allocator;
     const io = std.testing.io;
 
-    var result = try testing.runSubprocess(allocator, io, exe_path, &.{ "greet", "world", "--bogus" });
+    var result = try testing.runSubprocess(allocator, io, exe_path, &.{ "greet", "world", "--bogus" }, .{});
     defer result.deinit();
 
     // See DESIGN.md's exit-code table: 2 is reserved for CLI misuse (unknown
@@ -54,7 +54,7 @@ test "greet output matches a golden snapshot" {
     const allocator = std.testing.allocator;
     const io = std.testing.io;
 
-    var result = try testing.runSubprocess(allocator, io, exe_path, &.{ "greet", "snapshot-friend" });
+    var result = try testing.runSubprocess(allocator, io, exe_path, &.{ "greet", "snapshot-friend" }, .{});
     defer result.deinit();
 
     // Compares against the golden checked in at

--- a/packages/testing/examples/snapshot_example.zig
+++ b/packages/testing/examples/snapshot_example.zig
@@ -33,7 +33,7 @@ test "runSubprocess captures stdout and exit code" {
     // In a real suite the first arg is your built binary, e.g.
     // `"./zig-out/bin/myapp"`, and the slice is its CLI args. Here `echo hi`
     // stands in for that binary.
-    var result = testing.runSubprocess(allocator, io, "/bin/echo", &.{"hi"}) catch |err| {
+    var result = testing.runSubprocess(allocator, io, "/bin/echo", &.{"hi"}, .{}) catch |err| {
         // Spawning can be restricted in some sandboxes; skip rather than fail.
         std.log.warn("runSubprocess skipped: {any}", .{err});
         return;
@@ -54,7 +54,7 @@ test "runSubprocess sees a non-zero exit" {
     const io = std.testing.io;
 
     // `/usr/bin/false` exits 1 and prints nothing.
-    var result = testing.runSubprocess(allocator, io, "/usr/bin/false", &.{}) catch |err| {
+    var result = testing.runSubprocess(allocator, io, "/usr/bin/false", &.{}, .{}) catch |err| {
         std.log.warn("runSubprocess skipped: {any}", .{err});
         return;
     };

--- a/packages/testing/src/assertions.zig
+++ b/packages/testing/src/assertions.zig
@@ -88,6 +88,7 @@ test "expectExitCode" {
         .stdout = "",
         .stderr = "",
         .exit_code = 0,
+        .term = .{ .exited = 0 },
         .allocator = undefined,
     };
 
@@ -124,6 +125,7 @@ test "expectStdoutEmpty" {
         .stdout = "",
         .stderr = "some error",
         .exit_code = 0,
+        .term = .{ .exited = 0 },
         .allocator = undefined,
     };
 
@@ -131,6 +133,7 @@ test "expectStdoutEmpty" {
         .stdout = "output",
         .stderr = "",
         .exit_code = 0,
+        .term = .{ .exited = 0 },
         .allocator = undefined,
     };
 
@@ -143,6 +146,7 @@ test "expectStderrEmpty" {
         .stdout = "output",
         .stderr = "",
         .exit_code = 0,
+        .term = .{ .exited = 0 },
         .allocator = undefined,
     };
 
@@ -150,6 +154,7 @@ test "expectStderrEmpty" {
         .stdout = "",
         .stderr = "error",
         .exit_code = 0,
+        .term = .{ .exited = 0 },
         .allocator = undefined,
     };
 
@@ -181,6 +186,7 @@ test "expectExitCode with various codes" {
         .stdout = "",
         .stderr = "",
         .exit_code = 0,
+        .term = .{ .exited = 0 },
         .allocator = undefined,
     };
 
@@ -188,13 +194,15 @@ test "expectExitCode with various codes" {
         .stdout = "",
         .stderr = "",
         .exit_code = 1,
+        .term = .{ .exited = 1 },
         .allocator = undefined,
     };
 
     const signal_result = runner.Result{
         .stdout = "",
         .stderr = "",
-        .exit_code = 130, // SIGINT
+        .exit_code = 130, // SIGINT: 128 + 2
+        .term = .{ .signaled = 2 },
         .allocator = undefined,
     };
 

--- a/packages/testing/src/e2e.zig
+++ b/packages/testing/src/e2e.zig
@@ -4,6 +4,12 @@ const posix = std.posix;
 const conpty = @import("conpty.zig");
 const vterm = @import("vterm");
 const snapshot = @import("snapshot.zig");
+const runner = @import("runner.zig");
+
+/// How a child process terminated (exited / signaled / unknown). Shared with the
+/// integration tier so both surface signal deaths as `128 + signum` rather than
+/// collapsing them to exit code 1. See `runner.Termination`.
+pub const Termination = runner.Termination;
 
 /// Interactive testing support for CLIs that require user input.
 ///
@@ -810,8 +816,12 @@ fn toPosixSig(s: Signal) posix.SIG {
 
 /// Result of an interactive test execution
 pub const InteractiveResult = struct {
-    /// Final exit code of the process
+    /// Final exit code of the process. For a signal death this is the
+    /// shell-conventional `128 + signum` (derived from `term`), not a flat 1.
     exit_code: u8,
+    /// How the child terminated (exited / signaled / unknown), so a test can
+    /// distinguish a real `exited 1` from a kill and assert on the signal.
+    term: Termination = .{ .exited = 0 },
     /// Complete output captured during interaction
     output: []const u8,
     /// Complete input sent during interaction (for debugging)
@@ -1375,11 +1385,8 @@ fn runInteractivePosix(
         }
     }
 
-    const term = child.wait(io) catch return InteractiveError.ProcessCrashed;
-    const exit_code: u8 = switch (term) {
-        .exited => |code| code,
-        else => 1,
-    };
+    const term = Termination.fromChild(child.wait(io) catch return InteractiveError.ProcessCrashed);
+    const exit_code: u8 = term.exitCode();
 
     // A step that broke the run left the child blocked mid-prompt (we killed it
     // above), so the only visible symptom in the test would be a nonzero exit
@@ -1403,6 +1410,7 @@ fn runInteractivePosix(
 
     return InteractiveResult{
         .exit_code = exit_code,
+        .term = term,
         .output = try output_buffer.toOwnedSlice(allocator),
         .input = try input_buffer.toOwnedSlice(allocator),
         .success = script_success and exit_code == 0,
@@ -1540,6 +1548,9 @@ fn runInteractiveWindows(
 
     return InteractiveResult{
         .exit_code = exit_code,
+        // Windows has no POSIX signal deaths here — ConPTY reports a plain exit
+        // code, so the termination kind is always `.exited` with that code.
+        .term = .{ .exited = exit_code },
         .output = try output_buffer.toOwnedSlice(allocator),
         .input = try input_buffer.toOwnedSlice(allocator),
         .success = script_success and exit_code == 0,

--- a/packages/testing/src/main.zig
+++ b/packages/testing/src/main.zig
@@ -19,7 +19,7 @@
 //!
 //! // Integration test
 //! test "help flag" {
-//!     const result = try testing.integration.runSubprocess(allocator, std.testing.io, "./myapp", &.{"--help"});
+//!     const result = try testing.integration.runSubprocess(allocator, std.testing.io, "./myapp", &.{"--help"}, .{});
 //!     try testing.expectExitCode(result, 0);
 //!     try testing.expectContains(result.stdout, "USAGE:");
 //! }
@@ -75,6 +75,8 @@ pub const build_utils = @import("build_utils.zig");
 // ============================================================================
 
 pub const Result = integration.Result;
+pub const Termination = integration.Termination;
+pub const RunOptions = integration.RunOptions;
 pub const runSubprocess = integration.runSubprocess;
 
 pub const expectExitCode = assertions.expectExitCode;

--- a/packages/testing/src/runner.zig
+++ b/packages/testing/src/runner.zig
@@ -1,16 +1,71 @@
 const std = @import("std");
 
+/// How a child process terminated.
+///
+/// A clean `exited 1` and a death by SIGSEGV both used to collapse to
+/// `exit_code == 1`, so a test couldn't tell them apart. This distinguishes
+/// them: `Result.exit_code` is *derived* from this via `exitCode()` (signal
+/// deaths map to the conventional `128 + signum`), while the raw kind stays
+/// available for assertions like "was this killed, and by which signal?".
+pub const Termination = union(enum) {
+    /// Normal exit with this status code.
+    exited: u8,
+    /// Killed by this POSIX signal number (e.g. 11 = SIGSEGV, 6 = SIGABRT).
+    signaled: u8,
+    /// Stopped, or an unknown termination — neither a clean exit nor a kill.
+    unknown,
+
+    /// Translate a std child termination into this portable kind.
+    pub fn fromChild(term: std.process.Child.Term) Termination {
+        return switch (term) {
+            .exited => |code| .{ .exited = code },
+            .signal => |sig| .{ .signaled = @intCast(@intFromEnum(sig)) },
+            .stopped, .unknown => .unknown,
+        };
+    }
+
+    /// The conventional exit code for this termination: the real status for a
+    /// clean exit, `128 + signum` for a signal death (the shell convention, so
+    /// `expectExitCode(r, 139)` matches a SIGSEGV), and `1` otherwise.
+    pub fn exitCode(self: Termination) u8 {
+        return switch (self) {
+            .exited => |code| code,
+            .signaled => |sig| 128 +| sig,
+            .unknown => 1,
+        };
+    }
+};
+
 /// Result of running a CLI command
 pub const Result = struct {
     stdout: []const u8,
     stderr: []const u8,
+    /// Conventional exit code: the child's real status for a clean exit, or
+    /// `128 + signum` for a signal death. Derived from `term.exitCode()`.
     exit_code: u8,
+    /// How the child terminated (exited / signaled / unknown), so a test can
+    /// distinguish a real `exited 1` from a kill and assert on the signal.
+    term: Termination,
     allocator: std.mem.Allocator,
 
     pub fn deinit(self: *Result) void {
         self.allocator.free(self.stdout);
         self.allocator.free(self.stderr);
     }
+};
+
+/// Optional overrides for `runSubprocess`.
+pub const RunOptions = struct {
+    /// Environment for the child. `null` (the default) inherits the harness's
+    /// environment; supply a map to test env-driven behavior (e.g. `NO_COLOR`)
+    /// without escalating to the PTY e2e tier. Threaded through explicitly —
+    /// no ambient/C-level environ.
+    env: ?*const std.process.Environ.Map = null,
+    /// Bytes to feed the child on stdin, then close (giving it EOF). `null`
+    /// (the default) inherits the harness's stdin, preserving prior behavior.
+    /// Suited to modest input that fits the OS pipe buffer (~64 KiB): the bytes
+    /// are written in full before the output pipes are drained.
+    stdin: ?[]const u8 = null,
 };
 
 const max_output = 10 * 1024 * 1024;
@@ -80,20 +135,44 @@ fn drainPipe(io: std.Io, file: std.Io.File, alloc: std.mem.Allocator) std.Io.Rea
     return reader.interface.allocRemaining(alloc, .limited(max_output));
 }
 
-/// Run a command as a subprocess (for external binaries)
-pub fn runSubprocess(allocator: std.mem.Allocator, io: std.Io, exe_path: []const u8, args: []const []const u8) !Result {
+/// Run a command as a subprocess (for external binaries).
+///
+/// `options` optionally overrides the child's environment and pipes bytes to
+/// its stdin — so env-driven behavior (`NO_COLOR`) and stdin-reading commands
+/// are testable here, without escalating to the PTY e2e tier.
+pub fn runSubprocess(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    exe_path: []const u8,
+    args: []const []const u8,
+    options: RunOptions,
+) !Result {
     // Prepare arguments
     var argv = std.ArrayList([]const u8).empty;
     defer argv.deinit(allocator);
     try argv.append(allocator, exe_path);
     try argv.appendSlice(allocator, args);
 
-    // Spawn the subprocess with piped stdout/stderr
+    // Spawn the subprocess with piped stdout/stderr. Stdin is a pipe only when
+    // the caller supplies bytes to feed; otherwise it inherits (prior behavior).
     var child = try std.process.spawn(io, .{
         .argv = argv.items,
+        .environ_map = options.env,
+        .stdin = if (options.stdin != null) .pipe else .inherit,
         .stdout = .pipe,
         .stderr = .pipe,
     });
+
+    // Feed stdin (if any) to EOF before draining output. The child's stdout is
+    // piped and drained below, so a child that echoes as it reads won't deadlock
+    // us for modest input; oversized input that fills the OS pipe before the
+    // child reads any is out of scope for this tier (documented on RunOptions).
+    if (options.stdin) |input| {
+        var stdin_file = child.stdin.?;
+        stdin_file.writeStreamingAll(io, input) catch {};
+        stdin_file.close(io);
+        child.stdin = null;
+    }
 
     // Both pipes must drain simultaneously. Draining one to EOF before touching
     // the other deadlocks: a child that fills the un-drained pipe (>~64 KB, the
@@ -135,16 +214,13 @@ pub fn runSubprocess(allocator: std.mem.Allocator, io: std.Io, exe_path: []const
     };
     errdefer allocator.free(stderr);
 
-    const term = try child.wait(io);
-    const exit_code: u8 = switch (term) {
-        .exited => |code| @intCast(code),
-        else => 1,
-    };
+    const term = Termination.fromChild(try child.wait(io));
 
     return Result{
         .stdout = stdout,
         .stderr = stderr,
-        .exit_code = exit_code,
+        .exit_code = term.exitCode(),
+        .term = term,
         .allocator = allocator,
     };
 }
@@ -164,7 +240,7 @@ test "runSubprocess drains both pipes when the child floods stderr" {
     // the deadlock on the old sequential drain.
     const program = "yes zzzzzzzz | head -c 200000 1>&2; printf STDOUT_OK";
 
-    var result = runSubprocess(allocator, io, "/bin/sh", &.{ "-c", program }) catch |err| {
+    var result = runSubprocess(allocator, io, "/bin/sh", &.{ "-c", program }, .{}) catch |err| {
         // Spawning may be restricted in some sandboxes; don't fail the suite.
         std.log.warn("runSubprocess skipped: {any}", .{err});
         return;
@@ -197,7 +273,7 @@ test "runSubprocess reaps the child when the stderr drain errors" {
         .{over_cap},
     );
 
-    if (runSubprocess(allocator, io, "/bin/sh", &.{ "-c", program })) |res| {
+    if (runSubprocess(allocator, io, "/bin/sh", &.{ "-c", program }, .{})) |res| {
         var r = res;
         r.deinit();
         return error.ExpectedStreamTooLong;
@@ -215,10 +291,78 @@ test "Result deinitialization" {
         .stdout = try allocator.dupe(u8, "test output"),
         .stderr = try allocator.dupe(u8, "test error"),
         .exit_code = 0,
+        .term = .{ .exited = 0 },
         .allocator = allocator,
     };
     defer result.deinit();
 
     try std.testing.expectEqualStrings("test output", result.stdout);
     try std.testing.expectEqualStrings("test error", result.stderr);
+}
+
+test "Termination maps signal deaths to 128 + signum" {
+    // #682: a signal death is no longer collapsed to exit_code 1 — it maps to
+    // the shell-conventional 128 + signum, and the raw kind stays inspectable.
+    try std.testing.expectEqual(@as(u8, 0), (Termination{ .exited = 0 }).exitCode());
+    try std.testing.expectEqual(@as(u8, 1), (Termination{ .exited = 1 }).exitCode());
+    try std.testing.expectEqual(@as(u8, 139), (Termination{ .signaled = 11 }).exitCode()); // SIGSEGV
+    try std.testing.expectEqual(@as(u8, 130), (Termination{ .signaled = 2 }).exitCode()); // SIGINT
+    try std.testing.expectEqual(@as(u8, 1), (@as(Termination, .unknown)).exitCode());
+}
+
+test "runSubprocess env overrides the child environment" {
+    // #681: env-driven behavior is testable at the integration tier — no PTY.
+    if (@import("builtin").os.tag == .windows) return; // uses /bin/sh
+
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    var env = std.process.Environ.Map.init(allocator);
+    defer env.deinit();
+    try env.put("ZCLI_TEST_VAR", "from-env");
+
+    var result = runSubprocess(allocator, io, "/bin/sh", &.{ "-c", "printf %s \"$ZCLI_TEST_VAR\"" }, .{ .env = &env }) catch |err| {
+        std.log.warn("runSubprocess skipped: {any}", .{err});
+        return;
+    };
+    defer result.deinit();
+
+    try std.testing.expectEqual(@as(u8, 0), result.exit_code);
+    try std.testing.expectEqualStrings("from-env", result.stdout);
+}
+
+test "runSubprocess feeds stdin to the child" {
+    // #681: stdin-reading commands are testable at the integration tier — no PTY.
+    if (@import("builtin").os.tag == .windows) return; // uses /bin/cat
+
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    var result = runSubprocess(allocator, io, "/bin/cat", &.{}, .{ .stdin = "piped input\n" }) catch |err| {
+        std.log.warn("runSubprocess skipped: {any}", .{err});
+        return;
+    };
+    defer result.deinit();
+
+    try std.testing.expectEqual(@as(u8, 0), result.exit_code);
+    try std.testing.expectEqualStrings("piped input\n", result.stdout);
+}
+
+test "runSubprocess surfaces a signal death as termination kind and 128 + signum" {
+    // #682: a child killed by a signal reports `.signaled` with the number, and
+    // its exit_code is 128 + signum rather than a misleading 1.
+    if (@import("builtin").os.tag == .windows) return; // uses /bin/sh
+
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    // The shell kills itself with SIGSEGV (11); the process is reaped as signaled.
+    var result = runSubprocess(allocator, io, "/bin/sh", &.{ "-c", "kill -SEGV $$" }, .{}) catch |err| {
+        std.log.warn("runSubprocess skipped: {any}", .{err});
+        return;
+    };
+    defer result.deinit();
+
+    try std.testing.expectEqual(Termination{ .signaled = 11 }, result.term);
+    try std.testing.expectEqual(@as(u8, 139), result.exit_code);
 }

--- a/packages/testing/src/unit.zig
+++ b/packages/testing/src/unit.zig
@@ -98,19 +98,25 @@ fn contextParamType(comptime Command: type) ?type {
 }
 
 /// The `config` parameter type for `runCommand`, tailored to `Command`: `args`/
-/// `options` are only optional-to-pass when default-constructible, and `plugins`
-/// sets the command's plugin state (`.plugins = .{ .verbose = .{ .enabled = true } }`).
+/// `options` are only optional-to-pass when default-constructible, `plugins`
+/// sets the command's plugin state (`.plugins = .{ .verbose = .{ .enabled = true } }`),
+/// and `environ` injects environment variables the command reads via
+/// `context.environ` (defaults to an empty environment).
 fn RunConfig(comptime Command: type) type {
     const default_alloc: std.mem.Allocator = std.testing.allocator;
     const PluginData = @FieldType(ContextTypeFor(Command), "plugins");
     const default_plugins: PluginData = .{};
-    const names = [_][]const u8{ "args", "options", "allocator", "plugins" };
-    const field_types = [_]type{ Command.Args, Command.Options, std.mem.Allocator, PluginData };
+    const default_environ: ?*const std.process.Environ.Map = null;
+    const names = [_][]const u8{ "args", "options", "allocator", "plugins", "environ" };
+    const field_types = [_]type{ Command.Args, Command.Options, std.mem.Allocator, PluginData, ?*const std.process.Environ.Map };
     const attrs = [_]std.builtin.Type.StructField.Attributes{
         fieldAttrs(Command.Args),
         fieldAttrs(Command.Options),
         .{ .default_value_ptr = &default_alloc },
         .{ .default_value_ptr = &default_plugins },
+        // `&default_environ` is a pointer to an optional pointer; Zig won't
+        // implicitly coerce that double pointer to `?*const anyopaque`, so cast.
+        .{ .default_value_ptr = @ptrCast(&default_environ) },
     };
     return @Struct(.auto, null, &names, &field_types, &attrs);
 }
@@ -155,15 +161,18 @@ pub fn runCommand(
     defer arena.deinit();
 
     // Build the command's own Context (so a scaffolded command's project plugins
-    // are in scope), with an empty environment; commands that read env vars
-    // should take them as options instead.
-    const test_environ = std.process.Environ.Map.init(allocator);
+    // are in scope). The environment defaults to empty; a test that exercises
+    // env-driven behavior (e.g. `NO_COLOR`) injects one via `.environ` rather
+    // than escalating to the subprocess/PTY tiers.
+    var empty_environ = std.process.Environ.Map.init(allocator);
+    defer empty_environ.deinit();
+    const test_environ: *const std.process.Environ.Map = config.environ orelse &empty_environ;
     const Ctx = ContextTypeFor(Command);
     var context = Ctx{
         .allocator = arena.allocator(),
         .io = std.testing.io,
         .stdio = &stdio,
-        .environ = &test_environ,
+        .environ = test_environ,
         .plugins = config.plugins,
     };
     defer context.deinit();
@@ -388,6 +397,41 @@ test "runCommand sets plugin state for a command with a concrete context" {
         var r = try runCommand(TestCommand, .{ .plugins = .{ .flag = .{ .on = true } } });
         defer r.deinit();
         try std.testing.expectEqualStrings("flag on\n", r.stdout);
+    }
+}
+
+test "runCommand injects environment via .environ" {
+    // #681: env-driven behavior (e.g. NO_COLOR) is testable at the unit tier,
+    // no subprocess/PTY needed. The command reads context.environ directly.
+    const Ctx = zcli.TestContext(&.{});
+    const TestCommand = struct {
+        pub const Args = struct {};
+        pub const Options = struct {};
+
+        pub fn execute(_: Args, _: Options, context: *Ctx) !void {
+            if (context.environ.get("NO_COLOR") != null) {
+                try context.stdout().writeAll("plain\n");
+            } else {
+                try context.stdout().writeAll("colored\n");
+            }
+        }
+    };
+
+    // Default: empty environment — NO_COLOR is unset.
+    {
+        var r = try runCommand(TestCommand, .{});
+        defer r.deinit();
+        try std.testing.expectEqualStrings("colored\n", r.stdout);
+    }
+    // Inject NO_COLOR and observe the command adapt.
+    {
+        var env = std.process.Environ.Map.init(std.testing.allocator);
+        defer env.deinit();
+        try env.put("NO_COLOR", "1");
+
+        var r = try runCommand(TestCommand, .{ .environ = &env });
+        defer r.deinit();
+        try std.testing.expectEqualStrings("plain\n", r.stdout);
     }
 }
 


### PR DESCRIPTION
## Summary

Two gaps in `packages/testing`, from the Grade 12 whole-repo review.

### #681 — env vars and stdin testable below the e2e tier
Previously "behaves differently under `NO_COLOR`" or "reads piped stdin" could only be tested by escalating to the heavyweight PTY e2e tier.

- **Integration tier** (`runSubprocess`): new `RunOptions { env, stdin }` parameter. `env` overrides the child environment (threaded through `std.process.spawn` explicitly — no ambient/C-level environ); `stdin` feeds bytes to the child then closes for EOF. `null` for both preserves prior behavior.
- **Unit tier** (`runCommand`): new `.environ` config field injects an environment a command reads via `context.environ`, so env-driven behavior is testable fully in-process (no subprocess/PTY).

### #682 — signal deaths no longer collapse to exit code 1
Both tiers coerced any non-`.exited` termination to `1`, so a clean `exited 1` was indistinguishable from a SIGSEGV.

- New shared `Termination` kind (`exited` / `signaled` / `unknown`) surfaced on both `Result.term` and `InteractiveResult.term`.
- `exit_code` is now derived from it: signal deaths map to the conventional `128 + signum`, so `expectExitCode(r, 139)` matches a SIGSEGV and `expectExitCode(r, 130)` a SIGINT.

Signatures changed cleanly (no backward-compat shims); all callers updated (`runSubprocess` now takes a trailing options arg).

## Tests
New coverage in `runner.zig` (env override, piped stdin, signal-death → `128+signum` with `.signaled` kind) and `unit.zig` (`.environ` injection with NO_COLOR).

- `zig build test` — green (2717/2719 pass, 2 skipped)
- `zig build e2e` — green (exit 0)

Fixes #681, Fixes #682

🤖 Generated with [Claude Code](https://claude.com/claude-code)