### PR TITLE
core: consolidate comptime validation into one registry-level pass that sees the whole composition

### DIFF
--- a/packages/core/src/plugin_types.zig
+++ b/packages/core/src/plugin_types.zig
@@ -281,7 +281,8 @@ pub fn requirePluginId(comptime Plugin: type) void {
 
 /// Comptime backstop against silently-dead hooks. Hooks are detected by exact
 /// name (`@hasDecl`), so a typo'd hook — `preExeucte` — compiles fine and
-/// simply never fires. Called by Registry.registerPlugin: any *function* decl
+/// simply never fires. Called by the registry-level validation pass
+/// (registry/validation.zig) for every registered plugin: any *function* decl
 /// whose name is within edit distance 2 of a hook (but isn't one) is rejected
 /// with a pointer at the hook it resembles.
 pub fn validatePlugin(comptime Plugin: type) void {

--- a/packages/core/src/registry.zig
+++ b/packages/core/src/registry.zig
@@ -1,7 +1,8 @@
 //! Thin facade over the registry submodules. The implementation lives in
 //! registry/: paths.zig (comptime path/alias helpers), builder.zig (the
-//! comptime registration builder), compiled.zig (the compiled registry and
-//! runtime executor), and tests.zig (the test suite).
+//! comptime registration builder), validation.zig (the single registry-level
+//! comptime validation pass), compiled.zig (the compiled registry and runtime
+//! executor), and tests.zig (the test suite).
 const builder = @import("registry/builder.zig");
 
 pub const Config = builder.Config;
@@ -11,6 +12,7 @@ pub const Registry = builder.Registry;
 test {
     _ = @import("registry/paths.zig");
     _ = @import("registry/builder.zig");
+    _ = @import("registry/validation.zig");
     _ = @import("registry/compiled.zig");
     _ = @import("registry/tests.zig");
 }

--- a/packages/core/src/registry/builder.zig
+++ b/packages/core/src/registry/builder.zig
@@ -1,6 +1,4 @@
 const std = @import("std");
-const zcli = @import("../zcli.zig");
-const plugin_types = @import("../plugin_types.zig");
 
 const paths = @import("paths.zig");
 const compiled = @import("compiled.zig");
@@ -101,10 +99,11 @@ fn RegistryBuilder(comptime config: Config, comptime commands: []const CommandEn
         ) {
             _ = self;
 
-            // Validate the whole command contract at compile time, with errors
-            // that name this command by its path.
-            comptime zcli.validateCommand(path, Module);
-
+            // No validation here: `register` only accumulates. The command
+            // contract is checked by the single registry-level pass
+            // (registry/validation.zig), which `build()` runs over the whole
+            // composition — file-based commands, plugin commands, and global
+            // options together.
             return RegistryBuilder(
                 config,
                 computeEntriesWithAliases(commands, path, Module),
@@ -118,9 +117,9 @@ fn RegistryBuilder(comptime config: Config, comptime commands: []const CommandEn
             new_plugins ++ [_]type{Plugin},
         ) {
             _ = self;
-            // Backstop against silently-dead misspelled hooks (exact-name
-            // detection has no diagnostics of its own).
-            comptime plugin_types.validatePlugin(Plugin);
+            // No validation here either — the plugin contract (misspelled
+            // hooks, ContextData) is checked by the registry-level pass in
+            // registry/validation.zig when `build()` runs.
             return RegistryBuilder(
                 config,
                 commands,
@@ -145,6 +144,12 @@ fn isCommandDecl(comptime name: []const u8) bool {
 
 /// Recursively discover plugin commands from a struct type
 pub fn discoverPluginCommands(comptime CommandsStruct: type, comptime path_prefix: []const []const u8) []const CommandEntry {
+    // Discovery walks every decl of every plugin's `commands` struct with
+    // comptime string comparisons; the default 1000-branch quota is too small
+    // for a real plugin set. (validateCommand used to raise it as a side
+    // effect of being called here; validation now lives in the registry-level
+    // pass, so discovery sets its own headroom.)
+    @setEvalBranchQuota(100_000);
     const info = @typeInfo(CommandsStruct);
     if (info != .@"struct") return &.{};
 
@@ -171,17 +176,10 @@ pub fn discoverPluginCommands(comptime CommandsStruct: type, comptime path_prefi
         // Only process struct types
         if (command_type_info != .@"struct") continue;
 
-        // Build the path for this command
+        // Build the path for this command. (No validation here: discovery only
+        // collects entries; the registry-level pass in validation.zig runs
+        // `validateCommand` over every discovered plugin command.)
         const current_path = path_prefix ++ .{decl.name};
-
-        // Validate the whole command contract at compile time, naming the
-        // command by its space-joined path.
-        comptime var path_str: []const u8 = "";
-        inline for (current_path, 0..) |component, idx| {
-            if (idx > 0) path_str = path_str ++ " ";
-            path_str = path_str ++ component;
-        }
-        comptime zcli.validateCommand(path_str, CommandType);
 
         // Add this command/group to entries
         entries = entries ++ .{CommandEntry{

--- a/packages/core/src/registry/compiled.zig
+++ b/packages/core/src/registry/compiled.zig
@@ -8,6 +8,7 @@ const console_utf8 = @import("../console_utf8.zig");
 const response_file = @import("../response_file.zig");
 const paths = @import("paths.zig");
 const builder = @import("builder.zig");
+const validation = @import("validation.zig");
 const comptimeJoinPath = paths.comptimeJoinPath;
 const sortedByPathLengthDesc = paths.sortedByPathLengthDesc;
 const Config = builder.Config;
@@ -191,118 +192,23 @@ test "wroteToBrokenPipe: test overrides are never mistaken for a broken pipe" {
 
 /// Compiled registry with all command and plugin information
 pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const CommandEntry, comptime new_plugins: []const type) type {
-    // Validate plugin conflicts at compile time
-    comptime {
-        // Use arrays to check for conflicts since ComptimeStringMap may not be available
-        var command_paths: []const []const []const u8 = &.{};
-
-        // Check for command path conflicts among regular commands
-        for (cmd_entries) |cmd| {
-            for (command_paths) |existing_path| {
-                // Compare path arrays element by element
-                var paths_equal = existing_path.len == cmd.path.len;
-                if (paths_equal) {
-                    for (existing_path, 0..) |existing_component, i| {
-                        if (!std.mem.eql(u8, existing_component, cmd.path[i])) {
-                            paths_equal = false;
-                            break;
-                        }
-                    }
-                }
-                if (paths_equal) {
-                    @compileError("Duplicate command path: " ++ comptimeJoinPath(cmd.path));
-                }
-            }
-            command_paths = command_paths ++ .{cmd.path};
-        }
-
-        // Validate optional command groups (commands that have subcommands)
-        for (cmd_entries) |cmd| {
-            // Check if this command has subcommands
-            var has_subcommands = false;
-            for (cmd_entries) |other_cmd| {
-                // Skip self
-                if (other_cmd.path.len <= cmd.path.len) continue;
-
-                // Check if other_cmd is a subcommand of cmd
-                var is_subcommand = true;
-                for (cmd.path, 0..) |component, i| {
-                    if (!std.mem.eql(u8, component, other_cmd.path[i])) {
-                        is_subcommand = false;
-                        break;
-                    }
-                }
-
-                if (is_subcommand) {
-                    has_subcommands = true;
-                    break;
-                }
-            }
-
-            // If this command has subcommands, validate it's an optional command group
-            if (has_subcommands) {
-                if (@hasDecl(cmd.module, "Args")) {
-                    const args_fields = std.meta.fields(cmd.module.Args);
-                    if (args_fields.len > 0) {
-                        // Build path string for error message
-                        var path_str: []const u8 = "";
-                        for (cmd.path, 0..) |component, idx| {
-                            if (idx > 0) path_str = path_str ++ " ";
-                            path_str = path_str ++ component;
-                        }
-                        @compileError("Optional command group '" ++ path_str ++ "' cannot have Args fields. " ++
-                            "Command groups with subcommands must have an empty Args struct.");
-                    }
-                }
-            }
-        }
-
-        // Check for conflicts between plugin commands and regular commands
-        var plugin_command_paths: []const []const []const u8 = &.{};
+    // Discover every plugin command (including nested) up front, then run THE
+    // single registry-level validation pass over the whole composition —
+    // file-based commands, plugin commands, and plugin global options. All
+    // comptime validation (per-command contract, per-plugin contract, path
+    // uniqueness, group shape, global-option conflicts and shadowing) lives in
+    // validation.zig; nothing else in the framework calls @compileError over
+    // the composition.
+    const discovered_plugin_commands = comptime blk: {
+        var entries: []const CommandEntry = &.{};
         for (new_plugins) |Plugin| {
             if (@hasDecl(Plugin, "commands")) {
-                // Recursively discover all plugin commands (including nested)
-                const plugin_cmd_entries = discoverPluginCommands(Plugin.commands, &.{});
-
-                for (plugin_cmd_entries) |plugin_cmd| {
-                    // Check against regular commands
-                    for (command_paths) |existing_path| {
-                        var paths_equal = existing_path.len == plugin_cmd.path.len;
-                        if (paths_equal) {
-                            for (existing_path, 0..) |existing_component, i| {
-                                if (!std.mem.eql(u8, existing_component, plugin_cmd.path[i])) {
-                                    paths_equal = false;
-                                    break;
-                                }
-                            }
-                        }
-                        if (paths_equal) {
-                            @compileError("Plugin command conflicts with existing command: " ++ comptimeJoinPath(plugin_cmd.path));
-                        }
-                    }
-                    // Check against other plugin commands
-                    for (plugin_command_paths) |existing_plugin_path| {
-                        var paths_equal = existing_plugin_path.len == plugin_cmd.path.len;
-                        if (paths_equal) {
-                            for (existing_plugin_path, 0..) |existing_component, i| {
-                                if (!std.mem.eql(u8, existing_component, plugin_cmd.path[i])) {
-                                    paths_equal = false;
-                                    break;
-                                }
-                            }
-                        }
-                        if (paths_equal) {
-                            @compileError("Duplicate plugin command: " ++ comptimeJoinPath(plugin_cmd.path));
-                        }
-                    }
-                    plugin_command_paths = plugin_command_paths ++ .{plugin_cmd.path};
-                }
+                entries = entries ++ discoverPluginCommands(Plugin.commands, &.{});
             }
         }
-        // Global-option conflicts (both names and short flags) are validated once
-        // over the flattened `global_options` list below (see the `comptime` block
-        // after it) — no separate names-only pass here.
-    }
+        break :blk entries;
+    };
+    comptime validation.validateComposition(cmd_entries, discovered_plugin_commands, new_plugins);
 
     return struct {
         const Self = @This();
@@ -386,69 +292,14 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
             break :blk opts;
         };
 
-        // Validate no duplicate global option names or short flags
-        comptime {
-            for (global_options, 0..) |opt_a, i| {
-                for (global_options[i + 1 ..]) |opt_b| {
-                    if (std.mem.eql(u8, opt_a.name, opt_b.name)) {
-                        @compileError("Duplicate global option name: --" ++ opt_a.name ++ ". Two plugins define the same global option.");
-                    }
-                    if (opt_a.short != null and opt_b.short != null and opt_a.short.? == opt_b.short.?) {
-                        @compileError("Duplicate global option short flag: -" ++ &[_]u8{opt_a.short.?} ++ " (used by both --" ++ opt_a.name ++ " and --" ++ opt_b.name ++ ")");
-                    }
-                }
-            }
-        }
+        // Global-option conflicts (duplicate names/shorts across plugins) and
+        // global-vs-command shadowing (#663) are validated by the single
+        // registry-level pass in validation.zig, which sees the whole
+        // composition.
 
-        // Validate no command option is silently shadowed by a plugin global
-        // option. parseGlobalOptions() scans the entire argv and consumes any
-        // token matching a global option's long name or short flag *before*
-        // routing, so a command field that collides with a global would never
-        // receive its own flag — the global handler eats it and the field keeps
-        // its default (see issue #663). Catch it here with a message naming the
-        // command, the field, and the owning plugin.
-        comptime {
-            for (new_plugins) |Plugin| {
-                if (!plugin_types.hasGlobalOptions(Plugin)) continue;
-                for (Plugin.global_options) |gopt| {
-                    for (cmd_entries) |cmd| {
-                        if (!@hasDecl(cmd.module, "Options")) continue;
-                        const meta = if (@hasDecl(cmd.module, "meta")) cmd.module.meta else null;
-                        for (std.meta.fields(cmd.module.Options)) |field| {
-                            const long = option_utils.effectiveLongName(meta, field.name);
-                            if (std.mem.eql(u8, long, gopt.name)) {
-                                @compileError("Command '" ++ comptimeJoinPath(cmd.path) ++
-                                    "' option --" ++ long ++ " (field '" ++ field.name ++
-                                    "') collides with global option --" ++ gopt.name ++
-                                    " provided by plugin '" ++ @typeName(Plugin) ++
-                                    "'. The global handler consumes this flag before the command runs, so the command would never see it. Rename the command's option (e.g. `meta.options." ++
-                                    field.name ++ ".name`) or remove the conflicting global option.");
-                            }
-                            const short = option_utils.shortCharForField(meta, field.name);
-                            if (short != null and gopt.short != null and short.? == gopt.short.?) {
-                                @compileError("Command '" ++ comptimeJoinPath(cmd.path) ++
-                                    "' option -" ++ &[_]u8{short.?} ++ " (field '" ++ field.name ++
-                                    "') collides with global short flag -" ++ &[_]u8{gopt.short.?} ++
-                                    " (--" ++ gopt.name ++ ") provided by plugin '" ++ @typeName(Plugin) ++
-                                    "'. The global handler consumes this flag before the command runs, so the command would never see it. Rename the command's short (`meta.options." ++
-                                    field.name ++ ".short`) or remove the conflicting global option.");
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        // Discover all plugin command entries (including nested)
-        const plugin_command_entries = blk: {
-            var entries: []const CommandEntry = &.{};
-            for (new_plugins) |Plugin| {
-                if (@hasDecl(Plugin, "commands")) {
-                    entries = entries ++ discoverPluginCommands(Plugin.commands, &.{});
-                }
-            }
-            break :blk entries;
-        };
+        // All plugin command entries (including nested), discovered once above
+        // and already validated by the registry-level pass.
+        const plugin_command_entries = discovered_plugin_commands;
 
         // Sort plugins by priority at compile time
         const sorted_plugins = blk: {

--- a/packages/core/src/registry/validation.zig
+++ b/packages/core/src/registry/validation.zig
@@ -1,0 +1,283 @@
+//! The single registry-level comptime validation pass (#677).
+//!
+//! Validation used to be a reactive checklist split across three sites that
+//! each saw only part of the picture: `zcli.validateCommand` saw one module at
+//! a time (called from `register()` and plugin-command discovery), and
+//! `CompiledRegistry` carried separate comptime blocks for path conflicts and
+//! global options — nothing saw the *composition*. The varargs SEGV (#662),
+//! the global-vs-command option shadow (#663), and the `--no-X` negation
+//! shadow (#667) all lived in the gaps between those sites. This pass runs
+//! once, from `CompiledRegistry`, with total knowledge: every file-based
+//! command, every plugin command, and every plugin global option.
+//!
+//! Layering:
+//!   - Per-module rules — the command contract (`Args`/`Options` shape,
+//!     varargs order, optional/array default shapes, in-command option
+//!     spelling collisions including `--no-…` negations, meta hygiene) — live
+//!     in `zcli.validateCommand`. This pass drives that check over every
+//!     command in the composition, file-based and plugin alike, so a rule
+//!     added there automatically covers both populations.
+//!   - Per-plugin rules (misspelled lifecycle hooks, the ContextData
+//!     contract) live in `plugin_types.validatePlugin`, driven from here for
+//!     every registered plugin.
+//!   - Cross-module rules are implemented HERE, where the whole composition
+//!     is visible: command-path uniqueness (file vs file, plugin vs file,
+//!     plugin vs plugin), command-group shape, global-option uniqueness
+//!     across plugins, and global-vs-command option shadowing — effective
+//!     long names, declared shorts, and derived `--no-…` negations.
+//!
+//! Every error names the offending command by its space-joined path (which
+//! maps directly to a file under src/commands/ or a plugin's `commands`
+//! struct), the field/flag involved, and what to change.
+
+const std = @import("std");
+const zcli = @import("../zcli.zig");
+const plugin_types = @import("../plugin_types.zig");
+const option_utils = @import("../options/utils.zig");
+const paths = @import("paths.zig");
+const builder = @import("builder.zig");
+
+const CommandEntry = builder.CommandEntry;
+const comptimeJoinPath = paths.comptimeJoinPath;
+const pathsEqual = paths.pathsEqual;
+
+/// Validate the whole program composition at compile time. Called exactly once,
+/// from `CompiledRegistry`, with the file-based command entries, the discovered
+/// plugin command entries (including nested), and the registered plugin types.
+pub fn validateComposition(
+    comptime cmd_entries: []const CommandEntry,
+    comptime plugin_cmd_entries: []const CommandEntry,
+    comptime new_plugins: []const type,
+) void {
+    comptime {
+        // The pass is O(commands × options) with pairwise path comparisons on
+        // top; give it headroom well above the 1000 default so growing an app
+        // never trips the quota inside a validation loop.
+        @setEvalBranchQuota(1_000_000);
+
+        // ── Per-module contract, over the WHOLE composition ─────────────────
+        // File-based and plugin commands get the identical contract check, so
+        // a rule added to `validateCommand` can never cover only one
+        // population. (Alias entries share their canonical entry's module;
+        // re-validating them is free — comptime memoizes on identical args.)
+        for (cmd_entries) |cmd| {
+            zcli.validateCommand(comptimeJoinPath(cmd.path), cmd.module);
+        }
+        for (plugin_cmd_entries) |cmd| {
+            zcli.validateCommand(comptimeJoinPath(cmd.path), cmd.module);
+        }
+
+        // ── Per-plugin contract ─────────────────────────────────────────────
+        // Backstop against silently-dead misspelled hooks and ContextData
+        // contract violations (exact-name detection has no diagnostics of its
+        // own).
+        for (new_plugins) |Plugin| {
+            plugin_types.validatePlugin(Plugin);
+        }
+
+        // ── Command-path uniqueness ─────────────────────────────────────────
+        // The router resolves a path to exactly one module; a duplicate would
+        // silently shadow. Three distinct messages so the author knows which
+        // two populations collided.
+        for (cmd_entries, 0..) |cmd, i| {
+            for (cmd_entries[0..i]) |prev| {
+                if (pathsEqual(prev.path, cmd.path)) {
+                    @compileError("Duplicate command path: " ++ comptimeJoinPath(cmd.path));
+                }
+            }
+        }
+        for (plugin_cmd_entries, 0..) |plugin_cmd, i| {
+            for (cmd_entries) |cmd| {
+                if (pathsEqual(cmd.path, plugin_cmd.path)) {
+                    @compileError("Plugin command conflicts with existing command: " ++ comptimeJoinPath(plugin_cmd.path));
+                }
+            }
+            for (plugin_cmd_entries[0..i]) |prev| {
+                if (pathsEqual(prev.path, plugin_cmd.path)) {
+                    @compileError("Duplicate plugin command: " ++ comptimeJoinPath(plugin_cmd.path));
+                }
+            }
+        }
+
+        // ── Command-group shape ─────────────────────────────────────────────
+        // A command that has subcommands is a group: routing tries the longest
+        // path first, so the group's own positionals would swallow what looks
+        // like a subcommand name. Checked over the combined list so a plugin
+        // command nested under a file-based group (or vice versa) counts too.
+        const all_entries = cmd_entries ++ plugin_cmd_entries;
+        for (all_entries) |cmd| {
+            const has_subcommands = blk: {
+                for (all_entries) |other| {
+                    if (other.path.len <= cmd.path.len) continue;
+                    var is_subcommand = true;
+                    for (cmd.path, 0..) |component, i| {
+                        if (!std.mem.eql(u8, component, other.path[i])) {
+                            is_subcommand = false;
+                            break;
+                        }
+                    }
+                    if (is_subcommand) break :blk true;
+                }
+                break :blk false;
+            };
+            if (has_subcommands and @hasDecl(cmd.module, "Args")) {
+                if (std.meta.fields(cmd.module.Args).len > 0) {
+                    @compileError("Optional command group '" ++ comptimeJoinPath(cmd.path) ++
+                        "' cannot have Args fields. " ++
+                        "Command groups with subcommands must have an empty Args struct.");
+                }
+            }
+        }
+
+        // ── Global-option uniqueness across plugins ─────────────────────────
+        // Globals from every plugin share one namespace; the first match wins
+        // in parseGlobalOptions, so a duplicate would silently shadow.
+        const flat_globals = blk: {
+            var opts: []const plugin_types.GlobalOption = &.{};
+            for (new_plugins) |Plugin| {
+                if (plugin_types.hasGlobalOptions(Plugin)) {
+                    opts = opts ++ Plugin.global_options;
+                }
+            }
+            break :blk opts;
+        };
+        for (flat_globals, 0..) |opt_a, i| {
+            for (flat_globals[i + 1 ..]) |opt_b| {
+                if (std.mem.eql(u8, opt_a.name, opt_b.name)) {
+                    @compileError("Duplicate global option name: --" ++ opt_a.name ++ ". Two plugins define the same global option.");
+                }
+                if (opt_a.short != null and opt_b.short != null and opt_a.short.? == opt_b.short.?) {
+                    @compileError("Duplicate global option short flag: -" ++ &[_]u8{opt_a.short.?} ++ " (used by both --" ++ opt_a.name ++ " and --" ++ opt_b.name ++ ")");
+                }
+            }
+        }
+
+        // ── Global-vs-command option shadowing ──────────────────────────────
+        // parseGlobalOptions() scans the entire argv and consumes any token
+        // matching a global option's long name or short flag *before* routing,
+        // so a command spelling that collides with a global would never reach
+        // the command — the global handler eats it and the field keeps its
+        // default (#663). Checked for every command in the composition (plugin
+        // commands parse their options through the same pipeline), and for all
+        // three spellings a command can answer to: its effective long name,
+        // its declared short, and — for boolean options — the auto-generated
+        // `--no-<name>` negation.
+        for (new_plugins) |Plugin| {
+            if (!plugin_types.hasGlobalOptions(Plugin)) continue;
+            for (Plugin.global_options) |gopt| {
+                for (all_entries) |cmd| {
+                    if (!@hasDecl(cmd.module, "Options")) continue;
+                    const meta = if (@hasDecl(cmd.module, "meta")) cmd.module.meta else null;
+                    for (std.meta.fields(cmd.module.Options)) |field| {
+                        const long = option_utils.effectiveLongName(meta, field.name);
+                        if (std.mem.eql(u8, long, gopt.name)) {
+                            @compileError("Command '" ++ comptimeJoinPath(cmd.path) ++
+                                "' option --" ++ long ++ " (field '" ++ field.name ++
+                                "') collides with global option --" ++ gopt.name ++
+                                " provided by plugin '" ++ @typeName(Plugin) ++
+                                "'. The global handler consumes this flag before the command runs, so the command would never see it. Rename the command's option (e.g. `meta.options." ++
+                                field.name ++ ".name`) or remove the conflicting global option.");
+                        }
+                        const short = option_utils.shortCharForField(meta, field.name);
+                        if (short != null and gopt.short != null and short.? == gopt.short.?) {
+                            @compileError("Command '" ++ comptimeJoinPath(cmd.path) ++
+                                "' option -" ++ &[_]u8{short.?} ++ " (field '" ++ field.name ++
+                                "') collides with global short flag -" ++ &[_]u8{gopt.short.?} ++
+                                " (--" ++ gopt.name ++ ") provided by plugin '" ++ @typeName(Plugin) ++
+                                "'. The global handler consumes this flag before the command runs, so the command would never see it. Rename the command's short (`meta.options." ++
+                                field.name ++ ".short`) or remove the conflicting global option.");
+                        }
+                        // A boolean command option also answers to `--no-<long>`.
+                        // A global option carrying exactly that name would eat
+                        // the negation before the command parser sees it — the
+                        // same silent shadow as above, via the derived spelling.
+                        if (option_utils.isBooleanFlag(field.type) and
+                            std.mem.eql(u8, gopt.name, "no-" ++ long))
+                        {
+                            @compileError("Command '" ++ comptimeJoinPath(cmd.path) ++
+                                "' boolean option --" ++ long ++ " (field '" ++ field.name ++
+                                "') auto-generates the negation `--no-" ++ long ++
+                                "`, which collides with global option --" ++ gopt.name ++
+                                " provided by plugin '" ++ @typeName(Plugin) ++
+                                "'. The global handler consumes `--no-" ++ long ++
+                                "` before the command runs, so the negation would never reach the command. Rename the command's option (e.g. `meta.options." ++
+                                field.name ++ ".name`) or remove the conflicting global option.");
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+test "validateComposition accepts a well-formed composition" {
+    // A representative composition: a file-based group with a subcommand, a
+    // plugin providing both a command and global options. Reaching the final
+    // assertion means the whole pass ran without tripping a @compileError.
+    const Group = struct {
+        pub const meta = .{ .description = "A group" };
+    };
+    const Sub = struct {
+        pub const Args = struct { name: []const u8 };
+        pub const Options = struct { loud: bool = false };
+        pub fn execute(_: Args, _: Options, _: anytype) !void {}
+    };
+    const Plugin = struct {
+        pub const global_options = [_]plugin_types.GlobalOption{
+            zcli.option("verbose", bool, .{ .short = 'v', .default = false, .description = "chatty" }),
+        };
+        pub const commands = struct {
+            pub const version = struct {
+                pub const Args = struct {};
+                pub const Options = struct {};
+                pub fn execute(_: Args, _: Options, _: anytype) !void {}
+            };
+        };
+    };
+    const cmds = [_]CommandEntry{
+        .{ .path = &.{"users"}, .module = Group },
+        .{ .path = &.{ "users", "add" }, .module = Sub },
+    };
+    const plugin_cmds = comptime builder.discoverPluginCommands(Plugin.commands, &.{});
+    comptime validateComposition(&cmds, plugin_cmds, &.{Plugin});
+    try std.testing.expect(true);
+}
+
+// The negative cases below are compile errors by design, so they cannot be run
+// as tests. Each is verified by hand; uncomment one to see the message it
+// emits. (Per-module negative cases — varargs order, `--no-…` collisions
+// inside one command, default shapes, meta typos — live with
+// `zcli.validateCommand` in zcli.zig; the cases here are the ones only the
+// whole composition can reveal.)
+//
+//   Duplicate command path: users add
+//     two entries registered at the same path
+//
+//   Plugin command conflicts with existing command: version
+//     a plugin `commands.version` while src/commands/version.zig exists
+//
+//   Duplicate plugin command: version
+//     two plugins both exporting `commands.version`
+//
+//   Optional command group 'users' cannot have Args fields. ...
+//     a group with subcommands whose Args struct has fields
+//
+//   Duplicate global option name: --verbose. Two plugins define the same global option.
+//   Duplicate global option short flag: -v (used by both --verbose and --version)
+//
+//   Global-vs-command shadowing (#663) — long, short, and derived negation:
+//
+//   Command 'users add' option --verbose (field 'verbose') collides with global
+//     option --verbose provided by plugin '...'. The global handler consumes this
+//     flag before the command runs, ...
+//     pub const Options = struct { verbose: bool = false };  // + a --verbose global
+//
+//   Command 'users add' option -v (field 'verbose') collides with global short
+//     flag -v (--verbose) provided by plugin '...'. ...
+//     meta.options.verbose.short = 'v'  // + a global with .short = 'v'
+//
+//   Command 'users add' boolean option --color (field 'color') auto-generates
+//     the negation `--no-color`, which collides with global option --no-color
+//     provided by plugin '...'. The global handler consumes `--no-color` before
+//     the command runs, ...
+//     pub const Options = struct { color: bool = true };  // + a --no-color global

--- a/packages/core/src/zcli.zig
+++ b/packages/core/src/zcli.zig
@@ -930,6 +930,9 @@ test "validateCommand accepts a well-formed command" {
 
 // The negative cases below are compile errors by design, so they cannot be run
 // as tests. Each is verified by hand; uncomment one to see the message it emits.
+// (These are the PER-MODULE cases `validateCommand` catches; composition-level
+// cases — duplicate paths, global-option conflicts, global-vs-command
+// shadowing — live with the registry-level pass in registry/validation.zig.)
 //
 //   command 'broken': unknown meta field 'desciption'. Valid fields are: ...
 //     pub const meta = .{ .desciption = "typo" };


### PR DESCRIPTION
## Summary

Consolidates all comptime validation into a single registry-level pass that sees the whole composition — file-based commands, plugin commands, and plugin global options — closing the class of gaps that produced the varargs SEGV (#662), the global-vs-command option shadow (#663), and the `--no-X` negation shadow (#667).

### Architecture

The new pass lives in `packages/core/src/registry/validation.zig` (`validateComposition`), called exactly once from `CompiledRegistry` (`registry/compiled.zig`), i.e. when `build()` runs. It layers:

- **Per-module rules** — the existing command contract in `zcli.validateCommand` (Args/Options shape, varargs-must-be-last #662, optional/array default shapes #668, in-command spelling collisions including `--no-…` negations #667, meta hygiene). The pass drives it over *every* command in the composition, file-based and plugin alike, so a rule added there can never cover only one population.
- **Per-plugin rules** — `plugin_types.validatePlugin` (misspelled hooks, ContextData contract), driven from the pass for every registered plugin.
- **Cross-module rules** — implemented in the pass itself, where the whole composition is visible: command-path uniqueness (file/plugin/plugin-vs-file), command-group shape, global-option uniqueness across plugins, and global-vs-command shadowing (#663) over effective long names, declared shorts, **and** derived `--no-…` negations.

### Subsumed / moved

- `builder.zig` `register()` and `discoverPluginCommands()` no longer call `validateCommand`; `registerPlugin()` no longer calls `validatePlugin`. Registration is now pure accumulation; `build()` is the single validation point. (`discoverPluginCommands` now sets its own eval-branch quota — `validateCommand` used to raise it as a side effect of being called there.)
- `compiled.zig`'s three scattered comptime blocks (path/group/plugin-command conflicts; global duplicate names/shorts; the #663 shadow check) moved into the pass — every existing compile-error message preserved character-for-character.

### New coverage (gaps only the composition can see)

- Plugin commands are now checked against plugin global options (previously only file-based commands were).
- A plugin global named `no-<x>` that would silently eat the auto-generated negation of a command boolean `--<x>` is now a compile error.
- The command-group-shape rule now sees plugin commands nested in the same path space.

No behavior change for valid programs.

### Verification

- `zig build test` green at repo root (all packages + all example apps + projects/zcli tests); root `zig build` and `projects/zcli` `zig build` succeed; binary smoke-tested (`zcli --help`).
- Hand-verified 6 negative cases through the unified pass, each emitting its exact message: varargs-not-last (#662), in-command `--no-X` collision (#667), non-empty array default (#668), #663 long-name shadow, the new global-negation shadow, and duplicate command path. The hand-verified comment blocks in `zcli.zig` and `validation.zig` document each case.

Fixes #677

🤖 Generated with [Claude Code](https://claude.com/claude-code)
