### PR TITLE
init: compile-check the scaffold via an embedded reference project

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -114,6 +114,10 @@ pub fn build(b: *std.Build) void {
         .{ .name = "prompts-features", .path = "examples/prompts-features" },
         .{ .name = "testing-demo", .path = "examples/testing-demo" },
         .{ .name = "upgrade-demo", .path = "examples/upgrade-demo" },
+        // The `zcli init` scaffold's reference project: `init` embeds these files
+        // and substitutes the project's values in, so compiling it here guards the
+        // scaffold against framework API drift (issue #679 part 2).
+        .{ .name = "init-scaffold", .path = "examples/init-scaffold" },
     };
 
     // Add tests for each project that has them
@@ -161,6 +165,7 @@ pub fn build(b: *std.Build) void {
         .{ .name = "prompts-features", .path = "examples/prompts-features" },
         .{ .name = "testing-demo", .path = "examples/testing-demo" },
         .{ .name = "upgrade-demo", .path = "examples/upgrade-demo" },
+        .{ .name = "init-scaffold", .path = "examples/init-scaffold" },
         .{ .name = "vterm_example", .path = "packages/vterm/example" },
     };
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,5 +23,6 @@ included (see `build.zig` at the repo root, `test_projects`).
 | [**prompts-features**](prompts-features) | The `password` and `multi_select` prompt types (the other prompt types are covered in `tasks`). |
 | [**testing-demo**](testing-demo) | The `zcli-testing` harness used directly in app code: unit-tier `runCommand` inside a command's own tests, plus a subprocess/snapshot integration test against the compiled binary. |
 | [**upgrade-demo**](upgrade-demo) | Wires the `github_upgrade` plugin to add a self-upgrade `upgrade` command backed by GitHub Releases. |
+| [**init-scaffold**](init-scaffold) | Exactly what `zcli init` scaffolds — its `build.zig`, `main.zig`, and `hello.zig` are the reference sources `init` embeds, so compiling it here catches scaffold drift against the live framework API. |
 
 Building something with zcli? Open a PR to add it here.

--- a/examples/init-scaffold/.gitattributes
+++ b/examples/init-scaffold/.gitattributes
@@ -1,0 +1,7 @@
+# `zcli init` `@embedFile`s the sources in this project and splices them on LF
+# boundaries (the `//<zcli:plugins>` markers in build.zig), then emits them into
+# the scaffolded project verbatim. They must stay LF on every OS: without this,
+# Windows' default core.autocrlf=true rewrites them to CRLF at checkout, which
+# breaks the marker splice (error.MalformedReference in renderBuildZig) and would
+# emit CRLF scaffolds. Keep the whole reference project LF for the same reason.
+* text eol=lf

--- a/examples/init-scaffold/README.md
+++ b/examples/init-scaffold/README.md
@@ -1,0 +1,22 @@
+# init-scaffold
+
+This is the exact project `zcli init` scaffolds — its `build.zig`,
+`src/main.zig`, and `src/commands/hello.zig` are the **reference sources** the
+`init` command `@embedFile`s and (for `build.zig`) substitutes the project
+name, description, and selected plugins into.
+
+Because it lives in-repo and is registered as a test project (root `build.zig`),
+`zig build test` and `zig build build-examples` compile it against the local,
+unreleased zcli. That makes it the scaffold's drift-detector: if a change to
+`zcli.generate`, `zcli.addCommandTests`, `zcli.builtin`, `zcli.SharedModule`,
+`zcli.ui.panic`, or the command contract breaks the code `init` emits, **our own
+build fails here** — instead of shipping a broken scaffold that only fails inside
+a downstream user's `zig build`.
+
+Editing these files is editing the scaffold. Keep them buildable and keep them
+the idiomatic starting point a new zcli user should read first.
+
+The one difference from `init`'s output is `build.zig.zon`: `init` generates it
+programmatically (a random fingerprint, the `--app-version`, and a `zig fetch
+--save` of the pinned release tag), so it is not embedded here. This project's
+`build.zig.zon` uses a local path dependency like every other in-repo example.

--- a/examples/init-scaffold/build.zig
+++ b/examples/init-scaffold/build.zig
@@ -1,0 +1,84 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) !void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    // Debug info dominates binary size (roughly 10x on a static build).
+    // Release builds pass -Dstrip=true (the generated release workflow
+    // does); local builds keep debug info for stack traces.
+    const strip = b.option(bool, "strip", "Omit debug info from the binary") orelse false;
+
+    // Get zcli dependency
+    const zcli_dep = b.dependency("zcli", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    const zcli_module = zcli_dep.module("zcli");
+
+    // Create the executable
+    const exe = b.addExecutable(.{
+        .name = "myapp",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+            .strip = strip,
+        }),
+    });
+
+    exe.root_module.addImport("zcli", zcli_module);
+
+    const zcli = @import("zcli");
+
+    // Shared modules: helper code (e.g. a `store.zig`) imported by more
+    // than one command. Create it with `b.createModule(...)`, then add an
+    // entry here — this one list is wired into your commands AND their
+    // tests below, so you never register it twice. Editing this build
+    // config by hand is expected; `zcli add`/`rm`/`mv` manage command
+    // *structure*, not build wiring.
+    const shared_modules = [_]zcli.SharedModule{
+        // .{ .name = "store", .module = store_module },
+    };
+
+    // Generate command registry with built-in plugins
+    const cmd_registry = try zcli.generate(b, exe, zcli_dep, .{
+        .commands_dir = "src/commands",
+        // Local plugins in src/plugins/ are auto-discovered (add with
+        // `zcli add plugin <name>`). Harmless when the directory is absent.
+        .plugins_dir = "src/plugins",
+        .plugins = &.{
+            //<zcli:plugins>
+            zcli.builtin(.help, .{}),
+            zcli.builtin(.version, .{}),
+            zcli.builtin(.not_found, .{}),
+            //</zcli:plugins>
+        },
+        .shared_modules = &shared_modules,
+        .app_name = "myapp",
+        .app_description = "A CLI application built with zcli",
+    });
+
+    exe.root_module.addImport("command_registry", cmd_registry);
+    b.installArtifact(exe);
+
+    // Add run step for convenience
+    const run_cmd = b.addRunArtifact(exe);
+    run_cmd.step.dependOn(b.getInstallStep());
+    if (b.args) |args| run_cmd.addArgs(args);
+
+    const run_step = b.step("run", "Run the app");
+    run_step.dependOn(&run_cmd.step);
+
+    // `zig build test` — unit-test each command in-process. Command test
+    // blocks use `zcli-testing`'s runCommand (bundled with the zcli
+    // dependency, so no extra dependency is needed). `zcli add command`
+    // scaffolds a starting test alongside each new command.
+    _ = zcli.addCommandTests(b, exe, zcli_dep, .{
+        .commands_dir = "src/commands",
+        .target = target,
+        .optimize = optimize,
+        .plugins_dir = "src/plugins",
+        .shared_modules = &shared_modules,
+    });
+}

--- a/examples/init-scaffold/build.zig.zon
+++ b/examples/init-scaffold/build.zig.zon
@@ -1,0 +1,19 @@
+.{
+    .name = .myapp,
+    .version = "0.1.0",
+    .fingerprint = 0x8798022a9813d1b5,
+    .minimum_zig_version = "0.16.0",
+    .dependencies = .{
+        // Local path because this reference project lives in-repo (so CI
+        // compiles it against unreleased changes as the `zcli init` scaffold's
+        // drift-detector — see the README below). A real `zcli init` fetches a
+        // released zcli instead:
+        //   .zcli = .{ .url = "git+https://github.com/ryanhair/zcli#<tag>", .hash = "..." },
+        .zcli = .{ .path = "../.." },
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}

--- a/examples/init-scaffold/src/commands/hello.zig
+++ b/examples/init-scaffold/src/commands/hello.zig
@@ -1,0 +1,34 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
+
+pub const meta = .{
+    .description = "Say hello to someone",
+    .examples = &.{
+        "hello World",
+        "hello Alice --loud",
+    },
+    // Arg descriptions are plain strings; option descriptions are structs
+    // that can also declare a short flag (and .name/.env). These show up in
+    // `--help` and the generated docs, so the first command a user reads
+    // models the full grammar.
+    .args = .{
+        .name = "Who to greet",
+    },
+    .options = .{
+        .loud = .{ .description = "Shout the greeting", .short = 'l' },
+    },
+};
+
+pub const Args = struct {
+    name: []const u8,
+};
+
+pub const Options = struct {
+    loud: bool = false,
+};
+
+pub fn execute(args: Args, options: Options, context: *Context) !void {
+    const greeting = if (options.loud) "HELLO" else "Hello";
+    try context.stdout().print("{s}, {s}!\n", .{ greeting, args.name });
+}

--- a/examples/init-scaffold/src/main.zig
+++ b/examples/init-scaffold/src/main.zig
@@ -1,0 +1,13 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const registry = @import("command_registry");
+
+/// Prompts (`add`, `init`) and progress bars hide the cursor and drive raw
+/// mode, so a panic mid-prompt must restore the terminal.
+pub const panic = zcli.ui.panic;
+
+pub fn main(init: std.process.Init) !void {
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
+    var app = registry.init();
+    try app.run(init.gpa, init.io, init.environ_map, args);
+}

--- a/projects/zcli/build.zig
+++ b/projects/zcli/build.zig
@@ -32,6 +32,24 @@ pub fn build(b: *std.Build) !void {
         .target = target,
         .optimize = optimize,
     });
+    // The `zcli init` scaffold's reference sources (issue #679 part 2). `init`
+    // `@embedFile`s these and substitutes the project's values in; the same files
+    // are the `examples/init-scaffold` project, compiled against the local zcli by
+    // the root build's example/test-project steps. So a change to `zcli.generate`,
+    // `zcli.addCommandTests`, `zcli.builtin`, `zcli.SharedModule`, `zcli.ui.panic`,
+    // or the command contract breaks OUR build here — not a downstream user's
+    // `zig build` after `zcli init`. These are cross-package embeds, so they can
+    // only be reached through this build wiring (a bare relative `@embedFile` is
+    // rejected as "outside package path").
+    scaffold_module.addAnonymousImport("reference/build.zig", .{
+        .root_source_file = b.path("../../examples/init-scaffold/build.zig"),
+    });
+    scaffold_module.addAnonymousImport("reference/main.zig", .{
+        .root_source_file = b.path("../../examples/init-scaffold/src/main.zig"),
+    });
+    scaffold_module.addAnonymousImport("reference/hello.zig", .{
+        .root_source_file = b.path("../../examples/init-scaffold/src/commands/hello.zig"),
+    });
 
     // Canonical example sources embedded into `zcli guide` (ADR-0004/0008). Each
     // anonymous import binds a `@embedFile` name in guide_examples.zig to a real

--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -269,168 +269,39 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
     defer zon_file.close(io);
     try zon_file.writeStreamingAll(io, zon_content);
 
-    // Generate build.zig
+    // Generate build.zig from the embedded reference source. The reference is
+    // the `examples/init-scaffold` project the root build compiles against the
+    // local zcli, so a framework API change breaks that build instead of shipping
+    // a broken scaffold (issue #679 part 2; see renderBuildZig and
+    // scaffold/reference.zig).
     try stdout.print("  Creating build.zig...\n", .{});
-    const build_content = try std.fmt.allocPrint(allocator,
-        \\const std = @import("std");
-        \\
-        \\pub fn build(b: *std.Build) !void {{
-        \\    const target = b.standardTargetOptions(.{{}});
-        \\    const optimize = b.standardOptimizeOption(.{{}});
-        \\
-        \\    // Debug info dominates binary size (roughly 10x on a static build).
-        \\    // Release builds pass -Dstrip=true (the generated release workflow
-        \\    // does); local builds keep debug info for stack traces.
-        \\    const strip = b.option(bool, "strip", "Omit debug info from the binary") orelse false;
-        \\
-        \\    // Get zcli dependency
-        \\    const zcli_dep = b.dependency("zcli", .{{
-        \\        .target = target,
-        \\        .optimize = optimize,
-        \\    }});
-        \\    const zcli_module = zcli_dep.module("zcli");
-        \\
-        \\    // Create the executable
-        \\    const exe = b.addExecutable(.{{
-        \\        .name = "{s}",
-        \\        .root_module = b.createModule(.{{
-        \\            .root_source_file = b.path("src/main.zig"),
-        \\            .target = target,
-        \\            .optimize = optimize,
-        \\            .strip = strip,
-        \\        }}),
-        \\    }});
-        \\
-        \\    exe.root_module.addImport("zcli", zcli_module);
-        \\
-        \\    const zcli = @import("zcli");
-        \\
-        \\    // Shared modules: helper code (e.g. a `store.zig`) imported by more
-        \\    // than one command. Create it with `b.createModule(...)`, then add an
-        \\    // entry here — this one list is wired into your commands AND their
-        \\    // tests below, so you never register it twice. Editing this build
-        \\    // config by hand is expected; `zcli add`/`rm`/`mv` manage command
-        \\    // *structure*, not build wiring.
-        \\    const shared_modules = [_]zcli.SharedModule{{
-        \\        // .{{ .name = "store", .module = store_module }},
-        \\    }};
-        \\
-        \\    // Generate command registry with built-in plugins
-        \\    const cmd_registry = try zcli.generate(b, exe, zcli_dep, .{{
-        \\        .commands_dir = "src/commands",
-        \\        // Local plugins in src/plugins/ are auto-discovered (add with
-        \\        // `zcli add plugin <name>`). Harmless when the directory is absent.
-        \\        .plugins_dir = "src/plugins",
-        \\        .plugins = &.{{
-        \\{s}        }},
-        \\        .shared_modules = &shared_modules,
-        \\        .app_name = "{s}",
-        \\        .app_description = "{s}",
-        \\    }});
-        \\
-        \\    exe.root_module.addImport("command_registry", cmd_registry);
-        \\    b.installArtifact(exe);
-        \\
-        \\    // Add run step for convenience
-        \\    const run_cmd = b.addRunArtifact(exe);
-        \\    run_cmd.step.dependOn(b.getInstallStep());
-        \\    if (b.args) |args| run_cmd.addArgs(args);
-        \\
-        \\    const run_step = b.step("run", "Run the app");
-        \\    run_step.dependOn(&run_cmd.step);
-        \\
-        \\    // `zig build test` — unit-test each command in-process. Command test
-        \\    // blocks use `zcli-testing`'s runCommand (bundled with the zcli
-        \\    // dependency, so no extra dependency is needed). `zcli add command`
-        \\    // scaffolds a starting test alongside each new command.
-        \\    _ = zcli.addCommandTests(b, zcli_dep, .{{
-        \\        .commands_dir = "src/commands",
-        \\        .target = target,
-        \\        .optimize = optimize,
-        \\        .plugins_dir = "src/plugins",
-        \\        .shared_modules = &shared_modules,
-        \\    }});
-        \\}}
-        \\
-    , .{ project_name, plugins_block, project_name, app_description });
+    const build_content = try renderBuildZig(allocator, project_name, app_description, plugins_block);
     defer allocator.free(build_content);
 
     var build_file = try project_dir.createFile(io, "build.zig", .{});
     defer build_file.close(io);
     try build_file.writeStreamingAll(io, build_content);
 
-    // Generate src/main.zig
+    // Generate src/main.zig — emitted verbatim from the compiled reference.
     try stdout.print("  Creating src/main.zig...\n", .{});
-    const main_content =
-        \\const std = @import("std");
-        \\const zcli = @import("zcli");
-        \\const registry = @import("command_registry");
-        \\
-        \\/// Prompts (`add`, `init`) and progress bars hide the cursor and drive raw
-        \\/// mode, so a panic mid-prompt must restore the terminal.
-        \\pub const panic = zcli.ui.panic;
-        \\
-        \\pub fn main(init: std.process.Init) !void {
-        \\    const args = try init.minimal.args.toSlice(init.arena.allocator());
-        \\    var app = registry.init();
-        \\    try app.run(init.gpa, init.io, init.environ_map, args);
-        \\}
-        \\
-    ;
 
     var src_dir = try project_dir.openDir(io, "src", .{});
     defer src_dir.close(io);
 
     var main_file = try src_dir.createFile(io, "main.zig", .{});
     defer main_file.close(io);
-    try main_file.writeStreamingAll(io, main_content);
+    try main_file.writeStreamingAll(io, scaffold.reference.main_zig);
 
-    // Generate example command: src/commands/hello.zig
+    // Generate example command: src/commands/hello.zig — verbatim from the
+    // compiled reference.
     try stdout.print("  Creating example command (hello)...\n", .{});
-    const hello_content =
-        \\const std = @import("std");
-        \\const zcli = @import("zcli");
-        \\const Context = @import("command_registry").Context;
-        \\
-        \\pub const meta = .{
-        \\    .description = "Say hello to someone",
-        \\    .examples = &.{
-        \\        "hello World",
-        \\        "hello Alice --loud",
-        \\    },
-        \\    // Arg descriptions are plain strings; option descriptions are structs
-        \\    // that can also declare a short flag (and .name/.env). These show up in
-        \\    // `--help` and the generated docs, so the first command a user reads
-        \\    // models the full grammar.
-        \\    .args = .{
-        \\        .name = "Who to greet",
-        \\    },
-        \\    .options = .{
-        \\        .loud = .{ .description = "Shout the greeting", .short = 'l' },
-        \\    },
-        \\};
-        \\
-        \\pub const Args = struct {
-        \\    name: []const u8,
-        \\};
-        \\
-        \\pub const Options = struct {
-        \\    loud: bool = false,
-        \\};
-        \\
-        \\pub fn execute(args: Args, options: Options, context: *Context) !void {
-        \\    const greeting = if (options.loud) "HELLO" else "Hello";
-        \\    try context.stdout().print("{s}, {s}!\n", .{ greeting, args.name });
-        \\}
-        \\
-    ;
 
     var commands_dir = try src_dir.openDir(io, "commands", .{});
     defer commands_dir.close(io);
 
     var hello_file = try commands_dir.createFile(io, "hello.zig", .{});
     defer hello_file.close(io);
-    try hello_file.writeStreamingAll(io, hello_content);
+    try hello_file.writeStreamingAll(io, scaffold.reference.hello_zig);
 
     // Scaffold AGENTS.md — the thin, frozen, command-speaking spine that points
     // coding agents at `zcli guide` (ADR-0008). Marker-delimited so it never
@@ -616,6 +487,80 @@ test "renderPluginsBlock scaffolds a compiling github_upgrade config, not an emp
             "            }),\n",
         block,
     );
+}
+
+// The plugins-list region in the reference build.zig, delimited so init can
+// swap the reference's default builtins for the user's selection. The markers
+// keep the reference itself compiling (with the defaults between them).
+const ref_plugins_begin = "            //<zcli:plugins>\n";
+const ref_plugins_end = "            //</zcli:plugins>\n";
+
+/// Assemble the project's `build.zig` from the embedded reference source
+/// (`scaffold.reference.build_zig`), substituting this project's values:
+///   - the `//<zcli:plugins>…//</zcli:plugins>` region → the selected builtins;
+///   - the reference app name (`"myapp"`, at both `.name` and `.app_name`) and
+///     its default description string → this project's name and (already-escaped)
+///     description.
+///
+/// The reference is written against the *local* (unreleased) zcli so it stays
+/// compile-checked by the `examples/init-scaffold` build. `init`, though, pins
+/// the released tag `context.app_version` points at, whose `addCommandTests`
+/// still predates the `exe` parameter (#531) — so emit the 3-arg form that
+/// release expects. (The local-tree e2e build bridges it back up; the
+/// pinned-release e2e, #623, builds this unmodified against the real tag.) Drop
+/// this last rewrite once the pinned release carries the `exe` signature.
+fn renderBuildZig(
+    allocator: std.mem.Allocator,
+    project_name: []const u8,
+    app_description: []const u8,
+    plugins_block: []const u8,
+) ![]u8 {
+    const ref = scaffold.reference.build_zig;
+    const begin = std.mem.indexOf(u8, ref, ref_plugins_begin) orelse return error.MalformedReference;
+    const end = (std.mem.indexOf(u8, ref, ref_plugins_end) orelse return error.MalformedReference) + ref_plugins_end.len;
+
+    const name_quoted = try std.fmt.allocPrint(allocator, "\"{s}\"", .{project_name});
+    defer allocator.free(name_quoted);
+    const desc_quoted = try std.fmt.allocPrint(allocator, "\"{s}\"", .{app_description});
+    defer allocator.free(desc_quoted);
+
+    // 1) Replace the marked plugins region with the rendered selection.
+    const spliced = try std.mem.concat(allocator, u8, &.{ ref[0..begin], plugins_block, ref[end..] });
+    defer allocator.free(spliced);
+    // 2) App name — both the exe `.name` and `.app_name` sites.
+    const named = try std.mem.replaceOwned(u8, allocator, spliced, "\"myapp\"", name_quoted);
+    defer allocator.free(named);
+    // 3) Description (name is substituted first so it can't collide with a
+    //    user-supplied description, which is inserted last and never rescanned).
+    const described = try std.mem.replaceOwned(u8, allocator, named, "\"A CLI application built with zcli\"", desc_quoted);
+    defer allocator.free(described);
+    // 4) Pin `addCommandTests` down to the released 3-arg shape (see doc comment).
+    return std.mem.replaceOwned(u8, allocator, described, "zcli.addCommandTests(b, exe, zcli_dep,", "zcli.addCommandTests(b, zcli_dep,");
+}
+
+test "renderBuildZig substitutes name, description, plugins and pins addCommandTests" {
+    const allocator = std.testing.allocator;
+    const plugins =
+        "            zcli.builtin(.help, .{}),\n" ++
+        "            zcli.builtin(.version, .{}),\n";
+    const build = try renderBuildZig(allocator, "cool-app", "Say \\\"hi\\\"", plugins);
+    defer allocator.free(build);
+
+    // Name lands at the exe `.name` and `.app_name`; the reference sentinel is gone.
+    try std.testing.expect(std.mem.indexOf(u8, build, ".name = \"cool-app\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, build, ".app_name = \"cool-app\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, build, "myapp") == null);
+    // Description (already escaped) lands verbatim.
+    try std.testing.expect(std.mem.indexOf(u8, build, ".app_description = \"Say \\\"hi\\\"\"") != null);
+    // Selected plugins are spliced in, markers removed.
+    try std.testing.expect(std.mem.indexOf(u8, build, "zcli.builtin(.help, .{}),") != null);
+    try std.testing.expect(std.mem.indexOf(u8, build, "//<zcli:plugins>") == null);
+    // Emitted call matches the pinned release's 3-arg signature, not the
+    // reference's local 4-arg one.
+    try std.testing.expect(std.mem.indexOf(u8, build, "zcli.addCommandTests(b, zcli_dep,") != null);
+    try std.testing.expect(std.mem.indexOf(u8, build, "zcli.addCommandTests(b, exe, zcli_dep,") == null);
+    // Framework-coupled call the reference compile-guards survives verbatim.
+    try std.testing.expect(std.mem.indexOf(u8, build, "try zcli.generate(b, exe, zcli_dep, .{") != null);
 }
 
 /// True if `s` is a semantic version acceptable to Zig's build.zig.zon manifest

--- a/projects/zcli/src/scaffold.zig
+++ b/projects/zcli/src/scaffold.zig
@@ -8,6 +8,7 @@
 pub const spec = @import("scaffold/spec.zig");
 pub const splice = @import("scaffold/splice.zig");
 pub const fs = @import("scaffold/fs.zig");
+pub const reference = @import("scaffold/reference.zig");
 
 test {
     _ = spec;

--- a/projects/zcli/src/scaffold/reference.zig
+++ b/projects/zcli/src/scaffold/reference.zig
@@ -1,0 +1,20 @@
+//! Reference sources for the project `zcli init` scaffolds (issue #679 part 2).
+//!
+//! Each `@embedFile` name is bound by build.zig (via `addAnonymousImport` on the
+//! `scaffold` module) to a real file under `examples/init-scaffold/`, which the
+//! root build compiles against the local zcli as an ordinary example/test
+//! project. So these are compiled truth: a framework change that breaks the code
+//! `init` emits fails OUR build here, instead of shipping a broken scaffold that
+//! only fails inside a downstream user's `zig build`. `init` embeds these bytes
+//! and substitutes the project's name, description, and selected plugins in
+//! (see `init.zig`).
+//!
+//! The reference `build.zig` is written against the *local* (unreleased) zcli so
+//! it compiles here; `init` pins the released tag `context.app_version` points
+//! at, so it emits the API shape that release expects. The one call that has
+//! drifted since that release (`addCommandTests`) is adapted at emit time in
+//! `init.zig`; everything else is emitted verbatim.
+
+pub const build_zig = @embedFile("reference/build.zig");
+pub const main_zig = @embedFile("reference/main.zig");
+pub const hello_zig = @embedFile("reference/hello.zig");


### PR DESCRIPTION
## What

Completes part 2 of #679 (part 1 was #705).

The `zcli init` scaffold emitted `build.zig` / `main.zig` / `hello.zig` as hand-written string literals, coupled to the live `generate()` / `addCommandTests()` / `builtin()` / `SharedModule` / `ui.panic` signatures and the command contract **only by convention**. Drift was hand-managed at each release boundary and only surfaced by the e2e subprocess build (or, worse, a downstream user's `zig build` after `zcli init`).

## Change

Extract the three templates to real source files under **`examples/init-scaffold/`** — the exact project `init` produces:

- `init` now `@embedFile`s them via the `scaffold` module's anonymous imports (mirroring the existing `guide_examples` pattern) and substitutes the project's name, description, and selected plugins in. `renderBuildZig` does that splice; `main.zig`/`hello.zig` are emitted verbatim.
- The reference is registered as an ordinary **example/test project** in the root `build.zig`, so `zig build test` and `zig build build-examples` compile it against the **local (unreleased) zcli**. A framework API change now **breaks OUR build here** — `generate`, `builtin`, `SharedModule`, `ui.panic`, the 4-arg `addCommandTests`, and the command contract are all compile-guarded — instead of shipping a broken scaffold.

This extends the existing "canonical examples compile" CI mechanism (path-dep examples built as subprocesses), the home the issue pointed at. No network fetch, no musl.

## The version-pinning entanglement

`init` pins the released tag `context.app_version` points at (**v0.20.0**), whose `addCommandTests` still predates the `exe` parameter (#531, unreleased). So the *emitted* template must stay 3-arg, but a reference compiled against local HEAD must be 4-arg.

Resolution: the reference uses the local **4-arg** form (so it compiles here and guards that call against HEAD); `renderBuildZig` pins that **one** call down to the release's **3-arg** shape at emit time, documented as the sole remaining release-boundary coupling. The pinned-release e2e (`scaffold builds against the pinned release`, #623) and the local-tree e2e bridge are unchanged and still pass.

## Verification

- **Byte-identical** scaffold output confirmed against the previous string templates for the default case (build.zig after substitution, main.zig, hello.zig).
- `zig build test` (repo root) — green, including `✓ init-scaffold tests passed` (the reference compiled against local zcli as a CI test project).
- `zig build e2e` (projects/zcli) — green (init scaffolding, local-tree build, and the #623 pinned-release build).
- `zig build test` (projects/zcli) — green, including a new `renderBuildZig` unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)