### PR TITLE
ui: decompose the App god-object; give the cursor-parking invariant an owner

### DIFF
--- a/packages/ui/src/app.zig
+++ b/packages/ui/src/app.zig
@@ -1,9 +1,26 @@
 //! App: the static/live frame loop (ADR-0013 step 3), in two modes (ADR-0015).
 //!
-//! Owns everything the demo used to hand-roll: the frame arena, the
-//! double-buffered surfaces, reserving the live region's rows, parking the
-//! cursor at the region's top-left (the diff renderer's addressing
-//! contract), and cursor hide/restore.
+//! The App is the orchestrator over four owned components, each with one
+//! responsibility:
+//!
+//! - `RenderCore` (render_core.zig) — the pure measure→paint→diff pipeline:
+//!   double-buffered surfaces and the minimal-byte diff paint.
+//! - `RegionCursor` (region_cursor.zig) — owns the cursor-parking invariant:
+//!   between operations the real cursor sits at column 0 of the live
+//!   region's top row (or at the start of an empty line when no region is
+//!   painted). `place` is the one sanctioned excursion; every paint path
+//!   parks first and asserts `isParked()` before handing bytes to the diff
+//!   renderer. Callers must hand over the terminal at the start of a line,
+//!   and must not write to the App's writer directly while a live region is
+//!   up — that's what `emit` is for.
+//! - `TerminalSession` (terminal_session.zig) — raw mode, the resize
+//!   watcher, the signal/panic restore guard, and the full-screen
+//!   enter/restore protocol: the only part that touches real process state.
+//! - `HybridScrollback` (hybrid_scrollback.zig) — the retained static tail
+//!   and its width-resize reflow (ADR-0013 resize tier 2).
+//!
+//! What remains here is the region bookkeeping (`live_rows`, reserve/clear)
+//! and the mode orchestration.
 //!
 //! The default is `hybrid`: a static stream (`emit`) flowing into scrollback
 //! with a live region (`frame`) pinned above it, sharing the screen. Opting
@@ -27,12 +44,6 @@
 //! Build each frame's tree from `app.arena()`: allocations live until the
 //! next `frame()` call consumes them, then the arena resets wholesale —
 //! that's the immediate-mode contract.
-//!
-//! Cursor bookkeeping invariant: between calls, the cursor sits at column 0
-//! of the live region's top row (or at the start of an empty line when no
-//! region is painted). Callers must hand over the terminal at the start of a
-//! line, and must not write to the App's writer directly while a live region
-//! is up — that's what `emit` is for.
 
 const std = @import("std");
 const theme = @import("theme");
@@ -40,6 +51,10 @@ const terminal = @import("terminal");
 const surface_mod = @import("surface.zig");
 const node_mod = @import("node.zig");
 const diff_mod = @import("diff.zig");
+const render_core_mod = @import("render_core.zig");
+const region_cursor_mod = @import("region_cursor.zig");
+const session_mod = @import("terminal_session.zig");
+const scrollback_mod = @import("hybrid_scrollback.zig");
 
 const Surface = surface_mod.Surface;
 const Point = surface_mod.Point;
@@ -47,23 +62,15 @@ const Node = node_mod.Node;
 const Size = node_mod.Size;
 const Limits = node_mod.Limits;
 const RenderCtx = node_mod.RenderCtx;
+const RenderCore = render_core_mod.RenderCore;
+const RegionCursor = region_cursor_mod.RegionCursor;
+const TerminalSession = session_mod.TerminalSession;
+const HybridScrollback = scrollback_mod.HybridScrollback;
 
 /// An input event surfaced by `nextEvent` in full-screen mode: a key press, a
 /// terminal resize, or (when enabled) a mouse or focus event (re-exported from
 /// `terminal`). Bracketed paste joins here when it lands (ADR-0015 deferred).
 pub const Event = terminal.Event;
-
-// Full-screen takeover/restore escape sequences. The `*_on`/`*_off` pairs are
-// DECSET enable/disable for the opt-in input modes; `restore_tail` shows the
-// cursor and leaves the alt-screen. Restore order is the reverse of enter:
-// disable input modes, then cursor, then alt-screen.
-const mouse_on = "\x1b[?1002h\x1b[?1006h"; // button+drag tracking, SGR encoding
-const mouse_off = "\x1b[?1002l\x1b[?1006l";
-const focus_on = "\x1b[?1004h";
-const focus_off = "\x1b[?1004l";
-const paste_on = "\x1b[?2004h"; // bracketed paste
-const paste_off = "\x1b[?2004l";
-const restore_tail = "\x1b[?25h\x1b[?1049l";
 
 pub const App = struct {
     /// How the App shares the terminal (ADR-0015).
@@ -143,15 +150,6 @@ pub const App = struct {
         paste_max: usize = 5 << 20, // 5 MiB
     };
 
-    /// A static block kept for the resize tail repaint (ADR-0013 resize
-    /// tier 2): the SOURCE text, not rendered cells, so it can rewrap at a
-    /// new width. `rows` is what it occupies at the width it was last
-    /// printed at (terminal character-wrapping, not word-wrapping).
-    const StaticBlock = struct {
-        text: []u8,
-        rows: u16,
-    };
-
     writer: *std.Io.Writer,
     gpa: std.mem.Allocator,
     options: Options,
@@ -162,42 +160,28 @@ pub const App = struct {
     mode: Mode = .hybrid,
 
     frame_arena: std.heap.ArenaAllocator,
-    /// What the terminal currently shows (diff source) / the paint target.
-    front: Surface,
-    back: Surface,
+    /// The measure→paint→diff pipeline: double-buffered surfaces + validity.
+    core: RenderCore,
+    /// Owner of the cursor-parking invariant (see module docs).
+    cursor: RegionCursor = .{},
+    /// Process-global terminal state: raw mode, resize watcher, restore guard.
+    session: TerminalSession,
+    /// The retained static tail and its width-resize reflow (hybrid only).
+    scrollback: HybridScrollback,
     /// Rows currently reserved on screen for the live region.
     live_rows: u16 = 0,
-    /// Whether `front` matches what's on screen (false forces a full paint).
-    front_valid: bool = false,
     /// Whether we've taken over the terminal (cursor hidden) yet.
     started: bool = false,
-    /// Recently emitted static blocks that may still be visible above the
-    /// live region — the reflowable tail. Bounded to about a screenful by
-    /// `evictRetained`; oldest first.
-    retained: std.ArrayList(StaticBlock) = .empty,
     /// Terminal width at the last frame/emit; a change triggers the tail
     /// repaint.
     last_width: ?u16 = null,
-    /// Where `showCursorAt` placed the real cursor within the live region
-    /// (region-relative), if anywhere. Any frame/emit/clear un-places it.
-    placed: ?CursorPos = null,
     /// Guard for idempotent deinit (finish paths may close the App early).
     deinited: bool = false,
-    /// Whether this App armed the process-global restore guard (in `init` when
-    /// it took the caller's raw mode, in `start`/`enterFullScreen` on takeover).
-    /// Gates the `deinit` disarm — armed can precede `started`, so `started`
-    /// alone would leak the guard on a construct-then-error path.
-    guard_armed: bool = false,
-    /// Session-owned raw mode, in full-screen only (the App reads input via
-    /// `nextEvent`). `null` in hybrid, where input ownership stays external.
-    raw: ?terminal.RawMode = null,
-    /// Resize watcher backing `nextEvent`, full-screen only.
-    watcher: ?terminal.ResizeWatcher = null,
     /// Reused accumulator for bracketed-paste content (full-screen, `paste`
     /// enabled). `Event.paste` borrows its bytes until the next `nextEvent`.
     paste_buf: std.ArrayList(u8) = .empty,
 
-    pub const CursorPos = struct { x: u16, y: u16 };
+    pub const CursorPos = RegionCursor.Pos;
 
     /// A hybrid App (ADR-0013): a static stream flowing into scrollback with a
     /// live region pinned above it. Shares the screen, stays in cooked mode,
@@ -210,8 +194,16 @@ pub const App = struct {
             .options = options,
             .mode = .hybrid,
             .frame_arena = std.heap.ArenaAllocator.init(gpa),
-            .front = try Surface.init(gpa, 0, 0),
-            .back = try Surface.init(gpa, 0, 0),
+            .core = try RenderCore.init(gpa),
+            .session = .{
+                .out_handle = options.out_handle orelse std.Io.File.stdout().handle,
+                .modes = .{
+                    .mouse = options.mouse,
+                    .focus = options.focus,
+                    .paste = options.paste,
+                },
+            },
+            .scrollback = HybridScrollback.init(gpa),
         };
         // Arm the restore guard the moment we hold the caller's raw mode: in
         // hybrid the caller enables raw mode *before* constructing the App (a
@@ -221,8 +213,7 @@ pub const App = struct {
         // once it hides the cursor. The blob is empty here — nothing on screen to
         // undo yet, only the termios carried in `hybrid_raw`.
         if (options.term_size == null and options.hybrid_raw != null) {
-            terminal.guard.arm(self.outHandle(), "", options.hybrid_raw);
-            self.guard_armed = true;
+            self.session.arm("", options.hybrid_raw);
         }
         return self;
     }
@@ -240,8 +231,7 @@ pub const App = struct {
         var self = try init(gpa, writer, options);
         self.mode = .full_screen;
         errdefer {
-            self.front.deinit();
-            self.back.deinit();
+            self.core.deinit();
             self.frame_arena.deinit();
         }
         try self.enterFullScreen();
@@ -294,85 +284,25 @@ pub const App = struct {
         }
     }.call);
 
-    /// Take the terminal over: enable session raw mode, switch to the
-    /// alternate-screen buffer (saving the shell's screen + scrollback), hide
-    /// the cursor, and anchor at the origin — `?1049h` clears the alt buffer
-    /// but carries the cursor position over from the main screen, so the diff
-    /// renderer's "cursor parked at the region's top-left" contract must be
-    /// established explicitly before the first paint (ADR-0015 choice 2).
+    /// Take the terminal over (ADR-0015): the session enables raw mode,
+    /// starts the resize watcher, arms the guard, and writes the takeover
+    /// bytes; then the parked-cursor invariant is established explicitly at
+    /// the origin — `?1049h` clears the alt buffer but carries the cursor
+    /// position over from the main screen (ADR-0015 choice 2).
     fn enterFullScreen(self: *App) !void {
         if (!self.options.interactive) return error.NotATerminal;
         // Restore terminal state if any step below fails — same bytes/order as
         // deinit, so a half-entered session never strands the terminal.
-        errdefer {
-            terminal.guard.disarm();
-            self.writeRestore();
-            self.writer.flush() catch {};
-            if (self.watcher) |*w| w.deinit();
-            if (self.raw) |r| r.disable();
-        }
+        errdefer self.session.abortEnter(self.writer);
+        self.started = true; // cursor hidden, terminal owned
         // A fixed `term_size` is the headless-harness path (tests): there is
         // no real terminal to put in raw mode, watch for resizes, or arm the
-        // restore guard against (tests must not grab process signals). Still
-        // emit the alt-screen takeover so the byte stream is exercised; live
-        // input (`nextEvent`) is a real-terminal-only affair.
-        if (self.options.term_size == null) {
-            self.raw = try terminal.enableRawMode(std.Io.File.stdin().handle);
-            self.watcher = terminal.ResizeWatcher.init();
-            // Register the full restore (disable input modes → show cursor →
-            // leave alt-screen → restore termios) for the signal/panic paths
-            // that skip deinit. Armed before the takeover bytes go out so a
-            // signal in the gap still restores; disabling modes / leaving an
-            // alt-screen we haven't entered yet is a harmless no-op.
-            var blob: [64]u8 = undefined;
-            terminal.guard.arm(self.outHandle(), self.restoreBlob(&blob), self.raw);
-            self.guard_armed = true;
-        }
-        self.started = true; // cursor hidden, terminal owned
-        try self.writer.writeAll("\x1b[?1049h\x1b[?25l");
-        if (self.options.mouse) try self.writer.writeAll(mouse_on);
-        if (self.options.focus) try self.writer.writeAll(focus_on);
-        if (self.options.paste) try self.writer.writeAll(paste_on);
-        try self.anchor();
+        // restore guard against (tests must not grab process signals). The
+        // alt-screen takeover bytes still go out so the stream is exercised;
+        // live input (`nextEvent`) is a real-terminal-only affair.
+        try self.session.takeover(self.writer, self.options.term_size != null);
+        try self.cursor.anchor(self.writer, self.termSize().h);
         try self.writer.flush();
-    }
-
-    /// The restore blob for the signal/panic guard: disable whichever input
-    /// modes are on, then `restore_tail` (show cursor + leave alt-screen). Same
-    /// bytes `writeRestore` emits on the normal path, packed into `buf`.
-    fn restoreBlob(self: *App, buf: []u8) []const u8 {
-        var n: usize = 0;
-        const put = struct {
-            fn f(dst: []u8, at: *usize, s: []const u8) void {
-                @memcpy(dst[at.*..][0..s.len], s);
-                at.* += s.len;
-            }
-        }.f;
-        if (self.options.mouse) put(buf, &n, mouse_off);
-        if (self.options.focus) put(buf, &n, focus_off);
-        if (self.options.paste) put(buf, &n, paste_off);
-        put(buf, &n, restore_tail);
-        return buf[0..n];
-    }
-
-    /// Emit the restore sequence to the writer (normal teardown / errdefer):
-    /// disable input modes, then show cursor and leave the alt-screen.
-    fn writeRestore(self: *App) void {
-        if (self.options.mouse) self.writer.writeAll(mouse_off) catch {};
-        if (self.options.focus) self.writer.writeAll(focus_off) catch {};
-        if (self.options.paste) self.writer.writeAll(paste_off) catch {};
-        self.writer.writeAll(restore_tail) catch {};
-    }
-
-    /// Park the cursor at the screen origin (the diff renderer's addressing
-    /// anchor in full-screen). One relative sequence — CR plus a
-    /// viewport-height CUU that clamps at the top row — so the renderer stays
-    /// CUP-free and shared byte-for-byte with the hybrid. Used on entry and
-    /// after a resize, the two moments the parked position is invalidated.
-    fn anchor(self: *App) !void {
-        const h = self.termSize().h;
-        try self.writer.writeByte('\r');
-        if (h > 0) try self.writer.print("\x1b[{d}A", .{h});
     }
 
     /// Restores the terminal (cursor shown, parked on a fresh line below the
@@ -384,19 +314,18 @@ pub const App = struct {
         // Clean teardown owns the restore from here — disarm so a racing signal
         // doesn't also replay, and to put the old signal dispositions back.
         // Idempotent: a no-op on the headless path that never armed.
-        if (self.guard_armed) terminal.guard.disarm();
+        self.session.disarm();
         if (self.mode == .full_screen) {
             // Restore in strict reverse of enter (ADR-0015 choice 5): disable
             // input modes → show cursor → leave alt-screen (restores the shell's
             // screen and scrollback; the final frame is discarded by design) →
             // disable raw mode. The alt-screen leave must precede the raw-mode
             // restore so its bytes still go out while we own the terminal.
-            if (self.started) self.writeRestore();
+            if (self.started) self.session.writeRestore(self.writer);
             self.writer.flush() catch {};
-            if (self.watcher) |*w| w.deinit();
-            if (self.raw) |r| r.disable();
+            self.session.release();
         } else if (self.started) {
-            self.unplace() catch {};
+            self.cursor.park(self.writer) catch {};
             if (self.live_rows > 1) {
                 self.writer.print("\x1b[{d}B", .{self.live_rows - 1}) catch {};
             }
@@ -406,32 +335,24 @@ pub const App = struct {
         } else {
             self.writer.flush() catch {};
         }
-        for (self.retained.items) |b| self.gpa.free(b.text);
-        self.retained.deinit(self.gpa);
+        self.scrollback.deinit();
         self.paste_buf.deinit(self.gpa);
-        self.front.deinit();
-        self.back.deinit();
+        self.core.deinit();
         self.frame_arena.deinit();
     }
 
     /// Show the real terminal cursor at (x, y) in live-region coordinates —
     /// a line editor's insertion point. Cleared by the next frame, emit, or
     /// clear (the region invariant parks the cursor at the top-left between
-    /// operations; this is the one sanctioned excursion). No-op without an
-    /// interactive live region.
+    /// operations; `RegionCursor.place` is the one sanctioned excursion).
+    /// No-op without an interactive live region.
     pub fn showCursorAt(self: *App, x: u16, y: u16) !void {
         if (!self.options.interactive or self.live_rows == 0) return;
-        try self.unplace();
-        const pos = CursorPos{
-            .x = @min(x, self.front.width -| 1),
+        try self.cursor.place(self.writer, .{
+            .x = @min(x, self.core.front.width -| 1),
             .y = @min(y, self.live_rows - 1),
-        };
-        if (pos.y > 0) try self.writer.print("\x1b[{d}B", .{pos.y});
-        try self.writer.writeByte('\r');
-        if (pos.x > 0) try self.writer.print("\x1b[{d}C", .{pos.x});
-        try self.writer.writeAll("\x1b[?25h");
+        });
         try self.writer.flush();
-        self.placed = pos;
     }
 
     /// Place the real terminal cursor at an absolute screen cell, or hide it
@@ -445,18 +366,9 @@ pub const App = struct {
         if (p) |pt| {
             try self.showCursorAt(pt.x, pt.y);
         } else {
-            try self.unplace();
+            try self.cursor.park(self.writer);
             try self.writer.flush();
         }
-    }
-
-    /// Hide the placed cursor and return to the region's top-left, restoring
-    /// the parking invariant every other operation assumes.
-    fn unplace(self: *App) !void {
-        const pos = self.placed orelse return;
-        self.placed = null;
-        try self.writer.writeAll("\x1b[?25l\r");
-        if (pos.y > 0) try self.writer.print("\x1b[{d}A", .{pos.y});
     }
 
     /// The frame arena: build each frame's node tree from this. Valid until
@@ -492,19 +404,14 @@ pub const App = struct {
         const text = try std.fmt.allocPrint(self.gpa, base ++ "\r\n", args);
         errdefer self.gpa.free(text);
 
-        try self.unplace();
+        try self.cursor.park(self.writer);
         const had_live = self.live_rows > 0;
         try self.clearLive();
         try self.writer.writeAll(text);
         if (had_live) try self.repaintLive();
         try self.writer.flush();
 
-        // Retain last: eviction may free the block we just printed.
-        try self.retained.append(self.gpa, .{
-            .text = text,
-            .rows = textRows(text, ts.w),
-        });
-        _ = self.evictRetained(ts.h -| self.live_rows);
+        try self.scrollback.retain(text, ts.w, ts.h -| self.live_rows);
     }
 
     /// Live output: measure, lay out, paint the diff. The tree (built from
@@ -514,7 +421,7 @@ pub const App = struct {
         defer _ = self.frame_arena.reset(.retain_capacity);
         if (!self.options.interactive) return;
         if (self.mode == .full_screen) return self.frameFullScreen(node);
-        try self.unplace();
+        try self.cursor.park(self.writer);
 
         const ts = self.termSize();
         const width_changed = self.last_width != null and self.last_width.? != ts.w;
@@ -543,12 +450,7 @@ pub const App = struct {
         }
 
         try self.start();
-
-        if (size.w != self.back.width or size.h != self.back.height) {
-            try self.back.resize(size.w, size.h);
-            try self.front.resize(size.w, size.h);
-            self.front_valid = false;
-        }
+        try self.core.setSize(size.w, size.h);
 
         // Resize tier 2 (ADR-0013): on a width change, the visible static
         // tail is erased and reprinted reflowed at the new width, in the
@@ -557,7 +459,15 @@ pub const App = struct {
         const tail_repaint = width_changed and self.live_rows > 0;
         if (tail_repaint) {
             if (self.options.sync) try self.writer.writeAll("\x1b[?2026h");
-            try self.repaintTail(ts, size.h);
+            try self.scrollback.reflow(
+                self.writer,
+                self.frame_arena.allocator(),
+                ts.w,
+                ts.h -| size.h,
+            );
+            self.live_rows = 0;
+            self.core.invalidate();
+            try self.reserve(size.h);
         } else if (size.h != self.live_rows) {
             // Region height changed (or first frame): re-reserve from
             // scratch. Erasing rather than incrementally growing keeps the
@@ -566,17 +476,14 @@ pub const App = struct {
             try self.reserve(size.h);
         }
 
-        self.back.clear();
-        try node_mod.render(&rctx, &node, self.back.root());
-
-        const prev: ?*const Surface = if (self.front_valid) &self.front else null;
+        // The diff renderer addresses everything relative to the park —
+        // the invariant `RegionCursor` owns, checked before every paint.
+        std.debug.assert(self.cursor.isParked());
         const renderer = diff_mod.Renderer{
             .capability = self.options.capability,
             .sync = self.options.sync and !tail_repaint,
         };
-        try renderer.paint(self.writer, prev, &self.back);
-        std.mem.swap(Surface, &self.front, &self.back);
-        self.front_valid = true;
+        try self.core.frame(self.writer, &rctx, &node, renderer);
         if (tail_repaint and self.options.sync) try self.writer.writeAll("\x1b[?2026l");
         try self.writer.flush();
     }
@@ -598,7 +505,7 @@ pub const App = struct {
         // A hardware cursor placed after the last frame (`cursorAt`) sits away
         // from the origin the diff renderer addresses relative to — return it
         // before painting, mirroring the hybrid `frame`.
-        try self.unplace();
+        try self.cursor.park(self.writer);
 
         const ts = self.termSize();
         const size = Size{ .w = ts.w, .h = ts.h };
@@ -610,31 +517,22 @@ pub const App = struct {
         const resized = self.last_width != null and
             (self.last_width.? != ts.w or self.live_rows != ts.h);
         self.last_width = ts.w;
-        if (resized) try self.anchor();
+        if (resized) try self.cursor.anchor(self.writer, ts.h);
 
         const rctx = RenderCtx{
             .allocator = self.frame_arena.allocator(),
             .unicode = self.options.unicode,
         };
 
-        if (size.w != self.back.width or size.h != self.back.height) {
-            try self.back.resize(size.w, size.h);
-            try self.front.resize(size.w, size.h);
-            self.front_valid = false;
-        }
+        try self.core.setSize(size.w, size.h);
         self.live_rows = size.h;
 
-        self.back.clear();
-        try node_mod.render(&rctx, &node, self.back.root());
-
-        const prev: ?*const Surface = if (self.front_valid) &self.front else null;
+        std.debug.assert(self.cursor.isParked());
         const renderer = diff_mod.Renderer{
             .capability = self.options.capability,
             .sync = self.options.sync,
         };
-        try renderer.paint(self.writer, prev, &self.back);
-        std.mem.swap(Surface, &self.front, &self.back);
-        self.front_valid = true;
+        try self.core.frame(self.writer, &rctx, &node, renderer);
         try self.writer.flush();
     }
 
@@ -653,7 +551,7 @@ pub const App = struct {
         const reader = self.options.stdin orelse return error.NoInput;
         // No watcher means the headless-harness path (`term_size` set): there
         // is no real terminal to read from.
-        if (self.watcher == null) return error.NoInput;
+        if (self.session.watcher == null) return error.NoInput;
         try self.writer.flush();
         // The paste sink borrows `paste_buf` (reused each call); the returned
         // `Event.paste` is valid only until the next `nextEvent`.
@@ -665,7 +563,7 @@ pub const App = struct {
         return terminal.readEventTimeout(
             reader,
             std.Io.File.stdin().handle,
-            &self.watcher.?,
+            &self.session.watcher.?,
             timeout_ms,
             sink,
         );
@@ -746,14 +644,15 @@ pub const App = struct {
     /// for a widget whose result is an `emit`ted line (or no output at
     /// all), as opposed to `deinit`'s leave-the-final-frame-visible.
     pub fn clear(self: *App) !void {
-        try self.unplace();
+        try self.cursor.park(self.writer);
         try self.clearLive();
         try self.writer.flush();
     }
 
     // ------------------------------------------------------------------
-    // Region bookkeeping. Invariant: cursor at column 0 of the region's
-    // top row (or of an empty line when live_rows == 0).
+    // Region bookkeeping. The cursor-parking invariant (column 0 of the
+    // region's top row, or of an empty line when live_rows == 0) is owned
+    // by `RegionCursor`; these keep `live_rows` in step with the screen.
     // ------------------------------------------------------------------
 
     /// Erase the live region (cursor-to-end-of-screen — the region is the
@@ -762,7 +661,7 @@ pub const App = struct {
         if (self.live_rows == 0) return;
         try self.writer.writeAll("\r\x1b[0J");
         self.live_rows = 0;
-        self.front_valid = false;
+        self.core.invalidate();
     }
 
     /// Create `rows` rows starting at the cursor's line (scrolling as
@@ -780,96 +679,14 @@ pub const App = struct {
 
     /// Re-reserve and fully repaint the last frame (after `emit` erased it).
     fn repaintLive(self: *App) !void {
-        if (self.front.width == 0 or self.front.height == 0) return;
+        if (self.core.front.width == 0 or self.core.front.height == 0) return;
         try self.start();
-        try self.reserve(self.front.height);
-        const renderer = diff_mod.Renderer{
+        try self.reserve(self.core.front.height);
+        std.debug.assert(self.cursor.isParked());
+        try self.core.repaint(self.writer, .{
             .capability = self.options.capability,
             .sync = self.options.sync,
-        };
-        try renderer.paint(self.writer, null, &self.front);
-        self.front_valid = true;
-    }
-
-    /// The width-resize repaint (ADR-0013 resize tier 2). The cursor sits at
-    /// the live region's top; the retained tail sits directly above it. Move
-    /// up over the tail's footprint (bottom-anchored, relative — CUU clamps
-    /// at the viewport top exactly when the tail extends into scrollback),
-    /// erase from there down, reprint the tail so the terminal rewraps it at
-    /// the new width, and re-reserve the live region below.
-    ///
-    /// The erase covers the LARGER of the kept blocks' old footprint and
-    /// their new one: a tail that unwraps (width grew) must not leave its
-    /// old extra rows stale above the reprint. Content above that is never
-    /// touched; deeper scrollback keeps its old wrap width — that seam is
-    /// immutable by terminal authority.
-    fn repaintTail(self: *App, ts: Size, live_h: u16) !void {
-        // Old footprints, index-aligned with `retained` (frame arena — this
-        // runs inside frame(), which resets it on return).
-        const olds = try self.frame_arena.allocator().alloc(u16, self.retained.items.len);
-        for (self.retained.items, olds) |*b, *old| {
-            old.* = b.rows;
-            b.rows = textRows(b.text, ts.w);
-        }
-        const dropped = self.evictRetained(ts.h -| live_h);
-
-        var old_tail: u32 = 0;
-        for (olds[dropped..]) |r| old_tail += r;
-        var new_tail: u32 = 0;
-        for (self.retained.items) |b| new_tail += b.rows;
-
-        try self.writer.writeByte('\r');
-        const up = @max(old_tail, new_tail);
-        if (up > 0) try self.writer.print("\x1b[{d}A", .{up});
-        try self.writer.writeAll("\x1b[0J");
-        for (self.retained.items) |b| try self.writer.writeAll(b.text);
-        self.live_rows = 0;
-        self.front_valid = false;
-        try self.reserve(live_h);
-    }
-
-    /// Drop retained blocks (oldest first) whose rows no longer fit in
-    /// `budget` (the viewport rows above the live region) — they have
-    /// scrolled beyond the viewport, where nothing can repaint them anyway.
-    /// Returns how many were dropped.
-    fn evictRetained(self: *App, budget: u32) usize {
-        var total: u32 = 0;
-        var keep_from = self.retained.items.len;
-        var i = self.retained.items.len;
-        while (i > 0) {
-            i -= 1;
-            const rows = self.retained.items[i].rows;
-            if (total + rows > budget) break;
-            total += rows;
-            keep_from = i;
-        }
-        if (keep_from == 0) return 0;
-        for (self.retained.items[0..keep_from]) |b| self.gpa.free(b.text);
-        const kept = self.retained.items.len - keep_from;
-        std.mem.copyForwards(
-            StaticBlock,
-            self.retained.items[0..kept],
-            self.retained.items[keep_from..],
-        );
-        self.retained.shrinkRetainingCapacity(kept);
-        return keep_from;
-    }
-
-    /// Rows `text` occupies at `width` — the terminal's own soft-wrapping
-    /// (hard character wrap at the last column), NOT `terminal.wrap`'s word
-    /// wrap: emit prints raw text and the terminal breaks the lines, so the
-    /// bookkeeping must count the way the terminal counts. (Tabs would
-    /// desync this — emit output is expected tab-free.)
-    fn textRows(text: []const u8, width: u16) u16 {
-        const w: u32 = @max(width, 1);
-        const body = std.mem.trimEnd(u8, text, "\r\n");
-        var rows: u32 = 0;
-        var it = std.mem.splitScalar(u8, body, '\n');
-        while (it.next()) |line| {
-            const cols: u32 = @intCast(terminal.displayWidth(line));
-            rows += @max(1, (cols + w - 1) / w);
-        }
-        return @intCast(@min(rows, std.math.maxInt(u16)));
+        });
     }
 
     /// Hybrid takeover: hide the cursor (the only *display* state hybrid owns).
@@ -885,8 +702,7 @@ pub const App = struct {
         self.started = true;
         try self.writer.writeAll("\x1b[?25l");
         if (self.options.term_size == null) {
-            terminal.guard.arm(self.outHandle(), "\x1b[?25h", self.options.hybrid_raw);
-            self.guard_armed = true;
+            self.session.arm("\x1b[?25h", self.options.hybrid_raw);
         }
     }
 
@@ -899,9 +715,10 @@ pub const App = struct {
 
     /// The handle output escapes actually reach — `options.out_handle` when the
     /// caller's writer targets something other than stdout (e.g. progress on
-    /// stderr), stdout otherwise.
+    /// stderr), stdout otherwise. Owned by the session (it arms the guard
+    /// against it); exposed for the size poll above and tests.
     fn outHandle(self: *const App) std.Io.File.Handle {
-        return self.options.out_handle orelse std.Io.File.stdout().handle;
+        return self.session.out_handle;
     }
 };
 

--- a/packages/ui/src/app_test.zig
+++ b/packages/ui/src/app_test.zig
@@ -263,7 +263,7 @@ test "retention stays bounded at about a screenful" {
     }
     // Live region is 1 row on a 6-row terminal: at most 5 one-row blocks
     // can still be visible above it.
-    try testing.expect(h.app.retained.items.len <= 5);
+    try testing.expect(h.app.scrollback.len() <= 5);
     // (Leaks in evicted blocks would trip std.testing.allocator on deinit.)
 }
 

--- a/packages/ui/src/diff.zig
+++ b/packages/ui/src/diff.zig
@@ -5,8 +5,9 @@
 //! entry and is returned there on exit. All vertical movement is relative
 //! (CUD/CUU) and columns are addressed with CR + CUF, never absolute CUP —
 //! the live region floats in normal-screen scrollback, where absolute rows
-//! are meaningless. The caller (the App loop) owns creating the region's
-//! rows and parking the cursor; this renderer never scrolls.
+//! are meaningless. The App loop owns creating the region's rows; the parked
+//! cursor is owned and enforced by `RegionCursor` (region_cursor.zig) — the
+//! App asserts `isParked()` before every paint. This renderer never scrolls.
 
 const std = @import("std");
 const theme = @import("theme");

--- a/packages/ui/src/hybrid_scrollback.zig
+++ b/packages/ui/src/hybrid_scrollback.zig
@@ -1,0 +1,251 @@
+//! HybridScrollback: the retained static tail and its width-resize reflow
+//! (ADR-0013 resize tier 2), extracted from the App loop so the
+//! highest-complexity unit in the package is independently testable.
+//!
+//! In the hybrid mode, `emit` prints static text above the live region and it
+//! flows into scrollback. The blocks that may still be VISIBLE above the
+//! region are retained here in SOURCE form — the text, not rendered cells —
+//! so a terminal width change can erase and reprint them, letting the
+//! terminal rewrap the tail at the new width. Deeper scrollback keeps its old
+//! wrap width; that seam is immutable by terminal authority. Retention is
+//! bounded to about a screenful by eviction (nothing beyond the viewport can
+//! be repainted anyway).
+//!
+//! Cursor contract (owned by `RegionCursor` in the App loop): `reflow` must
+//! be entered with the cursor parked at column 0 of the live region's top
+//! row, and it leaves the cursor at column 0 on the row where the live
+//! region should be re-reserved, directly below the reprinted tail.
+
+const std = @import("std");
+const terminal = @import("terminal");
+
+pub const HybridScrollback = struct {
+    /// A static block kept for the resize tail repaint: the source text, plus
+    /// the rows it occupies at the width it was last printed at (terminal
+    /// character-wrapping, not word-wrapping).
+    const Block = struct {
+        text: []u8,
+        rows: u16,
+    };
+
+    gpa: std.mem.Allocator,
+    /// Recently emitted blocks that may still be visible above the live
+    /// region — the reflowable tail. Oldest first.
+    blocks: std.ArrayList(Block) = .empty,
+
+    pub fn init(gpa: std.mem.Allocator) HybridScrollback {
+        return .{ .gpa = gpa };
+    }
+
+    pub fn deinit(self: *HybridScrollback) void {
+        for (self.blocks.items) |b| self.gpa.free(b.text);
+        self.blocks.deinit(self.gpa);
+    }
+
+    /// How many blocks are currently retained.
+    pub fn len(self: *const HybridScrollback) usize {
+        return self.blocks.items.len;
+    }
+
+    /// Retain `text` (just printed at `width`), taking ownership, then evict
+    /// whatever no longer fits `budget` (the viewport rows above the live
+    /// region). Retain-then-evict, in that order: eviction may free the very
+    /// block being added. On error, ownership of `text` stays with the caller.
+    pub fn retain(self: *HybridScrollback, text: []u8, width: u16, budget: u32) !void {
+        try self.blocks.append(self.gpa, .{
+            .text = text,
+            .rows = textRows(text, width),
+        });
+        _ = self.evict(budget);
+    }
+
+    /// The width-resize repaint (ADR-0013 resize tier 2). The cursor sits at
+    /// the live region's top; the retained tail sits directly above it. Move
+    /// up over the tail's footprint (bottom-anchored, relative — CUU clamps
+    /// at the viewport top exactly when the tail extends into scrollback),
+    /// erase from there down, and reprint the tail so the terminal rewraps it
+    /// at `new_width`. The caller re-reserves the live region below.
+    ///
+    /// The erase covers the LARGER of the kept blocks' old footprint and
+    /// their new one: a tail that unwraps (width grew) must not leave its
+    /// old extra rows stale above the reprint. Content above that is never
+    /// touched. `scratch` is per-call working memory (the frame arena).
+    pub fn reflow(
+        self: *HybridScrollback,
+        writer: *std.Io.Writer,
+        scratch: std.mem.Allocator,
+        new_width: u16,
+        budget: u32,
+    ) !void {
+        // Old footprints, index-aligned with `blocks`.
+        const olds = try scratch.alloc(u16, self.blocks.items.len);
+        for (self.blocks.items, olds) |*b, *old| {
+            old.* = b.rows;
+            b.rows = textRows(b.text, new_width);
+        }
+        const dropped = self.evict(budget);
+
+        var old_tail: u32 = 0;
+        for (olds[dropped..]) |r| old_tail += r;
+        var new_tail: u32 = 0;
+        for (self.blocks.items) |b| new_tail += b.rows;
+
+        try writer.writeByte('\r');
+        const up = @max(old_tail, new_tail);
+        if (up > 0) try writer.print("\x1b[{d}A", .{up});
+        try writer.writeAll("\x1b[0J");
+        for (self.blocks.items) |b| try writer.writeAll(b.text);
+    }
+
+    /// Drop blocks (oldest first) whose rows no longer fit in `budget` (the
+    /// viewport rows above the live region) — they have scrolled beyond the
+    /// viewport, where nothing can repaint them anyway. Returns how many were
+    /// dropped.
+    fn evict(self: *HybridScrollback, budget: u32) usize {
+        var total: u32 = 0;
+        var keep_from = self.blocks.items.len;
+        var i = self.blocks.items.len;
+        while (i > 0) {
+            i -= 1;
+            const rows = self.blocks.items[i].rows;
+            if (total + rows > budget) break;
+            total += rows;
+            keep_from = i;
+        }
+        if (keep_from == 0) return 0;
+        for (self.blocks.items[0..keep_from]) |b| self.gpa.free(b.text);
+        const kept = self.blocks.items.len - keep_from;
+        std.mem.copyForwards(
+            Block,
+            self.blocks.items[0..kept],
+            self.blocks.items[keep_from..],
+        );
+        self.blocks.shrinkRetainingCapacity(kept);
+        return keep_from;
+    }
+
+    /// Rows `text` occupies at `width` — the terminal's own soft-wrapping
+    /// (hard character wrap at the last column), NOT `terminal.wrap`'s word
+    /// wrap: emit prints raw text and the terminal breaks the lines, so the
+    /// bookkeeping must count the way the terminal counts. (Tabs would
+    /// desync this — emit output is expected tab-free.)
+    pub fn textRows(text: []const u8, width: u16) u16 {
+        const w: u32 = @max(width, 1);
+        const body = std.mem.trimEnd(u8, text, "\r\n");
+        var rows: u32 = 0;
+        var it = std.mem.splitScalar(u8, body, '\n');
+        while (it.next()) |line| {
+            const cols: u32 = @intCast(terminal.displayWidth(line));
+            rows += @max(1, (cols + w - 1) / w);
+        }
+        return @intCast(@min(rows, std.math.maxInt(u16)));
+    }
+};
+
+// ============================================================================
+// Byte-level tests. Terminal-behavior tests (does the reprint actually rewrap
+// on a real screen model?) live in scrollback_test.zig against a vterm.
+// ============================================================================
+
+const testing = std.testing;
+
+fn retainDupe(sb: *HybridScrollback, text: []const u8, width: u16, budget: u32) !void {
+    const owned = try testing.allocator.dupe(u8, text);
+    errdefer testing.allocator.free(owned);
+    try sb.retain(owned, width, budget);
+}
+
+test "textRows counts terminal hard-wrapping" {
+    try testing.expectEqual(@as(u16, 1), HybridScrollback.textRows("hello\r\n", 20));
+    try testing.expectEqual(@as(u16, 2), HybridScrollback.textRows("exactly twenty col!!x\r\n", 20));
+    // A width-20 line at width 20 is one row, not a phantom second.
+    try testing.expectEqual(@as(u16, 1), HybridScrollback.textRows("exactly twenty cols!\r\n", 20));
+    // Multi-line blocks count each line's wrap independently.
+    try testing.expectEqual(@as(u16, 3), HybridScrollback.textRows("a\nb\nc\r\n", 20));
+    // An empty line still occupies a row.
+    try testing.expectEqual(@as(u16, 1), HybridScrollback.textRows("\r\n", 20));
+}
+
+test "retention stays bounded by the budget, evicting oldest first" {
+    var sb = HybridScrollback.init(testing.allocator);
+    defer sb.deinit();
+
+    var i: u32 = 0;
+    while (i < 12) : (i += 1) {
+        var buf: [16]u8 = undefined;
+        const line = try std.fmt.bufPrint(&buf, "line {d}\r\n", .{i});
+        try retainDupe(&sb, line, 30, 5);
+    }
+    // One-row blocks against a 5-row budget: at most 5 survive, the newest.
+    try testing.expect(sb.len() <= 5);
+    const last = sb.blocks.items[sb.len() - 1];
+    try testing.expect(std.mem.startsWith(u8, last.text, "line 11"));
+}
+
+test "a block taller than the budget is evicted outright" {
+    var sb = HybridScrollback.init(testing.allocator);
+    defer sb.deinit();
+    // 3 rows at width 10 against a budget of 2.
+    try retainDupe(&sb, "aaaaaaaaaabbbbbbbbbbcc\r\n", 10, 2);
+    try testing.expectEqual(@as(usize, 0), sb.len());
+}
+
+test "reflow erases the larger of old and new footprints" {
+    var sb = HybridScrollback.init(testing.allocator);
+    defer sb.deinit();
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    // 34 cols: 2 rows at width 20.
+    const line = "static: the quick brown fox jumps!\r\n";
+    try retainDupe(&sb, line, 20, 9);
+
+    // Width grows to 40: old footprint 2 rows, new 1 — the erase must cover
+    // the old 2, or the unwrapped reprint leaves a stale duplicate row.
+    var aw = std.Io.Writer.Allocating.init(testing.allocator);
+    defer aw.deinit();
+    try sb.reflow(&aw.writer, arena.allocator(), 40, 9);
+    try testing.expectEqualStrings("\r\x1b[2A\x1b[0J" ++ line, aw.written());
+    try testing.expectEqual(@as(u16, 1), sb.blocks.items[0].rows);
+
+    // Width shrinks back to 20: footprint 1 → 2, so up = max(1, 2) = 2 —
+    // the CUU clamps at the viewport top when it overshoots the screen's
+    // actual 1-row tail, which is exactly the bottom-anchored design.
+    aw.clearRetainingCapacity();
+    try sb.reflow(&aw.writer, arena.allocator(), 20, 9);
+    try testing.expectEqualStrings("\r\x1b[2A\x1b[0J" ++ line, aw.written());
+    try testing.expectEqual(@as(u16, 2), sb.blocks.items[0].rows);
+}
+
+test "reflow drops blocks that no longer fit and does not reprint them" {
+    var sb = HybridScrollback.init(testing.allocator);
+    defer sb.deinit();
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    try retainDupe(&sb, "old old old\r\n", 40, 9);
+    try retainDupe(&sb, "keep me\r\n", 40, 9);
+
+    // Budget collapses to 1 row: only the newest block survives the reflow,
+    // and the up-move counts only the KEPT blocks' old footprint (the
+    // dropped block has scrolled beyond the viewport).
+    var aw = std.Io.Writer.Allocating.init(testing.allocator);
+    defer aw.deinit();
+    try sb.reflow(&aw.writer, arena.allocator(), 40, 1);
+    try testing.expectEqual(@as(usize, 1), sb.len());
+    try testing.expectEqualStrings("\r\x1b[1A\x1b[0J" ++ "keep me\r\n", aw.written());
+}
+
+test "reflow with nothing retained erases nothing above the region" {
+    var sb = HybridScrollback.init(testing.allocator);
+    defer sb.deinit();
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    var aw = std.Io.Writer.Allocating.init(testing.allocator);
+    defer aw.deinit();
+    try sb.reflow(&aw.writer, arena.allocator(), 40, 9);
+    // No up-move (nothing to reflow over), just the clear-below for the
+    // region the caller is about to re-reserve.
+    try testing.expectEqualStrings("\r\x1b[0J", aw.written());
+}

--- a/packages/ui/src/region_cursor.zig
+++ b/packages/ui/src/region_cursor.zig
@@ -1,0 +1,147 @@
+//! RegionCursor: the owner of the diff renderer's addressing invariant.
+//!
+//! The invariant (ADR-0013): between operations, the real terminal cursor is
+//! PARKED at column 0 of the live region's top row. `diff.zig` addresses
+//! every paint relative to that cell — relative moves only, no absolute CUP,
+//! because the region floats in normal-screen scrollback where absolute rows
+//! are meaningless. Every paint, emit, and clear assumes the park; a cursor
+//! left anywhere else corrupts the next paint's addressing.
+//!
+//! This type is where the invariant lives in code rather than prose:
+//!
+//! - `place` is the one sanctioned excursion — show the hardware cursor at a
+//!   region-relative cell (a line editor's insertion point, a focused
+//!   field's caret, ADR-0019). It records the excursion so it can be undone.
+//! - `park` reverses the excursion: hide the cursor and return it to the
+//!   region's top-left. Idempotent — parking a parked cursor writes nothing.
+//! - `isParked` is the checkable form: anything about to hand bytes to the
+//!   diff renderer asserts it (see `App.frame`).
+//! - `anchor` re-establishes the park at the screen origin from an unknown
+//!   cursor position — full-screen entry and resize, the two moments the
+//!   terminal itself invalidates the parked position (ADR-0015 choice 2).
+//!
+//! The cursor-hide/show escapes emitted here are the region-excursion pair
+//! only; session-level cursor ownership (hide on takeover, show on restore)
+//! stays with `App`/`TerminalSession`.
+
+const std = @import("std");
+
+pub const RegionCursor = struct {
+    pub const Pos = struct { x: u16, y: u16 };
+
+    /// Where the cursor currently sits within the live region
+    /// (region-relative), if it is away from the park. `null` == parked.
+    placed: ?Pos = null,
+
+    /// Whether the invariant holds right now — the assertable form.
+    pub fn isParked(self: *const RegionCursor) bool {
+        return self.placed == null;
+    }
+
+    /// The sanctioned excursion: show the real cursor at `pos`
+    /// (region-relative). Re-parks any previous excursion first, so the
+    /// relative moves always start from the region's top-left. The caller
+    /// clamps `pos` to the region — this type tracks position, not geometry.
+    pub fn place(self: *RegionCursor, writer: *std.Io.Writer, pos: Pos) !void {
+        try self.park(writer);
+        if (pos.y > 0) try writer.print("\x1b[{d}B", .{pos.y});
+        try writer.writeByte('\r');
+        if (pos.x > 0) try writer.print("\x1b[{d}C", .{pos.x});
+        try writer.writeAll("\x1b[?25h");
+        self.placed = pos;
+    }
+
+    /// Restore the invariant: hide the placed cursor and return it to the
+    /// region's top-left. Idempotent — a parked cursor writes zero bytes.
+    pub fn park(self: *RegionCursor, writer: *std.Io.Writer) !void {
+        const pos = self.placed orelse return;
+        self.placed = null;
+        try writer.writeAll("\x1b[?25l\r");
+        if (pos.y > 0) try writer.print("\x1b[{d}A", .{pos.y});
+    }
+
+    /// Establish the park at the screen origin from an unknown cursor
+    /// position: CR plus a viewport-height CUU that clamps at the top row.
+    /// One relative sequence, so the diff renderer stays CUP-free. Used on
+    /// full-screen entry and after a resize — must not be called with an
+    /// outstanding excursion (`park` first; asserted).
+    pub fn anchor(self: *const RegionCursor, writer: *std.Io.Writer, viewport_h: u16) !void {
+        std.debug.assert(self.isParked());
+        try writer.writeByte('\r');
+        if (viewport_h > 0) try writer.print("\x1b[{d}A", .{viewport_h});
+    }
+};
+
+// ============================================================================
+// Tests: the invariant, enforced at the byte level.
+// ============================================================================
+
+const testing = std.testing;
+
+test "place moves down/right from the park and shows the cursor" {
+    var aw = std.Io.Writer.Allocating.init(testing.allocator);
+    defer aw.deinit();
+    var cur = RegionCursor{};
+
+    try cur.place(&aw.writer, .{ .x = 5, .y = 2 });
+    try testing.expectEqualStrings("\x1b[2B\r\x1b[5C\x1b[?25h", aw.written());
+    try testing.expect(!cur.isParked());
+}
+
+test "park reverses the excursion exactly and is idempotent" {
+    var aw = std.Io.Writer.Allocating.init(testing.allocator);
+    defer aw.deinit();
+    var cur = RegionCursor{};
+
+    try cur.place(&aw.writer, .{ .x = 5, .y = 2 });
+    aw.clearRetainingCapacity();
+
+    try cur.park(&aw.writer);
+    // Hide, CR, and undo the vertical move — back at the region's top-left.
+    try testing.expectEqualStrings("\x1b[?25l\r\x1b[2A", aw.written());
+    try testing.expect(cur.isParked());
+
+    // Parking a parked cursor writes nothing (the invariant already holds).
+    aw.clearRetainingCapacity();
+    try cur.park(&aw.writer);
+    try testing.expectEqual(@as(usize, 0), aw.written().len);
+}
+
+test "place while placed re-parks first so moves stay region-relative" {
+    var aw = std.Io.Writer.Allocating.init(testing.allocator);
+    defer aw.deinit();
+    var cur = RegionCursor{};
+
+    try cur.place(&aw.writer, .{ .x = 3, .y = 1 });
+    aw.clearRetainingCapacity();
+    try cur.place(&aw.writer, .{ .x = 0, .y = 2 });
+    // The second place starts by undoing the first (hide + up 1), then moves
+    // from the park — never a diagonal from the old excursion.
+    try testing.expectEqualStrings("\x1b[?25l\r\x1b[1A\x1b[2B\r\x1b[?25h", aw.written());
+    try testing.expectEqual(RegionCursor.Pos{ .x = 0, .y = 2 }, cur.placed.?);
+}
+
+test "row-0 place and park emit no vertical moves" {
+    var aw = std.Io.Writer.Allocating.init(testing.allocator);
+    defer aw.deinit();
+    var cur = RegionCursor{};
+
+    try cur.place(&aw.writer, .{ .x = 4, .y = 0 });
+    try testing.expectEqualStrings("\r\x1b[4C\x1b[?25h", aw.written());
+    aw.clearRetainingCapacity();
+    try cur.park(&aw.writer);
+    try testing.expectEqualStrings("\x1b[?25l\r", aw.written());
+}
+
+test "anchor emits CR + clamping CUU for the viewport height" {
+    var aw = std.Io.Writer.Allocating.init(testing.allocator);
+    defer aw.deinit();
+    var cur = RegionCursor{};
+
+    try cur.anchor(&aw.writer, 24);
+    try testing.expectEqualStrings("\r\x1b[24A", aw.written());
+
+    aw.clearRetainingCapacity();
+    try cur.anchor(&aw.writer, 0);
+    try testing.expectEqualStrings("\r", aw.written());
+}

--- a/packages/ui/src/render_core.zig
+++ b/packages/ui/src/render_core.zig
@@ -1,0 +1,149 @@
+//! RenderCore: the pure render pipeline state — the double-buffered surfaces
+//! a frame renders into and diffs against (ADR-0013). No terminal state, no
+//! cursor, no scrollback: given a laid-out node and a writer, it paints the
+//! minimal byte stream and swaps the buffers. Everything here is exercised
+//! headlessly; the terminal-owning pieces live in `TerminalSession` and the
+//! orchestration in `App`.
+//!
+//! Byte-stream contract: `frame` and `repaint` hand the writer to
+//! `diff.Renderer`, whose addressing assumes the cursor is parked at column 0
+//! of the region's top row — `RegionCursor` owns that invariant; `App`
+//! asserts it before calling in.
+
+const std = @import("std");
+const surface_mod = @import("surface.zig");
+const node_mod = @import("node.zig");
+const diff_mod = @import("diff.zig");
+
+const Surface = surface_mod.Surface;
+const Node = node_mod.Node;
+const RenderCtx = node_mod.RenderCtx;
+
+pub const RenderCore = struct {
+    /// What the terminal currently shows (diff source).
+    front: Surface,
+    /// The paint target.
+    back: Surface,
+    /// Whether `front` matches what's on screen (false forces a full paint).
+    front_valid: bool = false,
+
+    pub fn init(gpa: std.mem.Allocator) !RenderCore {
+        var front = try Surface.init(gpa, 0, 0);
+        errdefer front.deinit();
+        return .{
+            .front = front,
+            .back = try Surface.init(gpa, 0, 0),
+        };
+    }
+
+    pub fn deinit(self: *RenderCore) void {
+        self.front.deinit();
+        self.back.deinit();
+    }
+
+    /// The screen no longer matches `front` (the region was erased or
+    /// scrolled): the next `frame` must paint from scratch.
+    pub fn invalidate(self: *RenderCore) void {
+        self.front_valid = false;
+    }
+
+    /// Resize both buffers to the frame's size. A size change invalidates —
+    /// the diff renderer treats mismatched surfaces as a full repaint anyway,
+    /// and the region rows on screen are re-reserved by the caller.
+    pub fn setSize(self: *RenderCore, w: u16, h: u16) !void {
+        if (w == self.back.width and h == self.back.height) return;
+        try self.back.resize(w, h);
+        try self.front.resize(w, h);
+        self.front_valid = false;
+    }
+
+    /// Render `node` into the back buffer, paint the diff against the front,
+    /// and swap. Emits zero bytes for an unchanged frame.
+    pub fn frame(
+        self: *RenderCore,
+        writer: *std.Io.Writer,
+        rctx: *const RenderCtx,
+        node: *const Node,
+        renderer: diff_mod.Renderer,
+    ) !void {
+        self.back.clear();
+        try node_mod.render(rctx, node, self.back.root());
+        const prev: ?*const Surface = if (self.front_valid) &self.front else null;
+        try renderer.paint(writer, prev, &self.back);
+        std.mem.swap(Surface, &self.front, &self.back);
+        self.front_valid = true;
+    }
+
+    /// Fully repaint the last frame (`front`) assuming nothing about the
+    /// screen — after `emit` erased the region out from under it.
+    pub fn repaint(self: *RenderCore, writer: *std.Io.Writer, renderer: diff_mod.Renderer) !void {
+        try renderer.paint(writer, null, &self.front);
+        self.front_valid = true;
+    }
+};
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+const testing = std.testing;
+const theme = @import("theme");
+
+fn textNode(content: []const u8) Node {
+    return .{ .kind = .{ .text = .{ .content = content, .style = .{} } } };
+}
+
+test "second frame diffs against the first; unchanged frame emits zero bytes" {
+    var core = try RenderCore.init(testing.allocator);
+    defer core.deinit();
+    try core.setSize(10, 1);
+
+    var aw = std.Io.Writer.Allocating.init(testing.allocator);
+    defer aw.deinit();
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const rctx = RenderCtx{ .allocator = arena.allocator(), .unicode = true };
+    const renderer = diff_mod.Renderer{ .capability = .ansi_16, .sync = false };
+
+    const n = textNode("hello");
+    try core.frame(&aw.writer, &rctx, &n, renderer);
+    const first_len = aw.written().len;
+    try testing.expect(first_len > 0);
+
+    // Identical frame: the diff finds nothing to paint.
+    try core.frame(&aw.writer, &rctx, &n, renderer);
+    try testing.expectEqual(first_len, aw.written().len);
+}
+
+test "invalidate forces the next frame to repaint in full" {
+    var core = try RenderCore.init(testing.allocator);
+    defer core.deinit();
+    try core.setSize(10, 1);
+
+    var aw = std.Io.Writer.Allocating.init(testing.allocator);
+    defer aw.deinit();
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const rctx = RenderCtx{ .allocator = arena.allocator(), .unicode = true };
+    const renderer = diff_mod.Renderer{ .capability = .ansi_16, .sync = false };
+
+    const n = textNode("hello");
+    try core.frame(&aw.writer, &rctx, &n, renderer);
+    aw.clearRetainingCapacity();
+
+    core.invalidate();
+    try core.frame(&aw.writer, &rctx, &n, renderer);
+    // Not the zero-byte unchanged-diff path: the full row was repainted.
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "hello") != null);
+}
+
+test "setSize to the same size preserves the diff source" {
+    var core = try RenderCore.init(testing.allocator);
+    defer core.deinit();
+    try core.setSize(10, 1);
+    core.front_valid = true;
+    try core.setSize(10, 1);
+    try testing.expect(core.front_valid);
+    try core.setSize(12, 1);
+    try testing.expect(!core.front_valid);
+}

--- a/packages/ui/src/scrollback_test.zig
+++ b/packages/ui/src/scrollback_test.zig
@@ -1,0 +1,160 @@
+//! HybridScrollback against a vterm, standalone — no App in the loop. These
+//! prove the reflow component honors its cursor contract on a real screen
+//! model: entered with the cursor at column 0 of the live region's top row
+//! (here: the line just below the tail), it leaves the screen rewrapped at
+//! the new width and the cursor at column 0 of the row where the region
+//! would be re-reserved. vterm is a NON-reflowing terminal (resize
+//! truncates/pads rows), so every correct rewrap is the component's doing.
+
+const std = @import("std");
+const vterm = @import("vterm");
+const scrollback_mod = @import("hybrid_scrollback.zig");
+
+const testing = std.testing;
+const VTerm = vterm.VTerm;
+const HybridScrollback = scrollback_mod.HybridScrollback;
+
+const Harness = struct {
+    aw: std.Io.Writer.Allocating,
+    vt: VTerm,
+    sb: HybridScrollback,
+    arena: std.heap.ArenaAllocator,
+    fed: usize = 0,
+
+    fn init(w: u16, h: u16) !Harness {
+        return .{
+            .aw = std.Io.Writer.Allocating.init(testing.allocator),
+            .vt = try VTerm.init(testing.allocator, w, h),
+            .sb = HybridScrollback.init(testing.allocator),
+            .arena = std.heap.ArenaAllocator.init(testing.allocator),
+        };
+    }
+
+    fn deinit(self: *Harness) void {
+        self.arena.deinit();
+        self.sb.deinit();
+        self.vt.deinit();
+        self.aw.deinit();
+    }
+
+    /// Feed everything newly written into the terminal.
+    fn replay(self: *Harness) void {
+        self.vt.write(self.aw.written()[self.fed..]);
+        self.fed = self.aw.written().len;
+    }
+
+    /// What `emit` does with a static block: print it (the cursor advances
+    /// past it, landing at column 0 of the would-be region's top row) and
+    /// retain the source for later reflow.
+    fn emitBlock(self: *Harness, text: []const u8, width: u16, budget: u32) !void {
+        try self.aw.writer.writeAll(text);
+        const owned = try testing.allocator.dupe(u8, text);
+        errdefer testing.allocator.free(owned);
+        try self.sb.retain(owned, width, budget);
+        self.replay();
+    }
+
+    fn reflow(self: *Harness, new_width: u16, budget: u32) !void {
+        try self.sb.reflow(&self.aw.writer, self.arena.allocator(), new_width, budget);
+        self.replay();
+    }
+
+    fn expectLine(self: *Harness, row: u16, prefix: []const u8) !void {
+        const line = try self.vt.getLine(testing.allocator, row);
+        defer testing.allocator.free(line);
+        try testing.expect(std.mem.startsWith(u8, line, prefix));
+    }
+
+    fn expectBlank(self: *Harness, row: u16) !void {
+        const line = try self.vt.getLine(testing.allocator, row);
+        defer testing.allocator.free(line);
+        try testing.expectEqual(@as(usize, 0), std.mem.trim(u8, line, " ").len);
+    }
+};
+
+test "reflow rewraps the tail on a width shrink and parks below it" {
+    var h = try Harness.init(40, 10);
+    defer h.deinit();
+
+    // 34 cols: one row at width 40.
+    try h.emitBlock("static: the quick brown fox jumps!\r\n", 40, 9);
+    try testing.expect(h.vt.cursorAt(0, 1));
+
+    // The terminal narrows; vterm truncates the row (no self-reflow).
+    try h.vt.resize(20, 10);
+    try h.reflow(20, 9);
+
+    // The component erased and reprinted the tail; the terminal rewrapped it
+    // onto rows 0-1, and the cursor sits where the live region would be
+    // re-reserved: column 0 of row 2.
+    try h.expectLine(0, "static: the quick br");
+    try h.expectLine(1, "own fox jumps!");
+    try testing.expect(h.vt.cursorAt(0, 2));
+}
+
+test "reflow unwraps the tail on a width grow without stale rows" {
+    var h = try Harness.init(20, 10);
+    defer h.deinit();
+
+    // 34 cols: two rows at width 20.
+    try h.emitBlock("static: the quick brown fox jumps!\r\n", 20, 9);
+    try testing.expect(h.vt.cursorAt(0, 2));
+
+    try h.vt.resize(40, 10);
+    try h.reflow(40, 9);
+
+    // The whole line fits row 0 again; the old second row must not survive
+    // as a stale duplicate, and the park moves up with the shrunken tail.
+    try h.expectLine(0, "static: the quick brown fox jumps!");
+    try h.expectBlank(1);
+    try testing.expect(h.vt.cursorAt(0, 1));
+}
+
+test "multi-block tail survives a shrink-then-grow round trip" {
+    var h = try Harness.init(40, 12);
+    defer h.deinit();
+
+    try h.emitBlock("first: alpha beta gamma delta epsilon\r\n", 40, 11); // 37 cols
+    try h.emitBlock("second: one two three\r\n", 40, 11); // 21 cols
+    try testing.expect(h.vt.cursorAt(0, 2));
+
+    // Shrink: both blocks rewrap (37→2 rows, 21→2 rows at width 20).
+    try h.vt.resize(20, 12);
+    try h.reflow(20, 11);
+    try h.expectLine(0, "first: alpha beta ga");
+    try h.expectLine(1, "mma delta epsilon");
+    try h.expectLine(2, "second: one two thre");
+    try h.expectLine(3, "e");
+    try testing.expect(h.vt.cursorAt(0, 4));
+
+    // Grow back: both unwrap to one row each, nothing stale below.
+    try h.vt.resize(40, 12);
+    try h.reflow(40, 11);
+    try h.expectLine(0, "first: alpha beta gamma delta epsilon");
+    try h.expectLine(1, "second: one two three");
+    try h.expectBlank(2);
+    try testing.expect(h.vt.cursorAt(0, 2));
+}
+
+test "reflow reprints only what the budget keeps" {
+    var h = try Harness.init(40, 6);
+    defer h.deinit();
+
+    // Five one-row blocks against a 5-row budget (6-row terminal, 1-row
+    // region): all retained.
+    var i: u32 = 0;
+    while (i < 5) : (i += 1) {
+        var buf: [24]u8 = undefined;
+        const line = try std.fmt.bufPrint(&buf, "log line {d}\r\n", .{i});
+        try h.emitBlock(line, 40, 5);
+    }
+    try testing.expectEqual(@as(usize, 5), h.sb.len());
+
+    // Width shrink with a live region now 3 rows tall: budget drops to 3, so
+    // only the newest 3 blocks stay reflowable.
+    try h.vt.resize(30, 6);
+    try h.reflow(30, 3);
+    try testing.expectEqual(@as(usize, 3), h.sb.len());
+    try testing.expect(h.vt.containsText("log line 4"));
+    try testing.expect(h.vt.containsText("log line 2"));
+}

--- a/packages/ui/src/terminal_session.zig
+++ b/packages/ui/src/terminal_session.zig
@@ -1,0 +1,137 @@
+//! TerminalSession: the process-global terminal state an App takes over —
+//! raw mode, the resize watcher, the signal/panic restore guard, and the
+//! full-screen enter/restore byte protocol (ADR-0015).
+//!
+//! This is the honestly-untestable part of the App, isolated: enabling raw
+//! mode, watching SIGWINCH, and arming the guard all touch the real terminal
+//! or process signal state, so the headless `term_size` harness skips them
+//! (`headless` on `takeover`; the App never calls `arm` headlessly — tests
+//! must not grab process signals). Everything that CAN be tested headlessly
+//! lives elsewhere: the render pipeline in `RenderCore`, the parking
+//! invariant in `RegionCursor`, the scrollback reflow in `HybridScrollback`.
+//!
+//! Restore discipline: the guard blob and `writeRestore` emit the same bytes
+//! in the same order — disable input modes, then show cursor, then leave the
+//! alt-screen — and restore is the strict reverse of enter (ADR-0015 choice
+//! 5). Both live here so they can never diverge.
+
+const std = @import("std");
+const terminal = @import("terminal");
+
+// Full-screen takeover/restore escape sequences. The `*_on`/`*_off` pairs are
+// DECSET enable/disable for the opt-in input modes; `restore_tail` shows the
+// cursor and leaves the alt-screen.
+const mouse_on = "\x1b[?1002h\x1b[?1006h"; // button+drag tracking, SGR encoding
+const mouse_off = "\x1b[?1002l\x1b[?1006l";
+const focus_on = "\x1b[?1004h";
+const focus_off = "\x1b[?1004l";
+const paste_on = "\x1b[?2004h"; // bracketed paste
+const paste_off = "\x1b[?2004l";
+const restore_tail = "\x1b[?25h\x1b[?1049l";
+
+pub const TerminalSession = struct {
+    /// The opt-in full-screen input modes (`App.Options.mouse/focus/paste`).
+    pub const InputModes = struct {
+        mouse: bool = false,
+        focus: bool = false,
+        paste: bool = false,
+    };
+
+    /// The file handle output escapes actually reach — the guard's replay and
+    /// size polling must hit the same tty the escapes went to (#385).
+    out_handle: std.Io.File.Handle,
+    modes: InputModes = .{},
+    /// Session-owned raw mode, in full-screen only (the App reads input via
+    /// `nextEvent`). `null` in hybrid, where input ownership stays external.
+    raw: ?terminal.RawMode = null,
+    /// Resize watcher backing `nextEvent`, full-screen only.
+    watcher: ?terminal.ResizeWatcher = null,
+    /// Whether this session armed the process-global restore guard. Gates the
+    /// disarm — arming can precede the App's `started`, so `started` alone
+    /// would leak the guard on a construct-then-error path.
+    guard_armed: bool = false,
+
+    /// Arm the process-global restore guard: replay `restore` (and the raw
+    /// termios, when given) on a signal/panic that skips deinit. The single
+    /// arm site for both modes, so the disarm gate can't drift.
+    pub fn arm(self: *TerminalSession, restore: []const u8, raw: ?terminal.RawMode) void {
+        terminal.guard.arm(self.out_handle, restore, raw);
+        self.guard_armed = true;
+    }
+
+    /// Disarm the guard if this session armed it — clean teardown owns the
+    /// restore from here (and the old signal dispositions come back).
+    pub fn disarm(self: *TerminalSession) void {
+        if (!self.guard_armed) return;
+        self.guard_armed = false;
+        terminal.guard.disarm();
+    }
+
+    /// Full-screen takeover: enable session raw mode, start the resize
+    /// watcher, arm the guard, and write the enter bytes (alt-screen, hide
+    /// cursor, opt-in input modes). `headless` (the fixed-`term_size`
+    /// harness) skips the process state but still emits the takeover bytes so
+    /// the stream is exercised. The guard is armed BEFORE the bytes go out,
+    /// so a signal in the gap still restores; undoing modes we haven't
+    /// entered is a harmless no-op. The caller anchors the cursor and
+    /// flushes; on a later enter failure it calls `abortEnter`.
+    pub fn takeover(self: *TerminalSession, writer: *std.Io.Writer, headless: bool) !void {
+        if (!headless) {
+            self.raw = try terminal.enableRawMode(std.Io.File.stdin().handle);
+            self.watcher = terminal.ResizeWatcher.init();
+            var blob: [64]u8 = undefined;
+            self.arm(self.restoreBlob(&blob), self.raw);
+        }
+        try writer.writeAll("\x1b[?1049h\x1b[?25l");
+        if (self.modes.mouse) try writer.writeAll(mouse_on);
+        if (self.modes.focus) try writer.writeAll(focus_on);
+        if (self.modes.paste) try writer.writeAll(paste_on);
+    }
+
+    /// Unwind a half-entered full-screen session (the enter path's errdefer):
+    /// same bytes and order as clean teardown, so a failure between takeover
+    /// and the first frame never strands the terminal.
+    pub fn abortEnter(self: *TerminalSession, writer: *std.Io.Writer) void {
+        self.disarm();
+        self.writeRestore(writer);
+        writer.flush() catch {};
+        self.release();
+    }
+
+    /// The restore blob for the signal/panic guard: disable whichever input
+    /// modes are on, then `restore_tail` (show cursor + leave alt-screen).
+    /// Same bytes `writeRestore` emits on the normal path, packed into `buf`.
+    fn restoreBlob(self: *const TerminalSession, buf: []u8) []const u8 {
+        var n: usize = 0;
+        const put = struct {
+            fn f(dst: []u8, at: *usize, s: []const u8) void {
+                @memcpy(dst[at.*..][0..s.len], s);
+                at.* += s.len;
+            }
+        }.f;
+        if (self.modes.mouse) put(buf, &n, mouse_off);
+        if (self.modes.focus) put(buf, &n, focus_off);
+        if (self.modes.paste) put(buf, &n, paste_off);
+        put(buf, &n, restore_tail);
+        return buf[0..n];
+    }
+
+    /// Emit the restore sequence to the writer (normal teardown / abort):
+    /// disable input modes, then show cursor and leave the alt-screen.
+    pub fn writeRestore(self: *const TerminalSession, writer: *std.Io.Writer) void {
+        if (self.modes.mouse) writer.writeAll(mouse_off) catch {};
+        if (self.modes.focus) writer.writeAll(focus_off) catch {};
+        if (self.modes.paste) writer.writeAll(paste_off) catch {};
+        writer.writeAll(restore_tail) catch {};
+    }
+
+    /// Release the process state: stop the resize watcher and restore the
+    /// termios. Must come AFTER the restore bytes are flushed — the
+    /// alt-screen leave has to go out while we still own the terminal.
+    pub fn release(self: *TerminalSession) void {
+        if (self.watcher) |*w| w.deinit();
+        self.watcher = null;
+        if (self.raw) |r| r.disable();
+        self.raw = null;
+    }
+};

--- a/packages/ui/src/test.zig
+++ b/packages/ui/src/test.zig
@@ -9,4 +9,8 @@ test {
     _ = @import("input_test.zig");
     _ = @import("golden_test.zig");
     _ = @import("app_test.zig");
+    _ = @import("region_cursor.zig");
+    _ = @import("render_core.zig");
+    _ = @import("hybrid_scrollback.zig");
+    _ = @import("scrollback_test.zig");
 }


### PR DESCRIPTION
## Summary

`packages/ui/src/app.zig` (928 LOC) multiplexed five responsibilities: two frame paths, the retained-block scrollback reflow, the signal/panic guard, cursor excursions, and the run loop — with the cursor-parking invariant asserted only in prose across three files. This takes the refactor path from the issue: decompose App into cohesive components with clear ownership, no behavior change, no capability reduction.

## Component breakdown

- **`RenderCore`** (`render_core.zig`) — the pure measure→paint→diff pipeline: double-buffered surfaces, validity tracking, diff paint, full repaint. Headless unit tests.
- **`RegionCursor`** (`region_cursor.zig`) — **owns the cursor-parking invariant as a type**: `place()` is the one sanctioned excursion, `park()` reverses it (idempotent), `anchor()` re-establishes the park at the origin, `isParked()` is the checkable form. Every paint path parks first and `std.debug.assert(self.cursor.isParked())` before handing bytes to the diff renderer; `diff.zig`'s header now names the owner. Byte-level tests pin the exact escape sequences, including the re-park-before-re-place path.
- **`TerminalSession`** (`terminal_session.zig`) — raw mode, resize watcher, restore guard, and the full-screen enter/restore byte protocol: the honestly-untestable part, isolated. The guard blob and `writeRestore` sit side by side so signal-path and clean-path restore bytes can never diverge.
- **`HybridScrollback`** (`hybrid_scrollback.zig`) — the retained static tail + width-resize reflow (ADR-0013 resize tier 2), previously untestable by construction. Now a standalone unit with byte-level tests (footprint accounting, eviction, erase-covers-larger-footprint) **plus standalone vterm tests** (`scrollback_test.zig`): shrink rewrap, grow without stale rows, multi-block shrink→grow round trip, budget-driven eviction — no App in the loop.

`App` remains the orchestrator: same public API (`init`/`initFullScreen`/`emit`/`frame`/`run`/`nextEvent`/`showCursorAt`/`cursorAt`/`clear`/`deinit`), region bookkeeping (`live_rows`, reserve/clear), and mode dispatch. Byte streams are unchanged — the existing vterm App tests pass unmodified (one internal-field reference updated).

## Testing

- `packages/ui`: `zig build test` — 203/203 pass (was ~180; new RegionCursor, RenderCore, HybridScrollback, and standalone scrollback-vterm suites).
- Repo root: `zig build test` — green (all packages + examples + projects).
- `zig build e2e` — green (2/2 steps, real-PTY suite).

Fixes #680

🤖 Generated with [Claude Code](https://claude.com/claude-code)