### PR TITLE
parsing: extract one shared argv tokenizer for all three walkers

### DIFF
--- a/packages/core/src/command_parser.zig
+++ b/packages/core/src/command_parser.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const args_parser = @import("args.zig");
 const options_parser = @import("options.zig");
 const option_utils = @import("options/utils.zig");
+const tokenizer = @import("options/tokenizer.zig");
 const diagnostic_errors = @import("diagnostic_errors.zig");
 
 pub const ZcliError = diagnostic_errors.ZcliError;
@@ -70,77 +71,33 @@ pub fn parseCommandLine(
     var positional_args = std.ArrayList([]const u8).empty;
     defer positional_args.deinit(allocator);
 
-    var i: usize = 0;
-    while (i < args.len) {
-        const arg = args[i];
-
-        // Handle "--" separator (everything after is positional)
-        if (std.mem.eql(u8, arg, "--")) {
-            // Add remaining args as positional
-            for (args[i + 1 ..]) |remaining_arg| {
-                positional_args.append(allocator, remaining_arg) catch return ZcliError.SystemOutOfMemory;
-            }
-            break;
-        }
-
-        // Handle options. `isOption` (options/utils.zig — the single source of
-        // truth) excludes negative numbers (`-.5`, `-inf`) and the bare `-`
-        // stdin/stdout sentinel, which are positionals, not flags.
-        if (option_utils.isOption(arg)) {
-            option_args.append(allocator, arg) catch return ZcliError.SystemOutOfMemory;
-
-            // Check if this option expects a value
-            if (std.mem.startsWith(u8, arg, "--")) {
-                // Long option
-                if (std.mem.indexOf(u8, arg, "=")) |_| {
-                    // --option=value format, no additional arg needed
-                    i += 1;
-                    continue;
-                } else {
-                    // --option format, might need next arg as value. Uses the
-                    // same resolution the options parser uses (incl. custom
-                    // meta names) and the same "next token is a value, not
-                    // another flag" condition, so split and parse agree.
-                    const option_name = arg[2..]; // Remove "--"
-                    const takes_value = option_utils.longOptionTakesValue(OptionsType, meta, option_name) orelse false;
-                    if (takes_value and i + 1 < args.len and option_utils.isValueToken(args[i + 1])) {
-                        i += 1;
-                        option_args.append(allocator, args[i]) catch return ZcliError.SystemOutOfMemory;
-                    }
+    // Drive the shared argv tokenizer (options/tokenizer.zig) with the same
+    // Options/meta spec the options parser resolves against, so this split and
+    // the parse cannot disagree about which token is a flag's value (#287,
+    // #299, #427): the tokenizer owns the `--` terminator, the negative-number
+    // and bare-`-` positional rules, the short-bundle state machine, and the
+    // next-token value lookahead. Here a token classifies to one of two piles;
+    // a value the tokenizer consumed for an option travels with the option.
+    var tok = tokenizer.Tokenizer(tokenizer.OptionsSpec(OptionsType, meta)){ .args = args };
+    while (tok.next()) |token| {
+        switch (token) {
+            // The `--` itself is dropped; everything after it arrives as
+            // `.positional`, verbatim.
+            .terminator => {},
+            .positional => |item| positional_args.append(allocator, item.raw) catch return ZcliError.SystemOutOfMemory,
+            .long => |long| {
+                option_args.append(allocator, long.raw) catch return ZcliError.SystemOutOfMemory;
+                if (long.next_value) |value| {
+                    option_args.append(allocator, value) catch return ZcliError.SystemOutOfMemory;
                 }
-            } else {
-                // Short option `-x` or bundle `-xyz`. Walk the chars mirroring
-                // the options parser's mixed-bundle handling
-                // (parseShortOptionsWithMeta): skip leading boolean chars; the
-                // first value-taking char either carries the rest of the token
-                // as its attached value (no next-token lookahead) or — when it
-                // is the last char — consumes the next token as its value under
-                // the shared `isValueToken` rule (#299). Reusing the shared
-                // `shortOptionTakesValue`/`isValueToken` classifiers keeps this
-                // split and the parser in agreement so a bundle like
-                // `-vf out.txt` no longer strands its value (#427).
-                const option_chars = arg[1..];
-                var ci: usize = 0;
-                while (ci < option_chars.len) : (ci += 1) {
-                    const takes_value = option_utils.shortOptionTakesValue(OptionsType, meta, option_chars[ci]) orelse false;
-                    // Boolean (or unknown) leading char: keep walking.
-                    if (!takes_value) continue;
-                    // First value-taking char. If it is not the last char, the
-                    // rest of the token is its attached value — no lookahead. If
-                    // it is the last char, the next token may be its value.
-                    if (ci + 1 == option_chars.len and i + 1 < args.len and option_utils.isValueToken(args[i + 1])) {
-                        i += 1;
-                        option_args.append(allocator, args[i]) catch return ZcliError.SystemOutOfMemory;
-                    }
-                    break;
+            },
+            .shorts => |shorts| {
+                option_args.append(allocator, shorts.raw) catch return ZcliError.SystemOutOfMemory;
+                if (shorts.next_value) |value| {
+                    option_args.append(allocator, value) catch return ZcliError.SystemOutOfMemory;
                 }
-            }
-        } else {
-            // Positional argument
-            positional_args.append(allocator, arg) catch return ZcliError.SystemOutOfMemory;
+            },
         }
-
-        i += 1;
     }
 
     // Parse options from the collected option arguments. Always goes through

--- a/packages/core/src/options.zig
+++ b/packages/core/src/options.zig
@@ -44,4 +44,5 @@ test {
     _ = parser;
     _ = array_utils;
     _ = utils;
+    _ = @import("options/tokenizer.zig");
 }

--- a/packages/core/src/options/parser.zig
+++ b/packages/core/src/options/parser.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const types = @import("types.zig");
 const utils = @import("utils.zig");
+const tokenizer = @import("tokenizer.zig");
 const array_utils = @import("array_utils.zig");
 const logging = @import("../logging.zig");
 const args_parser = @import("../args.zig");
@@ -201,68 +202,60 @@ pub fn parseOptionsWithMeta(
         }
     }
 
-    // Parse options, converting any errors to structured errors
-    var arg_index: usize = 0;
+    // Parse options, converting any errors to structured errors. The shared
+    // argv tokenizer (tokenizer.zig) owns the walking: the `--` terminator,
+    // the GNU-style positional skip (a bare word, a negative number, or the
+    // bare `-` sentinel is left in place), the short-bundle state machine, and
+    // the next-token value lookahead. This parser only resolves names to
+    // fields and applies values.
     var option_counts = std.StringHashMap(u32).init(allocator);
     defer option_counts.deinit();
 
-    while (arg_index < args.len) {
-        const arg = args[arg_index];
+    var tok = tokenizer.Tokenizer(tokenizer.OptionsSpec(OptionsType, meta)){ .args = args };
+    parse: while (tok.next()) |token| {
+        switch (token) {
+            // Stop parsing options at "--"
+            .terminator => break :parse,
+            .positional => {},
+            .long, .shorts => {
+                // Check resource limits before processing option
+                resource_tracker.checkOptionCount() catch {
+                    if (diag) |d| d.* = .{ .ResourceLimitExceeded = .{
+                        .limit_type = "total options",
+                        .limit_value = resource_tracker.limits.max_total_options,
+                        .actual_value = resource_tracker.option_count,
+                        .suggestion = null,
+                    } };
+                    return ZcliError.ResourceLimitExceeded;
+                };
 
-        // Stop parsing options at "--"
-        if (std.mem.eql(u8, arg, "--")) {
-            arg_index += 1;
-            break;
-        }
+                switch (token) {
+                    .long => |long| {
+                        resource_tracker.checkOptionNameLength(long.name) catch {
+                            if (diag) |d| d.* = .{ .ResourceLimitExceeded = .{
+                                .limit_type = "option name length",
+                                .limit_value = resource_tracker.limits.max_option_name_length,
+                                .actual_value = long.name.len,
+                                .suggestion = null,
+                            } };
+                            return ZcliError.ResourceLimitExceeded;
+                        };
 
-        // Not an option — a bare word, a negative number (`-5`, `-.5`, `-inf`),
-        // or the bare `-` stdin/stdout sentinel: skip it (GNU-style parsing
-        // leaves positionals in place). `isOption` is the single source of truth.
-        if (!utils.isOption(arg)) {
-            arg_index += 1;
-            continue;
-        }
-
-        // Check resource limits before processing option
-        resource_tracker.checkOptionCount() catch {
-            if (diag) |d| d.* = .{ .ResourceLimitExceeded = .{
-                .limit_type = "total options",
-                .limit_value = resource_tracker.limits.max_total_options,
-                .actual_value = resource_tracker.option_count,
-                .suggestion = null,
-            } };
-            return ZcliError.ResourceLimitExceeded;
-        };
-
-        if (std.mem.startsWith(u8, arg, "--")) {
-            // Long option - check option name length
-            const option_name = if (std.mem.indexOf(u8, arg[2..], "=")) |eq_pos|
-                arg[2 .. 2 + eq_pos]
-            else
-                arg[2..];
-
-            resource_tracker.checkOptionNameLength(option_name) catch {
-                if (diag) |d| d.* = .{ .ResourceLimitExceeded = .{
-                    .limit_type = "option name length",
-                    .limit_value = resource_tracker.limits.max_option_name_length,
-                    .actual_value = option_name.len,
-                    .suggestion = null,
-                } };
-                return ZcliError.ResourceLimitExceeded;
-            };
-
-            const consumed = parseLongOptions(OptionsType, meta, &result, &option_counts, args, arg_index, &array_lists, allocator, &resource_tracker, diag) catch |err| {
-                return convertLongOptionError(err);
-            };
-            arg_index += consumed;
-        } else {
-            // Short option(s)
-            const consumed = parseShortOptionsWithMeta(OptionsType, meta, &result, &option_counts, args, arg_index, &array_lists, allocator, &resource_tracker, diag) catch |err| {
-                return convertShortOptionError(err);
-            };
-            arg_index += consumed;
+                        applyLongOption(OptionsType, meta, &result, &option_counts, long, &array_lists, allocator, &resource_tracker, diag) catch |err| {
+                            return convertLongOptionError(err);
+                        };
+                    },
+                    .shorts => |shorts| {
+                        applyShortBundle(OptionsType, meta, &result, &option_counts, shorts, &array_lists, allocator, &resource_tracker, diag) catch |err| {
+                            return convertShortOptionError(err);
+                        };
+                    },
+                    else => unreachable,
+                }
+            },
         }
     }
+    const arg_index = tok.index;
 
     // Fold CLI-set fields into `provided`. `option_counts` is keyed by field
     // name for every option the CLI touched (values, booleans, negations), so
@@ -527,35 +520,26 @@ fn countCsvArrayElements(
     }
 }
 
-/// Parse a long option with metadata support (--option or --option=value)
-fn parseLongOptions(
+/// Apply a tokenized long option (`--option`, `--option=value`) to the result
+/// struct. Field matching uses the shared resolution rules (options/utils.zig)
+/// that the tokenizer's spec classifies with, so the tokenizer's value decision
+/// (`long.next_value`) always concerns the field matched here.
+fn applyLongOption(
     comptime OptionsType: type,
     comptime meta: anytype,
     result: *OptionsType,
     option_counts: *std.StringHashMap(u32),
-    args: []const []const u8,
-    arg_index: usize,
+    long: anytype,
     array_lists: anytype,
     allocator: std.mem.Allocator,
     resource_tracker: *ResourceTracker,
     diag: ?*?ZcliDiagnostic,
-) !usize {
-    const arg = args[arg_index];
-    const option_part = arg[2..]; // Skip "--"
-
-    var option_name: []const u8 = undefined;
-    var option_value: ?[]const u8 = null;
-
-    // Check for --option=value syntax
-    if (std.mem.indexOf(u8, option_part, "=")) |eq_index| {
-        option_name = option_part[0..eq_index];
-        option_value = option_part[eq_index + 1 ..];
-    } else {
-        option_name = option_part;
-    }
+) !void {
+    const option_name = long.name;
+    const option_value: ?[]const u8 = long.attached;
 
     // Generate field matching code at comptime, via the shared resolution
-    // rules (options/utils.zig) that the pre-split classifier also uses.
+    // rules (options/utils.zig) that the tokenizer's spec also uses.
     var found = false;
     inline for (@typeInfo(OptionsType).@"struct".fields, 0..) |field, i| {
         const matches = utils.longNameMatchesField(meta, field.name, option_name);
@@ -571,27 +555,24 @@ fn parseLongOptions(
                 if (option_value) |val| return booleanWithValueError(diag, option_name, false, val);
                 try markBooleanFlagOnce(diag, option_counts, field.name, option_name, false);
                 @field(result, field.name) = true;
-                return 1;
+                return;
             }
 
             // Track usage count for duplicate detection (use field name for tracking)
             const count = option_counts.get(field.name) orelse 0;
             try option_counts.put(field.name, count + 1);
 
-            // Get the value
-            const value = blk: {
-                if (option_value) |val| {
-                    break :blk val;
-                } else if (arg_index + 1 < args.len and utils.isValueToken(args[arg_index + 1])) {
-                    break :blk args[arg_index + 1];
-                } else {
-                    if (diag) |d| d.* = .{ .OptionMissingValue = .{
-                        .option_name = option_name,
-                        .is_short = false,
-                        .expected_type = diagnostic_errors.expectedTypeName(field.type),
-                    } };
-                    return error.MissingOptionValue;
-                }
+            // The value: attached (`--opt=val`) or the next argv token the
+            // tokenizer consumed under the shared lookahead rule; neither
+            // present means the value is missing (a following flag is never
+            // consumed as a value, #299).
+            const value = long.value() orelse {
+                if (diag) |d| d.* = .{ .OptionMissingValue = .{
+                    .option_name = option_name,
+                    .is_short = false,
+                    .expected_type = diagnostic_errors.expectedTypeName(field.type),
+                } };
+                return error.MissingOptionValue;
             };
 
             // Parse and set the value based on field type
@@ -619,8 +600,7 @@ fn parseLongOptions(
                 @field(result, field.name) = parsed_value;
             }
 
-            // Return number of arguments consumed
-            return if (option_value != null) 1 else 2;
+            return;
         } else if (comptime utils.isBooleanFlag(field.type)) {
             // Not the positive name — is it the auto-generated `--no-<flag>`
             // negation? Only boolean flags have one. It sets the field false and,
@@ -630,7 +610,7 @@ fn parseLongOptions(
                 if (option_value) |val| return booleanWithValueError(diag, option_name, false, val);
                 try markBooleanFlagOnce(diag, option_counts, field.name, option_name, false);
                 @field(result, field.name) = false;
-                return 1;
+                return;
             }
         }
     }
@@ -643,168 +623,105 @@ fn parseLongOptions(
         } };
         return error.UnknownOption;
     }
-
-    return 1;
 }
 
-/// Parse short options with metadata support (-o or -ovalue or -abc)
-fn parseShortOptionsWithMeta(
+/// Apply a tokenized short token (`-o`, `-ovalue`, `-abc`) to the result
+/// struct, driving the shared short-bundle walk (GNU getopt semantics):
+/// leading boolean flags one at a time; the first value-taking char gets the
+/// rest of the token as an attached value, or the next argv token the
+/// tokenizer consumed (`-vf out.txt` == `-v -f out.txt`, `-vfout.txt` ==
+/// `-v -fout.txt`).
+fn applyShortBundle(
     comptime OptionsType: type,
     comptime meta: anytype,
     result: *OptionsType,
     option_counts: *std.StringHashMap(u32),
-    args: []const []const u8,
-    arg_index: usize,
+    shorts: anytype,
     array_lists: anytype,
     allocator: std.mem.Allocator,
     resource_tracker: *ResourceTracker,
     diag: ?*?ZcliDiagnostic,
-) !usize {
-    const arg = args[arg_index];
-    const options_part = arg[1..]; // Skip "-"
-
-    if (options_part.len == 0) {
-        if (diag) |d| d.* = .{ .OptionUnknown = .{
-            .option_name = options_part,
-            .is_short = true,
-            .suggestions = &.{},
-        } };
-        return error.UnknownOption;
-    }
-
-    // Try to parse as bundled boolean flags first
-    var all_boolean = true;
-    for (options_part) |char| {
-        var char_field_found = false;
-        var char_is_boolean = false;
-        inline for (@typeInfo(OptionsType).@"struct".fields) |field| {
-            // The field's declared short char, if any (undeclared → no match).
-            const expected_char = comptime utils.shortCharForField(meta, field.name);
-
-            const matches = if (expected_char) |ec| ec == char else false;
-
-            if (matches) {
-                char_field_found = true;
-                char_is_boolean = comptime utils.isBooleanFlag(field.type);
-                break;
-            }
-        }
-        if (!char_field_found or !char_is_boolean) {
-            all_boolean = false;
-            break;
-        }
-    }
-
-    if (all_boolean and options_part.len > 1) {
-        // Parse as bundled boolean flags
-        for (options_part, 0..) |char, ci| {
-            inline for (@typeInfo(OptionsType).@"struct".fields, 0..) |field, i| {
-                _ = i; // Unused for boolean flags
-                const expected_char = comptime utils.shortCharForField(meta, field.name);
-
-                const matches = if (expected_char) |ec| ec == char else false;
-
-                if (matches) {
-                    if (comptime utils.isBooleanFlag(field.type)) {
-                        try markBooleanFlagOnce(diag, option_counts, field.name, options_part[ci .. ci + 1], true);
-                        @field(result, field.name) = true;
+) !void {
+    const chars = shorts.chars;
+    var walk = shorts.walk();
+    while (walk.next()) |step| switch (step) {
+        .unknown => |ci| {
+            if (diag) |d| d.* = .{ .OptionUnknown = .{
+                .option_name = chars[ci .. ci + 1],
+                .is_short = true,
+                .suggestions = &.{},
+            } };
+            return error.UnknownOption;
+        },
+        .flag => |ci| {
+            // A boolean flag char: the spec classified it against the same
+            // first-matching field this loop finds.
+            const char = chars[ci];
+            inline for (@typeInfo(OptionsType).@"struct".fields) |field| {
+                if (comptime utils.isBooleanFlag(field.type)) {
+                    if (comptime utils.shortCharForField(meta, field.name)) |expected_char| {
+                        if (expected_char == char) {
+                            try markBooleanFlagOnce(diag, option_counts, field.name, chars[ci .. ci + 1], true);
+                            @field(result, field.name) = true;
+                            break;
+                        }
                     }
-                    break;
                 }
             }
-        }
-        return 1;
-    } else {
-        // Mixed bundle (GNU getopt semantics): consume leading boolean flags
-        // one at a time; the first value-taking option gets the rest of the
-        // token as an attached value, or the next argument (`-vf out.txt` ==
-        // `-v -f out.txt`, `-vfout.txt` == `-v -fout.txt`).
-        var ci: usize = 0;
-        while (ci < options_part.len) : (ci += 1) {
-            const char = options_part[ci];
-
-            var char_found = false;
+        },
+        .value => |v| {
+            const char = chars[v.index];
             inline for (@typeInfo(OptionsType).@"struct".fields, 0..) |field, i| {
-                // The field's declared short char, if any (undeclared → no match).
-                const expected_char = comptime utils.shortCharForField(meta, field.name);
+                if (comptime !utils.isBooleanFlag(field.type)) {
+                    if (comptime utils.shortCharForField(meta, field.name)) |expected_char| {
+                        if (expected_char == char) {
+                            // Track usage count for duplicate detection
+                            const count = option_counts.get(field.name) orelse 0;
+                            try option_counts.put(field.name, count + 1);
 
-                const matches = if (expected_char) |ec| ec == char else false;
-
-                if (matches and !char_found) {
-                    char_found = true;
-
-                    if (comptime utils.isBooleanFlag(field.type)) {
-                        try markBooleanFlagOnce(diag, option_counts, field.name, options_part[ci .. ci + 1], true);
-                        @field(result, field.name) = true;
-                    } else {
-                        // Track usage count for duplicate detection
-                        const count = option_counts.get(field.name) orelse 0;
-                        try option_counts.put(field.name, count + 1);
-
-                        // Value-taking option
-                        var value: []const u8 = undefined;
-                        var consumed: usize = 1;
-
-                        if (options_part.len > ci + 1) {
-                            // Value attached: -ovalue
-                            value = options_part[ci + 1 ..];
-                        } else {
-                            // Value in the next argument — but only if that token is
-                            // a value, not another option (#299). A following flag
-                            // (`-t --verbose`) is a missing value, mirroring the long
-                            // path; the bare `-` and negative numbers count as values.
-                            if (arg_index + 1 >= args.len or !utils.isValueToken(args[arg_index + 1])) {
+                            // The value: the rest of the token (`-ovalue`) or the
+                            // next argv token the tokenizer consumed; neither
+                            // present means the value is missing — a following
+                            // flag (`-t --verbose`) is never consumed as a value,
+                            // mirroring the long path (#299).
+                            const value = v.attached orelse shorts.next_value orelse {
                                 if (diag) |d| d.* = .{ .OptionMissingValue = .{
-                                    .option_name = options_part[ci .. ci + 1],
+                                    .option_name = chars[v.index .. v.index + 1],
                                     .is_short = true,
                                     .expected_type = diagnostic_errors.expectedTypeName(field.type),
                                 } };
                                 return error.MissingOptionValue;
-                            }
-                            value = args[arg_index + 1];
-                            consumed = 2;
-                        }
-
-                        if (comptime utils.isArrayType(field.type)) {
-                            // For array types, accumulate values
-                            if (array_lists.*[i]) |*list_union| {
-                                const element_type = @typeInfo(field.type).pointer.child;
-                                // CSV elements each count against the option budget.
-                                try countCsvArrayElements(resource_tracker, value, diag);
-                                try array_utils.appendCsvToArrayListUnionShort(element_type, allocator, list_union, value, char);
-                            }
-                        } else {
-                            const parsed_value = utils.parseOptionValue(field.type, value) catch |err| {
-                                if (diag) |d| d.* = .{ .OptionInvalidValue = .{
-                                    .option_name = options_part[ci .. ci + 1],
-                                    .is_short = true,
-                                    .provided_value = value,
-                                    .expected_type = diagnostic_errors.expectedTypeName(field.type),
-                                    .suggestion = diagnostic_errors.nearestEnumValue(field.type, value),
-                                    .reason = custom_type.describeError(field.type, value),
-                                } };
-                                return err;
                             };
-                            @field(result, field.name) = parsed_value;
-                        }
 
-                        return consumed;
+                            if (comptime utils.isArrayType(field.type)) {
+                                // For array types, accumulate values
+                                if (array_lists.*[i]) |*list_union| {
+                                    const element_type = @typeInfo(field.type).pointer.child;
+                                    // CSV elements each count against the option budget.
+                                    try countCsvArrayElements(resource_tracker, value, diag);
+                                    try array_utils.appendCsvToArrayListUnionShort(element_type, allocator, list_union, value, char);
+                                }
+                            } else {
+                                const parsed_value = utils.parseOptionValue(field.type, value) catch |err| {
+                                    if (diag) |d| d.* = .{ .OptionInvalidValue = .{
+                                        .option_name = chars[v.index .. v.index + 1],
+                                        .is_short = true,
+                                        .provided_value = value,
+                                        .expected_type = diagnostic_errors.expectedTypeName(field.type),
+                                        .suggestion = diagnostic_errors.nearestEnumValue(field.type, value),
+                                        .reason = custom_type.describeError(field.type, value),
+                                    } };
+                                    return err;
+                                };
+                                @field(result, field.name) = parsed_value;
+                            }
+                            return; // the value-taker always ends the bundle
+                        }
                     }
                 }
             }
-
-            if (!char_found) {
-                if (diag) |d| d.* = .{ .OptionUnknown = .{
-                    .option_name = options_part[ci .. ci + 1],
-                    .is_short = true,
-                    .suggestions = &.{},
-                } };
-                return error.UnknownOption;
-            }
-        }
-
-        return 1;
-    }
+        },
+    };
 }
 
 /// Helper function to clean up array fields in options

--- a/packages/core/src/options/tokenizer.zig
+++ b/packages/core/src/options/tokenizer.zig
@@ -1,0 +1,446 @@
+//! The one argv tokenizer (#678).
+//!
+//! Three walkers used to re-implement long/short/bundle/value-lookahead argv
+//! walking: the global-option layer (registry/compiled.zig), the pre-split
+//! classifier (command_parser.zig), and the options parser (options/parser.zig).
+//! The shared predicates in options/utils.zig (`isValueToken`, `isOption`,
+//! `longOptionTakesValue`, `shortOptionTakesValue`) kept their *answers* in
+//! agreement, but the short-bundle state machine and the next-token value
+//! lookahead were still written three times. This module owns both: it turns
+//! argv into a classified token stream, and all three walkers consume it.
+//!
+//! A `Spec` describes the option namespace being tokenized:
+//!
+//! - `longTakesValue(name) ?bool` — does long option `name` exist, and does it
+//!   take a value? `null` means unknown.
+//! - `shortTakesValue(char) ?bool` — same for a short option char.
+//! - `unknown_short_aborts: bool` — bundle policy for an unknown char seen
+//!   before the first value-taking char. The command layers keep walking (the
+//!   parser will report the unknown char with a diagnostic); the global layer
+//!   cannot partially consume a token, so an unknown char makes the whole
+//!   bundle non-consumable (`Shorts.consumable == false`) and suppresses the
+//!   value lookahead.
+//!
+//! The tokenizer only *classifies* — it never resolves names to fields, parses
+//! values, or reports errors. Consumers keep their own matching, mutation, and
+//! diagnostics; what they can no longer disagree on is where a token's value
+//! comes from.
+
+const std = @import("std");
+const utils = @import("utils.zig");
+
+/// The `Spec` for a command's `Options` struct + `meta`: delegates to the
+/// shared resolution rules in options/utils.zig, so the pre-split classifier
+/// and the options parser tokenize with exactly the semantics the parser
+/// matches with (custom `meta` names, explicit-only shorts, boolean flags).
+pub fn OptionsSpec(comptime OptionsType: type, comptime meta: anytype) type {
+    return struct {
+        pub const unknown_short_aborts = false;
+        pub fn longTakesValue(name: []const u8) ?bool {
+            return utils.longOptionTakesValue(OptionsType, meta, name);
+        }
+        pub fn shortTakesValue(char: u8) ?bool {
+            return utils.shortOptionTakesValue(OptionsType, meta, char);
+        }
+    };
+}
+
+/// One step of the short-bundle state machine. Indices point into the bundle's
+/// `chars` (the token without its leading `-`), so consumers can slice the
+/// exact one-char spelling for diagnostics (`chars[i .. i + 1]`).
+pub const ShortStep = union(enum) {
+    /// A boolean flag char — consumes nothing, the walk continues.
+    flag: usize,
+    /// A char the spec doesn't know. Emitted mid-walk; whether the walk was
+    /// worth continuing is the consumer's policy (the options parser errors
+    /// here, the pre-split keeps classifying, the global layer never sees one
+    /// because `unknown_short_aborts` already marked the bundle unconsumable).
+    unknown: usize,
+    /// The first value-taking char — always the last step. `attached` is the
+    /// rest of the token when the char isn't last (`-ovalue`), else null and
+    /// the value must come from the next argv token (`Shorts.next_value`).
+    value: struct {
+        index: usize,
+        attached: ?[]const u8,
+    },
+};
+
+/// The short-bundle walk over `chars`, shared by the tokenizer's own
+/// lookahead decision and by consumers that mutate per-char state. GNU getopt
+/// semantics: leading boolean flags one at a time; the first value-taking
+/// char ends the walk, claiming the rest of the token as its attached value
+/// when it isn't the last char.
+pub fn ShortWalk(comptime Spec: type) type {
+    return struct {
+        chars: []const u8,
+        i: usize = 0,
+        done: bool = false,
+
+        pub fn next(self: *@This()) ?ShortStep {
+            if (self.done or self.i >= self.chars.len) return null;
+            const idx = self.i;
+            const takes_value = Spec.shortTakesValue(self.chars[idx]);
+            if (takes_value == true) {
+                self.done = true;
+                return .{ .value = .{
+                    .index = idx,
+                    .attached = if (idx + 1 < self.chars.len) self.chars[idx + 1 ..] else null,
+                } };
+            }
+            self.i += 1;
+            return if (takes_value == null) .{ .unknown = idx } else .{ .flag = idx };
+        }
+    };
+}
+
+/// A classified argv tokenizer specialized on a `Spec`. Feed it argv; it
+/// yields one `Token` per primary argv token, consuming a following token
+/// itself when the shared lookahead rule says that token is an option's value
+/// (`isValueToken`: a bare word, a negative number, or the bare `-` sentinel —
+/// never another flag).
+pub fn Tokenizer(comptime Spec: type) type {
+    return struct {
+        args: []const []const u8,
+        /// The argv index of the next unread token. After `next()` returns, it
+        /// is past the returned token *and* past any value token it consumed.
+        index: usize = 0,
+        terminated: bool = false,
+
+        const Self = @This();
+
+        /// A token that classifies no further: its raw argv text and index.
+        pub const Item = struct {
+            raw: []const u8,
+            index: usize,
+        };
+
+        /// A `--name` / `--name=value` token.
+        pub const Long = struct {
+            raw: []const u8,
+            index: usize,
+            /// The option name (after `--`, before any `=`).
+            name: []const u8,
+            /// The `=value` part, if the token carried one.
+            attached: ?[]const u8,
+            /// `Spec.longTakesValue(name)`: null = unknown option.
+            takes_value: ?bool,
+            /// The following argv token, consumed as this option's value —
+            /// non-null only when the option takes a value, no value was
+            /// attached, and the next token is a value token.
+            next_value: ?[]const u8,
+
+            /// The option's value from either source, or null (missing).
+            pub fn value(self: @This()) ?[]const u8 {
+                return self.attached orelse self.next_value;
+            }
+        };
+
+        /// A `-x` / `-xyz` token.
+        pub const Shorts = struct {
+            raw: []const u8,
+            index: usize,
+            /// The bundle chars (token without its leading `-`).
+            chars: []const u8,
+            /// False only under `Spec.unknown_short_aborts` when an unknown
+            /// char precedes the first value-taking char: the whole token is
+            /// not this namespace's to consume (and no lookahead happened).
+            consumable: bool,
+            /// The following argv token, consumed as the trailing value-taking
+            /// char's value — non-null only when the bundle is consumable, its
+            /// value-taker is the last char, and the next token is a value.
+            next_value: ?[]const u8,
+
+            /// Iterate the bundle's steps (the same walk the tokenizer used
+            /// for its lookahead decision).
+            pub fn walk(self: @This()) ShortWalk(Spec) {
+                return .{ .chars = self.chars };
+            }
+        };
+
+        pub const Token = union(enum) {
+            /// The first bare `--`: end of options. Every later token —
+            /// including further `--` — is yielded as `.positional`.
+            terminator: Item,
+            /// A value token (bare word, negative number, bare `-`), or
+            /// anything at all after the terminator.
+            positional: Item,
+            long: Long,
+            shorts: Shorts,
+        };
+
+        pub fn next(self: *Self) ?Token {
+            if (self.index >= self.args.len) return null;
+            const raw = self.args[self.index];
+            const idx = self.index;
+            self.index += 1;
+
+            if (self.terminated) return .{ .positional = .{ .raw = raw, .index = idx } };
+            if (std.mem.eql(u8, raw, "--")) {
+                self.terminated = true;
+                return .{ .terminator = .{ .raw = raw, .index = idx } };
+            }
+            // `isOption` (options/utils.zig — the single source of truth)
+            // excludes negative numbers (`-.5`, `-inf`) and the bare `-`
+            // stdin/stdout sentinel, which are positionals, not flags.
+            if (!utils.isOption(raw)) return .{ .positional = .{ .raw = raw, .index = idx } };
+
+            if (std.mem.startsWith(u8, raw, "--")) {
+                const body = raw[2..];
+                const eq = std.mem.indexOfScalar(u8, body, '=');
+                const name = if (eq) |e| body[0..e] else body;
+                const attached: ?[]const u8 = if (eq) |e| body[e + 1 ..] else null;
+                const takes_value = Spec.longTakesValue(name);
+                var next_value: ?[]const u8 = null;
+                if (attached == null and takes_value == true) {
+                    // The one next-token-is-a-value rule (#299): the following
+                    // token is this option's value unless it is itself a flag.
+                    if (self.index < self.args.len and utils.isValueToken(self.args[self.index])) {
+                        next_value = self.args[self.index];
+                        self.index += 1;
+                    }
+                }
+                return .{ .long = .{
+                    .raw = raw,
+                    .index = idx,
+                    .name = name,
+                    .attached = attached,
+                    .takes_value = takes_value,
+                    .next_value = next_value,
+                } };
+            }
+
+            // Short token `-x` or bundle `-xyz`: walk it once to decide the
+            // lookahead (and, under `unknown_short_aborts`, consumability).
+            const chars = raw[1..];
+            var consumable = true;
+            var wants_next = false;
+            var probe = ShortWalk(Spec){ .chars = chars };
+            while (probe.next()) |step| switch (step) {
+                .flag => {},
+                .unknown => if (Spec.unknown_short_aborts) {
+                    consumable = false;
+                    break;
+                },
+                .value => |v| {
+                    wants_next = v.attached == null;
+                },
+            };
+            var next_value: ?[]const u8 = null;
+            if (consumable and wants_next and
+                self.index < self.args.len and utils.isValueToken(self.args[self.index]))
+            {
+                next_value = self.args[self.index];
+                self.index += 1;
+            }
+            return .{ .shorts = .{
+                .raw = raw,
+                .index = idx,
+                .chars = chars,
+                .consumable = consumable,
+                .next_value = next_value,
+            } };
+        }
+    };
+}
+
+// ============================================================================
+// Tests — the state machine directly, under both bundle policies.
+// ============================================================================
+
+const TestOptions = struct {
+    verbose: bool = false,
+    debug: bool = false,
+    file: ?[]const u8 = null,
+    count: u32 = 1,
+};
+const test_meta = .{ .options = .{
+    .verbose = .{ .short = 'v' },
+    .debug = .{ .short = 'd' },
+    .file = .{ .short = 'f' },
+} };
+const TestSpec = OptionsSpec(TestOptions, test_meta);
+
+/// A spec with the global layer's all-or-nothing bundle policy, over the same
+/// namespace, so the two policies can be contrasted on identical input.
+const AbortSpec = struct {
+    pub const unknown_short_aborts = true;
+    pub fn longTakesValue(name: []const u8) ?bool {
+        return TestSpec.longTakesValue(name);
+    }
+    pub fn shortTakesValue(char: u8) ?bool {
+        return TestSpec.shortTakesValue(char);
+    }
+};
+
+test "long: boolean flag does not look ahead" {
+    var tok = Tokenizer(TestSpec){ .args = &.{ "--verbose", "input.txt" } };
+    const t = tok.next().?.long;
+    try std.testing.expectEqualStrings("verbose", t.name);
+    try std.testing.expectEqual(@as(?bool, false), t.takes_value);
+    try std.testing.expect(t.attached == null);
+    try std.testing.expect(t.next_value == null);
+    // The word stays a positional.
+    try std.testing.expectEqualStrings("input.txt", tok.next().?.positional.raw);
+    try std.testing.expect(tok.next() == null);
+}
+
+test "long: value option consumes the next value token" {
+    var tok = Tokenizer(TestSpec){ .args = &.{ "--count", "5", "rest" } };
+    const t = tok.next().?.long;
+    try std.testing.expectEqual(@as(?bool, true), t.takes_value);
+    try std.testing.expectEqualStrings("5", t.next_value.?);
+    try std.testing.expectEqualStrings("5", t.value().?);
+    try std.testing.expectEqual(@as(usize, 2), tok.index);
+    try std.testing.expectEqualStrings("rest", tok.next().?.positional.raw);
+}
+
+test "long: --name=value carries its value attached, no lookahead" {
+    var tok = Tokenizer(TestSpec){ .args = &.{ "--count=5", "word" } };
+    const t = tok.next().?.long;
+    try std.testing.expectEqualStrings("count", t.name);
+    try std.testing.expectEqualStrings("5", t.attached.?);
+    try std.testing.expect(t.next_value == null);
+    try std.testing.expectEqualStrings("word", tok.next().?.positional.raw);
+}
+
+test "long: a flag is never consumed as another flag's value (#299)" {
+    var tok = Tokenizer(TestSpec){ .args = &.{ "--count", "--verbose" } };
+    const t = tok.next().?.long;
+    try std.testing.expectEqual(@as(?bool, true), t.takes_value);
+    try std.testing.expect(t.next_value == null); // missing value, not "--verbose"
+    try std.testing.expectEqualStrings("verbose", tok.next().?.long.name);
+}
+
+test "long: negative numbers and bare '-' are value tokens (#287, #315)" {
+    inline for ([_][]const u8{ "-5", "-.5", "-inf", "-1e5", "-" }) |val| {
+        var tok = Tokenizer(TestSpec){ .args = &.{ "--count", val } };
+        try std.testing.expectEqualStrings(val, tok.next().?.long.next_value.?);
+        try std.testing.expect(tok.next() == null);
+    }
+}
+
+test "long: unknown option gets no lookahead" {
+    var tok = Tokenizer(TestSpec){ .args = &.{ "--bogus", "word" } };
+    const t = tok.next().?.long;
+    try std.testing.expectEqual(@as(?bool, null), t.takes_value);
+    try std.testing.expect(t.next_value == null);
+    try std.testing.expectEqualStrings("word", tok.next().?.positional.raw);
+}
+
+test "shorts: all-boolean bundle walks every char, no lookahead" {
+    var tok = Tokenizer(TestSpec){ .args = &.{ "-vd", "word" } };
+    const t = tok.next().?.shorts;
+    try std.testing.expect(t.consumable);
+    try std.testing.expect(t.next_value == null);
+    var walk = t.walk();
+    try std.testing.expectEqual(@as(usize, 0), walk.next().?.flag);
+    try std.testing.expectEqual(@as(usize, 1), walk.next().?.flag);
+    try std.testing.expect(walk.next() == null);
+    try std.testing.expectEqualStrings("word", tok.next().?.positional.raw);
+}
+
+test "shorts: trailing value-taker consumes the next value token (#427)" {
+    var tok = Tokenizer(TestSpec){ .args = &.{ "-vf", "out.txt" } };
+    const t = tok.next().?.shorts;
+    try std.testing.expectEqualStrings("out.txt", t.next_value.?);
+    var walk = t.walk();
+    try std.testing.expectEqual(@as(usize, 0), walk.next().?.flag);
+    const v = walk.next().?.value;
+    try std.testing.expectEqual(@as(usize, 1), v.index);
+    try std.testing.expect(v.attached == null);
+    try std.testing.expect(walk.next() == null);
+    try std.testing.expect(tok.next() == null);
+}
+
+test "shorts: mid-bundle value-taker takes the rest attached, walk stops" {
+    var tok = Tokenizer(TestSpec){ .args = &.{ "-vfd", "word" } };
+    const t = tok.next().?.shorts;
+    try std.testing.expect(t.next_value == null); // rest of token is the value
+    var walk = t.walk();
+    try std.testing.expectEqual(@as(usize, 0), walk.next().?.flag);
+    const v = walk.next().?.value;
+    try std.testing.expectEqualStrings("d", v.attached.?); // NOT the -d flag
+    try std.testing.expect(walk.next() == null);
+    try std.testing.expectEqualStrings("word", tok.next().?.positional.raw);
+}
+
+test "shorts: value-taker followed by a flag is a missing value, not a swallow (#299)" {
+    var tok = Tokenizer(TestSpec){ .args = &.{ "-f", "--verbose" } };
+    try std.testing.expect(tok.next().?.shorts.next_value == null);
+    try std.testing.expectEqualStrings("verbose", tok.next().?.long.name);
+}
+
+test "shorts: unknown char — command policy keeps walking and looking ahead" {
+    var tok = Tokenizer(TestSpec){ .args = &.{ "-xf", "out.txt" } };
+    const t = tok.next().?.shorts;
+    try std.testing.expect(t.consumable);
+    try std.testing.expectEqualStrings("out.txt", t.next_value.?);
+    var walk = t.walk();
+    try std.testing.expectEqual(@as(usize, 0), walk.next().?.unknown);
+    try std.testing.expectEqual(@as(usize, 1), walk.next().?.value.index);
+}
+
+test "shorts: unknown char — abort policy marks unconsumable, no lookahead" {
+    var tok = Tokenizer(AbortSpec){ .args = &.{ "-xf", "out.txt" } };
+    const t = tok.next().?.shorts;
+    try std.testing.expect(!t.consumable);
+    try std.testing.expect(t.next_value == null);
+    // The would-be value stays an ordinary token for the next layer.
+    try std.testing.expectEqualStrings("out.txt", tok.next().?.positional.raw);
+}
+
+test "shorts: abort policy never checks chars after the value-taker" {
+    // `-fx`: f takes a value, so `x` is its attached value, not an option char.
+    var tok = Tokenizer(AbortSpec){ .args = &.{"-fx"} };
+    const t = tok.next().?.shorts;
+    try std.testing.expect(t.consumable);
+    var walk = t.walk();
+    try std.testing.expectEqualStrings("x", walk.next().?.value.attached.?);
+}
+
+test "terminator: everything after the first -- is positional, verbatim" {
+    var tok = Tokenizer(TestSpec){ .args = &.{ "--verbose", "--", "--count", "-vf", "--" } };
+    try std.testing.expectEqualStrings("verbose", tok.next().?.long.name);
+    const term = tok.next().?.terminator;
+    try std.testing.expectEqualStrings("--", term.raw);
+    try std.testing.expectEqual(@as(usize, 1), term.index);
+    try std.testing.expectEqualStrings("--count", tok.next().?.positional.raw);
+    try std.testing.expectEqualStrings("-vf", tok.next().?.positional.raw);
+    try std.testing.expectEqualStrings("--", tok.next().?.positional.raw);
+    try std.testing.expect(tok.next() == null);
+}
+
+test "positionals: bare words, negative numbers, bare '-', empty string" {
+    var tok = Tokenizer(TestSpec){ .args = &.{ "word", "-5", "-.5", "-inf", "-", "" } };
+    var count: usize = 0;
+    while (tok.next()) |t| : (count += 1) {
+        try std.testing.expect(t == .positional);
+        try std.testing.expectEqual(count, t.positional.index);
+    }
+    try std.testing.expectEqual(@as(usize, 6), count);
+}
+
+test "index bookkeeping spans consumed value tokens" {
+    var tok = Tokenizer(TestSpec){ .args = &.{ "-f", "a", "--count", "1", "w" } };
+    const s = tok.next().?.shorts;
+    try std.testing.expectEqual(@as(usize, 0), s.index);
+    try std.testing.expectEqual(@as(usize, 2), tok.index);
+    const l = tok.next().?.long;
+    try std.testing.expectEqual(@as(usize, 2), l.index);
+    try std.testing.expectEqual(@as(usize, 4), tok.index);
+    try std.testing.expectEqual(@as(usize, 4), tok.next().?.positional.index);
+}
+
+test "OptionsSpec resolves custom meta names and explicit-only shorts" {
+    const Opts = struct {
+        output_file: ?[]const u8 = null,
+        verbose: bool = false,
+    };
+    const meta = .{ .options = .{ .output_file = .{ .name = "out", .short = 'o' } } };
+    const Spec = OptionsSpec(Opts, meta);
+    try std.testing.expectEqual(@as(?bool, true), Spec.longTakesValue("out"));
+    try std.testing.expectEqual(@as(?bool, null), Spec.longTakesValue("output-file")); // custom name shadows
+    try std.testing.expectEqual(@as(?bool, false), Spec.longTakesValue("verbose"));
+    try std.testing.expectEqual(@as(?bool, true), Spec.shortTakesValue('o'));
+    try std.testing.expectEqual(@as(?bool, null), Spec.shortTakesValue('v')); // undeclared
+}

--- a/packages/core/src/registry/compiled.zig
+++ b/packages/core/src/registry/compiled.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const command_parser = @import("../command_parser.zig");
 const option_utils = @import("../options/utils.zig");
+const tokenizer = @import("../options/tokenizer.zig");
 const plugin_types = @import("../plugin_types.zig");
 const zcli = @import("../zcli.zig");
 
@@ -736,182 +737,131 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
             }
         }
 
+        /// The shared argv tokenizer's spec for the global-option namespace:
+        /// exact long-name matches (no dashed aliases, no negation) and the
+        /// plugins' declared shorts. `unknown_short_aborts` because this layer
+        /// cannot partially consume a bundle — a non-global char before the
+        /// first value-taking global leaves the whole token (and any would-be
+        /// value) for the command's own option parser.
+        const GlobalSpec = struct {
+            pub const unknown_short_aborts = true;
+            pub fn longTakesValue(name: []const u8) ?bool {
+                inline for (global_options) |global_opt| {
+                    if (std.mem.eql(u8, name, global_opt.name)) return global_opt.type != bool;
+                }
+                return null;
+            }
+            pub fn shortTakesValue(char: u8) ?bool {
+                inline for (global_options) |global_opt| {
+                    if (global_opt.short == char) return global_opt.type != bool;
+                }
+                return null;
+            }
+        };
+
         pub fn parseGlobalOptions(_: *Self, context: *Context, args: []const []const u8) !zcli.GlobalOptionsResult {
             var consumed = std.ArrayList(usize).empty;
             var remaining = std.ArrayList([]const u8).empty;
             defer consumed.deinit(context.allocator);
             defer remaining.deinit(context.allocator);
 
-            var i: usize = 0;
-            // Once a bare `--` is seen, stop matching global options for the rest
-            // of argv — the command-level parsers honor `--` as an end-of-options
-            // terminator (options/parser.zig, command_parser.zig), so the global
-            // layer must too or the two disagree (#501). The `--` itself and every
-            // token after it flow untouched into `remaining` so the command parser
-            // still sees its own terminator.
-            var options_ended = false;
-            while (i < args.len) {
-                const arg = args[i];
-                var handled = false;
-
-                if (!options_ended and std.mem.eql(u8, arg, "--")) {
-                    options_ended = true;
-                } else if (!options_ended and std.mem.startsWith(u8, arg, "--")) {
-                    // Split `--name=value` before matching, mirroring the
-                    // command-option long path (#391).
-                    const opt_body = arg[2..];
-                    const eq_idx = std.mem.indexOfScalar(u8, opt_body, '=');
-                    const opt_name = if (eq_idx) |e| opt_body[0..e] else opt_body;
-                    const attached: ?[]const u8 = if (eq_idx) |e| opt_body[e + 1 ..] else null;
-                    // Check if this is a global option
-                    inline for (global_options) |global_opt| {
-                        if (std.mem.eql(u8, opt_name, global_opt.name)) {
-                            // Handle the global option
-                            try consumed.append(context.allocator, i);
-
-                            var value: []const u8 = "true"; // Boolean flags: presence == true
-                            if (global_opt.type != bool) {
-                                if (attached) |v| {
-                                    value = v;
-                                } else if (i + 1 < args.len and option_utils.isValueToken(args[i + 1])) {
-                                    // Same next-token-is-a-value rule the command
-                                    // parsers share (options/utils.zig).
-                                    i += 1;
-                                    value = args[i];
-                                    try consumed.append(context.allocator, i);
-                                } else {
-                                    context.diagnostic = .{ .OptionMissingValue = .{
+            // The shared tokenizer (options/tokenizer.zig) owns the walking:
+            // the `--` terminator (#501 — after it, every token flows untouched
+            // into `remaining`, the `--` itself included, so the command parser
+            // still sees its own terminator), the `--name=value` split (#391),
+            // the short-bundle state machine, and the next-token value
+            // lookahead the command parsers share. This layer only filters:
+            // tokens that resolve to globals are consumed and dispatched,
+            // everything else passes through verbatim.
+            var tok = tokenizer.Tokenizer(GlobalSpec){ .args = args };
+            while (tok.next()) |token| {
+                switch (token) {
+                    .terminator, .positional => |item| try remaining.append(context.allocator, item.raw),
+                    .long => |long| {
+                        if (long.takes_value == null) {
+                            // Not a global option — the command's to parse.
+                            try remaining.append(context.allocator, long.raw);
+                            continue;
+                        }
+                        try consumed.append(context.allocator, long.index);
+                        inline for (global_options) |global_opt| {
+                            if (std.mem.eql(u8, long.name, global_opt.name)) {
+                                var value: []const u8 = "true"; // Boolean flags: presence == true
+                                if (global_opt.type != bool) {
+                                    if (long.attached) |v| {
+                                        value = v;
+                                    } else if (long.next_value) |v| {
+                                        value = v;
+                                        try consumed.append(context.allocator, long.index + 1);
+                                    } else {
+                                        context.diagnostic = .{ .OptionMissingValue = .{
+                                            .option_name = global_opt.name,
+                                            .is_short = false,
+                                            .expected_type = zcli.expectedTypeName(global_opt.type),
+                                        } };
+                                        return zcli.ZcliError.OptionMissingValue;
+                                    }
+                                } else if (long.attached) |v| {
+                                    // `--flag=x` on a boolean global errors like the
+                                    // command parser's boolean-with-value path.
+                                    context.diagnostic = .{ .OptionBooleanWithValue = .{
                                         .option_name = global_opt.name,
                                         .is_short = false,
-                                        .expected_type = zcli.expectedTypeName(global_opt.type),
+                                        .provided_value = v,
                                     } };
-                                    return zcli.ZcliError.OptionMissingValue;
+                                    return zcli.ZcliError.OptionBooleanWithValue;
                                 }
-                            } else if (attached) |v| {
-                                // `--flag=x` on a boolean global errors like the
-                                // command parser's boolean-with-value path.
-                                context.diagnostic = .{ .OptionBooleanWithValue = .{
-                                    .option_name = global_opt.name,
-                                    .is_short = false,
-                                    .provided_value = v,
-                                } };
-                                return zcli.ZcliError.OptionBooleanWithValue;
-                            }
 
-                            try dispatchGlobalOption(context, global_opt, value, false);
-
-                            handled = true;
-                            break;
-                        }
-                    }
-                } else if (!options_ended and std.mem.startsWith(u8, arg, "-") and arg.len == 2) {
-                    // Single short option: mirrors the long path, including
-                    // values for non-boolean globals (`-c config.json`).
-                    const short_char = arg[1];
-                    inline for (global_options) |global_opt| {
-                        if (global_opt.short == short_char) {
-                            try consumed.append(context.allocator, i);
-
-                            var value: []const u8 = "true";
-                            if (global_opt.type != bool) {
-                                if (i + 1 < args.len and option_utils.isValueToken(args[i + 1])) {
-                                    i += 1;
-                                    value = args[i];
-                                    try consumed.append(context.allocator, i);
-                                } else {
-                                    context.diagnostic = .{ .OptionMissingValue = .{
-                                        .option_name = global_opt.name,
-                                        .is_short = true,
-                                        .expected_type = zcli.expectedTypeName(global_opt.type),
-                                    } };
-                                    return zcli.ZcliError.OptionMissingValue;
-                                }
-                            }
-
-                            try dispatchGlobalOption(context, global_opt, value, true);
-
-                            handled = true;
-                            break;
-                        }
-                    }
-                } else if (!options_ended and std.mem.startsWith(u8, arg, "-") and arg.len > 2) {
-                    // Mixed short bundle (GNU getopt), mirroring the command-option
-                    // parser (options/parser.zig): consume leading boolean globals
-                    // one at a time; the first value-taking global short claims the
-                    // rest of the token as an attached value (`-cval` == `-c val`),
-                    // or the next argument when it ends the token (`-vc val`). The
-                    // whole token is consumed only when it resolves entirely to
-                    // globals — a non-global leading char aborts (the token layer
-                    // can't partially consume), leaving the token in `remaining`
-                    // for the command's own option parser.
-                    const short_opts = arg[1..];
-
-                    // First pass: decide whether the token is consumable without
-                    // mutating any state. Every char up to (and including) the first
-                    // value-taking global must resolve to a global; a value-taking
-                    // global ends the scan since the remainder is its value.
-                    var consumable = true;
-                    for (short_opts) |short_char| {
-                        var is_bool_global = false;
-                        var is_value_global = false;
-                        inline for (global_options) |global_opt| {
-                            if (global_opt.short == short_char) {
-                                if (global_opt.type == bool) {
-                                    is_bool_global = true;
-                                } else {
-                                    is_value_global = true;
-                                }
+                                try dispatchGlobalOption(context, global_opt, value, false);
+                                break;
                             }
                         }
-                        if (is_value_global) break; // rest of token is this option's value
-                        if (!is_bool_global) {
-                            consumable = false;
-                            break;
+                    },
+                    .shorts => |shorts| {
+                        if (!shorts.consumable) {
+                            // Some char isn't a global — the token layer can't
+                            // partially consume, so the whole token passes.
+                            try remaining.append(context.allocator, shorts.raw);
+                            continue;
                         }
-                    }
-
-                    if (consumable) {
-                        try consumed.append(context.allocator, i);
-                        var ci: usize = 0;
-                        dispatch: while (ci < short_opts.len) : (ci += 1) {
-                            const short_char = short_opts[ci];
-                            inline for (global_options) |global_opt| {
-                                if (global_opt.short == short_char) {
-                                    if (global_opt.type == bool) {
+                        try consumed.append(context.allocator, shorts.index);
+                        var walk = shorts.walk();
+                        while (walk.next()) |step| switch (step) {
+                            // A consumable bundle resolved every char before the
+                            // value-taker to a global.
+                            .unknown => unreachable,
+                            .flag => |ci| {
+                                const short_char = shorts.chars[ci];
+                                inline for (global_options) |global_opt| {
+                                    if (global_opt.short == short_char) {
                                         try dispatchGlobalOption(context, global_opt, "true", true);
-                                    } else {
-                                        const attached = short_opts[ci + 1 ..];
-                                        var value: []const u8 = attached;
-                                        if (attached.len == 0) {
-                                            if (i + 1 < args.len and option_utils.isValueToken(args[i + 1])) {
-                                                i += 1;
-                                                value = args[i];
-                                                try consumed.append(context.allocator, i);
-                                            } else {
-                                                context.diagnostic = .{ .OptionMissingValue = .{
-                                                    .option_name = global_opt.name,
-                                                    .is_short = true,
-                                                    .expected_type = zcli.expectedTypeName(global_opt.type),
-                                                } };
-                                                return zcli.ZcliError.OptionMissingValue;
-                                            }
+                                        break;
+                                    }
+                                }
+                            },
+                            .value => |v| {
+                                const short_char = shorts.chars[v.index];
+                                inline for (global_options) |global_opt| {
+                                    if (global_opt.short == short_char) {
+                                        const value = v.attached orelse shorts.next_value orelse {
+                                            context.diagnostic = .{ .OptionMissingValue = .{
+                                                .option_name = global_opt.name,
+                                                .is_short = true,
+                                                .expected_type = zcli.expectedTypeName(global_opt.type),
+                                            } };
+                                            return zcli.ZcliError.OptionMissingValue;
+                                        };
+                                        if (v.attached == null) {
+                                            try consumed.append(context.allocator, shorts.index + 1);
                                         }
                                         try dispatchGlobalOption(context, global_opt, value, true);
-                                        break :dispatch; // value claimed the rest of the token
+                                        break;
                                     }
-                                    break;
                                 }
-                            }
-                        }
-                        handled = true;
-                    }
+                            },
+                        };
+                    },
                 }
-
-                if (!handled) {
-                    try remaining.append(context.allocator, arg);
-                }
-
-                i += 1;
             }
 
             const result = zcli.GlobalOptionsResult{


### PR DESCRIPTION
## What

Extracts the argv walking that was written three times — `parseGlobalOptions` (registry/compiled.zig), the pre-split classifier (command_parser.zig), and the options parser (options/parser.zig) — into one shared, comptime-specialized tokenizer: `packages/core/src/options/tokenizer.zig`.

## Design

- `Tokenizer(Spec)` turns argv into a classified stream: `.terminator` (first `--`; everything after arrives as `.positional` verbatim), `.positional` (bare words, negative numbers `-5`/`-.5`/`-inf`, the bare `-` sentinel), `.long` (`--name` / `--name=value`, with the next-token value already consumed under the shared `isValueToken` rule), and `.shorts` (bundles, with the same lookahead).
- `ShortWalk(Spec)` is the one short-bundle state machine (GNU getopt: leading boolean flags one at a time; the first value-taking char claims the rest of the token or the next argv token). The tokenizer uses it for its lookahead decision and consumers iterate the same walk to mutate state.
- A `Spec` describes the namespace: `longTakesValue`/`shortTakesValue` (`?bool`, null = unknown) plus the bundle policy `unknown_short_aborts` — the global layer can't partially consume a token, so an unknown char marks the bundle non-consumable (and suppresses the lookahead); the command layers keep walking and let the parser report the char.
- `OptionsSpec(OptionsType, meta)` delegates to the existing resolution rules in options/utils.zig (custom meta names, explicit-only shorts, boolean flags), so the split and the parse still agree by construction; compiled.zig builds a `GlobalSpec` over the plugins' `global_options`.

Consumers keep only what is theirs: field matching, value parsing/dispatch, duplicate/negation handling, resource limits, and diagnostics — all byte-for-byte as before (same errors, same messages). The next flag-syntax feature now lands once.

## Tests

- New tokenizer-level unit tests exercise the state machine directly under both bundle policies (long/short/bundle classification, `=` split, lookahead vs. following-flag, terminator semantics, index bookkeeping, regression cases #287/#299/#427/#315/#501).
- All existing suites pass unchanged: full `zig build test` from repo root and `zig build e2e`, both green locally.
- Smoke-tested projects/zcli: `--help`, global `-h` (root and subcommand), `--no-<flag>` negation, boolean-with-value error, missing-value error (flag never eaten as a value), `--` passthrough, negative-number positionals.

Fixes #678

🤖 Generated with [Claude Code](https://claude.com/claude-code)