### PR TITLE
terminal/vterm: close cell-width and frame-text duplicate seams (#684, #687)

### DIFF
--- a/packages/terminal/src/terminal.zig
+++ b/packages/terminal/src/terminal.zig
@@ -33,6 +33,8 @@ pub const guard = @import("guard.zig");
 /// Display-width measurement and word-wrapping (grapheme- and ANSI-aware).
 pub const wrap = @import("wrap.zig");
 pub const displayWidth = wrap.displayWidth;
+pub const truncateToWidth = wrap.truncateToWidth;
+pub const visibleGraphemes = wrap.visibleGraphemes;
 pub const wrapToWidth = wrap.wrapToWidth;
 pub const wrapForEach = wrap.wrapForEach;
 pub const wrapCount = wrap.wrapCount;

--- a/packages/terminal/src/wrap.zig
+++ b/packages/terminal/src/wrap.zig
@@ -48,21 +48,70 @@ fn graphemeCols(g: Graphemes.Grapheme, text: []const u8) usize {
     return if (w > 0) @intCast(w) else 0;
 }
 
+/// A visible grapheme cluster within some text: its byte slice, byte offset
+/// into the original text, and display width in terminal cells.
+pub const VisibleGrapheme = struct {
+    bytes: []const u8,
+    offset: usize,
+    width: usize,
+};
+
+/// Walks the visible grapheme clusters of `text`, skipping ANSI escape
+/// sequences (CSI/OSC/two-byte) entirely and reporting each cluster's display
+/// width. This is the single grapheme-walking primitive terminal owns; callers
+/// that need to place cells (the UI surface) drive it instead of importing zg's
+/// `Graphemes` directly, so all cell-width math has one owner.
+pub const VisibleIterator = struct {
+    text: []const u8,
+    it: Graphemes.Iterator,
+    skip_until: usize = 0,
+
+    pub fn next(self: *VisibleIterator) ?VisibleGrapheme {
+        while (self.it.next()) |g| {
+            if (g.offset < self.skip_until) continue;
+            if (self.text[g.offset] == 0x1b) {
+                self.skip_until = escapeSeqEnd(self.text, g.offset);
+                continue;
+            }
+            return .{
+                .bytes = self.text[g.offset..][0..g.len],
+                .offset = g.offset,
+                .width = graphemeCols(g, self.text),
+            };
+        }
+        return null;
+    }
+};
+
+/// Iterate the visible (non-ANSI) grapheme clusters of `text`.
+pub fn visibleGraphemes(text: []const u8) VisibleIterator {
+    return .{ .text = text, .it = Graphemes.iterator(text) };
+}
+
 /// Total display width of `text` in terminal cells, grapheme-aware and skipping
 /// ANSI escape sequences.
 pub fn displayWidth(text: []const u8) usize {
     var total: usize = 0;
-    var skip_until: usize = 0;
-    var it = Graphemes.iterator(text);
-    while (it.next()) |g| {
-        if (g.offset < skip_until) continue;
-        if (text[g.offset] == 0x1b) {
-            skip_until = escapeSeqEnd(text, g.offset);
-            continue;
-        }
-        total += graphemeCols(g, text);
-    }
+    var it = visibleGraphemes(text);
+    while (it.next()) |g| total += g.width;
     return total;
+}
+
+/// Byte length of the longest prefix of `text` whose visible graphemes fit in
+/// `cols` display columns. ANSI escapes are zero width and are kept when they
+/// precede retained content; grapheme clusters are never split. This is the
+/// single owner of prefix-truncation — UI truncation drives it instead of
+/// re-walking graphemes itself.
+pub fn truncateToWidth(text: []const u8, cols: usize) usize {
+    var used: usize = 0;
+    var end: usize = 0;
+    var it = visibleGraphemes(text);
+    while (it.next()) |g| {
+        if (used + g.width > cols) break;
+        used += g.width;
+        end = g.offset + g.bytes.len;
+    }
+    return end;
 }
 
 /// Byte length of the trailing grapheme cluster of `text` (0 for empty text).
@@ -275,6 +324,27 @@ test "displayWidth: emoji and combining marks" {
 test "displayWidth: skips ANSI escapes" {
     // Without skipping, zg would count the '[36m' bytes → 6.
     try testing.expectEqual(@as(usize, 2), displayWidth("\x1b[36mhi\x1b[0m"));
+}
+
+test "truncateToWidth: ascii keeps the longest fitting prefix" {
+    try testing.expectEqual(@as(usize, 5), truncateToWidth("hello", 10));
+    try testing.expectEqual(@as(usize, 3), truncateToWidth("hello", 3));
+    try testing.expectEqual(@as(usize, 0), truncateToWidth("hello", 0));
+}
+
+test "truncateToWidth: never splits a wide grapheme across the boundary" {
+    // Each CJK char is 2 cols; width 3 fits only the first (2 + 2 > 3).
+    // 你 is 3 bytes, so the kept prefix is 3 bytes long.
+    try testing.expectEqual(@as(usize, 3), truncateToWidth("你好", 3));
+    try testing.expectEqual(@as(usize, 6), truncateToWidth("你好", 4));
+    // A single wide grapheme doesn't fit in one column.
+    try testing.expectEqual(@as(usize, 0), truncateToWidth("你", 1));
+}
+
+test "truncateToWidth: ANSI escapes are zero width and ride along" {
+    // "\x1b[36m" (5 bytes, 0 cols) + "hi" (2 cols); width 2 keeps both.
+    const s = "\x1b[36mhi";
+    try testing.expectEqual(@as(usize, s.len), truncateToWidth(s, 2));
 }
 
 test "trailingGraphemeLen: ascii, CJK, combining, ZWJ emoji" {

--- a/packages/testing/src/e2e.zig
+++ b/packages/testing/src/e2e.zig
@@ -1850,9 +1850,7 @@ fn assertFrameSnapshot(
 
     // Full rendered screen, rows joined by newlines, trailing blank rows kept so
     // the golden captures the exact frame geometry.
-    const actual = try screen.getAllText(allocator);
-    defer allocator.free(actual);
-    const framed = try reflowToRows(allocator, actual, screen.width, screen.height);
+    const framed = try screen.getAllLines(allocator);
     defer allocator.free(framed);
 
     const masked = try snapshot.maskDynamicContent(allocator, framed);
@@ -1895,28 +1893,6 @@ fn assertFrameSnapshot(
     }
 }
 
-/// getAllText emits width*height chars with no row breaks; split it back into
-/// `height` rows of `width`, trimming each row's trailing spaces.
-fn reflowToRows(allocator: std.mem.Allocator, flat: []const u8, width: u16, height: u16) ![]u8 {
-    var out: std.ArrayList(u8) = .empty;
-    errdefer out.deinit(allocator);
-    // getAllText UTF-8-encodes wide chars, so byte length can exceed width*height;
-    // fall back to a plain copy if the geometry doesn't line up (ASCII TUIs, the
-    // common case here, always line up).
-    if (flat.len != @as(usize, width) * @as(usize, height)) {
-        return allocator.dupe(u8, flat);
-    }
-    var row: u16 = 0;
-    while (row < height) : (row += 1) {
-        if (row > 0) try out.append(allocator, '\n');
-        const start = @as(usize, row) * width;
-        var end = start + width;
-        while (end > start and flat[end - 1] == ' ') end -= 1;
-        try out.appendSlice(allocator, flat[start..end]);
-    }
-    return out.toOwnedSlice(allocator);
-}
-
 /// Print a readable rendered-screen diagnostic for a failed contains/row frame
 /// assertion — the whole screen boxed, so the reader sees exactly what WAS
 /// drawn versus what was asserted.
@@ -1933,9 +1909,7 @@ fn printFrameMismatch(allocator: std.mem.Allocator, screen: *vterm.VTerm, assert
         .snapshot => {},
     }
     std.debug.print("\u{2502} rendered screen ({d}x{d}):\n", .{ screen.width, screen.height });
-    const flat = screen.getAllText(allocator) catch return;
-    defer allocator.free(flat);
-    const framed = reflowToRows(allocator, flat, screen.width, screen.height) catch return;
+    const framed = screen.getAllLines(allocator) catch return;
     defer allocator.free(framed);
     printBoxedScreen(framed);
     std.debug.print("\u{2514}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\n", .{});
@@ -1950,9 +1924,7 @@ fn printFrameNeverSettled(allocator: std.mem.Allocator, screen: *vterm.VTerm, na
     std.debug.print("\u{2502} expectFrame(\"{s}\") — frame never settled within {d}ms (still painting at the deadline)\n", .{ name, timeout_ms });
     std.debug.print("\u{2502} raise the step's timeout/settle window, or check the command for a render that never stops\n", .{});
     std.debug.print("\u{2502} rendered screen ({d}x{d}):\n", .{ screen.width, screen.height });
-    const flat = screen.getAllText(allocator) catch return;
-    defer allocator.free(flat);
-    const framed = reflowToRows(allocator, flat, screen.width, screen.height) catch return;
+    const framed = screen.getAllLines(allocator) catch return;
     defer allocator.free(framed);
     printBoxedScreen(framed);
     std.debug.print("\u{2514}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\n", .{});
@@ -1986,12 +1958,9 @@ fn dumpScriptFailure(
     }
     if (screen) |term| {
         std.debug.print("\u{2502} rendered screen ({d}x{d}):\n", .{ term.width, term.height });
-        if (term.getAllText(allocator)) |flat| {
-            defer allocator.free(flat);
-            if (reflowToRows(allocator, flat, term.width, term.height)) |framed| {
-                defer allocator.free(framed);
-                printBoxedScreen(framed);
-            } else |_| {}
+        if (term.getAllLines(allocator)) |framed| {
+            defer allocator.free(framed);
+            printBoxedScreen(framed);
         } else |_| {}
     } else {
         std.debug.print("\u{2502} (no VTerm allocated — cannot render screen)\n", .{});
@@ -2374,11 +2343,13 @@ test "endsWithSettled: exact match survives trailing newline and SGR resets" {
     try std.testing.expect(!endsWithSettled("", "ready"));
 }
 
-test "reflowToRows splits a flat screen into trimmed rows" {
+test "getAllLines renders a screen into trimmed rows" {
     const allocator = std.testing.allocator;
-    // 4 wide, 2 tall: "ab  " + "c   " → "ab\nc" (trailing spaces trimmed).
-    const flat = "ab  c   ";
-    const out = try reflowToRows(allocator, flat, 4, 2);
+    // 4 wide, 2 tall: "ab" on row 0, "c" on row 1 → "ab\nc" (padding trimmed).
+    var term = try vterm.VTerm.init(allocator, 4, 2);
+    defer term.deinit();
+    term.write("ab\nc");
+    const out = try term.getAllLines(allocator);
     defer allocator.free(out);
     try std.testing.expectEqualStrings("ab\nc", out);
 }

--- a/packages/ui/build.zig
+++ b/packages/ui/build.zig
@@ -4,7 +4,6 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const zg = b.dependency("zg", .{ .target = target, .optimize = optimize });
     const theme_dep = b.dependency("theme", .{ .target = target, .optimize = optimize });
     const terminal_dep = b.dependency("terminal", .{ .target = target, .optimize = optimize });
 
@@ -14,7 +13,6 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
-    mod.addImport("Graphemes", zg.module("Graphemes"));
     mod.addImport("theme", theme_dep.module("theme"));
     mod.addImport("terminal", terminal_dep.module("terminal"));
 
@@ -27,7 +25,6 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
-    test_mod.addImport("Graphemes", zg.module("Graphemes"));
     test_mod.addImport("theme", theme_dep.module("theme"));
     test_mod.addImport("terminal", terminal_dep.module("terminal"));
     test_mod.addImport("vterm", vterm_dep.module("vterm"));

--- a/packages/ui/src/node.zig
+++ b/packages/ui/src/node.zig
@@ -15,7 +15,6 @@
 //! what makes the ADR's zero-config defaults fall out.
 
 const std = @import("std");
-const Graphemes = @import("Graphemes");
 const terminal = @import("terminal");
 const surface_mod = @import("surface.zig");
 
@@ -303,24 +302,9 @@ fn writeTruncated(ctx: *const RenderCtx, region: Region, content: []const u8, st
         _ = try region.writeText(0, 0, ellipsis, style);
         return;
     }
-    const keep = prefixForWidth(content, w - ellipsis_w);
+    const keep = terminal.truncateToWidth(content, w - ellipsis_w);
     const cols = try region.writeText(0, 0, content[0..keep], style);
     _ = try region.writeText(cols, 0, ellipsis, style);
-}
-
-/// Byte length of the longest prefix of `text` that fits `width` columns.
-fn prefixForWidth(text: []const u8, width: u16) usize {
-    var cols: usize = 0;
-    var end: usize = 0;
-    var it = Graphemes.iterator(text);
-    while (it.next()) |g| {
-        const gw = g.displayWidth(text);
-        const w: usize = if (gw > 0) @intCast(gw) else 0;
-        if (cols + w > width) break;
-        cols += w;
-        end = g.offset + g.len;
-    }
-    return end;
 }
 
 fn renderBox(ctx: *const RenderCtx, b: *const Box, region: Region) !void {

--- a/packages/ui/src/surface.zig
+++ b/packages/ui/src/surface.zig
@@ -11,7 +11,7 @@
 //! region are dropped, not clamped into a sibling's cells.
 
 const std = @import("std");
-const Graphemes = @import("Graphemes");
+const terminal = @import("terminal");
 const theme = @import("theme");
 
 pub const Style = theme.Style;
@@ -272,21 +272,16 @@ pub const Region = struct {
         const right: u32 = @as(u32, self.rect.x) + self.rect.w;
         var col: u32 = start;
 
-        var skip_until: usize = 0;
-        var it = Graphemes.iterator(text);
+        var it = terminal.visibleGraphemes(text);
         while (it.next()) |g| {
             if (col >= right) break;
-            if (g.offset < skip_until) continue;
-            if (text[g.offset] == 0x1b) {
-                skip_until = escapeSeqEnd(text, g.offset);
-                continue;
-            }
-            if (text[g.offset] < 0x20 or text[g.offset] == 0x7f) continue;
-            const gw = g.displayWidth(text);
-            if (gw <= 0) continue;
-            const w: u8 = @intCast(@min(gw, 2));
+            // ANSI escapes are already skipped by the iterator; drop remaining
+            // control bytes (they paint nothing) and zero-width clusters.
+            if (g.bytes[0] < 0x20 or g.bytes[0] == 0x7f) continue;
+            if (g.width == 0) continue;
+            const w: u8 = @intCast(@min(g.width, 2));
             if (col + w > right) break;
-            try self.surface.put(@intCast(col), abs_y, text[g.offset..][0..g.len], w, style);
+            try self.surface.put(@intCast(col), abs_y, g.bytes, w, style);
             col += w;
         }
         return @intCast(col - start);
@@ -346,32 +341,6 @@ pub fn scrollThumb(total: usize, visible: usize, scroll: usize, h: u16) Thumb {
     const s = @min(scroll, max_scroll);
     const start: u16 = if (travel == 0) 0 else @intCast((travel * s + max_scroll / 2) / max_scroll);
     return .{ .start = start, .len = len };
-}
-
-/// Index just past the ANSI escape sequence starting at `text[i]` (an ESC the
-/// caller already saw). Same recognizer as `terminal.wrap`: CSI, OSC (BEL/ST
-/// terminated), and two-byte `ESC x` forms; a truncated sequence consumes to
-/// end of string.
-fn escapeSeqEnd(text: []const u8, i: usize) usize {
-    if (i + 1 >= text.len) return i + 1;
-    switch (text[i + 1]) {
-        '[' => {
-            var j = i + 2;
-            while (j < text.len) : (j += 1) {
-                if (text[j] >= 0x40 and text[j] <= 0x7e) return j + 1;
-            }
-            return text.len;
-        },
-        ']' => {
-            var j = i + 2;
-            while (j < text.len) : (j += 1) {
-                if (text[j] == 0x07) return j + 1;
-                if (text[j] == 0x1b and j + 1 < text.len and text[j + 1] == '\\') return j + 2;
-            }
-            return text.len;
-        },
-        else => return i + 2,
-    }
 }
 
 // ============================================================================

--- a/packages/vterm/src/tests/api_test.zig
+++ b/packages/vterm/src/tests/api_test.zig
@@ -53,6 +53,20 @@ test "getAllText" {
     try testing.expectEqualStrings("Hi    ", text); // 6 chars total (3*2)
 }
 
+test "getAllLines splits into rows and trims trailing spaces" {
+    var term = try VTerm.init(testing.allocator, 6, 4);
+    defer term.deinit();
+
+    // Two written rows plus two trailing blank rows; the blanks are kept so the
+    // frame geometry survives, and each row's trailing padding is trimmed.
+    term.write("Line1\nHi");
+
+    const lines = try term.getAllLines(testing.allocator);
+    defer testing.allocator.free(lines);
+
+    try testing.expectEqualStrings("Line1\nHi\n\n", lines);
+}
+
 test "expectOutput helper" {
     // Test the helper function from PLAN.md
     const expected = "Hello" ++ " " ** (80 * 24 - 5); // Fill with spaces to 80*24

--- a/packages/vterm/src/vterm.zig
+++ b/packages/vterm/src/vterm.zig
@@ -1083,6 +1083,26 @@ pub const VTerm = struct {
         return result.toOwnedSlice(allocator);
     }
 
+    /// The full screen as text: each row's visible content (trailing spaces
+    /// trimmed) joined by '\n', with all `height` rows present so trailing
+    /// blank rows preserve the frame geometry. Unlike `getAllText`, which emits
+    /// a flat width*height run with no row breaks, this reports the grid's real
+    /// row structure — callers rendering or snapshotting a frame use it directly
+    /// instead of re-deriving row breaks from geometry.
+    pub fn getAllLines(self: *VTerm, allocator: Allocator) ![]u8 {
+        var result: std.ArrayList(u8) = .empty;
+        errdefer result.deinit(allocator);
+
+        for (0..self.height) |y| {
+            if (y > 0) try result.append(allocator, '\n');
+            const line = try self.getLine(allocator, @intCast(y));
+            defer allocator.free(line);
+            try result.appendSlice(allocator, line);
+        }
+
+        return result.toOwnedSlice(allocator);
+    }
+
     pub fn getLine(self: *VTerm, allocator: Allocator, line_y: u16) ![]u8 {
         if (line_y >= self.height) return allocator.alloc(u8, 0);
 


### PR DESCRIPTION
Fixes #684, Fixes #687

Two duplicate-logic seams from the Grade 12 review, closed together because both are "one behavior, three hand-rolled owners" problems.

## #684 — cell-width math gets a single owner (`terminal`)
`terminal.displayWidth`/`wrapForEach` were the grapheme- and ANSI-aware source of truth, but the ui package reached past the seam into zg's `Graphemes` directly.

- **Added** `terminal.truncateToWidth(text, cols)` — byte length of the longest prefix fitting N columns — plus a public `terminal.visibleGraphemes` iterator (skips ANSI escapes, reports each cluster's display width). `displayWidth` now runs on the same iterator.
- **Deleted** `packages/ui/src/node.zig`'s `prefixForWidth` (re-implemented prefix truncation) → now calls `terminal.truncateToWidth`.
- **Deleted** `packages/ui/src/surface.zig`'s hand-rolled grapheme walk + local `escapeSeqEnd` in `writeText` → now drives `terminal.visibleGraphemes`.
- The ui module no longer imports zg's `Graphemes` at all (import removed from `node.zig`, `surface.zig`, and the `zg`/`Graphemes` wiring dropped from `packages/ui/build.zig`).

vterm's codepoint-level `charWidth` is left as-is: it is a per-codepoint width (vterm's parser is codepoint-driven, one cell per codepoint), not grapheme-cluster width, so it cannot consume the grapheme API without changing behavior or inverting the terminal↔vterm dependency (they are independent siblings, both on zg).

## #687 — vterm gets a row-structured text accessor
- **Added** `vterm.getAllLines(allocator)` — every row's visible text (trailing spaces trimmed) joined by `'\n'`, all `height` rows kept so trailing blanks preserve frame geometry. Unlike `getAllText` (a flat width*height run with no row breaks), it reports the grid's real row structure.
- **Deleted** `packages/testing/src/e2e.zig`'s `reflowToRows`, which re-derived row breaks from geometry. All four call sites (`assertFrameSnapshot`, `printFrameMismatch`, `printFrameNeverSettled`, `dumpScriptFailure`) now use `getAllLines`.

The other two sites named in #687 — `snapshot.stripAnsi` and `endsWithSettled`'s SGR trim — operate on the raw cumulative stdout **stream**, not the vterm grid. A grid accessor cannot serve them: running a stream through the fixed-size emulator would reflow/pad and change snapshot output, so they are left unchanged to keep behavior identical.

## Tests
- New unit tests: `truncateToWidth` (ascii/wide/ANSI), `vterm.getAllLines` (row split + trailing-space trim), and the converted e2e `getAllLines` test.
- `zig build test` (repo root) — green.
- `zig build e2e` (repo root and `projects/zcli`) — green.
- No committed frame-snapshot goldens exist, so the `getAllLines` swap has no golden-regression surface; it is byte-identical to `reflowToRows` for the ASCII case and more correct for wide chars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)