### PR TITLE
docs: document global .flag dispatch invariant (PR #711 review follow-up)

### DIFF
--- a/packages/core/src/registry/compiled.zig
+++ b/packages/core/src/registry/compiled.zig
@@ -833,6 +833,9 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
                             .flag => |ci| {
                                 const short_char = shorts.chars[ci];
                                 inline for (global_options) |global_opt| {
+                                    // A .flag step means shortTakesValue returned false for this
+                                    // char — the first-matching global is boolean — so first-match
+                                    // dispatch of "true" is safe.
                                     if (global_opt.short == short_char) {
                                         try dispatchGlobalOption(context, global_opt, "true", true);
                                         break;


### PR DESCRIPTION
Follow-up to the #711 review (approve, one suggestion): PR #711 was merged before the suggested comment could be added, so this lands it separately.

Adds the one-line invariant note on the global short-bundle `.flag` dispatch loop in `registry/compiled.zig`, mirroring the existing `.unknown => unreachable` note style: a `.flag` step is only emitted when `shortTakesValue` returned false for the char — i.e. the first-matching global is boolean — so first-match dispatch of `"true"` is safe.

Comment-only change; `zig fmt` clean, packages/core `zig build test` green.

Refs #678

🤖 Generated with [Claude Code](https://claude.com/claude-code)