### PR TITLE
init: CLI-shape templates and agent-contract flags (ADR-0028 increments 3+1)

### DIFF
--- a/docs/adr/0028-init-wizard.md
+++ b/docs/adr/0028-init-wizard.md
@@ -110,7 +110,10 @@ Each lands independently, in this order:
 
 1. **Flag parity + `--defaults`/`--yes`/`--dry-run`** for the existing surface
    (plugins flag, non-TTY = defaults formalized). Pure additive; unblocks agents
-   immediately.
+   immediately. — Implemented: `--plugins <list|none>` (comma-separated,
+   validated against the picker set, deduped), `--defaults`, `--yes`/`-y`
+   (implies `--defaults`; will additionally skip the confirm once increment 2
+   adds one), `--dry-run` (plan summary + file list, exit 0, nothing written).
 2. **Git + README + `zig build` verification** with spinners and the summary/
    confirm step. The bulk of the perceived-quality win.
 3. **`--template single`** (top-level `src/commands/index.zig` scaffold) and

--- a/docs/adr/0028-init-wizard.md
+++ b/docs/adr/0028-init-wizard.md
@@ -114,7 +114,12 @@ Each lands independently, in this order:
 2. **Git + README + `zig build` verification** with spinners and the summary/
    confirm step. The bulk of the perceived-quality win.
 3. **`--template single`** (top-level `src/commands/index.zig` scaffold) and
-   the shape prompt — blocked on ADR-0029 landing first.
+   the shape prompt — implemented on top of ADR-0029. Release-gated: init
+   pins generated projects to this CLI's released tag, and root index
+   support ships in the first release after 0.20.0, so while the CLI still
+   carries 0.20.0 the shape prompt is not offered and an explicit
+   `--template single` fails closed with the reason. The gate clears
+   automatically at the next release bump.
 4. **Plugin config prompt-through** (`github_upgrade` repo, `--upgrade-repo`,
    git-remote default).
 5. **`zcli gh add workflow ci`**, then the extras step reusing both gh

--- a/examples/init-scaffold/README.md
+++ b/examples/init-scaffold/README.md
@@ -1,9 +1,15 @@
 # init-scaffold
 
 This is the exact project `zcli init` scaffolds — its `build.zig`,
-`src/main.zig`, and `src/commands/hello.zig` are the **reference sources** the
-`init` command `@embedFile`s and (for `build.zig`) substitutes the project
-name, description, and selected plugins into.
+`src/main.zig`, `src/commands/hello.zig`, and `src/commands/index.zig` are the
+**reference sources** the `init` command `@embedFile`s and (for `build.zig`)
+substitutes the project name, description, and selected plugins into.
+
+A generated project gets ONE of the two command files, by template:
+`hello.zig` for `--template multi` (the default), `index.zig` — the root
+command (ADR-0029) — for `--template single`. They coexist here so one
+compiled project vouches for both scaffolds (an exact command name beats the
+root's positionals, so both are exercised).
 
 Because it lives in-repo and is registered as a test project (root `build.zig`),
 `zig build test` and `zig build build-examples` compile it against the local,

--- a/examples/init-scaffold/src/commands/index.zig
+++ b/examples/init-scaffold/src/commands/index.zig
@@ -1,0 +1,44 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const Context = @import("command_registry").Context;
+
+// The root command (ADR-0029): this file makes the app itself the command —
+// `myapp World` greets World, no subcommand needed. Emitted by
+// `zcli init --template single`; a multi-command project has no root index.
+// Sibling command files still work alongside it: an exact command name
+// always wins over the root's positionals.
+
+pub const meta = .{
+    .description = "Say hello to someone",
+    .examples = &.{
+        "World",
+        "Alice --loud",
+    },
+    // Arg descriptions are plain strings; option descriptions are structs
+    // that can also declare a short flag (and .name/.env). These show up in
+    // `--help` and the generated docs, so the first command a user reads
+    // models the full grammar.
+    .args = .{
+        .name = "Who to greet",
+    },
+    .options = .{
+        .loud = .{ .description = "Shout the greeting", .short = 'l' },
+    },
+};
+
+pub const Args = struct {
+    // Optional so the bare `myapp` still runs (greeting the world). Make it
+    // non-optional (`name: []const u8`) to require a value instead — then
+    // bare `myapp` reports a missing argument with usage, rg-style.
+    name: ?[]const u8 = null,
+};
+
+pub const Options = struct {
+    loud: bool = false,
+};
+
+pub fn execute(args: Args, options: Options, context: *Context) !void {
+    const name = args.name orelse "world";
+    const greeting = if (options.loud) "HELLO" else "Hello";
+    try context.stdout().print("{s}, {s}!\n", .{ greeting, name });
+}

--- a/projects/zcli/build.zig
+++ b/projects/zcli/build.zig
@@ -50,6 +50,9 @@ pub fn build(b: *std.Build) !void {
     scaffold_module.addAnonymousImport("reference/hello.zig", .{
         .root_source_file = b.path("../../examples/init-scaffold/src/commands/hello.zig"),
     });
+    scaffold_module.addAnonymousImport("reference/index.zig", .{
+        .root_source_file = b.path("../../examples/init-scaffold/src/commands/index.zig"),
+    });
 
     // Canonical example sources embedded into `zcli guide` (ADR-0004/0008). Each
     // anonymous import binds a `@embedFile` name in guide_examples.zig to a real

--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -256,7 +256,10 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
     }
     const selected = if (options.plugins) |plugins_arg|
         parsePluginsFlag(allocator, plugins_arg) catch |err| switch (err) {
-            error.UnknownPlugin => return context.fail("Error: unknown plugin in --plugins '{s}'\n  Valid plugins: {s} — or 'none'", .{ plugins_arg, valid_plugin_tags },),
+            error.UnknownPlugin => return context.fail(
+                "Error: unknown plugin in --plugins '{s}'\n  Valid plugins: {s} — or 'none'",
+                .{ plugins_arg, valid_plugin_tags },
+            ),
             else => return err,
         }
     else if (use_defaults)

--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -47,6 +47,7 @@ pub const meta = .{
         "init my-app",
         "init my-app --description \"My awesome CLI\"",
         "init my-app --app-version 1.0.0",
+        "init my-tool --template single",
         "init . --description \"Initialize in current directory\"",
     },
     .args = .{
@@ -59,8 +60,15 @@ pub const meta = .{
         // so a command option spelled --version would be unreachable from the
         // CLI (#565).
         .app_version = .{ .description = "Initial version number" },
+        .template = .{ .description = "CLI shape: multi (subcommands, git style) or single (the app itself is the command, rg style)" },
     },
 };
+
+/// The two scaffold shapes (ADR-0028/0029). `multi` is the classic subcommand
+/// tree seeded with an example `hello` command; `single` seeds a root
+/// `src/commands/index.zig` — the app itself is the command. Restructuring
+/// between shapes later is annoying, which is why init asks up front.
+const Template = enum { multi, single };
 
 pub const Args = struct {
     name: []const u8,
@@ -69,6 +77,7 @@ pub const Args = struct {
 pub const Options = struct {
     description: ?[]const u8 = null,
     app_version: ?[]const u8 = null,
+    template: ?Template = null,
 };
 
 pub fn execute(args: Args, options: Options, context: *Context) !void {
@@ -184,6 +193,40 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         try stdout.print("Creating new zcli project: {s}\n", .{project_name});
     }
 
+    const p = context.prompts();
+
+    // Root index support (ADR-0029) ships in the first release AFTER 0.20.0.
+    // init pins the generated project to this CLI's own version tag, so a CLI
+    // still carrying the 0.20.0 version would scaffold an index.zig the
+    // released library silently ignores — a project that builds but routes
+    // every positional to "Unknown command". While that's the pinned release,
+    // don't offer the shape (default multi) and fail closed on an explicit
+    // --template single. The guard clears automatically when the release bump
+    // moves the version past 0.20.0.
+    const root_index_ok = rootIndexSupported(context.app_version);
+
+    // Ask for the CLI shape first (ADR-0028 step 3) unless --template decided
+    // it. Restructuring between shapes later is annoying, so it's asked up
+    // front; non-interactive invocations default to multi (today's scaffold).
+    const template: Template = options.template orelse blk: {
+        if (!root_index_ok) break :blk .multi;
+        const shape = p.select(.{
+            .message = "What kind of CLI?",
+            .choices = &.{
+                "multi-command — subcommands like `app hello` (git style)",
+                "single-command — the app itself is the command (rg style)",
+            },
+        }) catch |err| switch (err) {
+            error.EndOfStream => break :blk .multi,
+            else => return err,
+        };
+        break :blk if (shape == 1) .single else .multi;
+    };
+
+    if (template == .single and !root_index_ok) {
+        return context.fail("Error: --template single requires the zcli library released after 0.20.0 (root index support, ADR-0029)\n  This zcli pins generated projects to v{s}, which ignores a top-level index.zig.\n  Upgrade zcli, or scaffold with the default multi-command template.", .{context.app_version});
+    }
+
     // Ask which built-in plugins to include, before touching the filesystem.
     // Falls back to the preselected defaults when stdin is not a TTY.
     var choices: [builtin_choices.len][]const u8 = undefined;
@@ -192,7 +235,6 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         choices[i] = choice.label;
         defaults[i] = choice.default;
     }
-    const p = context.prompts();
     const selected = p.multiSelect(.{
         .message = "Select built-in plugins to include:",
         .choices = &choices,
@@ -292,16 +334,26 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
     defer main_file.close(io);
     try main_file.writeStreamingAll(io, scaffold.reference.main_zig);
 
-    // Generate example command: src/commands/hello.zig — verbatim from the
-    // compiled reference.
-    try stdout.print("  Creating example command (hello)...\n", .{});
-
+    // Seed the chosen shape's starting command — verbatim from the compiled
+    // reference. multi: an example `hello` subcommand. single: a root
+    // `index.zig` (ADR-0029) — the app itself is the command.
     var commands_dir = try src_dir.openDir(io, "commands", .{});
     defer commands_dir.close(io);
 
-    var hello_file = try commands_dir.createFile(io, "hello.zig", .{});
-    defer hello_file.close(io);
-    try hello_file.writeStreamingAll(io, scaffold.reference.hello_zig);
+    switch (template) {
+        .multi => {
+            try stdout.print("  Creating example command (hello)...\n", .{});
+            var hello_file = try commands_dir.createFile(io, "hello.zig", .{});
+            defer hello_file.close(io);
+            try hello_file.writeStreamingAll(io, scaffold.reference.hello_zig);
+        },
+        .single => {
+            try stdout.print("  Creating root command (index.zig)...\n", .{});
+            var index_file = try commands_dir.createFile(io, "index.zig", .{});
+            defer index_file.close(io);
+            try index_file.writeStreamingAll(io, scaffold.reference.index_zig);
+        },
+    }
 
     // Scaffold AGENTS.md — the thin, frozen, command-speaking spine that points
     // coding agents at `zcli guide` (ADR-0008). Marker-delimited so it never
@@ -338,27 +390,28 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
 
     // Success message. When the fetch failed, `zig build` would only fail with
     // a missing-dependency error the user never asked for — don't claim success
-    // or suggest a next step that can't work yet.
+    // or suggest a next step that can't work yet. The try-it line matches the
+    // scaffolded shape: `hello World` for multi, a bare root positional for
+    // single.
     if (fetch_ok) {
         try stdout.print("\n✓ Project '{s}' created successfully!\n\n", .{project_name});
         try stdout.print("Next steps:\n", .{});
-        if (!use_current_dir) {
-            try stdout.print("  cd {s}\n", .{args.name});
-        }
-        try stdout.print("  zig build\n", .{});
-        try stdout.print("  ./zig-out/bin/{s} hello World\n", .{project_name});
-        try stdout.print("  ./zig-out/bin/{s} --help\n", .{project_name});
     } else {
         try stdout.print("\n⚠ Project '{s}' created, but the zcli dependency was not fetched.\n\n", .{project_name});
         try stdout.print("Next steps:\n", .{});
-        if (!use_current_dir) {
-            try stdout.print("  cd {s}\n", .{args.name});
-        }
-        try stdout.print("  zig fetch --save {s}\n", .{zcli_url});
-        try stdout.print("  zig build\n", .{});
-        try stdout.print("  ./zig-out/bin/{s} hello World\n", .{project_name});
-        try stdout.print("  ./zig-out/bin/{s} --help\n", .{project_name});
     }
+    if (!use_current_dir) {
+        try stdout.print("  cd {s}\n", .{args.name});
+    }
+    if (!fetch_ok) {
+        try stdout.print("  zig fetch --save {s}\n", .{zcli_url});
+    }
+    try stdout.print("  zig build\n", .{});
+    switch (template) {
+        .multi => try stdout.print("  ./zig-out/bin/{s} hello World\n", .{project_name}),
+        .single => try stdout.print("  ./zig-out/bin/{s} World\n", .{project_name}),
+    }
+    try stdout.print("  ./zig-out/bin/{s} --help\n", .{project_name});
 }
 
 // ---------------------------------------------------------------------------
@@ -409,7 +462,8 @@ const agents_section = agents_begin ++
     \\5. Verify with `zig build` and `zig build test`. Run `zcli guide <topic>` for
     \\   version-matched API detail and worked examples.
     \\6. File path = command path: `src/commands/foo/bar.zig` → `app foo bar`; a directory's
-    \\   `index.zig` is the group landing; plugins live in `src/plugins/`.
+    \\   `index.zig` is the group landing; a top-level `index.zig` is the root command
+    \\   (`app` itself — single-command CLIs); plugins live in `src/plugins/`.
     \\
     \\`zcli guide` topics: structure, sharing, storage, arena, output, prompts, http, secrets, plugins, testing.
     \\
@@ -561,6 +615,25 @@ test "renderBuildZig substitutes name, description, plugins and pins addCommandT
     try std.testing.expect(std.mem.indexOf(u8, build, "zcli.addCommandTests(b, exe, zcli_dep,") == null);
     // Framework-coupled call the reference compile-guards survives verbatim.
     try std.testing.expect(std.mem.indexOf(u8, build, "try zcli.generate(b, exe, zcli_dep, .{") != null);
+}
+
+/// True when the zcli release this CLI pins (its own version) contains root
+/// index support (ADR-0029) — i.e. is strictly newer than 0.20.0, the last
+/// release without it. Unparseable versions count as unsupported: fail closed
+/// rather than scaffold a silently-dead index.zig.
+fn rootIndexSupported(version_str: []const u8) bool {
+    const v = std.SemanticVersion.parse(version_str) catch return false;
+    const last_without = std.SemanticVersion{ .major = 0, .minor = 20, .patch = 0 };
+    return v.order(last_without) == .gt;
+}
+
+test "rootIndexSupported: strictly newer than 0.20.0, fail closed on junk" {
+    try std.testing.expect(!rootIndexSupported("0.20.0"));
+    try std.testing.expect(!rootIndexSupported("0.19.9"));
+    try std.testing.expect(rootIndexSupported("0.20.1"));
+    try std.testing.expect(rootIndexSupported("0.21.0"));
+    try std.testing.expect(rootIndexSupported("1.0.0"));
+    try std.testing.expect(!rootIndexSupported("not-a-version"));
 }
 
 /// True if `s` is a semantic version acceptable to Zig's build.zig.zon manifest

--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -48,6 +48,8 @@ pub const meta = .{
         "init my-app --description \"My awesome CLI\"",
         "init my-app --app-version 1.0.0",
         "init my-tool --template single",
+        "init my-app --plugins help,version,completions --defaults",
+        "init my-app --dry-run",
         "init . --description \"Initialize in current directory\"",
     },
     .args = .{
@@ -61,6 +63,10 @@ pub const meta = .{
         // CLI (#565).
         .app_version = .{ .description = "Initial version number" },
         .template = .{ .description = "CLI shape: multi (subcommands, git style) or single (the app itself is the command, rg style)" },
+        .plugins = .{ .description = "Built-in plugins as a comma-separated list (e.g. help,version,completions), or 'none'" },
+        .defaults = .{ .description = "Answer every prompt with its default (implied when stdin is not a TTY)" },
+        .yes = .{ .description = "Like --defaults, and skip any confirmation", .short = 'y' },
+        .dry_run = .{ .description = "Print what would be created without writing anything" },
     },
 };
 
@@ -78,6 +84,10 @@ pub const Options = struct {
     description: ?[]const u8 = null,
     app_version: ?[]const u8 = null,
     template: ?Template = null,
+    plugins: ?[]const u8 = null,
+    defaults: bool = false,
+    yes: bool = false,
+    dry_run: bool = false,
 };
 
 pub fn execute(args: Args, options: Options, context: *Context) !void {
@@ -180,7 +190,7 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
             return context.fail("Error: Current directory is not empty\nTip: only hidden files and an existing AGENTS.md are allowed", .{});
         }
 
-        try stdout.print("Initializing zcli project in current directory: {s}\n", .{project_name});
+        if (!options.dry_run) try stdout.print("Initializing zcli project in current directory: {s}\n", .{project_name});
     } else {
         // Check if directory already exists (access succeeds => the path exists).
         if (cwd.access(io, args.name, .{})) |_| {
@@ -190,10 +200,18 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
             else => return err,
         }
 
-        try stdout.print("Creating new zcli project: {s}\n", .{project_name});
+        if (!options.dry_run) try stdout.print("Creating new zcli project: {s}\n", .{project_name});
     }
 
     const p = context.prompts();
+
+    // The agent contract (ADR-0028): every prompt has a flag, and --defaults
+    // answers every remaining prompt with its default. --yes implies
+    // --defaults (it will additionally skip the confirm step when one
+    // exists). A non-TTY stdin gets the same effect through each prompt's
+    // EndOfStream fallback; --defaults also short-circuits the prompts
+    // entirely so a script WITH a terminal attached never blocks.
+    const use_defaults = options.defaults or options.yes;
 
     // Root index support (ADR-0029) ships in the first release AFTER 0.20.0.
     // init pins the generated project to this CLI's own version tag, so a CLI
@@ -209,7 +227,7 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
     // it. Restructuring between shapes later is annoying, so it's asked up
     // front; non-interactive invocations default to multi (today's scaffold).
     const template: Template = options.template orelse blk: {
-        if (!root_index_ok) break :blk .multi;
+        if (!root_index_ok or use_defaults) break :blk .multi;
         const shape = p.select(.{
             .message = "What kind of CLI?",
             .choices = &.{
@@ -227,29 +245,66 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         return context.fail("Error: --template single requires the zcli library released after 0.20.0 (root index support, ADR-0029)\n  This zcli pins generated projects to v{s}, which ignores a top-level index.zig.\n  Upgrade zcli, or scaffold with the default multi-command template.", .{context.app_version});
     }
 
-    // Ask which built-in plugins to include, before touching the filesystem.
-    // Falls back to the preselected defaults when stdin is not a TTY.
+    // Which built-in plugins to include: --plugins decides outright,
+    // --defaults/--yes takes the preselected defaults, otherwise ask (with
+    // the same defaults as the non-TTY fallback).
     var choices: [builtin_choices.len][]const u8 = undefined;
     var defaults: [builtin_choices.len]bool = undefined;
     for (builtin_choices, 0..) |choice, i| {
         choices[i] = choice.label;
         defaults[i] = choice.default;
     }
-    const selected = p.multiSelect(.{
-        .message = "Select built-in plugins to include:",
-        .choices = &choices,
-        .defaults = &defaults,
-    }) catch |err| switch (err) {
-        // Non-interactive invocation (piped/closed stdin): take the preselected
-        // defaults rather than aborting — `init` must work in scripts and CI.
-        error.EndOfStream => try collectDefaultPlugins(allocator, &defaults),
-        else => return err,
-    };
+    const selected = if (options.plugins) |plugins_arg|
+        parsePluginsFlag(allocator, plugins_arg) catch |err| switch (err) {
+            error.UnknownPlugin => return context.fail("Error: unknown plugin in --plugins '{s}'\n  Valid plugins: {s} — or 'none'", .{ plugins_arg, valid_plugin_tags },),
+            else => return err,
+        }
+    else if (use_defaults)
+        try collectDefaultPlugins(allocator, &defaults)
+    else
+        p.multiSelect(.{
+            .message = "Select built-in plugins to include:",
+            .choices = &choices,
+            .defaults = &defaults,
+        }) catch |err| switch (err) {
+            // Non-interactive invocation (piped/closed stdin): take the
+            // preselected defaults rather than aborting — `init` must work in
+            // scripts and CI.
+            error.EndOfStream => try collectDefaultPlugins(allocator, &defaults),
+            else => return err,
+        };
     defer allocator.free(selected);
 
     // Build the `zcli.builtin(...)` registration lines for build.zig.
     const plugins_block = try renderPluginsBlock(allocator, selected);
     defer allocator.free(plugins_block);
+
+    // --dry-run: everything is decided and validated; report what would be
+    // created and stop before touching the filesystem.
+    if (options.dry_run) {
+        try stdout.print("\nDry run — nothing written. Would create:\n", .{});
+        const prefix: []const u8 = if (use_current_dir) "" else args.name;
+        const sep: []const u8 = if (use_current_dir) "" else "/";
+        try stdout.print("  template: {s}\n", .{@tagName(template)});
+        try stdout.print("  plugins:  ", .{});
+        if (selected.len == 0) {
+            try stdout.print("(none)", .{});
+        } else for (selected, 0..) |idx, i| {
+            if (i > 0) try stdout.print(", ", .{});
+            try stdout.print("{s}", .{builtin_choices[idx].tag});
+        }
+        try stdout.print("\n  files:\n", .{});
+        try stdout.print("    {s}{s}build.zig\n", .{ prefix, sep });
+        try stdout.print("    {s}{s}build.zig.zon\n", .{ prefix, sep });
+        try stdout.print("    {s}{s}src/main.zig\n", .{ prefix, sep });
+        switch (template) {
+            .multi => try stdout.print("    {s}{s}src/commands/hello.zig\n", .{ prefix, sep }),
+            .single => try stdout.print("    {s}{s}src/commands/index.zig\n", .{ prefix, sep }),
+        }
+        try stdout.print("    {s}{s}AGENTS.md\n", .{ prefix, sep });
+        try stdout.print("  then: zig fetch --save https://github.com/ryanhair/zcli/archive/refs/tags/v{s}.tar.gz\n", .{context.app_version});
+        return;
+    }
 
     // Now that the destination is validated and plugins are chosen, create and
     // open the project directory.
@@ -480,6 +535,69 @@ const AgentsResult = enum { created, appended, refreshed };
 /// Owned slice of the indices whose `defaults` bit is set — the non-interactive
 /// fallback for the plugin picker (mirrors what `multiSelect` returns for a
 /// submitted-defaults selection).
+/// The valid --plugins names, comma-joined for the error message. Comptime so
+/// the list can never drift from builtin_choices.
+const valid_plugin_tags = blk: {
+    var s: []const u8 = "";
+    for (builtin_choices, 0..) |choice, i| {
+        if (i > 0) s = s ++ ", ";
+        s = s ++ choice.tag;
+    }
+    break :blk s;
+};
+
+/// Parse the --plugins flag: a comma-separated list of builtin_choices tags
+/// ('help,version,completions'), or 'none' for an empty selection. Returns
+/// owned picker indices (same shape as multiSelect). Empty items from
+/// stray/trailing commas are ignored; duplicates collapse (indices are
+/// deduped so build.zig never registers a plugin twice). Unknown names are
+/// error.UnknownPlugin — the caller renders the message with the valid list.
+fn parsePluginsFlag(allocator: std.mem.Allocator, arg: []const u8) ![]usize {
+    var list = std.ArrayList(usize).empty;
+    errdefer list.deinit(allocator);
+
+    if (std.mem.eql(u8, std.mem.trim(u8, arg, " "), "none")) {
+        return list.toOwnedSlice(allocator);
+    }
+
+    var it = std.mem.splitScalar(u8, arg, ',');
+    while (it.next()) |raw| {
+        const name = std.mem.trim(u8, raw, " ");
+        if (name.len == 0) continue;
+        const idx = for (builtin_choices, 0..) |choice, i| {
+            if (std.mem.eql(u8, choice.tag, name)) break i;
+        } else return error.UnknownPlugin;
+        const already = for (list.items) |have| {
+            if (have == idx) break true;
+        } else false;
+        if (!already) try list.append(allocator, idx);
+    }
+    return list.toOwnedSlice(allocator);
+}
+
+test "parsePluginsFlag: named plugins resolve to picker indices, deduped" {
+    const allocator = std.testing.allocator;
+    const selected = try parsePluginsFlag(allocator, "version,help,version");
+    defer allocator.free(selected);
+    // Indices follow builtin_choices order of the names given, first mention wins.
+    try std.testing.expectEqualSlices(usize, &.{ 1, 0 }, selected);
+}
+
+test "parsePluginsFlag: 'none' and empty items" {
+    const allocator = std.testing.allocator;
+    const none = try parsePluginsFlag(allocator, "none");
+    defer allocator.free(none);
+    try std.testing.expectEqual(@as(usize, 0), none.len);
+
+    const trailing = try parsePluginsFlag(allocator, "help,");
+    defer allocator.free(trailing);
+    try std.testing.expectEqualSlices(usize, &.{0}, trailing);
+}
+
+test "parsePluginsFlag: unknown names are rejected" {
+    try std.testing.expectError(error.UnknownPlugin, parsePluginsFlag(std.testing.allocator, "help,bogus"));
+}
+
 fn collectDefaultPlugins(allocator: std.mem.Allocator, defaults: []const bool) ![]usize {
     var list = std.ArrayList(usize).empty;
     errdefer list.deinit(allocator);

--- a/projects/zcli/src/scaffold/reference.zig
+++ b/projects/zcli/src/scaffold/reference.zig
@@ -18,3 +18,4 @@
 pub const build_zig = @embedFile("reference/build.zig");
 pub const main_zig = @embedFile("reference/main.zig");
 pub const hello_zig = @embedFile("reference/hello.zig");
+pub const index_zig = @embedFile("reference/index.zig");

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -306,6 +306,74 @@ test "init scaffolds a project with the expected files and wiring" {
     try expectContains(agents, "per-command arena");
 }
 
+test "init --template single scaffolds a root index.zig instead of hello (ADR-0028/0029)" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "mytool", "--template", "single" });
+    defer r.deinit();
+
+    // The single template needs a released library with root index support
+    // (> 0.20.0). While this CLI still pins 0.20.0, init fails closed with
+    // the reason rather than scaffolding a silently-dead index.zig — assert
+    // whichever outcome init declared (same pattern as the fetch-outcome
+    // branch above). The guard branch dies with the release bump.
+    if (r.exit_code != 0) {
+        try expectContains(r.stderr, "--template single requires");
+        try testing.expect(!fileExists(tmp.dir, "mytool/src/commands/index.zig"));
+        return;
+    }
+
+    var proj = try tmp.dir.openDir(io, "mytool", .{});
+    defer proj.close(io);
+
+    // The single shape seeds the root command, not the hello subcommand.
+    try testing.expect(fileExists(proj, "src/commands/index.zig"));
+    try testing.expect(!fileExists(proj, "src/commands/hello.zig"));
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // The root index is the app's own command: optional positional so bare
+    // invocation runs, executable (a meta-only root index is a compile error).
+    const index = try readFile(proj, a, "src/commands/index.zig");
+    try expectContains(index, "pub fn execute(");
+    try expectContains(index, "name: ?[]const u8 = null");
+
+    // Next-steps must demo the single shape (no `hello` anywhere).
+    try expectContains(r.stdout, "Creating root command (index.zig)");
+    try testing.expect(std.mem.indexOf(u8, r.stdout, "hello World") == null);
+}
+
+test "init defaults to the multi template when non-interactive" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // No --template and no TTY: the shape prompt falls back to multi —
+    // today's scaffold, an example hello subcommand and no root index.
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp" });
+    defer r.deinit();
+    try expectOk(r);
+
+    var proj = try tmp.dir.openDir(io, "myapp", .{});
+    defer proj.close(io);
+    try testing.expect(fileExists(proj, "src/commands/hello.zig"));
+    try testing.expect(!fileExists(proj, "src/commands/index.zig"));
+}
+
+test "init rejects an unknown --template value with the enum diagnostic" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--template", "solo" });
+    defer r.deinit();
+    try testing.expect(r.exit_code != 0);
+    // The enum parser names the valid choices; the project must not be created.
+    try expectContains(r.stderr, "single");
+    try testing.expect(!fileExists(tmp.dir, "myapp"));
+}
+
 test "init escapes free-text --description into a valid string literal" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -346,6 +346,99 @@ test "init --template single scaffolds a root index.zig instead of hello (ADR-00
     try testing.expect(std.mem.indexOf(u8, r.stdout, "hello World") == null);
 }
 
+test "init --plugins takes the list verbatim, no prompt (agent contract)" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--plugins", "help,completions" });
+    defer r.deinit();
+    try expectOk(r);
+
+    var proj = try tmp.dir.openDir(io, "myapp", .{});
+    defer proj.close(io);
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const build_zig = try readFile(proj, arena.allocator(), "build.zig");
+    try expectContains(build_zig, "zcli.builtin(.help");
+    try expectContains(build_zig, "zcli.builtin(.completions");
+    // Exactly the named plugins — not the picker defaults on top.
+    try testing.expect(std.mem.indexOf(u8, build_zig, "zcli.builtin(.version") == null);
+    try testing.expect(std.mem.indexOf(u8, build_zig, "zcli.builtin(.not_found") == null);
+    // The flag answered the prompt: no picker rendered.
+    try testing.expect(std.mem.indexOf(u8, r.stdout, "Select built-in plugins") == null);
+}
+
+test "init --plugins none scaffolds a plugin-free project" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--plugins", "none" });
+    defer r.deinit();
+    try expectOk(r);
+
+    var proj = try tmp.dir.openDir(io, "myapp", .{});
+    defer proj.close(io);
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const build_zig = try readFile(proj, arena.allocator(), "build.zig");
+    try testing.expect(std.mem.indexOf(u8, build_zig, "zcli.builtin(") == null);
+}
+
+test "init --plugins rejects unknown names, listing the valid set, creating nothing" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--plugins", "help,bogus" });
+    defer r.deinit();
+    try testing.expect(r.exit_code != 0);
+    try expectContains(r.stderr, "unknown plugin");
+    try expectContains(r.stderr, "github_upgrade");
+    try testing.expect(!fileExists(tmp.dir, "myapp"));
+}
+
+test "init --dry-run reports the plan and writes nothing" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--dry-run", "--defaults" });
+    defer r.deinit();
+    try expectOk(r);
+
+    try expectContains(r.stdout, "Dry run — nothing written");
+    try expectContains(r.stdout, "template: multi");
+    try expectContains(r.stdout, "help, version, not_found");
+    try expectContains(r.stdout, "myapp/src/commands/hello.zig");
+    try expectContains(r.stdout, "zig fetch --save");
+    // Nothing on disk, and no misleading "Creating..." banner.
+    try testing.expect(!fileExists(tmp.dir, "myapp"));
+    try testing.expect(std.mem.indexOf(u8, r.stdout, "Creating new zcli project") == null);
+}
+
+test "init --defaults answers the prompts without rendering them" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--defaults" });
+    defer r.deinit();
+    try expectOk(r);
+
+    // No prompt output even in the non-TTY numbered-list form.
+    try testing.expect(std.mem.indexOf(u8, r.stdout, "Select built-in plugins") == null);
+
+    var proj = try tmp.dir.openDir(io, "myapp", .{});
+    defer proj.close(io);
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const build_zig = try readFile(proj, arena.allocator(), "build.zig");
+    try expectContains(build_zig, "zcli.builtin(.help");
+    try expectContains(build_zig, "zcli.builtin(.version");
+    try expectContains(build_zig, "zcli.builtin(.not_found");
+    try testing.expect(fileExists(proj, "src/commands/hello.zig"));
+}
+
 test "init defaults to the multi template when non-interactive" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();


### PR DESCRIPTION
## Summary

Two ADR-0028 increments for `zcli init`, built on ADR-0029 (#716):

**Increment 3 — CLI shape** (`--template multi|single` + prompt):
- Interactive: a "What kind of CLI?" select before the plugin picker — multi-command (git style) or single-command (rg style).
- `single` seeds `src/commands/index.zig` — the root command — instead of `hello.zig`, with an optional positional (bare `app` greets the world) and a comment showing the required-arg rg-style variant. Next-steps output demos the chosen shape.
- Non-interactive default stays `multi`, byte-for-byte today's scaffold.
- The root-index reference joins `examples/init-scaffold/src/commands/` alongside `hello.zig`, so the one compiled example project vouches for both scaffolds (they coexist legally under ADR-0029; init emits one per template).

**Increment 1 — the agent contract** (every prompt has a flag):
- `--plugins <list|none>`: comma-separated built-in plugin names, validated against the picker set with the valid list in the error, deduped; skips the picker entirely. `none` scaffolds plugin-free.
- `--defaults`: answers every remaining prompt with its default without rendering it — a script with a TTY attached never blocks.
- `--yes`/`-y`: implies `--defaults`; will additionally skip the confirm step when increment 2 adds one.
- `--dry-run`: prints the decided plan (template, plugins, file list, fetch command) and exits 0 with nothing written; the "Creating…" banner is suppressed so the output can't read as a real run.

## Release gate (increment 3 only)

`init` pins generated projects to this CLI's released tag, and root-index support ships in the first release **after 0.20.0**. A `single` scaffold against v0.20.0 would build and then silently ignore its `index.zig` (every positional → "Unknown command") — so while the CLI still carries 0.20.0, the shape prompt isn't offered and an explicit `--template single` fails closed with the reason. `rootIndexSupported` (strictly-newer-than-0.20.0) and its e2e branch clear automatically at the next release bump — which also retires the existing #709 `addCommandTests` pin.

## Testing

- e2e: single-template scaffold (guard-era branch included), non-interactive multi default, unknown `--template` rejected; `--plugins` list/`none`/unknown-name; `--dry-run` writes nothing and hides the banner; `--defaults` renders no prompts. Full `zig build e2e` green.
- Unit: `rootIndexSupported` boundaries (0.20.0 out, 0.20.1+ in, junk fails closed); `parsePluginsFlag` (dedup, `none`, trailing commas, unknown names).
- Manually verified: guard message, non-interactive default, and — with a temporarily bumped version — the post-release emission path including the not-yet-fetched warning flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)