### PR TITLE
init: README, git init + initial commit, zig build verification, summary/confirm (ADR-0028 increment 2)

### DIFF
--- a/docs/adr/0028-init-wizard.md
+++ b/docs/adr/0028-init-wizard.md
@@ -115,7 +115,16 @@ Each lands independently, in this order:
    (implies `--defaults`; will additionally skip the confirm once increment 2
    adds one), `--dry-run` (plan summary + file list, exit 0, nothing written).
 2. **Git + README + `zig build` verification** with spinners and the summary/
-   confirm step. The bulk of the perceived-quality win.
+   confirm step. The bulk of the perceived-quality win. — Implemented:
+   README.md stub (shape-aware try-it line); `git init` + `.gitignore` +
+   initial commit (default on, `--no-git`; skipped silently when git is
+   absent or the destination is already inside a work tree; a commit
+   without a configured git identity degrades to a warning with the exact
+   commands); `zig build` verification with a spinner (default on,
+   `--no-build`, only after a successful fetch; failure is a warning naming
+   `zig build`, never a rollback) — a verified build drops `zig build` from
+   next-steps; summary + confirm before anything touches disk (skipped by
+   `--defaults`/`--yes`; non-TTY proceeds via the confirm's default).
 3. **`--template single`** (top-level `src/commands/index.zig` scaffold) and
    the shape prompt — implemented on top of ADR-0029. Release-gated: init
    pins generated projects to this CLI's released tag, and root index

--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -67,6 +67,8 @@ pub const meta = .{
         .defaults = .{ .description = "Answer every prompt with its default (implied when stdin is not a TTY)" },
         .yes = .{ .description = "Like --defaults, and skip any confirmation", .short = 'y' },
         .dry_run = .{ .description = "Print what would be created without writing anything" },
+        .git = .{ .description = "Initialize a git repository with a .gitignore and an initial commit (--no-git to skip)" },
+        .build = .{ .description = "Verify the scaffold with `zig build` after fetching (--no-build to skip)" },
     },
 };
 
@@ -88,6 +90,8 @@ pub const Options = struct {
     defaults: bool = false,
     yes: bool = false,
     dry_run: bool = false,
+    git: bool = true,
+    build: bool = true,
 };
 
 pub fn execute(args: Args, options: Options, context: *Context) !void {
@@ -161,7 +165,10 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
     // Free-text options are embedded in generated string literals — escape so
     // `--description 'say "hi"'` scaffolds a project that still compiles
     // instead of breaking (or injecting code into) build.zig / build.zig.zon.
-    const app_description = try escapeStringLiteral(allocator, options.description orelse "A CLI application built with zcli");
+    // Raw for README.md (markdown, no escaping); escaped below for generated
+    // Zig/zon string literals.
+    const description_raw = options.description orelse "A CLI application built with zcli";
+    const app_description = try escapeStringLiteral(allocator, description_raw);
     defer allocator.free(app_description);
     const app_version = try escapeStringLiteral(allocator, version_str);
     defer allocator.free(app_version);
@@ -282,21 +289,31 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
     const plugins_block = try renderPluginsBlock(allocator, selected);
     defer allocator.free(plugins_block);
 
-    // --dry-run: everything is decided and validated; report what would be
-    // created and stop before touching the filesystem.
+    // Everything is decided: one summary, shown for both the dry run and the
+    // interactive confirm (ADR-0028 step 6).
+    const summarize = struct {
+        fn print(w: anytype, tpl: Template, sel: []const usize, with_git: bool, with_build: bool) !void {
+            try w.print("  template: {s}\n", .{@tagName(tpl)});
+            try w.print("  plugins:  ", .{});
+            if (sel.len == 0) {
+                try w.print("(none)", .{});
+            } else for (sel, 0..) |idx, i| {
+                if (i > 0) try w.print(", ", .{});
+                try w.print("{s}", .{builtin_choices[idx].tag});
+            }
+            try w.print("\n  git:      {s}\n", .{if (with_git) "init + .gitignore + initial commit" else "skipped (--no-git)"});
+            try w.print("  build:    {s}\n", .{if (with_build) "verify with `zig build`" else "skipped (--no-build)"});
+        }
+    }.print;
+
+    // --dry-run: report what would be created and stop before touching the
+    // filesystem.
     if (options.dry_run) {
         try stdout.print("\nDry run — nothing written. Would create:\n", .{});
         const prefix: []const u8 = if (use_current_dir) "" else args.name;
         const sep: []const u8 = if (use_current_dir) "" else "/";
-        try stdout.print("  template: {s}\n", .{@tagName(template)});
-        try stdout.print("  plugins:  ", .{});
-        if (selected.len == 0) {
-            try stdout.print("(none)", .{});
-        } else for (selected, 0..) |idx, i| {
-            if (i > 0) try stdout.print(", ", .{});
-            try stdout.print("{s}", .{builtin_choices[idx].tag});
-        }
-        try stdout.print("\n  files:\n", .{});
+        try summarize(stdout, template, selected, options.git, options.build);
+        try stdout.print("  files:\n", .{});
         try stdout.print("    {s}{s}build.zig\n", .{ prefix, sep });
         try stdout.print("    {s}{s}build.zig.zon\n", .{ prefix, sep });
         try stdout.print("    {s}{s}src/main.zig\n", .{ prefix, sep });
@@ -304,9 +321,27 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
             .multi => try stdout.print("    {s}{s}src/commands/hello.zig\n", .{ prefix, sep }),
             .single => try stdout.print("    {s}{s}src/commands/index.zig\n", .{ prefix, sep }),
         }
+        try stdout.print("    {s}{s}README.md\n", .{ prefix, sep });
+        if (options.git) try stdout.print("    {s}{s}.gitignore\n", .{ prefix, sep });
         try stdout.print("    {s}{s}AGENTS.md\n", .{ prefix, sep });
         try stdout.print("  then: zig fetch --save https://github.com/ryanhair/zcli/archive/refs/tags/v{s}.tar.gz\n", .{context.app_version});
         return;
+    }
+
+    // Summary + confirm before anything touches disk. --yes/--defaults skip
+    // it; a non-TTY stdin answers the default (proceed) via EndOfStream, so
+    // scripts and CI sail through.
+    if (!use_defaults) {
+        try stdout.print("\nAbout to create '{s}':\n", .{project_name});
+        try summarize(stdout, template, selected, options.git, options.build);
+        try stdout.flush();
+        const proceed = p.confirm(.{ .message = "Proceed?" }) catch |err| switch (err) {
+            error.EndOfStream => true,
+            else => return err,
+        };
+        if (!proceed) {
+            return context.fail("Aborted — nothing written.", .{});
+        }
     }
 
     // Now that the destination is validated and plugins are chosen, create and
@@ -413,6 +448,15 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         },
     }
 
+    // README.md — the human-facing stub (name, description, build/run/test).
+    // The try-it line matches the scaffolded shape.
+    try stdout.print("  Creating README.md...\n", .{});
+    const readme_content = try renderReadme(allocator, project_name, description_raw, template);
+    defer allocator.free(readme_content);
+    var readme_file = try project_dir.createFile(io, "README.md", .{});
+    defer readme_file.close(io);
+    try readme_file.writeStreamingAll(io, readme_content);
+
     // Scaffold AGENTS.md — the thin, frozen, command-speaking spine that points
     // coding agents at `zcli guide` (ADR-0008). Marker-delimited so it never
     // clobbers a user's own AGENTS.md, and a future upgrade can refresh just the
@@ -422,6 +466,22 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         .appended => try stdout.print("  Adding zcli section to existing AGENTS.md...\n", .{}),
         .refreshed => try stdout.print("  Refreshing zcli section in AGENTS.md...\n", .{}),
     }
+
+    // git: init + .gitignore now, so the initial commit below captures exactly
+    // the verified scaffold. Skipped silently when git is absent or the
+    // destination is already inside a work tree (ADR-0028); any later git
+    // failure is a warning with the exact command — the project is valid
+    // either way, never a rollback.
+    const git_initialized = if (options.git) git: {
+        // Already inside a work tree (e.g. `init .` in a repo)? Leave it be.
+        if (spawnQuiet(io, project_dir, &.{ "git", "rev-parse", "--is-inside-work-tree" })) break :git false;
+        if (!spawnQuiet(io, project_dir, &.{ "git", "init", "--quiet" })) break :git false; // git absent: skip silently
+        try stdout.print("  Initializing git repository...\n", .{});
+        var gitignore_file = try project_dir.createFile(io, ".gitignore", .{});
+        defer gitignore_file.close(io);
+        try gitignore_file.writeStreamingAll(io, gitignore_content);
+        break :git true;
+    } else false;
 
     // Fetch the zcli dependency. `zig fetch --save` computes the real hash and
     // writes the dependency into build.zig.zon; without it the generated project
@@ -446,11 +506,44 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         try stderr.print("  Run this inside the project to finish setup:\n    zig fetch --save {s}\n", .{zcli_url});
     }
 
+    // Verify the scaffold with a real `zig build` (default on, --no-build to
+    // skip) so the user's first manual command runs their CLI instead of the
+    // compiler — and a broken scaffold is OUR failure, surfaced right here.
+    // Only meaningful after a successful fetch; a failure is a warning with
+    // the exact command (the project is valid), never a rollback.
+    const built_ok = if (options.build and fetch_ok) blk: {
+        try stdout.flush();
+        var spin = try context.progress().spinner(.{});
+        spin.start("Building (the first build may take a minute)...");
+        const ok = spawnQuiet(io, project_dir, &.{ "zig", "build" });
+        if (ok) {
+            spin.succeed("Build verified");
+        } else {
+            spin.fail("Build failed");
+            try stderr.print("  Warning: `zig build` failed. Run it inside the project to see the error:\n    zig build\n", .{});
+        }
+        break :blk ok;
+    } else false;
+
+    // Initial commit of exactly what was scaffolded (zig-out/.zig-cache are
+    // ignored, so building first changes nothing tracked). Commit needs a git
+    // identity, which fresh machines and CI runners often lack — warn with
+    // the exact commands instead of failing init.
+    if (git_initialized) {
+        const committed = spawnQuiet(io, project_dir, &.{ "git", "add", "-A" }) and
+            spawnQuiet(io, project_dir, &.{ "git", "commit", "--quiet", "-m", "Initial commit (zcli init)" });
+        if (!committed) {
+            try stderr.print("  Warning: could not create the initial commit (is your git identity configured?).\n", .{});
+            try stderr.print("  Run this inside the project when ready:\n    git add -A && git commit -m \"Initial commit\"\n", .{});
+        }
+    }
+
     // Success message. When the fetch failed, `zig build` would only fail with
     // a missing-dependency error the user never asked for — don't claim success
-    // or suggest a next step that can't work yet. The try-it line matches the
-    // scaffolded shape: `hello World` for multi, a bare root positional for
-    // single.
+    // or suggest a next step that can't work yet. When the build already
+    // verified, don't tell the user to build again — their next step is
+    // running the CLI. The try-it line matches the scaffolded shape: `hello
+    // World` for multi, a bare root positional for single.
     if (fetch_ok) {
         try stdout.print("\n✓ Project '{s}' created successfully!\n\n", .{project_name});
         try stdout.print("Next steps:\n", .{});
@@ -464,12 +557,91 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
     if (!fetch_ok) {
         try stdout.print("  zig fetch --save {s}\n", .{zcli_url});
     }
-    try stdout.print("  zig build\n", .{});
+    if (!built_ok) {
+        try stdout.print("  zig build\n", .{});
+    }
     switch (template) {
         .multi => try stdout.print("  ./zig-out/bin/{s} hello World\n", .{project_name}),
         .single => try stdout.print("  ./zig-out/bin/{s} World\n", .{project_name}),
     }
     try stdout.print("  ./zig-out/bin/{s} --help\n", .{project_name});
+}
+
+/// Run `argv` in `dir` with all output suppressed; true on exit code 0.
+/// The quiet building block for the post-scaffold steps (git probes/init/
+/// commit, the `zig build` verification): a spawn failure (binary absent)
+/// and a non-zero exit both read as "no".
+fn spawnQuiet(io: std.Io, dir: std.Io.Dir, argv: []const []const u8) bool {
+    var child = std.process.spawn(io, .{
+        .argv = argv,
+        .cwd = .{ .dir = dir },
+        .stdout = .ignore,
+        .stderr = .ignore,
+    }) catch return false;
+    const term = child.wait(io) catch return false;
+    return term == .exited and term.exited == 0;
+}
+
+/// The scaffold's .gitignore: Zig's two generated trees, nothing else — a
+/// fresh project has no other artifacts, and users grow it themselves.
+const gitignore_content =
+    \\.zig-cache/
+    \\zig-out/
+    \\
+;
+
+/// Render README.md: name, description, and the build/run/test loop with the
+/// try-it line matching the scaffolded shape. Owned slice.
+fn renderReadme(allocator: std.mem.Allocator, name: []const u8, description: []const u8, template: Template) ![]u8 {
+    const try_it: []const u8 = switch (template) {
+        .multi => " hello World",
+        .single => " World",
+    };
+    return std.fmt.allocPrint(allocator,
+        \\# {s}
+        \\
+        \\{s}
+        \\
+        \\Built with [zcli](https://github.com/ryanhair/zcli).
+        \\
+        \\## Build and run
+        \\
+        \\```sh
+        \\zig build
+        \\./zig-out/bin/{s}{s}
+        \\./zig-out/bin/{s} --help
+        \\```
+        \\
+        \\## Test
+        \\
+        \\```sh
+        \\zig build test
+        \\```
+        \\
+        \\## Project layout
+        \\
+        \\Commands are files: `src/commands/<name>.zig` is `{s} <name>`. Read the
+        \\current shape with `zcli tree`, and change it with `zcli add` / `zcli rm` /
+        \\`zcli mv`. See AGENTS.md and `zcli guide` for the full authoring loop.
+        \\
+    , .{ name, description, name, try_it, name, name });
+}
+
+test "renderReadme: single template demos the bare root positional" {
+    const allocator = std.testing.allocator;
+    const readme = try renderReadme(allocator, "mytool", "Does things", .single);
+    defer allocator.free(readme);
+    try std.testing.expect(std.mem.indexOf(u8, readme, "# mytool\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, readme, "Does things") != null);
+    try std.testing.expect(std.mem.indexOf(u8, readme, "./zig-out/bin/mytool World") != null);
+    try std.testing.expect(std.mem.indexOf(u8, readme, "hello World") == null);
+}
+
+test "renderReadme: multi template demos the hello subcommand" {
+    const allocator = std.testing.allocator;
+    const readme = try renderReadme(allocator, "myapp", "A CLI", .multi);
+    defer allocator.free(readme);
+    try std.testing.expect(std.mem.indexOf(u8, readme, "./zig-out/bin/myapp hello World") != null);
 }
 
 // ---------------------------------------------------------------------------

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -252,7 +252,7 @@ test "init scaffolds a project with the expected files and wiring" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp" });
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--no-build" });
     defer r.deinit();
     try expectOk(r);
 
@@ -304,13 +304,106 @@ test "init scaffolds a project with the expected files and wiring" {
     try expectContains(agents, "<!-- zcli:end -->");
     try expectContains(agents, "zcli guide");
     try expectContains(agents, "per-command arena");
+
+    // Increment 2 (ADR-0028): README stub by default. Git is NOT asserted
+    // here — testing.tmpDir lives under the zcli repo's own work tree, where
+    // init deliberately skips `git init`; see the dedicated outside-a-work-
+    // tree test below.
+    const readme = try readFile(proj, a, "README.md");
+    try expectContains(readme, "# myapp");
+    try expectContains(readme, "zig build test");
+    try testing.expect(!fileExists(proj, ".git/HEAD"));
+}
+
+test "init inside an existing work tree skips git; outside it initializes one" {
+    // The inside-a-work-tree half is covered by every other test here (tmpDir
+    // sits under the zcli repo). The outside half needs a scaffold in the
+    // system temp dir. POSIX-only: the path below is /tmp; the git code path
+    // is identical on Windows.
+    if (builtin.os.tag == .windows) return;
+
+    var bytes: [8]u8 = undefined;
+    io.random(&bytes);
+    var name_buf: [64]u8 = undefined;
+    const dir_name = try std.fmt.bufPrint(&name_buf, "zcli-e2e-git-{x}", .{&bytes});
+
+    var tmp_root = try std.Io.Dir.cwd().openDir(io, "/tmp", .{});
+    defer tmp_root.close(io);
+    try tmp_root.createDir(io, dir_name, .default_dir);
+    defer tmp_root.deleteTree(io, dir_name) catch {};
+    var work = try tmp_root.openDir(io, dir_name, .{});
+    defer work.close(io);
+
+    var r = try run(work, &.{ zcli_exe, "init", "myapp", "--no-build" });
+    defer r.deinit();
+    try expectOk(r);
+
+    var proj = try work.openDir(io, "myapp", .{});
+    defer proj.close(io);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    try expectContains(r.stdout, "Initializing git repository");
+    try testing.expect(fileExists(proj, ".git/HEAD"));
+    const gitignore = try readFile(proj, arena.allocator(), ".gitignore");
+    try expectContains(gitignore, ".zig-cache/");
+    try expectContains(gitignore, "zig-out/");
+    // The initial commit needs a configured git identity (absent on CI
+    // runners) — init degrades to a warning; either outcome is correct here.
+}
+
+test "init --no-git skips the repository, README still scaffolds" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--no-git", "--no-build" });
+    defer r.deinit();
+    try expectOk(r);
+
+    var proj = try tmp.dir.openDir(io, "myapp", .{});
+    defer proj.close(io);
+    try testing.expect(!fileExists(proj, ".git/HEAD"));
+    try testing.expect(!fileExists(proj, ".gitignore"));
+    try testing.expect(fileExists(proj, "README.md"));
+}
+
+test "init verifies the scaffold with zig build by default (full flow)" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // The one init test WITHOUT --no-build: the real end-to-end promise —
+    // after init, the user's first manual command runs their CLI. Deliberately
+    // slow (fetches and compiles the released zcli once per suite run).
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "built" });
+    defer r.deinit();
+    try expectOk(r);
+
+    var proj = try tmp.dir.openDir(io, "built", .{});
+    defer proj.close(io);
+
+    if (std.mem.indexOf(u8, r.stdout, "was not fetched") != null) {
+        // Release-run window: the pinned tag doesn't exist yet, so the build
+        // step is skipped by design and next-steps must include `zig build`.
+        try expectContains(r.stdout, "zig build");
+        return;
+    }
+
+    // Fetch succeeded: the build must have been verified and the binary must
+    // exist — and next-steps must NOT tell the user to build again. The
+    // spinner renders on stderr (Progress convention: stdout stays clean for
+    // pipes), so the verification line lands there.
+    try expectContains(r.stderr, "Build verified");
+    try testing.expect(fileExists(proj, "zig-out/bin/built") or fileExists(proj, "zig-out/bin/built.exe"));
+    const after_success = std.mem.indexOf(u8, r.stdout, "created successfully").?;
+    try testing.expect(std.mem.indexOf(u8, r.stdout[after_success..], "\n  zig build\n") == null);
 }
 
 test "init --template single scaffolds a root index.zig instead of hello (ADR-0028/0029)" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    var r = try run(tmp.dir, &.{ zcli_exe, "init", "mytool", "--template", "single" });
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "mytool", "--template", "single", "--no-build" });
     defer r.deinit();
 
     // The single template needs a released library with root index support
@@ -350,7 +443,7 @@ test "init --plugins takes the list verbatim, no prompt (agent contract)" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--plugins", "help,completions" });
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--plugins", "help,completions", "--no-build" });
     defer r.deinit();
     try expectOk(r);
 
@@ -373,7 +466,7 @@ test "init --plugins none scaffolds a plugin-free project" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--plugins", "none" });
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--plugins", "none", "--no-build" });
     defer r.deinit();
     try expectOk(r);
 
@@ -390,7 +483,7 @@ test "init --plugins rejects unknown names, listing the valid set, creating noth
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--plugins", "help,bogus" });
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--plugins", "help,bogus", "--no-build" });
     defer r.deinit();
     try testing.expect(r.exit_code != 0);
     try expectContains(r.stderr, "unknown plugin");
@@ -402,7 +495,7 @@ test "init --dry-run reports the plan and writes nothing" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--dry-run", "--defaults" });
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--dry-run", "--defaults", "--no-build" });
     defer r.deinit();
     try expectOk(r);
 
@@ -420,7 +513,7 @@ test "init --defaults answers the prompts without rendering them" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--defaults" });
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--defaults", "--no-build" });
     defer r.deinit();
     try expectOk(r);
 
@@ -445,7 +538,7 @@ test "init defaults to the multi template when non-interactive" {
 
     // No --template and no TTY: the shape prompt falls back to multi —
     // today's scaffold, an example hello subcommand and no root index.
-    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp" });
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--no-build" });
     defer r.deinit();
     try expectOk(r);
 
@@ -459,7 +552,7 @@ test "init rejects an unknown --template value with the enum diagnostic" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--template", "solo" });
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--template", "solo", "--no-build" });
     defer r.deinit();
     try testing.expect(r.exit_code != 0);
     // The enum parser names the valid choices; the project must not be created.
@@ -471,7 +564,7 @@ test "init escapes free-text --description into a valid string literal" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--description", "say \"hi\"\\back" });
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--description", "say \"hi\"\\back", "--no-build" });
     defer r.deinit();
     try expectOk(r);
 
@@ -492,7 +585,7 @@ test "init rejects a project name that would break generated source" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    var r = try run(tmp.dir, &.{ zcli_exe, "init", "bad\"name" });
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "bad\"name", "--no-build" });
     defer r.deinit();
     try testing.expect(r.exit_code != 0);
     try expectContains(r.stderr, "Invalid project name");
@@ -505,7 +598,7 @@ test "init rejects a Zig reserved word as the project name" {
     defer tmp.cleanup();
 
     // `error` is a keyword: `.name = .error` in build.zig.zon won't compile.
-    var r = try run(tmp.dir, &.{ zcli_exe, "init", "error" });
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "error", "--no-build" });
     defer r.deinit();
     try testing.expect(r.exit_code != 0);
     try expectContains(r.stderr, "Invalid project name");
@@ -520,7 +613,7 @@ test "init --app-version lands in build.zig.zon (#565)" {
     // The option is spelled --app-version, not --version: the tool's global
     // --version/-V flag (zcli_version plugin) is consumed before routing and
     // would shadow a same-named command option (#565).
-    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--app-version", "2.3.4" });
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--app-version", "2.3.4", "--no-build" });
     defer r.deinit();
     try expectOk(r);
 
@@ -539,7 +632,7 @@ test "init rejects a non-semver --app-version before touching the filesystem (#5
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--app-version", "foo" });
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--app-version", "foo", "--no-build" });
     defer r.deinit();
     try testing.expect(r.exit_code != 0);
     try expectContains(r.stderr, "Invalid version");
@@ -557,7 +650,7 @@ test "init . scaffolds into the current directory" {
     var proj = try tmp.dir.openDir(io, "myapp", .{});
     defer proj.close(io);
 
-    var r = try run(proj, &.{ zcli_exe, "init", "." });
+    var r = try run(proj, &.{ zcli_exe, "init", ".", "--no-build" });
     defer r.deinit();
     try expectOk(r);
 
@@ -575,7 +668,7 @@ test "init . rejects a directory name that can't be a project name" {
     var proj = try tmp.dir.openDir(io, "7wonders", .{});
     defer proj.close(io);
 
-    var r = try run(proj, &.{ zcli_exe, "init", "." });
+    var r = try run(proj, &.{ zcli_exe, "init", ".", "--no-build" });
     defer r.deinit();
     try testing.expect(r.exit_code != 0);
     try expectContains(r.stderr, "Invalid project name");
@@ -596,7 +689,7 @@ test "init . appends to a pre-existing AGENTS.md instead of refusing" {
     // treats it as appendable, not a conflict (ADR-0008).
     try proj.writeFile(io, .{ .sub_path = "AGENTS.md", .data = "# House rules\n\nRun the linter.\n" });
 
-    var r = try run(proj, &.{ zcli_exe, "init", "." });
+    var r = try run(proj, &.{ zcli_exe, "init", ".", "--no-build" });
     defer r.deinit();
     try expectOk(r);
     try testing.expect(fileExists(proj, "build.zig"));
@@ -1037,7 +1130,7 @@ test "scaffolded project builds, runs, and round-trips add command" {
     defer tmp.cleanup();
 
     {
-        var r = try run(tmp.dir, &.{ zcli_exe, "init", "demo" });
+        var r = try run(tmp.dir, &.{ zcli_exe, "init", "demo", "--no-build" });
         defer r.deinit();
         try expectOk(r);
     }
@@ -1529,7 +1622,7 @@ test "scaffold builds against the pinned release (#623)" {
     defer tmp.cleanup();
 
     const pinned_dep_present = present: {
-        var r = try run(tmp.dir, &.{ zcli_exe, "init", "demo" });
+        var r = try run(tmp.dir, &.{ zcli_exe, "init", "demo", "--no-build" });
         defer r.deinit();
         try expectOk(r);
         // `init` runs `zig fetch --save` of the pinned tag itself; it says so
@@ -1554,7 +1647,7 @@ test "required options and enum args: end-user messages and help" {
     defer tmp.cleanup();
 
     {
-        var r = try run(tmp.dir, &.{ zcli_exe, "init", "demo" });
+        var r = try run(tmp.dir, &.{ zcli_exe, "init", "demo", "--no-build" });
         defer r.deinit();
         try expectOk(r);
     }
@@ -1671,7 +1764,7 @@ test "root zcli_theme declaration themes help output" {
     defer tmp.cleanup();
 
     {
-        var r = try run(tmp.dir, &.{ zcli_exe, "init", "demo" });
+        var r = try run(tmp.dir, &.{ zcli_exe, "init", "demo", "--no-build" });
         defer r.deinit();
         try expectOk(r);
     }
@@ -1810,7 +1903,7 @@ test "scaffolded commands are unit-testable via zig build test" {
     defer tmp.cleanup();
 
     {
-        var r = try run(tmp.dir, &.{ zcli_exe, "init", "app" });
+        var r = try run(tmp.dir, &.{ zcli_exe, "init", "app", "--no-build" });
         defer r.deinit();
         try expectOk(r);
     }
@@ -1898,7 +1991,7 @@ test "a shared module reaches both commands and their tests" {
     defer tmp.cleanup();
 
     {
-        var r = try run(tmp.dir, &.{ zcli_exe, "init", "app" });
+        var r = try run(tmp.dir, &.{ zcli_exe, "init", "app", "--no-build" });
         defer r.deinit();
         try expectOk(r);
     }
@@ -1976,7 +2069,7 @@ test "a command's plugin state is testable via runCommand .plugins" {
     defer tmp.cleanup();
 
     {
-        var r = try run(tmp.dir, &.{ zcli_exe, "init", "app" });
+        var r = try run(tmp.dir, &.{ zcli_exe, "init", "app", "--no-build" });
         defer r.deinit();
         try expectOk(r);
     }
@@ -2053,7 +2146,7 @@ test "a command that uses zcli_secrets is runCommand-testable without the keycha
     defer tmp.cleanup();
 
     {
-        var r = try run(tmp.dir, &.{ zcli_exe, "init", "app" });
+        var r = try run(tmp.dir, &.{ zcli_exe, "init", "app", "--no-build" });
         defer r.deinit();
         try expectOk(r);
     }
@@ -2371,12 +2464,13 @@ test "interactive: init's plugin multi-select toggles an opt-in plugin" {
     defer script.deinit();
     _ = script
         .expect("Select built-in plugins").delay(settle_ms)
-        .sendRaw("\x1b[B\x1b[B\x1b[B \r");
+        .sendRaw("\x1b[B\x1b[B\x1b[B \r")
+        .expect("Proceed?").delay(settle_ms).sendRaw("\r");
 
     var result = harness.runInteractive(
         testing.allocator,
         io,
-        &.{ zcli_exe, "init", "myapp" },
+        &.{ zcli_exe, "init", "myapp", "--no-build", "--template", "multi" },
         script,
         .{ .cwd = proj_abs, .allocate_pty = true, .total_timeout_ms = 30000 },
     ) catch |err| switch (err) {
@@ -2436,12 +2530,13 @@ test "interactive: init's plugin multi-select toggles github_upgrade and the sca
     defer script.deinit();
     _ = script
         .expect("Select built-in plugins").delay(settle_ms)
-        .sendRaw("\x1b[B\x1b[B\x1b[B\x1b[B\x1b[B \r");
+        .sendRaw("\x1b[B\x1b[B\x1b[B\x1b[B\x1b[B \r")
+        .expect("Proceed?").delay(settle_ms).sendRaw("\r");
 
     var result = harness.runInteractive(
         testing.allocator,
         io,
-        &.{ zcli_exe, "init", "myapp" },
+        &.{ zcli_exe, "init", "myapp", "--no-build", "--template", "multi" },
         script,
         .{ .cwd = try tmpDirAbs(arena.allocator(), tmp), .allocate_pty = true, .total_timeout_ms = 30000 },
     ) catch |err| switch (err) {
@@ -2539,7 +2634,7 @@ test "dev builds, runs the app, restarts on change, survives a failed build, and
     defer tmp.cleanup();
 
     {
-        var r = try run(tmp.dir, &.{ zcli_exe, "init", "demo" });
+        var r = try run(tmp.dir, &.{ zcli_exe, "init", "demo", "--no-build" });
         defer r.deinit();
         try expectOk(r);
     }


### PR DESCRIPTION
## Summary

The biggest UX increment of the init wizard plan (ADR-0028): init now finishes the setup instead of leaving it to the user.

- **README.md stub** — name, description, build/run/test loop; the try-it line matches the chosen template (`hello World` vs bare `World`).
- **git** (default on, `--no-git`) — `git init`, a Zig `.gitignore` (`.zig-cache/`, `zig-out/`), and an initial commit of exactly the scaffolded tree. Skipped silently when git is absent or the destination is already inside a work tree (`init .` in an existing repo). A commit without a configured git identity (fresh machines, CI) degrades to a warning naming the exact commands.
- **`zig build` verification** (default on, `--no-build`) — runs under a spinner after a successful fetch, so the user's first manual command runs their CLI, not the compiler, and a broken scaffold is our failure surfaced right there. A verified build drops `zig build` from next-steps. Failure is a warning naming the command — never a rollback (the project is valid).
- **Summary + confirm** — one block (template, plugins, git, build) and one Y/n before anything touches disk. `--defaults`/`--yes` skip it; non-TTY stdin proceeds via the confirm's default so scripts and CI sail through; declining aborts with nothing written, exit 1. `--dry-run` shows the same summary.

## Testing notes

- Existing init e2e tests now pass `--no-build` so the suite doesn't compile a fresh project per test. **One dedicated full-flow test** runs the real default path — fetch, build, binary exists, no `zig build` next-step — deliberately slow (one released-zcli compile per suite run, per OS). Trim it if the CI budget complains.
- Git assertions live in a dedicated outside-a-work-tree test (`/tmp`, POSIX-only): `testing.tmpDir` sits **inside the zcli repo's work tree**, where skipping `git init` is the correct behavior — every other init test doubles as coverage for the skip half.
- The PTY picker tests answer the new confirm and pin `--template multi`, so the post-release shape prompt cannot break their keystroke scripts.
- Verified manually: full run (git repo + initial commit + `Build verified` + corrected next-steps), confirm rejection (aborts, exit 1, nothing written), `--no-git`/`--no-build`, work-tree skip for `init .` inside a repo, and the identity-missing commit warning path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)