### PR TITLE
init: --upgrade-repo prompt-through and GitHub Actions extras (ADR-0028 increments 4+5)

### DIFF
--- a/docs/adr/0028-init-wizard.md
+++ b/docs/adr/0028-init-wizard.md
@@ -133,9 +133,20 @@ Each lands independently, in this order:
    `--template single` fails closed with the reason. The gate clears
    automatically at the next release bump.
 4. **Plugin config prompt-through** (`github_upgrade` repo, `--upgrade-repo`,
-   git-remote default).
+   git-remote default). — Implemented: `--upgrade-repo OWNER/REPO` implies
+   selecting the plugin; interactive picker selection gets a follow-up text
+   prompt defaulted from the destination's github origin remote; slug
+   validated to `[A-Za-z0-9._-]` + one `/` (doubles as the generated-literal
+   injection guard); empty/`--defaults` keep the compiling TODO placeholder,
+   and `verification` stays a TODO either way.
 5. **`zcli gh add workflow ci`**, then the extras step reusing both gh
-   scaffolds from init.
+   scaffolds from init. — Implemented: workflow content + write logic moved
+   to the `scaffold` shared module (command modules can't import each
+   other); new `gh add workflow ci` (single ubuntu build+test job, pinned
+   actions); init's `--github <ci,release|none>` flag and interactive
+   multi-select with `release` preselected when github_upgrade was chosen
+   (it feeds the self-updater); workflows written with the project files so
+   the initial commit captures them.
 
 Every increment keeps `zig build e2e` green and adds e2e coverage for its
 non-interactive path (the interactive paths are covered by the existing

--- a/projects/zcli/src/commands/gh/add/workflow/ci.zig
+++ b/projects/zcli/src/commands/gh/add/workflow/ci.zig
@@ -1,0 +1,37 @@
+const std = @import("std");
+const zcli = @import("zcli");
+const scaffold = @import("scaffold");
+
+pub const meta = .{
+    .description = "Add GitHub Actions workflow that builds and tests on every push and PR",
+    .examples = &.{
+        "gh add workflow ci",
+    },
+};
+
+pub const Args = struct {};
+
+pub const Options = struct {};
+
+// Convention: this command takes `context: anytype` (not `*Context`) so tests
+// can pass a lightweight stub instead of a full app registry; commands that
+// don't need that testability use `*Context` for the compile-time contract.
+pub fn execute(_: Args, _: Options, context: anytype) !void {
+    var stdout = context.stdout();
+    const io = context.io;
+
+    const outcome = try scaffold.workflows.write(std.Io.Dir.cwd(), io, "ci.yml", scaffold.workflows.ci_yml);
+    switch (outcome) {
+        .not_a_project => return context.fail("Error: Not in a zcli project directory\nRun this command from the root of your zcli project (where build.zig is)", .{}),
+        .already_exists => return context.fail("Error: .github/workflows/ci.yml already exists\nRemove it first if you want to regenerate it", .{}),
+        .created => {},
+    }
+
+    try stdout.print("Creating GitHub Actions CI workflow...\n", .{});
+    try stdout.print("✓ Created .github/workflows/ci.yml\n\n", .{});
+    try stdout.print("Next steps:\n", .{});
+    try stdout.print("  Commit and push the workflow file:\n", .{});
+    try stdout.print("     git add .github/workflows/ci.yml\n", .{});
+    try stdout.print("     git commit -m \"Add CI workflow\"\n", .{});
+    try stdout.print("     git push\n", .{});
+}

--- a/projects/zcli/src/commands/gh/add/workflow/release.zig
+++ b/projects/zcli/src/commands/gh/add/workflow/release.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const zcli = @import("zcli");
+const scaffold = @import("scaffold");
 
 pub const meta = .{
     .description = "Add GitHub Actions workflow for building and releasing binaries",
@@ -15,11 +16,13 @@ pub const Options = struct {};
 // Convention: this command takes `context: anytype` (not `*Context`) so tests
 // can pass a lightweight stub instead of a full app registry; commands that
 // don't need that testability use `*Context` for the compile-time contract.
+// The workflow content and write logic live in scaffold/workflows.zig, shared
+// with `zcli init`'s extras step (ADR-0028) and `gh add workflow ci`.
 pub fn execute(_: Args, _: Options, context: anytype) !void {
     var stdout = context.stdout();
     const io = context.io;
 
-    const outcome = try writeReleaseWorkflow(std.Io.Dir.cwd(), io);
+    const outcome = try scaffold.workflows.write(std.Io.Dir.cwd(), io, "release.yml", scaffold.workflows.release_yml);
     switch (outcome) {
         .not_a_project => return context.fail("Error: Not in a zcli project directory\nRun this command from the root of your zcli project (where build.zig is)", .{}),
         .already_exists => return context.fail("Error: .github/workflows/release.yml already exists\nRemove it first if you want to regenerate it", .{}),
@@ -41,215 +44,4 @@ pub fn execute(_: Args, _: Options, context: anytype) !void {
     try stdout.print("     zcli release major   # 0.1.0 → 1.0.0\n\n", .{});
     try stdout.print("  3. Monitor builds at:\n", .{});
     try stdout.print("     https://github.com/YOUR_USERNAME/YOUR_REPO/actions\n\n", .{});
-}
-
-const WorkflowOutcome = enum { created, not_a_project, already_exists };
-
-/// Writes the release workflow into `dir`. Takes `dir` explicitly (rather
-/// than hardcoding `std.Io.Dir.cwd()`) so it can be exercised against a
-/// scratch directory in tests without touching the real repo.
-fn writeReleaseWorkflow(dir: std.Io.Dir, io: std.Io) !WorkflowOutcome {
-    dir.access(io, "src/commands", .{}) catch return .not_a_project;
-
-    dir.createDir(io, ".github", .default_dir) catch |err| switch (err) {
-        error.PathAlreadyExists => {},
-        else => return err,
-    };
-
-    dir.createDir(io, ".github/workflows", .default_dir) catch |err| switch (err) {
-        error.PathAlreadyExists => {},
-        else => return err,
-    };
-
-    if (dir.access(io, ".github/workflows/release.yml", .{})) {
-        return .already_exists;
-    } else |err| switch (err) {
-        error.FileNotFound => {}, // Good, safe to create
-        else => return err,
-    }
-
-    var workflow_file = try dir.createFile(io, ".github/workflows/release.yml", .{});
-    defer workflow_file.close(io);
-    try workflow_file.writeStreamingAll(io, workflow_content);
-
-    return .created;
-}
-
-// Generate workflow content
-const workflow_content =
-    \\name: Release
-    \\
-    \\# Actions are pinned to full commit SHAs (with the version as a comment)
-    \\# so a moved or compromised tag can't change what runs in this workflow.
-    \\# When upgrading an action, update the SHA and the comment together.
-    \\
-    \\on:
-    \\  push:
-    \\    tags:
-    \\      - '*-v*'
-    \\
-    \\jobs:
-    \\  build:
-    \\    name: Build ${{ matrix.target }}
-    \\    runs-on: ${{ matrix.os }}
-    \\    strategy:
-    \\      matrix:
-    \\        include:
-    \\          - os: ubuntu-latest
-    \\            target: x86_64-linux
-    \\            zig_target: x86_64-linux-musl
-    \\          - os: ubuntu-latest
-    \\            target: aarch64-linux
-    \\            zig_target: aarch64-linux-musl
-    \\          - os: macos-latest
-    \\            target: x86_64-macos
-    \\            zig_target: x86_64-macos
-    \\          - os: macos-latest
-    \\            target: aarch64-macos
-    \\            zig_target: aarch64-macos
-    \\
-    \\    steps:
-    \\      - name: Checkout code
-    \\        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-    \\
-    \\      - name: Setup Zig
-    \\        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
-    \\        with:
-    \\          version: 0.16.0
-    \\
-    \\      - name: Build binary
-    \\        # ReleaseSafe keeps runtime safety checks (bounds/overflow) in a
-    \\        # binary that parses untrusted input; -Dstrip=true drops debug info,
-    \\        # which dominates size. If your build.zig predates the `strip`
-    \\        # option, add: b.option(bool, "strip", "...") and `.strip = strip`
-    \\        # on the exe module.
-    \\        run: zig build -Doptimize=ReleaseSafe -Dstrip=true -Dtarget=${{ matrix.zig_target }}
-    \\
-    \\      - name: Get app name from build.zig.zon
-    \\        id: appname
-    \\        run: |
-    \\          # Extract .name from build.zig.zon (handles both quoted strings and identifiers)
-    \\          NAME_LINE=$(grep -m1 '\.name = ' build.zig.zon)
-    \\          if [[ "$NAME_LINE" =~ \.name\ =\ \"([^\"]+)\" ]]; then
-    \\            APP_NAME="${BASH_REMATCH[1]}"
-    \\          elif [[ "$NAME_LINE" =~ \.name\ =\ \.([^,}\ ]+) ]]; then
-    \\            APP_NAME="${BASH_REMATCH[1]}"
-    \\          else
-    \\            echo "Error: Could not parse .name from build.zig.zon"
-    \\            exit 1
-    \\          fi
-    \\          echo "name=$APP_NAME" >> $GITHUB_OUTPUT
-    \\
-    \\      - name: Package binary
-    \\        run: |
-    \\          mkdir -p dist
-    \\          cp zig-out/bin/${{ steps.appname.outputs.name }} dist/${{ steps.appname.outputs.name }}-${{ matrix.target }}
-    \\          chmod +x dist/${{ steps.appname.outputs.name }}-${{ matrix.target }}
-    \\
-    \\      - name: Generate checksum
-    \\        run: |
-    \\          cd dist
-    \\          shasum -a 256 ${{ steps.appname.outputs.name }}-${{ matrix.target }} > ${{ steps.appname.outputs.name }}-${{ matrix.target }}.sha256
-    \\
-    \\      - name: Upload artifact
-    \\        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-    \\        with:
-    \\          name: ${{ steps.appname.outputs.name }}-${{ matrix.target }}
-    \\          path: |
-    \\            dist/${{ steps.appname.outputs.name }}-${{ matrix.target }}
-    \\            dist/${{ steps.appname.outputs.name }}-${{ matrix.target }}.sha256
-    \\
-    \\  release:
-    \\    name: Create Release
-    \\    needs: build
-    \\    runs-on: ubuntu-latest
-    \\    permissions:
-    \\      contents: write
-    \\
-    \\    steps:
-    \\      - name: Checkout code
-    \\        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-    \\
-    \\      - name: Download all artifacts
-    \\        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-    \\        with:
-    \\          path: dist
-    \\
-    \\      - name: Flatten artifact structure
-    \\        run: |
-    \\          mkdir -p release
-    \\          find dist -type f \( -name '*-x86_64-*' -o -name '*-aarch64-*' \) -exec cp {} release/ \;
-    \\          ls -la release/
-    \\
-    \\      - name: Create checksums file
-    \\        run: |
-    \\          cd release
-    \\          cat *.sha256 > checksums.txt
-    \\          rm *.sha256
-    \\
-    \\      - name: Create Release
-    \\        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
-    \\        with:
-    \\          files: release/*
-    \\          generate_release_notes: true
-    \\          draft: false
-    \\          prerelease: false
-    \\        env:
-    \\          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    \\
-;
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
-const testing = std.testing;
-
-test "writeReleaseWorkflow fails outside a zcli project" {
-    const io = testing.io;
-    var tmp = testing.tmpDir(.{});
-    defer tmp.cleanup();
-
-    const outcome = try writeReleaseWorkflow(tmp.dir, io);
-    try testing.expectEqual(WorkflowOutcome.not_a_project, outcome);
-}
-
-test "writeReleaseWorkflow creates a pinned, version-matched workflow" {
-    const io = testing.io;
-    var tmp = testing.tmpDir(.{});
-    defer tmp.cleanup();
-    try tmp.dir.createDir(io, "src", .default_dir);
-    try tmp.dir.createDir(io, "src/commands", .default_dir);
-
-    const outcome = try writeReleaseWorkflow(tmp.dir, io);
-    try testing.expectEqual(WorkflowOutcome.created, outcome);
-
-    const content = try tmp.dir.readFileAlloc(io, ".github/workflows/release.yml", testing.allocator, .limited(1 << 20));
-    defer testing.allocator.free(content);
-
-    try testing.expect(std.mem.indexOf(u8, content, "name: Release") != null);
-    // Every `uses:` action must be pinned to a full commit SHA (with the
-    // version as a trailing comment), never a mutable tag.
-    try testing.expect(std.mem.indexOf(u8, content, "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1") != null);
-    try testing.expect(std.mem.indexOf(u8, content, "mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1") != null);
-    try testing.expect(std.mem.indexOf(u8, content, "version: 0.16.0") != null);
-    try testing.expect(std.mem.indexOf(u8, content, "-Dstrip=true") != null);
-}
-
-test "writeReleaseWorkflow refuses to overwrite an existing workflow" {
-    const io = testing.io;
-    var tmp = testing.tmpDir(.{});
-    defer tmp.cleanup();
-    try tmp.dir.createDir(io, "src", .default_dir);
-    try tmp.dir.createDir(io, "src/commands", .default_dir);
-    try tmp.dir.createDir(io, ".github", .default_dir);
-    try tmp.dir.createDir(io, ".github/workflows", .default_dir);
-    try tmp.dir.writeFile(io, .{ .sub_path = ".github/workflows/release.yml", .data = "custom content\n" });
-
-    const outcome = try writeReleaseWorkflow(tmp.dir, io);
-    try testing.expectEqual(WorkflowOutcome.already_exists, outcome);
-
-    const content = try tmp.dir.readFileAlloc(io, ".github/workflows/release.yml", testing.allocator, .limited(4096));
-    defer testing.allocator.free(content);
-    try testing.expectEqualStrings("custom content\n", content);
 }

--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -69,6 +69,7 @@ pub const meta = .{
         .dry_run = .{ .description = "Print what would be created without writing anything" },
         .git = .{ .description = "Initialize a git repository with a .gitignore and an initial commit (--no-git to skip)" },
         .build = .{ .description = "Verify the scaffold with `zig build` after fetching (--no-build to skip)" },
+        .upgrade_repo = .{ .description = "GitHub OWNER/REPO the zcli_github_upgrade plugin pulls releases from (implies selecting that plugin)" },
     },
 };
 
@@ -92,6 +93,7 @@ pub const Options = struct {
     dry_run: bool = false,
     git: bool = true,
     build: bool = true,
+    upgrade_repo: ?[]const u8 = null,
 };
 
 pub fn execute(args: Args, options: Options, context: *Context) !void {
@@ -261,7 +263,7 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         choices[i] = choice.label;
         defaults[i] = choice.default;
     }
-    const selected = if (options.plugins) |plugins_arg|
+    var selected = if (options.plugins) |plugins_arg|
         parsePluginsFlag(allocator, plugins_arg) catch |err| switch (err) {
             error.UnknownPlugin => return context.fail(
                 "Error: unknown plugin in --plugins '{s}'\n  Valid plugins: {s} — or 'none'",
@@ -285,14 +287,54 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         };
     defer allocator.free(selected);
 
+    // The github_upgrade plugin's repo (ADR-0028 increment 4): the picker no
+    // longer has to leave an OWNER/REPO TODO in build.zig. --upgrade-repo
+    // decides outright and implies selecting the plugin (one flag, one
+    // intent); otherwise an interactive selection gets a follow-up prompt,
+    // defaulted from the destination's github remote when there is one
+    // (`init .` in an existing repo). Empty answer / --defaults keep the
+    // compiling TODO placeholder — never a broken scaffold.
+    const upgrade_idx = pluginIndex("github_upgrade").?;
+    if (options.upgrade_repo != null and std.mem.indexOfScalar(usize, selected, upgrade_idx) == null) {
+        const grown = try allocator.alloc(usize, selected.len + 1);
+        @memcpy(grown[0..selected.len], selected);
+        grown[selected.len] = upgrade_idx;
+        allocator.free(selected);
+        selected = grown;
+    }
+    const upgrade_repo: ?[]const u8 = repo: {
+        if (options.upgrade_repo) |r| {
+            if (!isValidRepoSlug(r)) {
+                return context.fail("Error: invalid --upgrade-repo '{s}'\n  Expected OWNER/REPO (letters, digits, '-', '_', '.')", .{r});
+            }
+            break :repo r;
+        }
+        if (use_defaults or std.mem.indexOfScalar(usize, selected, upgrade_idx) == null) break :repo null;
+        const remote_default = gitRemoteSlug(allocator, io);
+        defer if (remote_default) |d| allocator.free(d);
+        const answer = p.text(.{
+            .message = "GitHub repo for self-update releases (OWNER/REPO, empty to fill in later):",
+            .default = remote_default,
+        }) catch |err| switch (err) {
+            error.EndOfStream => break :repo null,
+            else => return err,
+        };
+        const trimmed = std.mem.trim(u8, answer, " ");
+        if (trimmed.len == 0) break :repo null;
+        if (!isValidRepoSlug(trimmed)) {
+            return context.fail("Error: invalid repo '{s}'\n  Expected OWNER/REPO (letters, digits, '-', '_', '.')", .{trimmed});
+        }
+        break :repo trimmed;
+    };
+
     // Build the `zcli.builtin(...)` registration lines for build.zig.
-    const plugins_block = try renderPluginsBlock(allocator, selected);
+    const plugins_block = try renderPluginsBlock(allocator, selected, upgrade_repo);
     defer allocator.free(plugins_block);
 
     // Everything is decided: one summary, shown for both the dry run and the
     // interactive confirm (ADR-0028 step 6).
     const summarize = struct {
-        fn print(w: anytype, tpl: Template, sel: []const usize, with_git: bool, with_build: bool) !void {
+        fn print(w: anytype, tpl: Template, sel: []const usize, up_repo: ?[]const u8, with_git: bool, with_build: bool) !void {
             try w.print("  template: {s}\n", .{@tagName(tpl)});
             try w.print("  plugins:  ", .{});
             if (sel.len == 0) {
@@ -301,7 +343,9 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
                 if (i > 0) try w.print(", ", .{});
                 try w.print("{s}", .{builtin_choices[idx].tag});
             }
-            try w.print("\n  git:      {s}\n", .{if (with_git) "init + .gitignore + initial commit" else "skipped (--no-git)"});
+            try w.print("\n", .{});
+            if (up_repo) |r| try w.print("  upgrades: github.com/{s} releases\n", .{r});
+            try w.print("  git:      {s}\n", .{if (with_git) "init + .gitignore + initial commit" else "skipped (--no-git)"});
             try w.print("  build:    {s}\n", .{if (with_build) "verify with `zig build`" else "skipped (--no-build)"});
         }
     }.print;
@@ -312,7 +356,7 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         try stdout.print("\nDry run — nothing written. Would create:\n", .{});
         const prefix: []const u8 = if (use_current_dir) "" else args.name;
         const sep: []const u8 = if (use_current_dir) "" else "/";
-        try summarize(stdout, template, selected, options.git, options.build);
+        try summarize(stdout, template, selected, upgrade_repo, options.git, options.build);
         try stdout.print("  files:\n", .{});
         try stdout.print("    {s}{s}build.zig\n", .{ prefix, sep });
         try stdout.print("    {s}{s}build.zig.zon\n", .{ prefix, sep });
@@ -333,7 +377,7 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
     // scripts and CI sail through.
     if (!use_defaults) {
         try stdout.print("\nAbout to create '{s}':\n", .{project_name});
-        try summarize(stdout, template, selected, options.git, options.build);
+        try summarize(stdout, template, selected, upgrade_repo, options.git, options.build);
         try stdout.flush();
         const proceed = p.confirm(.{ .message = "Proceed?" }) catch |err| switch (err) {
             error.EndOfStream => true,
@@ -710,6 +754,93 @@ const AgentsResult = enum { created, appended, refreshed };
 /// Owned slice of the indices whose `defaults` bit is set — the non-interactive
 /// fallback for the plugin picker (mirrors what `multiSelect` returns for a
 /// submitted-defaults selection).
+/// Picker index of the builtin choice named `tag`, or null. Runtime lookup
+/// over the (tiny) comptime table so call sites can't drift from it.
+fn pluginIndex(tag: []const u8) ?usize {
+    for (builtin_choices, 0..) |choice, i| {
+        if (std.mem.eql(u8, choice.tag, tag)) return i;
+    }
+    return null;
+}
+
+/// True when `s` is a plausible GitHub OWNER/REPO slug: exactly one '/',
+/// nonempty halves, characters limited to [A-Za-z0-9._-]. The slug lands
+/// inside a generated string literal, so the restricted charset doubles as
+/// the injection guard (no escaping needed).
+fn isValidRepoSlug(s: []const u8) bool {
+    const slash = std.mem.indexOfScalar(u8, s, '/') orelse return false;
+    if (slash == 0 or slash == s.len - 1) return false;
+    if (std.mem.indexOfScalarPos(u8, s, slash + 1, '/') != null) return false;
+    for (s, 0..) |c, i| {
+        if (i == slash) continue;
+        if (!std.ascii.isAlphanumeric(c) and c != '-' and c != '_' and c != '.') return false;
+    }
+    return true;
+}
+
+test "isValidRepoSlug: OWNER/REPO shapes" {
+    try std.testing.expect(isValidRepoSlug("ryanhair/zcli"));
+    try std.testing.expect(isValidRepoSlug("a-b.c_d/e.f-g_h"));
+    try std.testing.expect(!isValidRepoSlug("noslash"));
+    try std.testing.expect(!isValidRepoSlug("/repo"));
+    try std.testing.expect(!isValidRepoSlug("owner/"));
+    try std.testing.expect(!isValidRepoSlug("o/r/extra"));
+    try std.testing.expect(!isValidRepoSlug("own er/repo"));
+    try std.testing.expect(!isValidRepoSlug("owner/re\"po"));
+}
+
+/// OWNER/REPO parsed from a github.com remote URL (https or ssh, optional
+/// trailing .git or '/'), or null when it isn't a recognizable github slug.
+/// Owned by the caller.
+fn parseGithubSlug(allocator: std.mem.Allocator, url: []const u8) ?[]u8 {
+    const host = "github.com";
+    const host_at = std.mem.indexOf(u8, url, host) orelse return null;
+    const after_host = url[host_at + host.len ..];
+    if (after_host.len < 2 or (after_host[0] != ':' and after_host[0] != '/')) return null;
+    var slug = after_host[1..];
+    if (std.mem.endsWith(u8, slug, "/")) slug = slug[0 .. slug.len - 1];
+    if (std.mem.endsWith(u8, slug, ".git")) slug = slug[0 .. slug.len - 4];
+    if (!isValidRepoSlug(slug)) return null;
+    return allocator.dupe(u8, slug) catch null;
+}
+
+test "parseGithubSlug: https, ssh, .git, and non-github forms" {
+    const a = std.testing.allocator;
+    inline for (.{
+        .{ "https://github.com/ryanhair/zcli.git", "ryanhair/zcli" },
+        .{ "https://github.com/ryanhair/zcli", "ryanhair/zcli" },
+        .{ "git@github.com:ryanhair/zcli.git", "ryanhair/zcli" },
+    }) |case| {
+        const slug = parseGithubSlug(a, case[0]).?;
+        defer a.free(slug);
+        try std.testing.expectEqualStrings(case[1], slug);
+    }
+    try std.testing.expect(parseGithubSlug(a, "https://gitlab.com/o/r.git") == null);
+    try std.testing.expect(parseGithubSlug(a, "git@github.com:only-owner") == null);
+}
+
+/// OWNER/REPO from the current directory's `origin` github remote, or null
+/// (no git, no remote, not github). Only meaningful for `init .` inside an
+/// existing repo — a fresh project directory has no remote yet. Owned by the
+/// caller.
+fn gitRemoteSlug(allocator: std.mem.Allocator, io: std.Io) ?[]u8 {
+    var child = std.process.spawn(io, .{
+        .argv = &.{ "git", "config", "--get", "remote.origin.url" },
+        .stdout = .pipe,
+        .stderr = .ignore,
+    }) catch return null;
+    var buf: [512]u8 = undefined;
+    var reader = child.stdout.?.reader(io, &buf);
+    const out = reader.interface.allocRemaining(allocator, .limited(4096)) catch {
+        _ = child.wait(io) catch {};
+        return null;
+    };
+    defer allocator.free(out);
+    const term = child.wait(io) catch return null;
+    if (!(term == .exited and term.exited == 0)) return null;
+    return parseGithubSlug(allocator, std.mem.trim(u8, out, " \r\n"));
+}
+
 /// The valid --plugins names, comma-joined for the error message. Comptime so
 /// the list can never drift from builtin_choices.
 const valid_plugin_tags = blk: {
@@ -791,21 +922,43 @@ test "collectDefaultPlugins returns only the preselected indices" {
 
 /// Render the `zcli.builtin(...)` registration lines the generated build.zig
 /// splices into its `.plugins = &.{ ... }` list, one line per selected picker
-/// index, each with that choice's config snippet. Owned slice.
-fn renderPluginsBlock(allocator: std.mem.Allocator, selected: []const usize) ![]u8 {
+/// index, each with that choice's config snippet. When `upgrade_repo` is set
+/// (validated OWNER/REPO — the restricted charset is the literal-injection
+/// guard), github_upgrade renders it in place of the OWNER/REPO TODO; the
+/// verification TODO stays either way (pinning a key is a deliberate act).
+/// Owned slice.
+fn renderPluginsBlock(allocator: std.mem.Allocator, selected: []const usize, upgrade_repo: ?[]const u8) ![]u8 {
     var aw = std.Io.Writer.Allocating.init(allocator);
     defer aw.deinit();
     for (selected) |idx| {
+        if (upgrade_repo != null and std.mem.eql(u8, builtin_choices[idx].tag, "github_upgrade")) {
+            try aw.writer.print("            zcli.builtin(.github_upgrade, .{{\n" ++
+                "                .repo = \"{s}\",\n" ++
+                "                .verification = .checksum_only, // TODO: pin a minisign key for fail-closed signature verification (see zcli's docs/RELEASE-SIGNING.md)\n" ++
+                "            }}),\n", .{upgrade_repo.?});
+            continue;
+        }
         try aw.writer.print("            zcli.builtin(.{s}, {s}),\n", .{ builtin_choices[idx].tag, builtin_choices[idx].config });
     }
     var al = aw.toArrayList();
     return al.toOwnedSlice(allocator);
 }
 
+test "renderPluginsBlock renders a known upgrade repo instead of the TODO placeholder" {
+    const allocator = std.testing.allocator;
+    const idx = pluginIndex("github_upgrade").?;
+    const block = try renderPluginsBlock(allocator, &.{idx}, "ryanhair/zcli");
+    defer allocator.free(block);
+    try std.testing.expect(std.mem.indexOf(u8, block, ".repo = \"ryanhair/zcli\",") != null);
+    try std.testing.expect(std.mem.indexOf(u8, block, "OWNER/REPO") == null);
+    // Verification stays an explicit TODO — key pinning is a deliberate act.
+    try std.testing.expect(std.mem.indexOf(u8, block, ".verification = .checksum_only") != null);
+}
+
 test "renderPluginsBlock renders configless plugins as .{}" {
     const allocator = std.testing.allocator;
     // help (0) and version (1) take no config.
-    const block = try renderPluginsBlock(allocator, &.{ 0, 1 });
+    const block = try renderPluginsBlock(allocator, &.{ 0, 1 }, null);
     defer allocator.free(block);
     try std.testing.expectEqualStrings(
         "            zcli.builtin(.help, .{}),\n" ++
@@ -825,7 +978,7 @@ test "renderPluginsBlock scaffolds a compiling github_upgrade config, not an emp
         if (std.mem.eql(u8, choice.tag, "github_upgrade")) break i;
     } else return error.TestUnexpectedResult;
 
-    const block = try renderPluginsBlock(allocator, &.{idx});
+    const block = try renderPluginsBlock(allocator, &.{idx}, null);
     defer allocator.free(block);
     try std.testing.expectEqualStrings(
         "            zcli.builtin(.github_upgrade, .{\n" ++

--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -70,6 +70,7 @@ pub const meta = .{
         .git = .{ .description = "Initialize a git repository with a .gitignore and an initial commit (--no-git to skip)" },
         .build = .{ .description = "Verify the scaffold with `zig build` after fetching (--no-build to skip)" },
         .upgrade_repo = .{ .description = "GitHub OWNER/REPO the zcli_github_upgrade plugin pulls releases from (implies selecting that plugin)" },
+        .github = .{ .description = "GitHub Actions workflows as a comma-separated list of ci,release — or 'none'" },
     },
 };
 
@@ -94,7 +95,11 @@ pub const Options = struct {
     git: bool = true,
     build: bool = true,
     upgrade_repo: ?[]const u8 = null,
+    github: ?[]const u8 = null,
 };
+
+/// Which GitHub Actions workflows to scaffold (the extras step).
+const Workflows = struct { ci: bool = false, release: bool = false };
 
 pub fn execute(args: Args, options: Options, context: *Context) !void {
     const allocator = context.allocator;
@@ -310,7 +315,11 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
             break :repo r;
         }
         if (use_defaults or std.mem.indexOfScalar(usize, selected, upgrade_idx) == null) break :repo null;
-        const remote_default = gitRemoteSlug(allocator, io);
+        // The remote default only makes sense for `init .` in an existing
+        // repo — the process cwd IS the destination there. For a new
+        // subdirectory project, the enclosing directory's remote (if any)
+        // names a *different* project; suggesting it would be a trap.
+        const remote_default = if (use_current_dir) gitRemoteSlug(allocator, io) else null;
         defer if (remote_default) |d| allocator.free(d);
         const answer = p.text(.{
             .message = "GitHub repo for self-update releases (OWNER/REPO, empty to fill in later):",
@@ -327,6 +336,38 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         break :repo trimmed;
     };
 
+    // GitHub Actions extras (ADR-0028 step 5): --github decides outright;
+    // otherwise ask, with `release` preselected when github_upgrade was
+    // chosen — the release workflow is what feeds the self-updater.
+    // --defaults / non-TTY take the preselection, same as the plugin picker.
+    const upgrade_selected = std.mem.indexOfScalar(usize, selected, upgrade_idx) != null;
+    const workflows: Workflows = if (options.github) |github_arg|
+        parseGithubFlag(github_arg) catch {
+            return context.fail("Error: unknown workflow in --github '{s}'\n  Valid workflows: ci, release — or 'none'", .{github_arg});
+        }
+    else if (use_defaults)
+        Workflows{ .release = upgrade_selected }
+    else wf: {
+        var wf_defaults = [_]bool{ false, upgrade_selected };
+        const wf_selected = p.multiSelect(.{
+            .message = "GitHub Actions workflows to add:",
+            .choices = &.{
+                "ci — build and test on every push and PR",
+                "release — build binaries and publish a GitHub release on tag push",
+            },
+            .defaults = &wf_defaults,
+        }) catch |err| switch (err) {
+            error.EndOfStream => break :wf Workflows{ .release = upgrade_selected },
+            else => return err,
+        };
+        defer allocator.free(wf_selected);
+        var wf = Workflows{};
+        for (wf_selected) |idx| {
+            if (idx == 0) wf.ci = true else wf.release = true;
+        }
+        break :wf wf;
+    };
+
     // Build the `zcli.builtin(...)` registration lines for build.zig.
     const plugins_block = try renderPluginsBlock(allocator, selected, upgrade_repo);
     defer allocator.free(plugins_block);
@@ -334,7 +375,7 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
     // Everything is decided: one summary, shown for both the dry run and the
     // interactive confirm (ADR-0028 step 6).
     const summarize = struct {
-        fn print(w: anytype, tpl: Template, sel: []const usize, up_repo: ?[]const u8, with_git: bool, with_build: bool) !void {
+        fn print(w: anytype, tpl: Template, sel: []const usize, up_repo: ?[]const u8, wf: Workflows, with_git: bool, with_build: bool) !void {
             try w.print("  template: {s}\n", .{@tagName(tpl)});
             try w.print("  plugins:  ", .{});
             if (sel.len == 0) {
@@ -345,6 +386,14 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
             }
             try w.print("\n", .{});
             if (up_repo) |r| try w.print("  upgrades: github.com/{s} releases\n", .{r});
+            if (wf.ci or wf.release) {
+                try w.print("  github:   {s}{s}{s} workflow{s}\n", .{
+                    if (wf.ci) "ci" else "",
+                    if (wf.ci and wf.release) ", " else "",
+                    if (wf.release) "release" else "",
+                    if (wf.ci and wf.release) "s" else "",
+                });
+            }
             try w.print("  git:      {s}\n", .{if (with_git) "init + .gitignore + initial commit" else "skipped (--no-git)"});
             try w.print("  build:    {s}\n", .{if (with_build) "verify with `zig build`" else "skipped (--no-build)"});
         }
@@ -356,7 +405,7 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         try stdout.print("\nDry run — nothing written. Would create:\n", .{});
         const prefix: []const u8 = if (use_current_dir) "" else args.name;
         const sep: []const u8 = if (use_current_dir) "" else "/";
-        try summarize(stdout, template, selected, upgrade_repo, options.git, options.build);
+        try summarize(stdout, template, selected, upgrade_repo, workflows, options.git, options.build);
         try stdout.print("  files:\n", .{});
         try stdout.print("    {s}{s}build.zig\n", .{ prefix, sep });
         try stdout.print("    {s}{s}build.zig.zon\n", .{ prefix, sep });
@@ -366,6 +415,8 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
             .single => try stdout.print("    {s}{s}src/commands/index.zig\n", .{ prefix, sep }),
         }
         try stdout.print("    {s}{s}README.md\n", .{ prefix, sep });
+        if (workflows.ci) try stdout.print("    {s}{s}.github/workflows/ci.yml\n", .{ prefix, sep });
+        if (workflows.release) try stdout.print("    {s}{s}.github/workflows/release.yml\n", .{ prefix, sep });
         if (options.git) try stdout.print("    {s}{s}.gitignore\n", .{ prefix, sep });
         try stdout.print("    {s}{s}AGENTS.md\n", .{ prefix, sep });
         try stdout.print("  then: zig fetch --save https://github.com/ryanhair/zcli/archive/refs/tags/v{s}.tar.gz\n", .{context.app_version});
@@ -377,7 +428,7 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
     // scripts and CI sail through.
     if (!use_defaults) {
         try stdout.print("\nAbout to create '{s}':\n", .{project_name});
-        try summarize(stdout, template, selected, upgrade_repo, options.git, options.build);
+        try summarize(stdout, template, selected, upgrade_repo, workflows, options.git, options.build);
         try stdout.flush();
         const proceed = p.confirm(.{ .message = "Proceed?" }) catch |err| switch (err) {
             error.EndOfStream => true,
@@ -500,6 +551,26 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
     var readme_file = try project_dir.createFile(io, "README.md", .{});
     defer readme_file.close(io);
     try readme_file.writeStreamingAll(io, readme_content);
+
+    // GitHub Actions workflows (extras): written with the other project files
+    // so the initial commit below captures them. The shared scaffold is the
+    // same one `gh add workflow ci|release` uses. A fresh scaffold can't hit
+    // .not_a_project (src/commands was just created) or .already_exists for a
+    // new directory; `init .` tolerates a pre-existing workflow by warning.
+    if (workflows.ci) {
+        switch (try scaffold.workflows.write(project_dir, io, "ci.yml", scaffold.workflows.ci_yml)) {
+            .created => try stdout.print("  Creating .github/workflows/ci.yml...\n", .{}),
+            .already_exists => try stderr.print("  Warning: .github/workflows/ci.yml already exists — left untouched.\n", .{}),
+            .not_a_project => unreachable,
+        }
+    }
+    if (workflows.release) {
+        switch (try scaffold.workflows.write(project_dir, io, "release.yml", scaffold.workflows.release_yml)) {
+            .created => try stdout.print("  Creating .github/workflows/release.yml...\n", .{}),
+            .already_exists => try stderr.print("  Warning: .github/workflows/release.yml already exists — left untouched.\n", .{}),
+            .not_a_project => unreachable,
+        }
+    }
 
     // Scaffold AGENTS.md — the thin, frozen, command-speaking spine that points
     // coding agents at `zcli guide` (ADR-0008). Marker-delimited so it never
@@ -754,6 +825,35 @@ const AgentsResult = enum { created, appended, refreshed };
 /// Owned slice of the indices whose `defaults` bit is set — the non-interactive
 /// fallback for the plugin picker (mirrors what `multiSelect` returns for a
 /// submitted-defaults selection).
+/// Parse the --github flag: a comma-separated subset of {ci, release}, or
+/// 'none'. Unknown names are error.UnknownWorkflow — the caller renders the
+/// message with the valid list.
+fn parseGithubFlag(arg: []const u8) !Workflows {
+    var wf = Workflows{};
+    if (std.mem.eql(u8, std.mem.trim(u8, arg, " "), "none")) return wf;
+    var it = std.mem.splitScalar(u8, arg, ',');
+    while (it.next()) |raw| {
+        const name = std.mem.trim(u8, raw, " ");
+        if (name.len == 0) continue;
+        if (std.mem.eql(u8, name, "ci")) {
+            wf.ci = true;
+        } else if (std.mem.eql(u8, name, "release")) {
+            wf.release = true;
+        } else {
+            return error.UnknownWorkflow;
+        }
+    }
+    return wf;
+}
+
+test "parseGithubFlag: subsets, none, and unknown names" {
+    try std.testing.expectEqual(Workflows{ .ci = true, .release = true }, try parseGithubFlag("ci,release"));
+    try std.testing.expectEqual(Workflows{ .ci = true }, try parseGithubFlag("ci"));
+    try std.testing.expectEqual(Workflows{}, try parseGithubFlag("none"));
+    try std.testing.expectEqual(Workflows{ .release = true }, try parseGithubFlag("release,"));
+    try std.testing.expectError(error.UnknownWorkflow, parseGithubFlag("ci,deploy"));
+}
+
 /// Picker index of the builtin choice named `tag`, or null. Runtime lookup
 /// over the (tiny) comptime table so call sites can't drift from it.
 fn pluginIndex(tag: []const u8) ?usize {

--- a/projects/zcli/src/scaffold.zig
+++ b/projects/zcli/src/scaffold.zig
@@ -9,9 +9,11 @@ pub const spec = @import("scaffold/spec.zig");
 pub const splice = @import("scaffold/splice.zig");
 pub const fs = @import("scaffold/fs.zig");
 pub const reference = @import("scaffold/reference.zig");
+pub const workflows = @import("scaffold/workflows.zig");
 
 test {
     _ = spec;
     _ = splice;
     _ = fs;
+    _ = workflows;
 }

--- a/projects/zcli/src/scaffold/workflows.zig
+++ b/projects/zcli/src/scaffold/workflows.zig
@@ -1,0 +1,274 @@
+//! GitHub Actions workflow scaffolds, shared by the `gh add workflow ...`
+//! commands and `zcli init`'s extras step (ADR-0028 increment 5). Command
+//! modules can't import each other, so the content and the write logic live
+//! here in the `scaffold` shared module.
+//!
+//! Actions are pinned to full commit SHAs (with the version as a comment) so
+//! a moved or compromised tag can't change what runs — when upgrading an
+//! action, update the SHA and the comment together, in every workflow here.
+
+const std = @import("std");
+
+pub const Outcome = enum { created, not_a_project, already_exists };
+
+/// Write one workflow file into `dir`'s .github/workflows/, creating the
+/// directories as needed. Refuses to overwrite an existing file and refuses
+/// to run outside a zcli project (no src/commands). Takes `dir` explicitly
+/// so tests exercise a scratch directory.
+pub fn write(dir: std.Io.Dir, io: std.Io, file_name: []const u8, content: []const u8) !Outcome {
+    dir.access(io, "src/commands", .{}) catch return .not_a_project;
+
+    dir.createDir(io, ".github", .default_dir) catch |err| switch (err) {
+        error.PathAlreadyExists => {},
+        else => return err,
+    };
+    dir.createDir(io, ".github/workflows", .default_dir) catch |err| switch (err) {
+        error.PathAlreadyExists => {},
+        else => return err,
+    };
+
+    var path_buf: [128]u8 = undefined;
+    const sub_path = try std.fmt.bufPrint(&path_buf, ".github/workflows/{s}", .{file_name});
+
+    if (dir.access(io, sub_path, .{})) {
+        return .already_exists;
+    } else |err| switch (err) {
+        error.FileNotFound => {}, // Good, safe to create
+        else => return err,
+    }
+
+    var file = try dir.createFile(io, sub_path, .{});
+    defer file.close(io);
+    try file.writeStreamingAll(io, content);
+
+    return .created;
+}
+
+/// CI: build + unit tests on every push/PR. Deliberately minimal — one job,
+/// ubuntu only; a project that needs a matrix grows one itself.
+pub const ci_yml =
+    \\name: CI
+    \\
+    \\# Actions are pinned to full commit SHAs (with the version as a comment)
+    \\# so a moved or compromised tag can't change what runs in this workflow.
+    \\# When upgrading an action, update the SHA and the comment together.
+    \\
+    \\on:
+    \\  push:
+    \\    branches: [main]
+    \\  pull_request:
+    \\
+    \\jobs:
+    \\  test:
+    \\    name: Build and test
+    \\    runs-on: ubuntu-latest
+    \\    steps:
+    \\      - name: Checkout code
+    \\        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    \\
+    \\      - name: Setup Zig
+    \\        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+    \\        with:
+    \\          version: 0.16.0
+    \\
+    \\      - name: Build
+    \\        run: zig build
+    \\
+    \\      - name: Test
+    \\        run: zig build test
+    \\
+;
+
+/// Release: cross-compile on tag push, checksum, and publish a GitHub
+/// release with the binaries attached.
+pub const release_yml =
+    \\name: Release
+    \\
+    \\# Actions are pinned to full commit SHAs (with the version as a comment)
+    \\# so a moved or compromised tag can't change what runs in this workflow.
+    \\# When upgrading an action, update the SHA and the comment together.
+    \\
+    \\on:
+    \\  push:
+    \\    tags:
+    \\      - '*-v*'
+    \\
+    \\jobs:
+    \\  build:
+    \\    name: Build ${{ matrix.target }}
+    \\    runs-on: ${{ matrix.os }}
+    \\    strategy:
+    \\      matrix:
+    \\        include:
+    \\          - os: ubuntu-latest
+    \\            target: x86_64-linux
+    \\            zig_target: x86_64-linux-musl
+    \\          - os: ubuntu-latest
+    \\            target: aarch64-linux
+    \\            zig_target: aarch64-linux-musl
+    \\          - os: macos-latest
+    \\            target: x86_64-macos
+    \\            zig_target: x86_64-macos
+    \\          - os: macos-latest
+    \\            target: aarch64-macos
+    \\            zig_target: aarch64-macos
+    \\
+    \\    steps:
+    \\      - name: Checkout code
+    \\        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    \\
+    \\      - name: Setup Zig
+    \\        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+    \\        with:
+    \\          version: 0.16.0
+    \\
+    \\      - name: Build binary
+    \\        # ReleaseSafe keeps runtime safety checks (bounds/overflow) in a
+    \\        # binary that parses untrusted input; -Dstrip=true drops debug info,
+    \\        # which dominates size. If your build.zig predates the `strip`
+    \\        # option, add: b.option(bool, "strip", "...") and `.strip = strip`
+    \\        # on the exe module.
+    \\        run: zig build -Doptimize=ReleaseSafe -Dstrip=true -Dtarget=${{ matrix.zig_target }}
+    \\
+    \\      - name: Get app name from build.zig.zon
+    \\        id: appname
+    \\        run: |
+    \\          # Extract .name from build.zig.zon (handles both quoted strings and identifiers)
+    \\          NAME_LINE=$(grep -m1 '\.name = ' build.zig.zon)
+    \\          if [[ "$NAME_LINE" =~ \.name\ =\ \"([^\"]+)\" ]]; then
+    \\            APP_NAME="${BASH_REMATCH[1]}"
+    \\          elif [[ "$NAME_LINE" =~ \.name\ =\ \.([^,}\ ]+) ]]; then
+    \\            APP_NAME="${BASH_REMATCH[1]}"
+    \\          else
+    \\            echo "Error: Could not parse .name from build.zig.zon"
+    \\            exit 1
+    \\          fi
+    \\          echo "name=$APP_NAME" >> $GITHUB_OUTPUT
+    \\
+    \\      - name: Package binary
+    \\        run: |
+    \\          mkdir -p dist
+    \\          cp zig-out/bin/${{ steps.appname.outputs.name }} dist/${{ steps.appname.outputs.name }}-${{ matrix.target }}
+    \\          chmod +x dist/${{ steps.appname.outputs.name }}-${{ matrix.target }}
+    \\
+    \\      - name: Generate checksum
+    \\        run: |
+    \\          cd dist
+    \\          shasum -a 256 ${{ steps.appname.outputs.name }}-${{ matrix.target }} > ${{ steps.appname.outputs.name }}-${{ matrix.target }}.sha256
+    \\
+    \\      - name: Upload artifact
+    \\        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+    \\        with:
+    \\          name: ${{ steps.appname.outputs.name }}-${{ matrix.target }}
+    \\          path: |
+    \\            dist/${{ steps.appname.outputs.name }}-${{ matrix.target }}
+    \\            dist/${{ steps.appname.outputs.name }}-${{ matrix.target }}.sha256
+    \\
+    \\  release:
+    \\    name: Create Release
+    \\    needs: build
+    \\    runs-on: ubuntu-latest
+    \\    permissions:
+    \\      contents: write
+    \\
+    \\    steps:
+    \\      - name: Checkout code
+    \\        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    \\
+    \\      - name: Download all artifacts
+    \\        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+    \\        with:
+    \\          path: dist
+    \\
+    \\      - name: Flatten artifact structure
+    \\        run: |
+    \\          mkdir -p release
+    \\          find dist -type f \( -name '*-x86_64-*' -o -name '*-aarch64-*' \) -exec cp {} release/ \;
+    \\          ls -la release/
+    \\
+    \\      - name: Create checksums file
+    \\        run: |
+    \\          cd release
+    \\          cat *.sha256 > checksums.txt
+    \\          rm *.sha256
+    \\
+    \\      - name: Create Release
+    \\        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
+    \\        with:
+    \\          files: release/*
+    \\          generate_release_notes: true
+    \\          draft: false
+    \\          prerelease: false
+    \\        env:
+    \\          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    \\
+;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const testing = std.testing;
+
+test "write fails outside a zcli project" {
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try testing.expectEqual(Outcome.not_a_project, try write(tmp.dir, io, "release.yml", release_yml));
+}
+
+test "write creates a pinned, version-matched release workflow" {
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDir(io, "src", .default_dir);
+    try tmp.dir.createDir(io, "src/commands", .default_dir);
+
+    try testing.expectEqual(Outcome.created, try write(tmp.dir, io, "release.yml", release_yml));
+
+    const content = try tmp.dir.readFileAlloc(io, ".github/workflows/release.yml", testing.allocator, .limited(1 << 20));
+    defer testing.allocator.free(content);
+
+    try testing.expect(std.mem.indexOf(u8, content, "name: Release") != null);
+    // Every `uses:` action must be pinned to a full commit SHA (with the
+    // version as a trailing comment), never a mutable tag.
+    try testing.expect(std.mem.indexOf(u8, content, "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1") != null);
+    try testing.expect(std.mem.indexOf(u8, content, "mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1") != null);
+    try testing.expect(std.mem.indexOf(u8, content, "version: 0.16.0") != null);
+    try testing.expect(std.mem.indexOf(u8, content, "-Dstrip=true") != null);
+}
+
+test "write creates the CI workflow with pinned actions" {
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDir(io, "src", .default_dir);
+    try tmp.dir.createDir(io, "src/commands", .default_dir);
+
+    try testing.expectEqual(Outcome.created, try write(tmp.dir, io, "ci.yml", ci_yml));
+
+    const content = try tmp.dir.readFileAlloc(io, ".github/workflows/ci.yml", testing.allocator, .limited(1 << 20));
+    defer testing.allocator.free(content);
+
+    try testing.expect(std.mem.indexOf(u8, content, "name: CI") != null);
+    try testing.expect(std.mem.indexOf(u8, content, "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1") != null);
+    try testing.expect(std.mem.indexOf(u8, content, "zig build test") != null);
+}
+
+test "write refuses to overwrite an existing workflow" {
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDir(io, "src", .default_dir);
+    try tmp.dir.createDir(io, "src/commands", .default_dir);
+    try tmp.dir.createDir(io, ".github", .default_dir);
+    try tmp.dir.createDir(io, ".github/workflows", .default_dir);
+    try tmp.dir.writeFile(io, .{ .sub_path = ".github/workflows/release.yml", .data = "custom content\n" });
+
+    try testing.expectEqual(Outcome.already_exists, try write(tmp.dir, io, "release.yml", release_yml));
+
+    const content = try tmp.dir.readFileAlloc(io, ".github/workflows/release.yml", testing.allocator, .limited(4096));
+    defer testing.allocator.free(content);
+    try testing.expectEqualStrings("custom content\n", content);
+}

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -491,6 +491,117 @@ test "init --plugins rejects unknown names, listing the valid set, creating noth
     try testing.expect(!fileExists(tmp.dir, "myapp"));
 }
 
+test "init --upgrade-repo renders the repo and implies the github_upgrade plugin" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--plugins", "help", "--upgrade-repo", "acme/mytool", "--no-build" });
+    defer r.deinit();
+    try expectOk(r);
+
+    var proj = try tmp.dir.openDir(io, "myapp", .{});
+    defer proj.close(io);
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const build_zig = try readFile(proj, arena.allocator(), "build.zig");
+    // The flag implies the plugin even though --plugins named only help...
+    try expectContains(build_zig, "zcli.builtin(.github_upgrade");
+    // ...and the repo lands in the config instead of the TODO placeholder.
+    try expectContains(build_zig, ".repo = \"acme/mytool\",");
+    try testing.expect(std.mem.indexOf(u8, build_zig, "OWNER/REPO") == null);
+    // Verification stays an explicit TODO — key pinning is a deliberate act.
+    try expectContains(build_zig, ".verification = .checksum_only");
+}
+
+test "init --upgrade-repo rejects a malformed slug, creating nothing" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--upgrade-repo", "not-a-slug", "--no-build" });
+    defer r.deinit();
+    try testing.expect(r.exit_code != 0);
+    try expectContains(r.stderr, "Expected OWNER/REPO");
+    try testing.expect(!fileExists(tmp.dir, "myapp"));
+}
+
+test "init --github ci,release scaffolds both workflows; default scaffolds none" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--github", "ci,release", "--defaults", "--no-build" });
+    defer r.deinit();
+    try expectOk(r);
+
+    var proj = try tmp.dir.openDir(io, "myapp", .{});
+    defer proj.close(io);
+    try testing.expect(fileExists(proj, ".github/workflows/ci.yml"));
+    try testing.expect(fileExists(proj, ".github/workflows/release.yml"));
+
+    var r2 = try run(tmp.dir, &.{ zcli_exe, "init", "plain", "--defaults", "--no-build" });
+    defer r2.deinit();
+    try expectOk(r2);
+    var plain = try tmp.dir.openDir(io, "plain", .{});
+    defer plain.close(io);
+    try testing.expect(!fileExists(plain, ".github/workflows/ci.yml"));
+    try testing.expect(!fileExists(plain, ".github/workflows/release.yml"));
+}
+
+test "init --defaults with github_upgrade selected preselects the release workflow" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--plugins", "github_upgrade", "--defaults", "--no-build" });
+    defer r.deinit();
+    try expectOk(r);
+
+    var proj = try tmp.dir.openDir(io, "myapp", .{});
+    defer proj.close(io);
+    // The release workflow feeds the self-updater — suggested on by default.
+    try testing.expect(fileExists(proj, ".github/workflows/release.yml"));
+    try testing.expect(!fileExists(proj, ".github/workflows/ci.yml"));
+}
+
+test "init --github rejects unknown workflow names, creating nothing" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--github", "ci,deploy", "--no-build" });
+    defer r.deinit();
+    try testing.expect(r.exit_code != 0);
+    try expectContains(r.stderr, "unknown workflow");
+    try testing.expect(!fileExists(tmp.dir, "myapp"));
+}
+
+test "gh add workflow ci scaffolds the pinned CI workflow" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var r = try run(tmp.dir, &.{ zcli_exe, "init", "myapp", "--defaults", "--no-build" });
+    defer r.deinit();
+    try expectOk(r);
+
+    var proj = try tmp.dir.openDir(io, "myapp", .{});
+    defer proj.close(io);
+
+    var r2 = try run(proj, &.{ zcli_exe, "gh", "add", "workflow", "ci" });
+    defer r2.deinit();
+    try expectOk(r2);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const ci = try readFile(proj, arena.allocator(), ".github/workflows/ci.yml");
+    try expectContains(ci, "name: CI");
+    try expectContains(ci, "zig build test");
+    try expectContains(ci, "mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1");
+
+    // Idempotence guard: a second run refuses rather than overwrites.
+    var r3 = try run(proj, &.{ zcli_exe, "gh", "add", "workflow", "ci" });
+    defer r3.deinit();
+    try testing.expect(r3.exit_code != 0);
+    try expectContains(r3.stderr, "already exists");
+}
+
 test "init --dry-run reports the plan and writes nothing" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -2465,6 +2576,7 @@ test "interactive: init's plugin multi-select toggles an opt-in plugin" {
     _ = script
         .expect("Select built-in plugins").delay(settle_ms)
         .sendRaw("\x1b[B\x1b[B\x1b[B \r")
+        .expect("GitHub Actions workflows").delay(settle_ms).sendRaw("\r")
         .expect("Proceed?").delay(settle_ms).sendRaw("\r");
 
     var result = harness.runInteractive(
@@ -2531,6 +2643,8 @@ test "interactive: init's plugin multi-select toggles github_upgrade and the sca
     _ = script
         .expect("Select built-in plugins").delay(settle_ms)
         .sendRaw("\x1b[B\x1b[B\x1b[B\x1b[B\x1b[B \r")
+        .expect("GitHub repo for self-update").delay(settle_ms).sendRaw("\r")
+        .expect("GitHub Actions workflows").delay(settle_ms).sendRaw("\r")
         .expect("Proceed?").delay(settle_ms).sendRaw("\r");
 
     var result = harness.runInteractive(


### PR DESCRIPTION
## Summary

The last two increments of the init wizard plan (ADR-0028). With these, all five increments have shipped.

**Increment 4 — github_upgrade repo prompt-through:**
- `--upgrade-repo OWNER/REPO` supplies the repo outright and *implies* selecting the plugin (one flag, one intent).
- An interactive picker selection gets a follow-up text prompt instead of leaving an `OWNER/REPO` TODO in build.zig — defaulted from the destination's github `origin` remote for `init .` in an existing repo (ssh and https forms parse). New-subdirectory projects deliberately get **no** remote default: the enclosing directory's remote names a different project.
- The slug is validated to `[A-Za-z0-9._-]` with exactly one `/`, which doubles as the generated-literal injection guard. Empty answer / `--defaults` keep the compiling TODO placeholder; `verification` stays an explicit TODO either way (pinning a minisign key is a deliberate act).

**Increment 5 — CI workflow + the extras step:**
- Workflow content and write logic move from the release command into `scaffold/workflows.zig` (command modules can't import each other; the scaffold shared module is the reuse point). The release command becomes a thin delegate — byte-identical output.
- New `zcli gh add workflow ci`: one pinned ubuntu build+test job (same SHA-pinned actions discipline as release.yml).
- init's extras: `--github <ci,release|none>`, or an interactive multi-select with `release` preselected when github_upgrade was chosen (it feeds the self-updater); `--defaults`/non-TTY take the preselection. Workflows are written with the project files so the initial commit captures them.

## Testing

- e2e: `--upgrade-repo` renders the repo and implies the plugin; malformed slug rejected with nothing created; `--github ci,release` / default-none / unknown-name rejection; the github_upgrade+`--defaults` release preselection; `gh add workflow ci` including the refuse-to-overwrite second run. The interactive PTY scripts answer the new prompts, with the github_upgrade path submitting an empty repo — locking in that the TODO-placeholder scaffold still compiles for real.
- Unit: slug validation, github-remote URL parsing (https/ssh/.git), `--github` parsing, `renderPluginsBlock` with a known repo; the workflow write/overwrite/not-a-project tests moved to `scaffold/workflows.zig` and gained a ci.yml case.
- Full `zig build e2e` green (53 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)