### PR TITLE
release.yml: push finalize via the release deploy key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: Release
 on:
   push:
     tags:
-      - "*-v*"  # CLI releases (e.g., zcli-v0.9.0)
-      - "v*"    # Library releases (e.g., v0.9.0)
+      - "*-v*" # CLI releases (e.g., zcli-v0.9.0)
+      - "v*" # Library releases (e.g., v0.9.0)
   # One-button release: pick a version, CI bumps both build.zig.zon files,
   # stages the bump on a scratch branch, runs the full test + build gate
   # against it, and only THEN commits to main and tags v<version> +
@@ -360,6 +360,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ needs.setup.outputs.ref }}
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
           fetch-depth: 0
 
       - name: Push to main and cut tags


### PR DESCRIPTION
The 0.21.0 release run failed at **Promote staged release to main**: the main-branch ruleset's required "CI OK" status check rejects pushes from the workflow's `GITHUB_TOKEN`, and GitHub doesn't allow the built-in `github-actions` identity as a ruleset bypass actor. (0.21.0 was recovered by pushing the staged commit to main manually and re-running the failed job.)

This makes future one-button dispatches work end-to-end:

- The `finalize` job's checkout now uses `ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}`, so its `git push` to main and both tag pushes authenticate as the **zcli-release-key** deploy key — which is registered as a bypass actor on the ruleset.
- **Security model unchanged**: the secret lives in the gated `release` environment (required reviewers), so the bypass-capable key is only exposed to jobs a human has approved. The ungated `setup` job keeps plain `GITHUB_TOKEN` — it only ever pushes the disposable staging branch.
- `release`/`library-release` need no change: they create GitHub releases via API on tags that already exist.

Repo-settings side (already done): write-access deploy key `zcli-release-key`, `RELEASE_DEPLOY_KEY` secret in the `release` environment, `DeployKey` added to the ruleset's bypass list.

Note: this path is only truly exercised by the next `workflow_dispatch` release — this run's finalize succeeded because main already carried the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)