### PR TITLE
init: retire the 0.20.0 release gates (fixes main e2e)

### DIFF
--- a/projects/zcli/src/commands/init.zig
+++ b/projects/zcli/src/commands/init.zig
@@ -227,21 +227,11 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
     // entirely so a script WITH a terminal attached never blocks.
     const use_defaults = options.defaults or options.yes;
 
-    // Root index support (ADR-0029) ships in the first release AFTER 0.20.0.
-    // init pins the generated project to this CLI's own version tag, so a CLI
-    // still carrying the 0.20.0 version would scaffold an index.zig the
-    // released library silently ignores — a project that builds but routes
-    // every positional to "Unknown command". While that's the pinned release,
-    // don't offer the shape (default multi) and fail closed on an explicit
-    // --template single. The guard clears automatically when the release bump
-    // moves the version past 0.20.0.
-    const root_index_ok = rootIndexSupported(context.app_version);
-
     // Ask for the CLI shape first (ADR-0028 step 3) unless --template decided
     // it. Restructuring between shapes later is annoying, so it's asked up
     // front; non-interactive invocations default to multi (today's scaffold).
     const template: Template = options.template orelse blk: {
-        if (!root_index_ok or use_defaults) break :blk .multi;
+        if (use_defaults) break :blk .multi;
         const shape = p.select(.{
             .message = "What kind of CLI?",
             .choices = &.{
@@ -254,10 +244,6 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
         };
         break :blk if (shape == 1) .single else .multi;
     };
-
-    if (template == .single and !root_index_ok) {
-        return context.fail("Error: --template single requires the zcli library released after 0.20.0 (root index support, ADR-0029)\n  This zcli pins generated projects to v{s}, which ignores a top-level index.zig.\n  Upgrade zcli, or scaffold with the default multi-command template.", .{context.app_version});
-    }
 
     // Which built-in plugins to include: --plugins decides outright,
     // --defaults/--yes takes the preselected defaults, otherwise ask (with
@@ -1103,12 +1089,9 @@ const ref_plugins_end = "            //</zcli:plugins>\n";
 ///     description.
 ///
 /// The reference is written against the *local* (unreleased) zcli so it stays
-/// compile-checked by the `examples/init-scaffold` build. `init`, though, pins
-/// the released tag `context.app_version` points at, whose `addCommandTests`
-/// still predates the `exe` parameter (#531) — so emit the 3-arg form that
-/// release expects. (The local-tree e2e build bridges it back up; the
-/// pinned-release e2e, #623, builds this unmodified against the real tag.) Drop
-/// this last rewrite once the pinned release carries the `exe` signature.
+/// compile-checked by the `examples/init-scaffold` build; the pinned-release
+/// e2e (#623) builds the emitted file unmodified against the real tag, which
+/// guards any drift between the reference and the release it pins.
 fn renderBuildZig(
     allocator: std.mem.Allocator,
     project_name: []const u8,
@@ -1132,13 +1115,10 @@ fn renderBuildZig(
     defer allocator.free(named);
     // 3) Description (name is substituted first so it can't collide with a
     //    user-supplied description, which is inserted last and never rescanned).
-    const described = try std.mem.replaceOwned(u8, allocator, named, "\"A CLI application built with zcli\"", desc_quoted);
-    defer allocator.free(described);
-    // 4) Pin `addCommandTests` down to the released 3-arg shape (see doc comment).
-    return std.mem.replaceOwned(u8, allocator, described, "zcli.addCommandTests(b, exe, zcli_dep,", "zcli.addCommandTests(b, zcli_dep,");
+    return std.mem.replaceOwned(u8, allocator, named, "\"A CLI application built with zcli\"", desc_quoted);
 }
 
-test "renderBuildZig substitutes name, description, plugins and pins addCommandTests" {
+test "renderBuildZig substitutes name, description, and plugins" {
     const allocator = std.testing.allocator;
     const plugins =
         "            zcli.builtin(.help, .{}),\n" ++
@@ -1155,31 +1135,9 @@ test "renderBuildZig substitutes name, description, plugins and pins addCommandT
     // Selected plugins are spliced in, markers removed.
     try std.testing.expect(std.mem.indexOf(u8, build, "zcli.builtin(.help, .{}),") != null);
     try std.testing.expect(std.mem.indexOf(u8, build, "//<zcli:plugins>") == null);
-    // Emitted call matches the pinned release's 3-arg signature, not the
-    // reference's local 4-arg one.
-    try std.testing.expect(std.mem.indexOf(u8, build, "zcli.addCommandTests(b, zcli_dep,") != null);
-    try std.testing.expect(std.mem.indexOf(u8, build, "zcli.addCommandTests(b, exe, zcli_dep,") == null);
-    // Framework-coupled call the reference compile-guards survives verbatim.
+    // Framework-coupled calls the reference compile-guards survive verbatim.
+    try std.testing.expect(std.mem.indexOf(u8, build, "zcli.addCommandTests(b, exe, zcli_dep,") != null);
     try std.testing.expect(std.mem.indexOf(u8, build, "try zcli.generate(b, exe, zcli_dep, .{") != null);
-}
-
-/// True when the zcli release this CLI pins (its own version) contains root
-/// index support (ADR-0029) — i.e. is strictly newer than 0.20.0, the last
-/// release without it. Unparseable versions count as unsupported: fail closed
-/// rather than scaffold a silently-dead index.zig.
-fn rootIndexSupported(version_str: []const u8) bool {
-    const v = std.SemanticVersion.parse(version_str) catch return false;
-    const last_without = std.SemanticVersion{ .major = 0, .minor = 20, .patch = 0 };
-    return v.order(last_without) == .gt;
-}
-
-test "rootIndexSupported: strictly newer than 0.20.0, fail closed on junk" {
-    try std.testing.expect(!rootIndexSupported("0.20.0"));
-    try std.testing.expect(!rootIndexSupported("0.19.9"));
-    try std.testing.expect(rootIndexSupported("0.20.1"));
-    try std.testing.expect(rootIndexSupported("0.21.0"));
-    try std.testing.expect(rootIndexSupported("1.0.0"));
-    try std.testing.expect(!rootIndexSupported("not-a-version"));
 }
 
 /// True if `s` is a semantic version acceptable to Zig's build.zig.zon manifest

--- a/projects/zcli/test/e2e.zig
+++ b/projects/zcli/test/e2e.zig
@@ -406,16 +406,7 @@ test "init --template single scaffolds a root index.zig instead of hello (ADR-00
     var r = try run(tmp.dir, &.{ zcli_exe, "init", "mytool", "--template", "single", "--no-build" });
     defer r.deinit();
 
-    // The single template needs a released library with root index support
-    // (> 0.20.0). While this CLI still pins 0.20.0, init fails closed with
-    // the reason rather than scaffolding a silently-dead index.zig — assert
-    // whichever outcome init declared (same pattern as the fetch-outcome
-    // branch above). The guard branch dies with the release bump.
-    if (r.exit_code != 0) {
-        try expectContains(r.stderr, "--template single requires");
-        try testing.expect(!fileExists(tmp.dir, "mytool/src/commands/index.zig"));
-        return;
-    }
+    try expectOk(r);
 
     var proj = try tmp.dir.openDir(io, "mytool", .{});
     defer proj.close(io);
@@ -1201,24 +1192,6 @@ fn pointDependencyAtLocalTree(proj: std.Io.Dir, proj_abs: []const u8) !void {
         .{ orig[0..dep_start], rel, orig[paths_start..] },
     );
     try proj.writeFile(io, .{ .sub_path = "build.zig.zon", .data = rewritten });
-
-    // The template targets the *pinned release* API (init pins the same tag this
-    // CLI was released as; see init.zig). The local working tree can be ahead of
-    // that release — right now HEAD's `addCommandTests` takes the project `exe`
-    // (#531) while the last release's is 3-arg — so building the release-shaped
-    // template against the local tree needs that one call bridged up to HEAD.
-    // This only adapts the local-tree path; the `scaffold builds against the
-    // pinned release` test below builds the template *unmodified* against the
-    // real tag, which is what actually guards the release-drift this bridges.
-    const build_zig = try readFile(proj, a, "build.zig");
-    const bridged = try std.mem.replaceOwned(
-        u8,
-        a,
-        build_zig,
-        "zcli.addCommandTests(b, zcli_dep,",
-        "zcli.addCommandTests(b, exe, zcli_dep,",
-    );
-    try proj.writeFile(io, .{ .sub_path = "build.zig", .data = bridged });
 }
 
 /// Absolute path of a sub-directory created in this test run's temp dir.


### PR DESCRIPTION
Main's CI e2e went red after the 0.21.0 release ([run 29634082899](https://github.com/ryanhair/zcli/actions/runs/29634082899)): init pins scaffolds to the CLI's own release tag, and the freshly-published v0.21.0 library takes the 4-arg `addCommandTests(b, exe, zcli_dep, ...)` — but init was still pinning emissions down to the 3-arg 0.20.0 form (#709). Both failing tests (`init verifies the scaffold with zig build by default` and `scaffold builds against the pinned release (#623)`) share that root cause.

This retires the whole batch of 0.20.0-era gates, all of which were documented to die at this release:

- **`renderBuildZig`**: drop the 3-arg pin-down — the scaffold now emits the reference's 4-arg call verbatim (the doc comment said to remove this "once the pinned release carries the `exe` signature").
- **`test/e2e.zig`**: drop the matching bridge that rewrote the emitted 3-arg call back up for local-tree builds.
- **`rootIndexSupported()` gate**: removed along with the fail-closed `--template single` error — the version check auto-passes at 0.21.0, so the shape prompt now shows on a TTY and `--template single` scaffolds against a release that actually routes the root index.
- **Guard-era e2e branch**: the `--template single` test now requires success instead of accepting the fail-closed outcome.

Verified: `zig build test` and the **full `zig build e2e`** pass locally (including the two tests red on main, now building against the real v0.21.0 tag), and a manual scaffold emits the 4-arg call pinned to v0.21.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)