### PR TITLE
upgrade plugin: flush progress lines before slow work

### DIFF
--- a/packages/core/src/plugins/zcli_github_upgrade/plugin.zig
+++ b/packages/core/src/plugins/zcli_github_upgrade/plugin.zig
@@ -351,6 +351,9 @@ pub fn init(config: Config) type {
             } else {
                 try stdout.print("Upgrading from {s} to {s}...\n", .{ current_version, target_version });
             }
+            // Progress lines must reach the terminal before the slow work they
+            // announce — stdout is buffered and only auto-flushes at exit.
+            try stdout.flush();
 
             // Detect platform
             const platform = try detectPlatform(allocator);
@@ -390,6 +393,7 @@ pub fn init(config: Config) type {
             } else {
                 try stdout.print("Verifying checksum...\n", .{});
             }
+            try stdout.flush();
             // Fetch the asset, then verify its integrity into scratch_dir. When a
             // signing key is pinned, checksums.txt is authenticated under it
             // (fail closed) before any digest is trusted.
@@ -404,15 +408,18 @@ pub fn init(config: Config) type {
 
             // Test new binary
             try stdout.print("Testing new binary...\n", .{});
+            try stdout.flush();
             try testBinary(allocator, context.io, scratch_dir, binary_name);
 
             // Replace current binary
             try stdout.print("Installing new version...\n", .{});
+            try stdout.flush();
             try replaceBinaryAt(allocator, context.io, scratch_dir, binary_name, exe_path);
 
             const action = if (is_downgrade) "downgraded" else "upgraded";
+            const action_noun = if (is_downgrade) "downgrade" else "upgrade";
             try stdout.print("✓ Successfully {s} to {s}\n", .{ action, target_version });
-            try stdout.print("\nThe {s} is complete. Run '{s} --version' to verify.\n", .{ action, context.app_name });
+            try stdout.print("\nThe {s} is complete. Run '{s} --version' to verify.\n", .{ action_noun, context.app_name });
         }
 
         /// Startup hook to check for updates if configured


### PR DESCRIPTION
## Summary
- `zcli upgrade` printed nothing until the very end: progress lines went into the 4KB buffered stdout, which only auto-flushes at process exit. Add `stdout.flush()` after each progress message that precedes a long-running step (version fetch/download, signature/checksum verify, binary smoke test, install) so users see progress as it happens.
- Fix completion-message grammar: "The upgraded is complete" → "The upgrade is complete" ("downgrade" on the downgrade path).

## Test plan
- `zig build` and `zig build test` pass locally.
- No tests asserted the old message text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YDJysqodQXgBaDJQMJRoDA