### PR TITLE
website: accuracy pass — fix broken samples, stale versions, wrong output

### DIFF
--- a/website/content/docs/build.smd
+++ b/website/content/docs/build.smd
@@ -94,7 +94,7 @@ const store = @import("store");
 `addCommandTests` discovers every command file and compiles each one's `test` blocks against the [testing harness]($link.page('docs/testing')) — with the `zcli-testing` module, your shared modules, and an in-memory secrets stub wired in:
 
 ```zig
-_ = zcli.addCommandTests(b, zcli_dep, .{
+_ = zcli.addCommandTests(b, exe, zcli_dep, .{
     .commands_dir = "src/commands",
     .target = target,
     .optimize = optimize,

--- a/website/content/docs/cli.smd
+++ b/website/content/docs/cli.smd
@@ -37,7 +37,7 @@ On a TTY, init is a short wizard — every step has a sensible default:
 
 1. **Description** — one line that anchors every `--help` render.
 2. **CLI shape** — `multi` (subcommands, git style — the default) or `single` (the app itself is the command, rg style; see [single-command CLIs]($link.page('docs/commands').unsafeRef('single-command-clis'))). Asked up front because restructuring between shapes later is annoying.
-3. **Plugins** — multi-select of the built-ins (help, version, and not-found are preselected). Selecting `github_upgrade` gets a follow-up prompt for the `OWNER/REPO` it pulls releases from, defaulted from your git remote — no `TODO:` placeholders in generated code.
+3. **Plugins** — multi-select of the built-ins (help, version, and not-found are preselected). Selecting `github_upgrade` gets a follow-up prompt for the `OWNER/REPO` it pulls releases from — defaulted from your git remote when running `zcli init .` in an existing repo — no `TODO:` placeholders in generated code.
 4. **GitHub Actions** — optionally scaffold the `ci` and/or `release` workflows (release is preselected when `github_upgrade` was chosen — it completes the self-update loop).
 5. **Summary + confirm** — one block showing every decision before anything touches disk.
 

--- a/website/content/docs/commands.smd
+++ b/website/content/docs/commands.smd
@@ -90,7 +90,7 @@ A mistyped command gets a "did you mean?" computed by edit distance, followed by
 
 ```sh
 $ myapp usrs list
-Unknown command 'usrs'
+Error: Unknown command 'usrs'
 Did you mean 'users'?
 ```
 

--- a/website/content/docs/config.smd
+++ b/website/content/docs/config.smd
@@ -27,7 +27,7 @@ The first match wins:
 2. `./.{app}.config.json|toml|yaml|yml` — a project-local dotfile in the working directory
 3. `{user config dir}/{app}/config.json|toml|yaml|yml` — the user-level config (`$XDG_CONFIG_HOME` or `~/.config` on POSIX; `%APPDATA%`, else `%USERPROFILE%`, on Windows)
 
-If more than one candidate exists, the first in this order is used and the plugin prints a notice naming the file it chose.
+The first match wins outright. When the winner is the project-local dotfile, the plugin always prints a `note: applied config from ./…` naming it (the explicit `--config` file and the user-level config load silently). Separately, if one tier contains files in several formats — say both `.myapp.config.json` and `.myapp.config.toml` — the plugin warns that multiple config files were found and names the one it used.
 
 ## Global and per-command values
 

--- a/website/content/docs/context.smd
+++ b/website/content/docs/context.smd
@@ -67,12 +67,12 @@ The context hands you each terminal package already wired to the command's strea
 
 ## Plugin data
 
-Anything a plugin stores in its `ContextData` is namespaced under `context.plugins.<plugin_id>` and fully typed:
+Anything a plugin stores in its `ContextData` is namespaced under `context.plugins.<plugin_id>` and fully typed. Say you wrote a `timing` plugin that tracks a `--time` flag:
 
 ```zig
 if (context.plugins.timing.started_ns != 0) {
-    // the --time flag was set; the timing plugin is tracking this run
+    // the --time flag was set; your timing plugin is tracking this run
 }
 ```
 
-The [secrets plugin]($link.page('docs/secrets')) is the same shape: `context.plugins.zcli_secrets.get("token")`. See [Plugins]($link.page('docs/plugins')) for the full model.
+The [secrets plugin]($link.page('docs/secrets')) is the same shape: `try context.plugins.zcli_secrets.get("token")`. See [Plugins]($link.page('docs/plugins')) for the full model.

--- a/website/content/docs/errors.smd
+++ b/website/content/docs/errors.smd
@@ -1,6 +1,6 @@
 ---
 .title = "zcli — Error handling",
-.description = "How zcli reports errors: structured ZcliError unions, rich diagnostics with did-you-mean suggestions, automatic framework handling inside commands, and the parseArgs/parseOptions API for standalone parsing.",
+.description = "How zcli reports errors: structured ZcliError unions, rich diagnostics with did-you-mean suggestions, automatic framework handling inside commands, and the parseCommandLine API for standalone parsing.",
 .date = @date("2026-07-11"),
 .author = "Ryan Hair",
 .layout = "guide.shtml",
@@ -29,6 +29,7 @@ pub const ZcliError = error{
     ArgumentMissingRequired,
     ArgumentInvalidValue,
     ArgumentTooMany,
+    ArgumentValidationFailed,
 
     // Option parsing errors
     OptionUnknown,
@@ -36,6 +37,10 @@ pub const ZcliError = error{
     OptionInvalidValue,
     OptionBooleanWithValue,
     OptionDuplicate,
+    OptionMissingRequired,
+    OptionMutuallyExclusive,
+    OptionMissingDependency,
+    OptionValidationFailed,
 
     // Command routing errors
     CommandNotFound,
@@ -69,66 +74,37 @@ When errors occur, zcli provides detailed diagnostic information through the `Zc
 - **Type expectations**: What was expected vs. what was provided
 - **Suggestions**: Smart suggestions for typos and similar names
 
-## API functions
+## API: parseCommandLine
 
-### parseArgs
-
-Parse positional arguments into a struct:
+For standalone parsing outside the framework, the public entry point is `zcli.parseCommandLine`. It handles positionals and options together in a single pass — the same parser the framework runs for your commands:
 
 ```zig
-pub fn parseArgs(comptime ArgsType: type, args: []const []const u8, diag: ?*?ZcliDiagnostic) ZcliError!ArgsType
+pub fn parseCommandLine(
+    comptime ArgsType: type,
+    comptime OptionsType: type,
+    comptime meta: anytype,
+    allocator: std.mem.Allocator,
+    environ: ?*const std.process.Environ.Map,
+    args: []const []const u8,
+    diag: ?*?ZcliDiagnostic,
+) ZcliError!CommandParseResult(ArgsType, OptionsType)
 ```
 
-The final `diag` parameter is an optional out-parameter: pass `null` if you only need the error, or a `*?ZcliDiagnostic` to capture rich context about the failure (see [Diagnostic-driven error messages](#diagnostic-driven-error-messages) below).
-
-**Example:**
+The final `diag` parameter is an optional out-parameter: pass `null` if you only need the error, or a `*?ZcliDiagnostic` to capture rich context about the failure (see [Diagnostic-driven error messages](#diagnostic-driven-error-messages) below). The result owns any parsed arrays — release everything with a single `result.deinit()`.
 
 ```zig
 const Args = struct {
     name: []const u8,
+};
+
+const Options = struct {
+    verbose: bool = false,
     count: u32 = 1,
 };
 
-const parsed = parseArgs(Args, &.{"Alice", "42"}, null) catch |err| switch (err) {
+const result = zcli.parseCommandLine(Args, Options, null, allocator, null, args, null) catch |err| switch (err) {
     error.ArgumentMissingRequired => {
         std.debug.print("Missing required argument\n", .{});
-        return;
-    },
-    error.ArgumentInvalidValue => {
-        std.debug.print("Invalid argument value\n", .{});
-        return;
-    },
-    else => return err,
-};
-
-std.debug.print("Name: {s}, Count: {}\n", .{ parsed.name, parsed.count });
-```
-
-### parseOptions
-
-Parse command-line options into a struct:
-
-```zig
-pub fn parseOptions(
-    comptime OptionsType: type,
-    allocator: std.mem.Allocator,
-    args: []const []const u8,
-    diag: ?*?ZcliDiagnostic,
-) ZcliError!OptionsResult(OptionsType)
-```
-
-**Example:**
-
-```zig
-const Options = struct {
-    verbose: bool = false,
-    output: ?[]const u8 = null,
-    files: [][]const u8 = &.{},
-};
-
-const result = parseOptions(Options, allocator, args, null) catch |err| switch (err) {
-    error.OptionUnknown => {
-        std.debug.print("Unknown option provided\n", .{});
         return;
     },
     error.OptionInvalidValue => {
@@ -137,9 +113,9 @@ const result = parseOptions(Options, allocator, args, null) catch |err| switch (
     },
     else => return err,
 };
+defer result.deinit();
 
-defer cleanupOptions(Options, result.options, allocator);
-// Use result.options and result.remaining_args
+std.debug.print("Name: {s}, Count: {}\n", .{ result.args.name, result.options.count });
 ```
 
 ## Error handling patterns
@@ -147,17 +123,17 @@ defer cleanupOptions(Options, result.options, allocator);
 ### Basic pattern
 
 ```zig
-const parsed = parseOptions(Options, allocator, args, null) catch |err| {
+const result = zcli.parseCommandLine(Args, Options, null, allocator, null, args, null) catch |err| {
     std.debug.print("Parse error: {}\n", .{err});
     std.process.exit(1);
 };
-defer cleanupOptions(Options, parsed.options, allocator);
+defer result.deinit();
 ```
 
 ### Detailed error handling
 
 ```zig
-const parsed = parseOptions(Options, allocator, args, null) catch |err| switch (err) {
+const result = zcli.parseCommandLine(Args, Options, null, allocator, null, args, null) catch |err| switch (err) {
     error.OptionUnknown => {
         std.debug.print("Unknown option. Run with --help for usage.\n", .{});
         std.process.exit(2);
@@ -176,6 +152,7 @@ const parsed = parseOptions(Options, allocator, args, null) catch |err| switch (
         std.process.exit(1);
     },
 };
+defer result.deinit();
 ```
 
 ### [Diagnostic-driven error messages]($heading.id('diagnostic-driven-error-messages'))
@@ -184,7 +161,7 @@ The `catch`-and-switch patterns above only know *which* error occurred. To tell 
 
 ```zig
 var diag: ?zcli.ZcliDiagnostic = null;
-const result = parseOptions(Options, allocator, args, &diag) catch {
+const result = zcli.parseCommandLine(Args, Options, null, allocator, null, args, &diag) catch {
     if (diag) |d| {
         const msg = try zcli.formatDiagnostic(d, allocator);
         defer allocator.free(msg);
@@ -192,14 +169,14 @@ const result = parseOptions(Options, allocator, args, &diag) catch {
     }
     std.process.exit(2);
 };
-defer cleanupOptions(Options, result.options, allocator);
+defer result.deinit();
 ```
 
 The formatted messages carry the full context, for example:
 
 ```
-Missing required argument 'name' at position 1. Expected type: []const u8
-Invalid value 'abc' for option '--count'. Expected type: u32
+Missing required argument 'name' at position 1. Expected text.
+Invalid value 'abc' for option '--count'. Expected an integer.
 Boolean option '--verbose' does not accept a value (got 'yes')
 Unknown option '--verbos'
 Did you mean:
@@ -258,13 +235,13 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
 
 ## Memory management
 
-### Option cleanup
+### Result cleanup
 
-When using `parseOptions` directly, always clean up array options:
+When using `parseCommandLine` directly, the returned result owns any allocated values (array options, accumulated positionals) — release them with `deinit`:
 
 ```zig
-const result = try parseOptions(Options, allocator, args, null);
-defer cleanupOptions(Options, result.options, allocator);
+const result = try zcli.parseCommandLine(Args, Options, null, allocator, null, args, null);
+defer result.deinit();
 ```
 
 The framework handles this cleanup automatically for command implementations.
@@ -282,13 +259,13 @@ Error contexts are lightweight and don't require explicit cleanup.
    - `1` for general errors
    - `2` for usage errors (wrong arguments/options)
 4. **Let framework handle parsing**: Use command implementations instead of manual parsing when possible
-5. **Clean up resources**: Always use `defer` for cleanup, especially for array options
+5. **Clean up resources**: Always `defer result.deinit()` on a `parseCommandLine` result
 
 ## Examples
 
 ### Complete command-line parser
 
-For standalone parsing outside the framework, the unified entry point re-exported at the package root is `zcli.parseCommandLine` — it handles positionals and options together in a single pass:
+A full standalone program using `zcli.parseCommandLine`, wired through `std.process.Init`:
 
 ```zig
 const std = @import("std");

--- a/website/content/docs/progress.smd
+++ b/website/content/docs/progress.smd
@@ -10,10 +10,10 @@
 
 The `progress` package covers the three shapes of "still working": a **spinner** when you can't measure, a **progress bar** when you can, and a **multi-bar** when several things run at once. All three render on the [UI engine]($link.page('docs/ui'))'s live region — diffed repaints, resize-aware — and animations auto-disable when output isn't a TTY.
 
-In a command, `context.progress()` returns an instance pre-wired to the command's stdout, io, arena allocator, and [theme]($link.page('docs/theming')):
+In a command, `context.progress()` returns an instance pre-wired to the command's **stderr**, io, arena allocator, and [theme]($link.page('docs/theming')) — stderr so progress survives `myapp | tee` and stdout redirection while piped output stays clean:
 
 ```zig
-// Pre-wired to the command's stdout, io, allocator, and theme.
+// Pre-wired to the command's stderr, io, allocator, and theme.
 const p = context.progress();
 
 var spinner = try p.spinner(.{ .style = .dots });

--- a/website/content/docs/secrets.smd
+++ b/website/content/docs/secrets.smd
@@ -50,7 +50,7 @@ try context.plugins.zcli_secrets.delete("token");
 
 The Linux backend deliberately **shells out** instead of linking libsecret — so a static musl build of your CLI stays fully static and still gets real keychain storage on desktops that have it. Autodetection prefers a live Secret Service and falls through to `pass`; set `ZCLI_SECRETS_BACKEND=secret-service|pass` to force one. Any other target is a compile error — never a plaintext file.
 
-Secret **names** must be valid UTF-8 with no NUL byte — validated once, up front, so the contract is uniform across every backend.
+Secret **names** must be valid UTF-8 with no NUL byte, no `/`, no `..`, and no leading `-` (the last three guard the `pass` filesystem namespace and subprocess argv) — validated once, up front, so the contract is uniform across every backend.
 
 ### Value size limits
 

--- a/website/content/docs/testing.smd
+++ b/website/content/docs/testing.smd
@@ -29,7 +29,7 @@ The unit-testing tier ships with the `zcli` dependency itself — no separate de
 test_module.addImport("zcli-testing", zcli_dep.module("zcli_testing_unit"));
 ```
 
-The unit tier lives in its own module (`zcli_testing_unit`) because `runCommand` runs in-process and so needs zcli + vterm; the subprocess and PTY tiers below are std-only and live in separate modules, so importing them doesn't drag those dependencies into your test build.
+The unit tier lives in its own module (`zcli_testing_unit`) because `runCommand` runs in-process and so needs zcli + vterm; the subprocess and PTY tiers below live in a separate module that stays free of zcli itself (the PTY tier does use vterm to render child output for frame assertions), so importing them doesn't drag the framework into your test build.
 
 ### Writing tests
 
@@ -93,6 +93,7 @@ test "command respects verbose mode" {
 | `config.args` | `Command.Args` | Positional arguments to pass |
 | `config.options` | `Command.Options` | Option values to pass |
 | `config.plugins` | derived from `Context` | Initial plugin state, e.g. `.{ .verbose = .{ .enabled = true } }`; defaults to each plugin's `ContextData` defaults |
+| `config.environ` | `?*const std.process.Environ.Map` | Environment variables the command sees via `context.environ`; defaults to empty |
 | `config.allocator` | `std.mem.Allocator` | Defaults to `std.testing.allocator` |
 
 **Returns `CommandResult`:**
@@ -166,7 +167,7 @@ Test your compiled CLI binary as a subprocess. This validates the full stack —
 
 ### Setup
 
-The integration tier lives in the std-only `zcli_testing` module (separate from the unit tier's `zcli_testing_unit`) — it ships with the `zcli` dependency, so the wiring is one line:
+The integration tier lives in the framework-free `zcli_testing` module (separate from the unit tier's `zcli_testing_unit`) — it ships with the `zcli` dependency, so the wiring is one line:
 
 ```zig
 // build.zig
@@ -185,6 +186,7 @@ test "help flag shows usage" {
         std.testing.io,
         "./zig-out/bin/myapp",
         &.{"--help"},
+        .{},
     );
     defer result.deinit();
 
@@ -199,6 +201,7 @@ test "version flag" {
         std.testing.io,
         "./zig-out/bin/myapp",
         &.{"--version"},
+        .{},
     );
     defer result.deinit();
 
@@ -212,6 +215,7 @@ test "unknown command shows suggestions" {
         std.testing.io,
         "./zig-out/bin/myapp",
         &.{"hlep"},
+        .{},
     );
     defer result.deinit();
 
@@ -246,6 +250,7 @@ test "help output matches snapshot" {
         std.testing.io,
         "./zig-out/bin/myapp",
         &.{"--help"},
+        .{},
     );
     defer result.deinit();
 

--- a/website/content/docs/validation.smd
+++ b/website/content/docs/validation.smd
@@ -110,11 +110,10 @@ $ myapp export --json --yaml
 Options '--json' and '--yaml' cannot be used together.
 ```
 
-Help gets a section per set:
+Help gets a line per set:
 
 ```
-Mutually exclusive:
-  --json, --yaml, --xml (at most one)
+    Mutually exclusive: --json, --yaml, --xml
 ```
 
 `meta.exclusive` takes multiple sets. Membership is compile-checked: naming a field that doesn't exist, listing a member twice, or a set with fewer than two members is a build error. So is putting a *required* option in a set — a required option is always supplied, so "at most one of several" would be unsatisfiable; the compile error tells you to give it a default, make it optional, or drop it from the set.

--- a/website/layouts/ai.shtml
+++ b/website/layouts/ai.shtml
@@ -81,7 +81,7 @@
     <span class="kw">try</span> context.<span class="fn">stdout</span>().<span class="fn">print</span>(<span class="str">"{s} — ★ {d}\n"</span>, .{ repo.full_name, repo.stargazers_count });
 }</pre>
           </div>
-          <div class="callout"><b>ADR-0001</b> The one advanced case — a long-running <code>watch</code>/<code>dev</code> loop — uses a child arena per iteration. Everything else just never frees.</div>
+          <div class="callout"><b>ADR-0001</b> The one advanced case — a long-running <code>watch</code>/<code>dev</code> loop — resets its arena between iterations. Everything else just never frees.</div>
         </section>
 
         <section id="contract">
@@ -136,9 +136,9 @@
 <pre><span class="c-prompt">$</span> <span class="c-cmd">zcli</span> guide arena
 arena — the per-command allocator
 
-  context.allocator is an arena, dropped when execute() returns.
-  Allocate freely; never free. For a long-running loop, use a
-  child arena per iteration.</pre>
+`context.allocator` is an arena scoped to this one command run. Allocate
+freely and NEVER free/deinit memory you take from it — the whole arena is
+reclaimed when execute() returns (ADR-0001).</pre>
           </div>
           <div class="callout"><b>ADR-0004 · ADR-0008</b> Three layers, each with the stability its content needs: a frozen spine, a version-matched guide, and the live project state (<code>zcli tree --show-options</code>). Drift-sensitive content lives only in the layer pinned to the code.</div>
         </section>

--- a/website/layouts/getting-started.shtml
+++ b/website/layouts/getting-started.shtml
@@ -89,7 +89,7 @@
     <p class="lead">Install the <code class="mono" style="color:var(--accent)">zcli</code> binary, scaffold a project with <code class="mono" style="color:var(--accent)">zcli&nbsp;init</code>, then grow it one file at a time with <code class="mono" style="color:var(--accent)">zcli&nbsp;add&nbsp;command</code>. Each step below shows exactly what runs and what lands on disk.</p>
     <div class="meta-row">
       <span class="chip">Requires <b>Zig 0.16+</b></span>
-      <span class="chip"><b>4</b> plugins wired in on init</span>
+      <span class="chip"><b>3</b> plugins wired in on init</span>
       <span class="chip"><b>MIT</b> licensed</span>
     </div>
   </div>
@@ -124,7 +124,7 @@
             <pre><span class="pr">$</span> curl -fsSL https://zcli.sh/install.sh | sh</pre>
             <button onclick="cp(this,'curl -fsSL https://zcli.sh/install.sh | sh')">copy</button>
           </div>
-          <p class="note">The script detects your platform, pulls the matching binary from the latest GitHub release, verifies the checksum when available, and marks it executable.</p>
+          <p class="note">The script detects your platform, pulls the matching binary from the latest GitHub release, verifies the minisign signature and SHA-256 checksum (fail-closed — it aborts rather than install unverified), and marks it executable.</p>
         </div>
 
         <div class="alt">
@@ -163,7 +163,7 @@ zcli <span :text="$site.asset('site-data.json').ziggy().get('version')"></span>
 <span class="c-mut">COMMANDS</span>
   <span class="c-cmd">init</span>   Initialize a new zcli project
   <span class="c-cmd">add</span>    Add commands and plugins
-  <span class="c-cmd">tree</span>   Visualize your command structure<span class="cursor"></span></pre>
+  <span class="c-cmd">tree</span>   Show the command tree discovered from src/commands<span class="cursor"></span></pre>
           </div>
         </div>
         <div class="callout">
@@ -233,7 +233,7 @@ Creating new zcli project: myapp
 ├── build.zig         <span class="an"># zcli.generate + builtin plugins</span>
 ├── README.md         <span class="an"># build/run/test instructions</span>
 ├── AGENTS.md         <span class="an"># points coding agents at zcli guide</span>
-├── .gitignore        <span class="an"># zig-cache/, zig-out/ — first commit made</span>
+├── .gitignore        <span class="an"># .zig-cache/, zig-out/ — first commit made</span>
 └── src/
     ├── main.zig      <span class="an"># generated entrypoint</span>
     └── commands/
@@ -271,7 +271,7 @@ HELLO, Alice!<span class="cursor"></span></pre>
       <span class="step-n">03</span>
       <div>
         <h2>Add a new command</h2>
-        <p class="what"><code>zcli add command</code> writes a ready-to-edit command file at the right path under <code>src/commands/</code> — with <b>meta</b>, <b>Args</b>, <b>Options</b>, and an <b>execute()</b> stub already filled in. Nested paths like <code>users/create</code> create the folders for you. Run it from your project root (where <code>build.zig</code> lives).</p>
+        <p class="what"><code>zcli add command</code> writes a ready-to-edit command file at the right path under <code>src/commands/</code> — with <b>meta</b>, <b>Args</b>, <b>Options</b>, and an <b>execute()</b> stub already filled in. Nested paths like <code>users/create</code> create the folders for you. Run it from your project root (where <code>build.zig</code> lives). In a terminal it opens a short wizard — add typed arguments and options interactively, review, confirm — seeded from any flags you pass; with piped input it writes the skeleton straight away.</p>
       </div>
     </div>
 
@@ -296,13 +296,15 @@ HELLO, Alice!<span class="cursor"></span></pre>
 <pre><span class="c-prompt">$</span> <span class="c-cmd">zcli</span> add command deploy \
     <span class="c-flag">--description</span> "Deploy your application"
 
+<span class="c-mut">  … wizard: arguments · options · review → Create it …</span>
+
 <span class="c-ok">  ✔</span> Created src/commands/deploy.zig
 
 <span class="c-mut">  Next steps</span>
     1. Implement execute() in
        src/commands/deploy.zig
     2. zig build
-    3. ./zig-out/bin/myapp deploy <span class="c-flag">--help</span><span class="cursor"></span></pre>
+    3. ./zig-out/bin/&lt;app&gt; deploy <span class="c-flag">--help</span><span class="cursor"></span></pre>
           </div>
         </div>
         <div class="callout">
@@ -324,16 +326,21 @@ HELLO, Alice!<span class="cursor"></span></pre>
     .examples = &.{
         <span class="str">"deploy"</span>,
     },
+    <span class="cm">// .aliases = &.{"alias"}, // alternate names this command answers to</span>
+    <span class="cm">// .hidden = true,          // omit from help and tree listings</span>
 };
 
 <span class="kw">pub const</span> Args = <span class="kw">struct</span> {};
 <span class="kw">pub const</span> Options = <span class="kw">struct</span> {};
 
-<span class="kw">pub fn</span> <span class="fn">execute</span>(args: Args, options: Options, context: *Context) !<span class="kw">void</span> {
-    _ = args;
-    _ = options;
+<span class="kw">pub fn</span> <span class="fn">execute</span>(_: Args, _: Options, context: *Context) !<span class="kw">void</span> {
     <span class="kw">const</span> stdout = context.<span class="fn">stdout</span>();
     <span class="kw">try</span> stdout.<span class="fn">print</span>(<span class="str">"TODO: Implement deploy\n"</span>, .{});
+}
+
+<span class="kw">test</span> <span class="str">"deploy"</span> {
+    <span class="cm">// Scaffolded smoke test — replace with real assertions.</span>
+    _ = <span class="at">@This</span>();
 }</pre>
         </div>
         <p class="note">Fill in <code>execute()</code>, then <code>zig build</code> — routing regenerates and <code>myapp deploy</code> is live with auto-generated <code>--help</code>.</p>
@@ -379,14 +386,16 @@ HELLO, Alice!<span class="cursor"></span></pre>
           </div>
           <div class="term-body">
 <pre><span class="c-prompt">$</span> <span class="c-cmd">zcli</span> tree
+<span class="c-cmd">myapp</span>
 <span class="c-mut">├──</span> <span class="c-cmd">deploy</span> <span class="c-mut">[Deploy your application]</span>
 <span class="c-mut">└──</span> <span class="c-cmd">hello</span> <span class="c-mut">[Say hello to someone]</span>
 
 <span class="c-prompt">$</span> <span class="c-cmd">zcli</span> tree <span class="c-flag">--show-options</span>
+<span class="c-cmd">myapp</span>
 <span class="c-mut">├──</span> <span class="c-cmd">deploy</span> <span class="c-mut">[Deploy your application]</span>
 <span class="c-mut">└──</span> <span class="c-cmd">hello</span> <span class="c-mut">[Say hello to someone]</span>
     <span class="c-mut">args:</span>    <span class="c-flag">&lt;name:[]const u8&gt;</span>
-    <span class="c-mut">options:</span> <span class="c-flag">--loud</span><span class="cursor"></span></pre>
+    <span class="c-mut">options:</span> <span class="c-flag">[--loud/-l]</span><span class="cursor"></span></pre>
           </div>
         </div>
       </div>

--- a/website/layouts/home.shtml
+++ b/website/layouts/home.shtml
@@ -118,7 +118,7 @@
 					<span class="chip"><b>8</b>
 					prompt types</span>
 					<span class="chip"><b>215 KB</b>
-					hello-world</span>
+					hello-world (v0.19.0)</span>
 				</div>
 			</div>
 

--- a/website/layouts/install.shtml
+++ b/website/layouts/install.shtml
@@ -69,11 +69,11 @@
         <div class="cmdbox">
           <pre>.dependencies = .{
     .zcli = .{
-        <span class="pr">.url</span> = "https://github.com/ryanhair/zcli/archive/refs/tags/v0.20.0.tar.gz",
+        <span class="pr">.url</span> = "https://github.com/ryanhair/zcli/archive/refs/tags/v0.21.0.tar.gz",
         <span class="pr">.hash</span> = "...", // zig build prints the correct hash
     },
 },</pre>
-          <button onclick="cp(this,'.zcli = .{ .url = &quot;https://github.com/ryanhair/zcli/archive/refs/tags/v0.20.0.tar.gz&quot;, .hash = &quot;...&quot; },')">copy</button>
+          <button onclick="cp(this,'.zcli = .{ .url = &quot;https://github.com/ryanhair/zcli/archive/refs/tags/v0.21.0.tar.gz&quot;, .hash = &quot;...&quot; },')">copy</button>
         </div>
         <p style="font-size:13.5px;">To track the development branch instead, fetch <code class="mono" style="color:var(--accent)">.../archive/refs/heads/main.tar.gz</code> — its hash changes with every commit, so re-run <code class="mono">zig fetch --save</code> to update.</p>
         <p style="font-size:13.5px;">Then follow steps 2 & 3 in the <a href="$site.page('docs').link().suffix('#quick-start')">docs</a> to wire up <code class="mono">zcli.generate</code>.</p>

--- a/website/layouts/plugins.shtml
+++ b/website/layouts/plugins.shtml
@@ -169,10 +169,13 @@
     zcli.<span class="fn">builtin</span>(.github_upgrade, .{
         .repo = <span class="str">"ryanhair/zcli"</span>,
         .command_name = <span class="str">"upgrade"</span>,
+        <span class="cm">// required — pin a minisign key, or opt out with .checksum_only</span>
+        .verification = .{ .minisign = <span class="str">"RWT…"</span> },
     }),
 },</pre>
           </div>
           <p>The generator introspects that config struct at comptime and folds it into the generated registry — fully compile-time, no runtime string building. Handrolled <code>.{ .name, .path }</code> entries can still pass an <code>.init</code> string for the same effect.</p>
+          <p>One extra requirement for <code>github_upgrade</code>: its <code>upgrade</code> command renders progress as live spinners on zcli's ui engine, so your root source file must declare the terminal-restoring panic handler — <code>pub const panic = zcli.ui.panic;</code> — enforced at compile time. Projects scaffolded by <code>zcli init</code> already have it. See <a href="$site.page('docs/shipping').link()">Shipping</a> for the full upgrade flow.</p>
         </section>
 
         <!-- ===== WRITING PLUGINS ===== -->

--- a/website/layouts/theming.shtml
+++ b/website/layouts/theming.shtml
@@ -163,10 +163,10 @@
           <div class="code">
             <div class="code-head"><span class="fname">a full-screen frame</span><span class="lang">zig</span></div>
 <pre><span class="cm">// A modal whose border and fill derive from the theme's surface tokens.</span>
-<span class="kw">try</span> ui.<span class="fn">panel</span>(a, .{ .padding = .<span class="fn">all</span>(<span class="num">1</span>) }, children);
+<span class="kw">try</span> ui.<span class="fn">panel</span>(a, .{ .box = .{ .padding = .<span class="fn">all</span>(<span class="num">1</span>) } }, children);
 
 <span class="cm">// ui.role pulls a palette role into any text node — one word, themed.</span>
-ui.<span class="fn">text</span>(ui.<span class="fn">role</span>(.success), <span class="str">"done"</span>);</pre>
+ui.<span class="fn">text</span>(ui.<span class="fn">role</span>(ui.<span class="fn">appTheme</span>(), .success), <span class="str">"done"</span>);</pre>
           </div>
           <div class="callout"><b>Why compile-time</b> The app theme is a comptime constant reached through the root declaration (the same <code>std_options</code> idiom), so every default resolves where it's declared — the <code>ui</code>, <code>prompts</code>, and <code>progress</code> packages read your theme with no value threaded through their APIs. Custom chrome costs nothing at runtime, and a package compiled into your app picks up <em>your</em> theme automatically.</div>
         </section>

--- a/website/layouts/ui.shtml
+++ b/website/layouts/ui.shtml
@@ -335,14 +335,15 @@
 
         <section id="try">
           <h2>Try it</h2>
-          <p>Five runnable examples live in the <code>ui</code> package — all want a real terminal. Resize the window while the hybrid ones run and watch the live frame re-lay-out as the visible static tail rewraps with it; press <code>?</code> in the full-screen demo, Tab through the form.</p>
+          <p>Six runnable examples live in the <code>ui</code> package — all want a real terminal. Resize the window while the hybrid ones run and watch the live frame re-lay-out as the visible static tail rewraps with it; press <code>?</code> in the full-screen demo, Tab through the form.</p>
           <div class="code">
             <div class="code-head"><span class="fname">packages/ui</span><span class="lang">sh</span></div>
 <pre>zig build run-demo        <span class="cm"># hybrid: deploy-style task frame — spinner, task list, gauges</span>
 zig build run-hybrid      <span class="cm"># hybrid: the Claude-Code shape — streaming prose + a live multi-bar</span>
 zig build run-fullscreen  <span class="cm"># full-screen: a top-style table, scrolling viewport, help overlay</span>
 zig build run-form        <span class="cm"># full-screen: a focusable form — text fields, select, checkbox, button</span>
-zig build run-popup       <span class="cm"># full-screen: anchored dropdowns that flip and clamp on screen</span></pre>
+zig build run-popup       <span class="cm"># full-screen: anchored dropdowns that flip and clamp on screen</span>
+zig build run-textarea    <span class="cm"># full-screen: a multi-line editor — soft wrap, visual-row cursor motion</span></pre>
           </div>
           <div class="nextlinks">
             <a href="https://github.com/ryanhair/zcli/blob/main/docs/adr/0013-terminal-native-layout-engine.md" target="_blank" rel="noopener"><span class="k">→ design</span><span class="t">ADR-0013: the layout engine</span></a>


### PR DESCRIPTION
A full source-verified audit of the website (every docs page, layout, and marketing page cross-checked against the actual code) surfaced 22 substantive issues. This PR fixes all of them.

## Broken code samples (would not compile)
- **build.smd** — `addCommandTests` was missing the `exe` argument
- **testing.smd** — all four `runSubprocess` examples were missing the trailing `options` param (`.{}`)
- **theming.shtml** — `ui.panel` padding must nest under `.box`; `ui.role` takes the theme as its first argument (#683)
- **plugins.shtml** — the `github_upgrade` config example omitted the **required** `verification` field
- **errors.smd** — documented `parseArgs`/`parseOptions`/`cleanupOptions`, which are internal; rewritten around the public `zcli.parseCommandLine` API with `result.deinit()` cleanup

## Wrong output/behavior shown
- **progress.smd** — `context.progress()` wires to **stderr**, not stdout
- **getting-started.shtml** — init wires **3** plugins, not 4; the generated-command sample now matches the real scaffold (`_: Args, _: Options`, commented `.aliases`/`.hidden`, co-located test block); `add command` is a wizard on a TTY; `zcli tree` output shows the root app line and `[--loud/-l]`; install verification is fail-closed, not "when available"
- **validation.smd** — `meta.exclusive` renders as one inline help line, no "(at most one)"
- **errors.smd** — diagnostics render humanType phrases ("Expected text." / "Expected an integer."); `ZcliError` listing gained the 5 missing tags
- **config.smd** — untangled the applied-config note (project dotfile only, always) from the multiple-formats-in-one-tier warning

## Outdated / missing
- **install.shtml** — dependency tarball pinned to v0.21.0 (was v0.20.0)
- **testing.smd** — e2e tier now uses vterm (dropped stale "std-only" claims); documented the `config.environ` field
- **ui.shtml** — six runnable examples incl. `run-textarea`
- **secrets.smd** — name validation also rejects `/`, `..`, and leading `-`
- **plugins.shtml** — documents the `pub const panic = zcli.ui.panic;` requirement for `github_upgrade`
- **home.shtml** — hero size chip now carries its v0.19.0 measurement baseline
- **ai.shtml** — dev loop resets one arena (not a child arena per iteration); `zcli guide arena` transcript now matches real output
- **cli.smd / commands.smd / context.smd** — minor wording accuracy

Verified with a full `zine release` build; spot-checked the rendered HTML for each fix.

Not addressed here: re-measuring the binary-size/dependency numbers on why.shtml + home.shtml against 0.21.0 — they remain honestly badged as v0.19.0 measurements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YDJysqodQXgBaDJQMJRoDA