### PR TITLE
Stop discarding write failures on the way out (silent exit 0 on data loss)

### DIFF
--- a/examples/testing-demo/src/integration_test.zig
+++ b/examples/testing-demo/src/integration_test.zig
@@ -64,3 +64,100 @@ test "greet output matches a golden snapshot" {
     // and review the diff like any other file.
     try testing.expectSnapshot(allocator, io, std.Io.Dir.cwd(), result.stdout, @src(), "greet-output", .{});
 }
+
+// ---------------------------------------------------------------------------
+// Output-integrity tier: what the exit status says when a standard stream
+// cannot be written at all (#731 / #740). These need a *closed* descriptor,
+// which `runSubprocess` cannot express — it always pipes both streams — so
+// they spawn directly with `StdIo.close`, the harness equivalent of the shell's
+// `>&-` / `2>&-`: the child is started with that descriptor missing and its
+// writes fail, exactly as they do under the redirection.
+// ---------------------------------------------------------------------------
+
+const ClosedStream = enum { stdout, stderr };
+
+/// Spawn `greeter` with one standard stream closed and the other piped.
+/// Returns the child's exit status and whatever the open stream produced
+/// (caller frees).
+fn runWithClosedStream(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    closed: ClosedStream,
+    args: []const []const u8,
+) !struct { exit_code: u8, other: []u8 } {
+    var argv = std.ArrayList([]const u8).empty;
+    defer argv.deinit(allocator);
+    try argv.append(allocator, exe_path);
+    try argv.appendSlice(allocator, args);
+
+    var child = try std.process.spawn(io, .{
+        .argv = argv.items,
+        .stdin = .inherit,
+        .stdout = if (closed == .stdout) .close else .pipe,
+        .stderr = if (closed == .stderr) .close else .pipe,
+    });
+
+    // Exactly one stream is a pipe here, so draining it to EOF cannot deadlock
+    // against an un-drained sibling — the hazard that makes `runSubprocess`
+    // drain both concurrently does not arise.
+    const open_stream = if (closed == .stdout) child.stderr.? else child.stdout.?;
+    var buf: [4096]u8 = undefined;
+    var reader = open_stream.reader(io, &buf);
+    const captured = reader.interface.allocRemaining(allocator, .limited(64 * 1024)) catch |err| {
+        _ = child.wait(io) catch {};
+        return err;
+    };
+    errdefer allocator.free(captured);
+
+    const term = testing.Termination.fromChild(try child.wait(io));
+    return .{ .exit_code = term.exitCode(), .other = captured };
+}
+
+test "output that cannot be written exits non-zero, not a silent success" {
+    // A closed standard descriptor is a POSIX shell situation (`>&-`); Windows
+    // has no equivalent spelling and the contract under test is the shell one.
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    // Regression for #731: `greeter greet world >&-`. "Hello, world!\n" is 14
+    // bytes — far under the 4096-byte stdout buffer — so nothing reaches the
+    // descriptor until the framework's final flush, and that flush is the only
+    // write that can fail. Its error used to be swallowed outright, so the
+    // process exited **0** having written nothing at all: `myapp gen-manifest
+    // > /mnt/full/manifest.json && deploy` reported success and deployed an
+    // empty manifest.
+    const r = try runWithClosedStream(allocator, io, .stdout, &.{ "greet", "world" });
+    defer allocator.free(r.other);
+
+    try std.testing.expectEqual(@as(u8, 1), r.exit_code);
+    // And it says so, rather than failing mutely. The prefix is
+    // framework-authored (the errno name after it varies by platform).
+    try testing.expectContains(r.other, "failed to write output");
+}
+
+test "a misuse diagnostic that cannot be written still exits 2" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    // Regression for #740: `greeter greet world --bogus 2>&-`. The diagnostic
+    // is under 4 KB, so the only write that reaches the descriptor is
+    // `reportParseError`'s trailing flush; while that was a `try`, its
+    // `error.WriteFailed` replaced `error.OptionUnknown` and the misuse status
+    // degraded from 2 to 1. Scripts key on 2 to tell "you used it wrong" apart
+    // from "it failed" (see the exit-code table test above).
+    //
+    // This is also the precedence test, and the reason it uses stderr rather
+    // than stdout: the failed flush genuinely records a write error on the
+    // stderr writer, so at the moment `run()` decides, *both* a classified
+    // parse error and lost output are true at once. Exit 2 is the assertion
+    // that the classification outranks the lost write. (Closing stdout here
+    // would prove nothing — a parse error never writes to stdout, so there
+    // would be no buffered bytes to fail on and nothing to outrank.)
+    const closed_stderr = try runWithClosedStream(allocator, io, .stderr, &.{ "greet", "world", "--bogus" });
+    defer allocator.free(closed_stderr.other);
+    try std.testing.expectEqual(@as(u8, 2), closed_stderr.exit_code);
+    // Nothing leaked onto stdout in the process.
+    try std.testing.expectEqualStrings("", closed_stderr.other);
+}

--- a/packages/core/src/context.zig
+++ b/packages/core/src/context.zig
@@ -290,14 +290,38 @@ pub fn ContextFor(comptime plugins: []const type) type {
         /// Exit the process with the given code, flushing buffered output
         /// first — std.process.exit alone silently drops anything printed
         /// just before the call.
+        ///
+        /// `std.process.exit` runs no `defer`, so every unwind `run()` and the
+        /// command itself would have performed has to be replayed here by hand.
+        /// Missing one of them is what made this the framework's only
+        /// `noreturn` hole (#732): the *error* path is fine, because
+        /// `context.fail()` returns an error and defers unwind normally.
         pub fn exit(self: *Self, code: u8) noreturn {
             self.stdio.flush();
+            // Restore process-global terminal state: raw mode, the alternate
+            // screen, a hidden cursor. A `uiFullScreen` TUI (or a spinner) that
+            // validates input and exits from inside its session never runs
+            // `defer app.deinit()`, so without this the shell comes back with
+            // no echo, no line editing and an invisible cursor — blind `reset`
+            // is the only recovery. Replays whatever the session armed; a no-op
+            // when nothing did. After the flush, so buffered output still lands
+            // on the screen it was drawn for (#732).
+            zcli.ui.guard.restore();
+            // Output integrity has the last word on a *success* exit, exactly
+            // as it does on run()'s normal return: a closed downstream pipe
+            // becomes 141, any other lost write becomes a diagnosed general
+            // failure. Bypassing this is why `context.exit(0)` after a broken
+            // pipe used to report success (#732/#731). Reported before the
+            // console restore below so the diagnostic is written under the same
+            // code page the rest of this run's output used.
+            const write_err = self.stdio.writeError();
+            if (code == 0) if (write_err) |e| self.stdio.reportWriteFailure(e);
             // Restore the Windows console code pages `run()` switched to UTF-8;
             // std.process.exit skips run()'s deferred restore, so without this
             // an early exit leaks CP_UTF8 into the parent shell. No-op on POSIX
             // and for callers that never enabled it.
             self.console.restore();
-            std.process.exit(code);
+            std.process.exit(exitStatus(code, write_err));
         }
 
         /// Fail the command with a friendly, user-facing message: print `fmt`
@@ -310,10 +334,76 @@ pub fn ContextFor(comptime plugins: []const type) type {
         /// For an *unexpected* failure, return a plain error instead — its name
         /// and Debug-only trace are what you want while debugging.
         pub fn fail(self: *Self, comptime fmt: []const u8, args: anytype) error{CommandFailed} {
-            self.stderr().print(fmt ++ "\n", args) catch {};
+            // Render first, sanitize on the way out (#734). `args` are routinely
+            // user-controlled — a rejected `--config` path, a version string
+            // echoed back *because* it contained a byte outside [A-Za-z0-9._-],
+            // a set that includes ESC — and printing them raw hands the terminal
+            // an OSC 52 clipboard write or a window-title rewrite. This is the
+            // failure API the framework documents for command authors, so
+            // sanitizing here fixes every downstream CLI at once instead of
+            // asking each author to remember. Same sanitize-the-whole-rendered-
+            // string boundary reportParseError uses: framework prose can't
+            // contain control bytes, so nothing is lost by covering all of it.
+            var rendered = std.Io.Writer.Allocating.init(self.allocator);
+            defer rendered.deinit();
+            // The message is arena-allocated and the arena is this command's;
+            // on OOM the message is dropped rather than printed unsanitized —
+            // falling back to a raw write would reopen the hole this closes.
+            if (rendered.writer.print(fmt ++ "\n", args)) |_| {
+                zcli.writeSanitized(self.stderr(), rendered.written()) catch {};
+            } else |_| {}
             return error.CommandFailed;
         }
     };
+}
+
+/// The status `Context.exit(code)` actually takes, given what the run's
+/// stdout/stderr writers recorded. Split out because `exit` is `noreturn` and
+/// so untestable in-process.
+///
+/// A non-zero `code` is the command's own classification and wins — the same
+/// rule `run()` follows when it lets a reported CLI error outrank a write
+/// failure (#740). The process is already reporting failure, so no loss can
+/// pass as success. Only `exit(0)` — a claim that everything worked — is
+/// overridden, and then through the shared `statusForWriteError` mapping so
+/// an early exit and a normal return can never disagree (#732).
+///
+/// That makes the two ways a command reports its own failure agree exactly:
+/// with a closed downstream pipe, `context.exit(1)` and `return
+/// context.fail(...)` both exit 1, because in both the command classified the
+/// failure itself and its classification is the answer. Only an *unclassified*
+/// failure lets the pipe decide (141).
+fn exitStatus(code: u8, write_err: ?std.Io.File.Writer.Error) u8 {
+    if (code != 0) return code;
+    const e = write_err orelse return 0;
+    return zcli.statusForWriteError(e);
+}
+
+test "exitStatus: a success exit can't outrank lost output" {
+    // Nothing failed: the caller's code stands.
+    try std.testing.expectEqual(@as(u8, 0), exitStatus(0, null));
+    try std.testing.expectEqual(@as(u8, 3), exitStatus(3, null));
+
+    // context.exit(0) after a broken pipe is the case #732 names: the framework
+    // documents 141 for `yourcli cmd | head`, and bypassing run() must not
+    // quietly turn that into success.
+    try std.testing.expectEqual(@as(u8, 141), exitStatus(0, error.BrokenPipe));
+    // Any other lost write is a general failure, never 0.
+    try std.testing.expectEqual(@as(u8, 1), exitStatus(0, error.NoSpaceLeft));
+    try std.testing.expectEqual(@as(u8, 1), exitStatus(0, error.NotOpenForWriting));
+
+    // A command that already decided it failed keeps its own status; it is
+    // not reporting success, so there is nothing to correct.
+    try std.testing.expectEqual(@as(u8, 2), exitStatus(2, error.NoSpaceLeft));
+    try std.testing.expectEqual(@as(u8, 7), exitStatus(7, error.BrokenPipe));
+
+    // The sibling-API agreement: with a broken pipe, `context.exit(1)` is 1 —
+    // and so is `return context.fail(...)`, because CommandFailed is a
+    // classified error and run() gives it exitCodeForReportedError's 1 rather
+    // than 141. Same physical situation, same status, whichever API the author
+    // reached for. The other half of the pairing is pinned next to
+    // `exitCodeForReportedError` in registry/compiled.zig.
+    try std.testing.expectEqual(@as(u8, 1), exitStatus(1, error.BrokenPipe));
 }
 
 test "context accessors type-check" {
@@ -356,6 +446,76 @@ test "Context carries the console State so exit() can restore code pages" {
     };
     try std.testing.expectEqual(@as(console_utf8.UINT, 0), plain.console.prev_in);
     plain.console.restore(); // no-op, must not crash
+}
+
+test "exit() restores the terminal, not just the Windows code pages" {
+    // Regression for #732: `grep -n guard packages/core/src/context.zig`
+    // returned nothing — a `uiFullScreen` TUI that called context.exit() died
+    // inside the alt-screen with raw mode on and the cursor hidden, because
+    // std.process.exit runs no `defer` and so skips `app.deinit()`. exit() is
+    // `noreturn` and the state it repairs is process-global terminal state, so
+    // — like the #438 test above — this locks in the wiring rather than the
+    // effect: the guard must be reachable from here and safe to replay
+    // unconditionally.
+    //
+    // The behavioral proof is a PTY capture of a full-screen command that ends
+    // in `context.exit(3)`, recorded here so the expectation is reproducible
+    // (`script -q out.raw myapp tui-cmd`, then `cat -v out.raw`):
+    //
+    //     before:  ^[[?1049h ^[[?25l ^M
+    //     after:   ^[[?1049h ^[[?25l ^M ^[[?25h ^[[?1049l
+    //
+    // i.e. enter alt-screen + hide cursor, and now also show cursor + leave
+    // alt-screen on the way out. Without the trailing pair the user's shell
+    // comes back inside the alt-screen with echo off.
+    try std.testing.expect(@TypeOf(zcli.ui.guard.restore) == fn () void);
+    // Never armed (no session took the terminal over): a no-op, must not
+    // crash — exit() calls it on every path, TUI or not.
+    zcli.ui.guard.restore();
+}
+
+test "fail() sanitizes its rendered message" {
+    // Regression for #734: `fail` is the failure API the framework documents
+    // for command authors, and it printed `args` raw. Those args are routinely
+    // user-controlled — the upgrade plugin echoes back a version string
+    // *because* it contained a byte outside [A-Za-z0-9._-], a set that
+    // includes ESC — so an OSC 52 clipboard write or a window-title rewrite
+    // rode straight through to the operator's terminal.
+    const Ctx = ContextFor(&.{});
+    var stdio: zcli.Stdio = undefined;
+    stdio.init(std.testing.io);
+    var err_aw = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer err_aw.deinit();
+    stdio.stderr_override = &err_aw.writer;
+    const env = std.process.Environ.Map.init(std.testing.allocator);
+
+    var ctx = Ctx{
+        .allocator = std.testing.allocator,
+        .io = std.testing.io,
+        .stdio = &stdio,
+        .environ = &env,
+    };
+
+    // An OSC 52 payload smuggled through a command's own failure message.
+    try std.testing.expectEqual(error.CommandFailed, ctx.fail("invalid version '{s}'", .{"\x1b]52;c;cHduZWQ=\x07"}));
+    const text = err_aw.written();
+    try std.testing.expect(std.mem.indexOfScalar(u8, text, 0x1b) == null);
+    try std.testing.expect(std.mem.indexOfScalar(u8, text, 0x07) == null);
+    // The framework prose and the inert part of the value still read normally,
+    // and the trailing newline `fail` appends survives sanitization.
+    try std.testing.expectEqualStrings("invalid version ']52;c;cHduZWQ='\n", text);
+
+    // UTF-8 multibyte passes through untouched: continuation bytes (0x80-0xBF)
+    // and lead bytes (0xC0+) both fall outside the stripped C0/DEL range.
+    err_aw.clearRetainingCapacity();
+    try std.testing.expectEqual(error.CommandFailed, ctx.fail("no note: {s}", .{"café-日本語-🎉"}));
+    try std.testing.expectEqualStrings("no note: café-日本語-🎉\n", err_aw.written());
+
+    // Tab and newline are the two control bytes worth keeping — a multi-line
+    // failure message must still render as multiple lines.
+    err_aw.clearRetainingCapacity();
+    try std.testing.expectEqual(error.CommandFailed, ctx.fail("a\tb\nc", .{}));
+    try std.testing.expectEqualStrings("a\tb\nc\n", err_aw.written());
 }
 
 test "initPluginData runs declared init hook and mutates ContextData" {

--- a/packages/core/src/registry/compiled.zig
+++ b/packages/core/src/registry/compiled.zig
@@ -20,6 +20,16 @@ const discoverPluginCommands = builder.discoverPluginCommands;
 /// precise, human-readable message on stderr (flushed — the process is about
 /// to exit with an error). Falls back silently when no diagnostic was filled
 /// (the error name still reaches the caller).
+///
+/// Every write here is best-effort (`catch {}`), never `try` (#740). Rendering
+/// the diagnostic is cosmetic; classifying the error is not. A `try` on any of
+/// these — the trailing `flush` above all, since a sub-4KB diagnostic only
+/// touches the fd there — replaces the caller's classified parse error with
+/// `error.WriteFailed`, so `myapp --bogus 2>&-` exits 1 (general failure)
+/// instead of 2 (misuse) and scripts that key on 2 break. A stderr that
+/// genuinely failed is still not lost: the writer records it, and `run()`
+/// consults that record (see `exitOnWriteFailure`) — but only for a failure
+/// nothing else classified, so the parse error keeps its status either way.
 fn reportParseError(context: anytype, diag: ?zcli.ZcliDiagnostic) !void {
     const d = diag orelse return;
     const message = zcli.formatDiagnostic(d, context.allocator) catch return;
@@ -28,9 +38,9 @@ fn reportParseError(context: anytype, diag: ?zcli.ZcliDiagnostic) !void {
     // a rejected argument/option value) alongside framework-authored prose —
     // sanitize the whole rendered string so a crafted value can't smuggle a
     // raw terminal escape sequence through.
-    try stderr.print("Error: ", .{});
-    try zcli.writeSanitized(stderr, message);
-    try stderr.print("\n", .{});
+    stderr.print("Error: ", .{}) catch {};
+    zcli.writeSanitized(stderr, message) catch {};
+    stderr.print("\n", .{}) catch {};
 
     // A one-line usage pointer, mirroring the not-found plugin's closing line.
     // Points at the resolved command's own --help when we're inside a command,
@@ -38,11 +48,11 @@ fn reportParseError(context: anytype, diag: ?zcli.ZcliDiagnostic) !void {
     if (context.command_path.len > 0) {
         const path = try std.mem.join(context.allocator, " ", context.command_path);
         defer context.allocator.free(path);
-        try stderr.print("Run '{s} {s} --help' for usage.\n", .{ context.app_name, path });
+        stderr.print("Run '{s} {s} --help' for usage.\n", .{ context.app_name, path }) catch {};
     } else {
-        try stderr.print("Run '{s} --help' for usage.\n", .{context.app_name});
+        stderr.print("Run '{s} --help' for usage.\n", .{context.app_name}) catch {};
     }
-    try stderr.flush();
+    stderr.flush() catch {};
 }
 
 /// Convert a global option's argv string to its declared type through the
@@ -109,33 +119,32 @@ fn exitCodeForReportedError(err: anyerror) u8 {
     };
 }
 
-/// Conventional exit status for a process terminated by SIGPIPE (128 + 13).
-/// A zcli CLI whose stdout/stderr pipe is closed by a downstream reader (the
-/// classic `yourcli cmd | head` case) mimics that status so shell pipelines
-/// and `set -o pipefail` see the same result they would from `grep | head`.
-const broken_pipe_status: u8 = 141;
-
-/// Did a `WriteFailed` originate from a broken pipe (EPIPE / closed read end)?
+/// End the process for output that never landed, or return and let the caller
+/// carry on when every byte did (#731).
+///
+/// The final drain is `executeWithStdio`'s `defer stdio.flush()`, which cannot
+/// propagate an error out of a `defer` — so it records the cause on the writer
+/// and `Stdio.writeError()` reads it back. Before #731 that record was only
+/// ever consulted for EPIPE, which meant ENOSPC / EIO / EBADF on a sub-4KB run
+/// (output that fits the 4096-byte buffer never forces an earlier drain)
+/// exited 0 having written nothing at all: silent data loss reported as
+/// success.
 ///
 /// Zig's start code ignores SIGPIPE, so a write to a pipe whose reader has
-/// closed returns EPIPE, which the buffered `std.Io.Writer` surfaces to us as
-/// the opaque `error.WriteFailed`. The concrete cause is recorded on the
-/// underlying `std.Io.File.Writer.err` field, so we recover it there. This is
-/// the same mechanism on Windows, where there is no SIGPIPE at all and a
-/// broken pipe only ever appears as a write error — so this one check handles
-/// both platforms with no signal handling required.
+/// closed returns EPIPE — the same mechanism as on Windows, where there is no
+/// SIGPIPE at all and a broken pipe only ever appears as a write error, so one
+/// check covers both platforms with no signal handling required. A closed pipe
+/// keeps its established treatment: no diagnostic, the conventional SIGPIPE
+/// status. Anything else gets a one-line diagnostic and a general-failure
+/// status.
 ///
-/// Only the framework-owned file writers can carry this state; a test-provided
-/// `stdout_override`/`stderr_override` (an in-memory writer) never breaks a
-/// pipe, so those are simply not inspected.
-fn wroteToBrokenPipe(stdio: *zcli.Stdio) bool {
-    if (stdio.stdout_override == null and isBrokenPipe(stdio.stdout_writer.err)) return true;
-    if (stdio.stderr_override == null and isBrokenPipe(stdio.stderr_writer.err)) return true;
-    return false;
-}
-
-fn isBrokenPipe(err: ?std.Io.File.Writer.Error) bool {
-    return if (err) |e| e == error.BrokenPipe else false;
+/// This is the *last* word, never the first — see `run()` for why a classified
+/// CLI error outranks it.
+fn exitOnWriteFailure(stdio: *zcli.Stdio, console: console_utf8.State) void {
+    const err = stdio.writeError() orelse return;
+    stdio.reportWriteFailure(err);
+    console.restore();
+    std.process.exit(zcli.statusForWriteError(err));
 }
 
 test "isReportedCliError: context.fail's error exits cleanly, unexpected errors don't" {
@@ -163,33 +172,32 @@ test "exitCodeForReportedError: misuse=2, not-found=3, general=1" {
     try std.testing.expectEqual(@as(u8, 1), exitCodeForReportedError(error.CommandFailed));
 }
 
-test "isBrokenPipe: only BrokenPipe counts as a broken pipe" {
-    try std.testing.expect(isBrokenPipe(error.BrokenPipe));
-    // A different write error (e.g. a full disk) is a genuine failure and must
-    // keep its trace, not be silently swallowed as a broken pipe.
-    try std.testing.expect(!isBrokenPipe(error.NoSpaceLeft));
-    // No recorded error means the write never failed.
-    try std.testing.expect(!isBrokenPipe(null));
+test "only an unclassified failure lets output integrity pick the status" {
+    // The hinge of `run()`'s precedence. A classified error answers with
+    // `exitCodeForReportedError` and never consults the writers, so its status
+    // survives a closed stderr (`2>&-`, #740), a closed stdout (`>&-`), and a
+    // reader that walked away (`| head`) alike — protecting exit 2 against one
+    // failed stream but not another would be arbitrary.
+    //
+    // `error.WriteFailed` is the failure nobody classified, so it — and only
+    // it — falls through to `exitOnWriteFailure`, where a broken pipe is still
+    // the conventional 141 and anything else is diagnosed lost output (#731).
+    try std.testing.expect(!isReportedCliError(error.WriteFailed));
+    try std.testing.expectEqual(zcli.broken_pipe_status, zcli.statusForWriteError(error.BrokenPipe));
+    try std.testing.expectEqual(zcli.write_failure_status, zcli.statusForWriteError(error.NoSpaceLeft));
+
+    // The sibling-API agreement (context.zig's `exitStatus` test holds the
+    // other half): with a broken pipe, `return context.fail(...)` exits 1 here
+    // — CommandFailed is classified — and `context.exit(1)` exits 1 there.
+    // Same physical situation, same status, whichever API the author reached
+    // for. Before this pairing, fail() gave 141 and exit(1) gave 1.
+    try std.testing.expectEqual(@as(u8, 1), exitCodeForReportedError(error.CommandFailed));
 }
 
-test "wroteToBrokenPipe: test overrides are never mistaken for a broken pipe" {
-    var stdio: zcli.Stdio = .{ .io = std.testing.io };
-    // A test provides its own in-memory writers via the overrides; those cannot
-    // break a pipe, so the (undefined) file-writer state must not be inspected.
-    var buf: [16]u8 = undefined;
-    var out_aw = std.Io.Writer.fixed(&buf);
-    var err_aw = std.Io.Writer.fixed(&buf);
-    stdio.stdout_override = &out_aw;
-    stdio.stderr_override = &err_aw;
-    try std.testing.expect(!wroteToBrokenPipe(&stdio));
-
-    // Simulate the framework's own file writer recording EPIPE.
-    stdio.stdout_override = null;
-    stdio.stdout_writer.err = error.BrokenPipe;
-    stdio.stderr_override = null;
-    stdio.stderr_writer.err = null;
-    try std.testing.expect(wroteToBrokenPipe(&stdio));
-}
+// The broken-pipe recognition these once tested now lives on `Stdio` — see
+// `Stdio.writeError` (which stream's error wins, and why test overrides are
+// never inspected) and `statusForWriteError` (EPIPE is 141, a full disk is
+// not) in zcli.zig, both tested there.
 
 /// Compiled registry with all command and plugin information
 pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const CommandEntry, comptime new_plugins: []const type) type {
@@ -589,13 +597,17 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
                 // A missing/unreadable response file is reported CLI misuse:
                 // print the offending path (sanitized — it comes from argv) and
                 // a usage pointer, then let run() map it to exit code 2.
+                // Best-effort writes, never `try`: same reasoning as
+                // reportParseError (#740) — a stderr that can't be written must
+                // not turn this classified misuse into `error.WriteFailed` and
+                // demote its exit status from 2 to 1.
                 if (rf_diag) |d| {
                     var stderr = context.stderr();
-                    try stderr.print("Error: cannot read response file '", .{});
-                    try zcli.writeSanitized(stderr, d.path);
-                    try stderr.print("'\n", .{});
-                    try stderr.print("Run '{s} --help' for usage.\n", .{context.app_name});
-                    try stderr.flush();
+                    stderr.print("Error: cannot read response file '", .{}) catch {};
+                    zcli.writeSanitized(stderr, d.path) catch {};
+                    stderr.print("'\n", .{}) catch {};
+                    stderr.print("Run '{s} --help' for usage.\n", .{context.app_name}) catch {};
+                    stderr.flush() catch {};
                 }
                 return err;
             };
@@ -666,46 +678,54 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
             stdio.init(io);
 
             self.executeWithStdio(allocator, io, environ, if (args.len > 0) args[1..] else args, &stdio) catch |err| {
-                // A write to a closed downstream pipe (`yourcli cmd | head`)
-                // surfaces as WriteFailed. Behave like a well-mannered unix
-                // program: no trace, no diagnostic, just the conventional
-                // SIGPIPE exit status. Checked before the reported-error path
-                // because WriteFailed is not itself a "reported" error — the
-                // pipe closing is a normal end to a pipeline, not a user error.
-                // Windows has no SIGPIPE, but the broken pipe still lands here
-                // as a write error, so this covers it too.
-                if (err == error.WriteFailed and wroteToBrokenPipe(&stdio)) {
-                    console.restore();
-                    std.process.exit(broken_pipe_status);
-                }
-                // CLI-entry semantics: some failures already showed the user a
-                // message — parse/routing diagnostics, a plugin, the framework
+                // Two questions, in this order — the ordering *is* the design,
+                // because a classified error and a failed write can both be
+                // true at once and demand different statuses.
+                //
+                // 1. CLI-entry semantics: some failures already showed the user
+                // a message — parse/routing diagnostics, a plugin, the framework
                 // fallback, or a command's own context.fail(). Exit non-zero
                 // with the conventional status (2 misuse / 3 command-not-found
                 // / 1 general) without letting a raw error trace follow that
                 // friendly message. Anything else is an unexpected failure;
                 // propagate it so the name and trace aid debugging. Library/test
                 // callers who want the error itself use execute() directly.
+                //
+                // This deliberately outranks question 2, including a broken
+                // pipe. "You invoked it wrong" is the fact the caller acts on,
+                // and it must survive an output failure of *any* kind on
+                // *either* stream: #740 restored exit 2 for `myapp --bogus
+                // 2>&-`, and a closed stdout (`myapp --bogus | head`) is the
+                // same event — protecting the signal against one and not the
+                // other would be arbitrary. It also keeps context.exit(n) and
+                // `return context.fail(...)` in agreement: both are the command
+                // classifying its own failure, so both keep their status when
+                // the pipe closes. A command that does *not* reclassify a
+                // broken pipe still propagates WriteFailed, lands unclassified
+                // in question 2, and exits 141 as before.
                 if (isReportedCliError(err)) {
                     console.restore();
                     std.process.exit(exitCodeForReportedError(err));
                 }
+                // 2. Nothing classified this failure, so output integrity has
+                // the last word: a closed pipe is the conventional SIGPIPE
+                // status, silently; any other lost write gets a diagnostic
+                // rather than a raw error trace (#731). This is where the
+                // `error.WriteFailed` that reached us lands.
+                exitOnWriteFailure(&stdio, console);
                 return err;
             };
 
             // The command completed without erroring, but the writers may still
-            // have hit a broken pipe on the *final* buffered flush — the one
+            // have failed on the *final* buffered flush — the one
             // `executeWithStdio`'s `defer stdio.flush()` runs on its way out,
-            // which swallows the write error (`catch {}`) rather than surfacing
-            // it as `error.WriteFailed`. A whole-output-fits-in-one-buffer
-            // command (`yourcli cmd | head -c0`) never sees a mid-command write
-            // failure, so without this check it would exit 0 instead of the
-            // conventional SIGPIPE status. Check the recorded writer error the
-            // same way the error path above does.
-            if (wroteToBrokenPipe(&stdio)) {
-                console.restore();
-                std.process.exit(broken_pipe_status);
-            }
+            // which cannot propagate an error out of a `defer` and so records
+            // it on the writer instead. A whole-output-fits-in-one-buffer
+            // command (`yourcli cmd | head -c0`, or `yourcli gen >/mnt/full/f`)
+            // never sees a mid-command write failure, so without this check it
+            // would exit 0 having written nothing (#731). Read the recorded
+            // error back the same way the error path above does.
+            exitOnWriteFailure(&stdio, console);
         }
 
         /// Convert `value` and hand it to the plugin that declared

--- a/packages/core/src/registry/tests.zig
+++ b/packages/core/src/registry/tests.zig
@@ -1132,6 +1132,48 @@ test "reportParseError sanitizes a terminal-escape-laced option value" {
     try testing.expect(std.mem.indexOf(u8, err_text, "Invalid value") != null);
 }
 
+test "reportParseError's own write failure can't replace the classified parse error" {
+    // Regression for #740. `myapp --bogus 2>&-` must exit 2 (misuse), not 1
+    // (general failure): scripts key on 2 to tell "you used it wrong" apart
+    // from "it failed". A `try` on any write in reportParseError — the
+    // trailing flush above all, since a sub-4KB diagnostic only touches the
+    // fd there — swapped the caller's `error.OptionInvalidValue` for
+    // `error.WriteFailed` before exitCodeForReportedError ever saw it.
+    const TestApp = Registry.init(.{
+        .app_name = "diag-test",
+        .app_version = "1.0.0",
+        .app_description = "diagnostic pipeline test",
+    })
+        .register("ping", EscValueCommand)
+        .build();
+
+    var app = TestApp.init();
+    const test_environ = std.process.Environ.Map.init(testing.allocator);
+
+    var out_aw = std.Io.Writer.Allocating.init(testing.allocator);
+    defer out_aw.deinit();
+    // A zero-capacity fixed writer stands in for a closed stderr: every write
+    // fails immediately with WriteFailed, exactly like `2>&-`.
+    var dead_stderr = std.Io.Writer.fixed(&.{});
+    var stdio: zcli.Stdio = undefined;
+    stdio.init(std.testing.io);
+    stdio.stdout_override = &out_aw.writer;
+    stdio.stderr_override = &dead_stderr;
+
+    // The error that comes back is still the classified one, which is what
+    // lets run() map it to 2 (`exitCodeForReportedError`, pinned by its own
+    // test in compiled.zig). The status itself is asserted end-to-end against
+    // a real `2>&-` in examples/testing-demo's integration tier — this tier
+    // owns the half that can be checked in-process: the error identity
+    // survives a stderr that cannot be written.
+    try testing.expectError(error.OptionInvalidValue, app.executeWithStdio(testing.allocator, std.testing.io, &test_environ, &.{ "ping", "--count", "lots" }, &stdio));
+
+    // Same for an unknown command, whose status is 3 rather than 2 — the
+    // not-found plugin isn't registered here, so this is the bare routing
+    // error taking the same path.
+    try testing.expectError(error.CommandNotFound, app.executeWithStdio(testing.allocator, std.testing.io, &test_environ, &.{"nosuch"}, &stdio));
+}
+
 // Fixture for the typed-global-options pipeline: declares one global of each
 // supported category (also exercising declaration-time type validation),
 // records what handleGlobalOption receives, and captures parse failures.

--- a/packages/core/src/zcli.zig
+++ b/packages/core/src/zcli.zig
@@ -345,11 +345,150 @@ pub const Stdio = struct {
 
     /// Flush stdout and stderr writers. Must be called before exit
     /// to ensure buffered output reaches the terminal.
+    ///
+    /// The write error is swallowed *here* and surfaced through `writeError()`
+    /// instead — not dropped (#731). Every caller is either a `defer` (the
+    /// registry's final drain) or a `noreturn` exit (`context.exit`), and
+    /// neither can propagate an error; the writers record the concrete cause
+    /// on themselves, so the caller reads it back afterwards and classifies it
+    /// there. Both streams are flushed even when the first fails: a dead
+    /// stdout must not strand buffered stderr, which is where the diagnostic
+    /// about the dead stdout is going to land.
     pub fn flush(self: *@This()) void {
         self.stdout().flush() catch {};
         self.stderr().flush() catch {};
     }
+
+    /// The write error recorded by the framework-owned stdout/stderr writers,
+    /// or null when every byte — including the final `flush()` — reached its
+    /// fd.
+    ///
+    /// The buffered `std.Io.Writer` reports failures as the opaque
+    /// `error.WriteFailed`; the concrete cause is stored on the underlying
+    /// `std.Io.File.Writer.err` field, which survives `flush()`'s `catch {}`.
+    /// That is what makes a swallowed deferred flush recoverable at all.
+    ///
+    /// Only the framework's own file writers can carry this state; a
+    /// test-provided `stdout_override`/`stderr_override` is an in-memory
+    /// writer that has no `err` field to consult, so those are skipped (their
+    /// backing `*_writer` is `undefined`).
+    ///
+    /// When both streams failed, a `BrokenPipe` on *either* one outranks the
+    /// other's error: a closed reader ends the pipeline normally and the
+    /// framework's documented answer for that is 141, whatever else went wrong
+    /// on the way out.
+    pub fn writeError(self: *@This()) ?std.Io.File.Writer.Error {
+        const out: ?std.Io.File.Writer.Error = if (self.stdout_override == null) self.stdout_writer.err else null;
+        const err: ?std.Io.File.Writer.Error = if (self.stderr_override == null) self.stderr_writer.err else null;
+        if (out) |e| if (e == error.BrokenPipe) return error.BrokenPipe;
+        if (err) |e| if (e == error.BrokenPipe) return error.BrokenPipe;
+        return out orelse err;
+    }
+
+    /// Tell the user their output was lost, best-effort. A closed pipe gets no
+    /// diagnostic at all — a well-mannered unix program is silent when its
+    /// reader walks away (`yourcli cmd | head`) — but a full disk, a closed
+    /// fd, or an I/O error must not be silent, which is exactly the hole #731
+    /// closed. Written to stderr, which may itself be the stream that failed;
+    /// nothing more can be done in that case, and the non-zero exit status
+    /// still carries the signal.
+    pub fn reportWriteFailure(self: *@This(), err: std.Io.File.Writer.Error) void {
+        if (err == error.BrokenPipe) return;
+        const w = self.stderr();
+        w.print("Error: failed to write output: {s}\n", .{@errorName(err)}) catch {};
+        w.flush() catch {};
+    }
 };
+
+/// Conventional exit status for a process terminated by SIGPIPE (128 + 13).
+/// A zcli CLI whose stdout/stderr pipe is closed by a downstream reader (the
+/// classic `yourcli cmd | head` case) mimics that status so shell pipelines
+/// and `set -o pipefail` see the same result they would from `grep | head`.
+pub const broken_pipe_status: u8 = 141;
+
+/// Exit status for output that could not be written for any reason other than
+/// a closed pipe — a full filesystem, a closed descriptor, an I/O error. The
+/// command was well-formed and did its work, but the result never reached the
+/// consumer, so this is a general failure (1), not CLI misuse.
+pub const write_failure_status: u8 = 1;
+
+/// The exit status a recorded write failure forces on the process. Shared by
+/// the registry's `run()` and by `context.exit()` (#731/#732) so an early exit
+/// and a normal return can never disagree about what a lost write means.
+pub fn statusForWriteError(err: std.Io.File.Writer.Error) u8 {
+    return if (err == error.BrokenPipe) broken_pipe_status else write_failure_status;
+}
+
+test "statusForWriteError: a closed pipe is 141, lost output is a general failure" {
+    // A downstream reader that walked away is the conventional SIGPIPE status.
+    try std.testing.expectEqual(broken_pipe_status, statusForWriteError(error.BrokenPipe));
+    // Everything else means bytes the caller promised never landed (#731):
+    // a full disk, a closed fd, a hardware error. Never exit 0 for these.
+    try std.testing.expectEqual(write_failure_status, statusForWriteError(error.NoSpaceLeft));
+    try std.testing.expectEqual(write_failure_status, statusForWriteError(error.NotOpenForWriting));
+    try std.testing.expectEqual(write_failure_status, statusForWriteError(error.InputOutput));
+    try std.testing.expectEqual(write_failure_status, statusForWriteError(error.DiskQuota));
+}
+
+test "Stdio.writeError: reports a recorded failure, ignores in-memory overrides" {
+    var stdio: Stdio = .{ .io = std.testing.io };
+
+    // A test's in-memory writers cannot fail a real write, and the file
+    // writers behind them are `undefined` — never inspect them.
+    var buf: [16]u8 = undefined;
+    var out_aw = std.Io.Writer.fixed(&buf);
+    var err_aw = std.Io.Writer.fixed(&buf);
+    stdio.stdout_override = &out_aw;
+    stdio.stderr_override = &err_aw;
+    try std.testing.expect(stdio.writeError() == null);
+
+    // A sub-4KB run whose only write attempt is the deferred final flush: the
+    // flush swallows the error but the writer keeps it, which is the whole
+    // recovery mechanism behind #731.
+    stdio.stdout_override = null;
+    stdio.stdout_writer.err = error.NoSpaceLeft;
+    stdio.stderr_override = null;
+    stdio.stderr_writer.err = null;
+    try std.testing.expectEqual(@as(?std.Io.File.Writer.Error, error.NoSpaceLeft), stdio.writeError());
+
+    // A failure on stderr alone counts too — the diagnostic never landed.
+    stdio.stdout_writer.err = null;
+    stdio.stderr_writer.err = error.BrokenPipe;
+    try std.testing.expectEqual(@as(?std.Io.File.Writer.Error, error.BrokenPipe), stdio.writeError());
+
+    // Both failed: a closed pipe on either stream wins, so `yourcli cmd |
+    // head` keeps reporting 141 rather than a general write failure.
+    stdio.stdout_writer.err = error.NoSpaceLeft;
+    stdio.stderr_writer.err = error.BrokenPipe;
+    try std.testing.expectEqual(@as(?std.Io.File.Writer.Error, error.BrokenPipe), stdio.writeError());
+    stdio.stdout_writer.err = error.BrokenPipe;
+    stdio.stderr_writer.err = error.NoSpaceLeft;
+    try std.testing.expectEqual(@as(?std.Io.File.Writer.Error, error.BrokenPipe), stdio.writeError());
+
+    stdio.stdout_writer.err = null;
+    stdio.stderr_writer.err = null;
+    try std.testing.expect(stdio.writeError() == null);
+}
+
+test "Stdio.reportWriteFailure: diagnoses lost output, stays silent on a closed pipe" {
+    var stdio: Stdio = .{ .io = std.testing.io };
+    var out_buf: [64]u8 = undefined;
+    var out_aw = std.Io.Writer.fixed(&out_buf);
+    stdio.stdout_override = &out_aw;
+
+    var err_buf: [256]u8 = undefined;
+    var err_aw = std.Io.Writer.fixed(&err_buf);
+    stdio.stderr_override = &err_aw;
+
+    // A closed pipe is a normal end to a pipeline: no diagnostic (#731 must
+    // not make `yourcli cmd | head` noisy).
+    stdio.reportWriteFailure(error.BrokenPipe);
+    try std.testing.expectEqualStrings("", err_aw.buffered());
+
+    // Anything else is silent data loss unless we say so.
+    stdio.reportWriteFailure(error.NoSpaceLeft);
+    try std.testing.expectEqualStrings("Error: failed to write output: NoSpaceLeft\n", err_aw.buffered());
+}
 
 /// Environ.Map re-export for convenience.
 pub const EnvironMap = std.process.Environ.Map;

--- a/packages/ui/src/ui.zig
+++ b/packages/ui/src/ui.zig
@@ -59,6 +59,14 @@ pub const widgets = @import("widgets.zig");
 /// `context.uiFullScreen` (enforced at compile time); optional for hybrid.
 pub const panic = App.panic;
 
+/// The process-global terminal restore guard (re-exported from `terminal`).
+/// A session arms it on takeover; `restore()` replays the registered blob —
+/// show cursor, leave the alt-screen, undo raw mode — and is a no-op when
+/// nothing armed it. Every exit path that skips `defer app.deinit()` must call
+/// it, and `std.process.exit` always skips defers: that is how
+/// `context.exit()` avoids stranding the shell in the alt-screen (#732).
+pub const guard = terminal.guard;
+
 /// Whether the terminal supports unicode glyphs (re-exported from `terminal`
 /// for App/RenderCtx configuration — `App.Options.unicode`).
 pub const unicodeSupported = terminal.unicodeSupported;


### PR DESCRIPTION
Four issues that are all the same failure shape — *something that went wrong on the way out was discarded, and the exit status stopped matching what reached the user* — so they get one design rather than four patches.

## The critical one (#731)

```zig
// packages/core/src/zcli.zig:348 (before)
pub fn flush(self: *@This()) void {
    self.stdout().flush() catch {};   // <- ENOSPC / EIO / EBADF vanish here
```

`run()`'s compensating check tested **only** EPIPE. Output under 4 KB never forces a real drain, so the deferred flush was the only write — meaning **a command could write nothing and exit 0**:

```
myapp gen-manifest > /mnt/full/manifest.json && deploy
```
wrote nothing, reported success, and `deploy` ran against an empty manifest.

## The design

`Stdio.writeError()` reads the concrete cause the underlying `File.Writer` records — which survives `flush()`'s `catch {}`, and is the only channel that exists, since `flush` is only ever called from a `defer` or a `noreturn` exit. `statusForWriteError()` maps it. Both `run()` and `context.exit()` go through that one mapping, so an early exit and a normal return cannot disagree.

**Precedence** (this is the part that matters, and it changed during review):
1. A **classified** CLI error keeps its status — even when writing its diagnostic failed (#740).
2. Otherwise an unclassified lost write decides: `BrokenPipe` → 141 silent, anything else → exit 1 + diagnostic (#731).

`context.exit(code)` follows the same rule: a non-zero `code` is the command's own classification and stands; only `exit(0)` — a claim that everything worked — can be overridden.

Diagnostic renderers are now best-effort on **every** write, not just the trailing flush: rendering the message is cosmetic, classifying the error is not.

`context.exit()` also now calls `terminal.guard.restore()` (#732) — previously it restored the Windows console code page but left the terminal in alt-screen/raw-mode/hidden-cursor. And `context.fail()` renders through `writeSanitized` (#734), closing an ANSI-injection hole whose sharpest instance was the upgrade plugin echoing a version *rejected precisely because it contained bytes outside `[A-Za-z0-9._-]`* — a set that includes ESC.

## Behavior (verified by hand against `examples/notes`)

```
#731 13-byte output to closed stdout   exit=1 + "failed to write output: NotOpenForWriting"   (was: exit 0, silent)
     240KB to closed stdout            exit=1 + diagnostic                (was: exit 1 + raw Zig trace)
     broken pipe                       exit=141, stderr empty             (preserved)
#740 --bogus 2>/dev/null -> 2          --bogus 2>&- -> 2                  (was 1)
#732 exit(0) | head -c 1 -> 141        exit(7) -> 7                       (was 0)
     alt-screen, PTY capture   before: ^[[?1049h^[[?25l   after: …^[[?25h^[[?1049l
#734 OSC 52 / title-set payloads stripped; café-日本語-🎉 passes intact
```

## Review

Composer 2.5: **APPROVE_WITH_NITS**. It traced the full precedence table, confirmed no path where a successful command still exits 0 after non-EPIPE data loss, and found that my original ordering (broken-pipe first) created a real inconsistency: `context.exit(1)` gave 1 while `context.fail()` gave 141 in the identical situation. Reordering to classified-first also turns out to restore the *pre-existing* behavior, so the diff now only adds #731 rather than perturbing the EPIPE/classified interaction — smaller blast radius. Test-coverage nits were addressed.

## Verification

**Verified:** `zig fmt --check` clean. `zig ast-check` clean on all six changed files (it caught three real `var`-never-mutated errors in the new subprocess helper). An earlier full `zig build test` passed 2875/2877 (2 skipped) — but that predates both the new regression tests and the precedence reorder.

**Not verified — please read:** the new subprocess tests have **never executed**; `syspolicyd` wedged this machine and every newly-linked binary hangs in `_dyld_start`. The precedence reorder has not been re-run at runtime. The behavioral transcript above was captured under the old ordering; every case it covers is unaffected by the reorder except one — a classified error with a broken pipe now yields the classified code instead of 141, which is untested at runtime. `zig build e2e` never ran.

**CI is the gate.**

Fixes #731
Fixes #732
Fixes #734
Fixes #740
