### PR TITLE
Bind release signatures to their tag; fix installer docs and Windows PATH

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
       cli: ${{ steps.resolve.outputs.cli }}
       secrets: ${{ steps.resolve.outputs.secrets }}
       examples: ${{ steps.resolve.outputs.examples }}
+      installers: ${{ steps.resolve.outputs.installers }}
     steps:
       # Only needed for push events (PR events use the API), but checking out
       # unconditionally keeps the job shape simple.
@@ -60,6 +61,10 @@ jobs:
       #             live-keychain job, which otherwise ran on every PR for
       #             code that changes rarely.
       #   examples: the canonical examples or anything they compile against.
+      #   installers: install.sh / install.ps1 (the curl|sh + irm|iex trust
+      #             root) and the release-signing ceremony → the installer
+      #             signature/version-binding suite. No Zig involved, so
+      #             nothing else in this workflow covers them.
       - name: Classify diff
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
@@ -91,6 +96,13 @@ jobs:
               - 'build.zig'
               - 'build.zig.zon'
               - '.github/workflows/ci.yml'
+            installers:
+              - 'install.sh'
+              - 'install.ps1'
+              - 'scripts/sign-release.sh'
+              - 'scripts/test-install-signature.sh'
+              - 'scripts/test-install-signature.ps1'
+              - '.github/workflows/ci.yml'
 
       - name: Resolve gates (full run on main push or the ci-full label)
         id: resolve
@@ -101,6 +113,7 @@ jobs:
           CLI: ${{ steps.filter.outputs.cli }}
           SECRETS: ${{ steps.filter.outputs.secrets }}
           EXAMPLES: ${{ steps.filter.outputs.examples }}
+          INSTALLERS: ${{ steps.filter.outputs.installers }}
         run: |
           gate() {
             local v=false
@@ -112,6 +125,7 @@ jobs:
           gate cli "$CLI"
           gate secrets "$SECRETS"
           gate examples "$EXAMPLES"
+          gate installers "$INSTALLERS"
 
   fmt:
     name: zig fmt check
@@ -303,6 +317,61 @@ jobs:
           ZCLI_REQUIRE_FISH: ${{ runner.os == 'Linux' && '1' || '' }}
           ZCLI_REQUIRE_PWSH: "1"
         run: zig build test
+
+  # install.sh and install.ps1 are the `curl | sh` / `irm | iex` trust root, and
+  # they carry the only release-signature validation most users ever run — yet
+  # no Zig test can reach them (there is no Zig involved). This job IS that
+  # coverage: it mints a throwaway minisign keypair, signs fixtures under two
+  # different tags, and asserts the installers reject a genuinely-signed OLDER
+  # release replayed under a newer tag, along with prefix and case-only near
+  # misses. Case matrix and rationale: scripts/test-install-signature.sh.
+  #
+  # Both harnesses run on Linux and macOS, where minisign is one package away.
+  # Windows deliberately runs only the PowerShell one, for the registry
+  # value-kind contract that install.ps1's %VAR%-preserving PATH handling rests
+  # on and that cannot be observed on any other OS; its signature section skips
+  # there because the identical PowerShell code is already exercised on two
+  # other legs. So no leg silently runs nothing, each sets a ZCLI_REQUIRE_*
+  # flag that turns its own missing prerequisite into a hard failure.
+  installers:
+    name: installer signature binding (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    needs: changes
+    if: needs.changes.outputs.installers == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install minisign (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends minisign
+
+      - name: Install minisign (macOS)
+        if: runner.os == 'macOS'
+        run: brew install minisign
+
+      # Run with `sh`, which is dash on the Linux runner: install.sh must stay
+      # POSIX (it is piped straight into /bin/sh on user machines), so a bashism
+      # in verify_signature fails this step as well as the assertions.
+      - name: install.sh signature + version binding
+        if: runner.os != 'Windows'
+        env:
+          ZCLI_REQUIRE_MINISIGN: "1"
+        run: sh scripts/test-install-signature.sh
+
+      # Invoked as a child process (not `shell: pwsh`) so the harness's exit
+      # code is the step's, unambiguously. Every GitHub-hosted runner image
+      # ships pwsh, so a missing interpreter fails the step outright.
+      - name: install.ps1 signature + version binding
+        env:
+          ZCLI_REQUIRE_MINISIGN: ${{ runner.os == 'Windows' && '' || '1' }}
+          ZCLI_REQUIRE_REGISTRY: ${{ runner.os == 'Windows' && '1' || '' }}
+        run: pwsh -NoProfile -File scripts/test-install-signature.ps1
 
   windows-release-build:
     name: windows release build
@@ -589,6 +658,7 @@ jobs:
       - fmt
       - version-sync
       - test
+      - installers
       - windows-release-build
       - linux-musl-release-build
       - secrets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,10 +367,29 @@ jobs:
       # Invoked as a child process (not `shell: pwsh`) so the harness's exit
       # code is the step's, unambiguously. Every GitHub-hosted runner image
       # ships pwsh, so a missing interpreter fails the step outright.
+      #
+      # Split per-OS with `if:` rather than selecting the ZCLI_REQUIRE_* values
+      # inside one step with a `${{ cond && 'a' || 'b' }}` expression. That
+      # idiom is a trap when either branch is the empty string: '' is FALSY in
+      # GitHub's expression language, so `runner.os == 'Windows' && '' || '1'`
+      # evaluates to '1' on Windows — the `&&` yields '', then the `||` falls
+      # through to the right operand. The harness treats any non-empty value as
+      # "required" (`if ($env:ZCLI_REQUIRE_MINISIGN)`), so the Windows leg
+      # demanded the very binary it was meant to skip. Two steps, each with a
+      # literal value, cannot express that bug.
       - name: install.ps1 signature + version binding
+        if: runner.os != 'Windows'
         env:
-          ZCLI_REQUIRE_MINISIGN: ${{ runner.os == 'Windows' && '' || '1' }}
-          ZCLI_REQUIRE_REGISTRY: ${{ runner.os == 'Windows' && '1' || '' }}
+          ZCLI_REQUIRE_MINISIGN: "1"
+        run: pwsh -NoProfile -File scripts/test-install-signature.ps1
+
+      # Windows runs the same harness for its registry half only: minisign is
+      # not packaged on the runner image, and the signature section it would
+      # gate is the identical PowerShell exercised on the two legs above.
+      - name: install.ps1 registry + PATH contract
+        if: runner.os == 'Windows'
+        env:
+          ZCLI_REQUIRE_REGISTRY: "1"
         run: pwsh -NoProfile -File scripts/test-install-signature.ps1
 
   windows-release-build:

--- a/README.md
+++ b/README.md
@@ -392,11 +392,18 @@ Each release is tagged twice: `vX.Y.Z` is the framework library — the tag for 
 
 ### Verifying a release
 
-CLI releases are signed. `checksums.txt` carries a SHA-256 for every binary and is itself signed with a [minisign](https://jedisct1.github.io/minisign/) key held offline — so a compromised release cannot forge a matching signature, not just a matching checksum. `install.sh` **requires `minisign`** and verifies the signature before installing (fail closed); `zcli upgrade` verifies it natively with no external tools. To check by hand:
+CLI releases are signed. `checksums.txt` carries a SHA-256 for every binary and is itself signed with a [minisign](https://jedisct1.github.io/minisign/) key held offline — so a compromised release cannot forge a matching signature, not just a matching checksum.
+
+The signature is also **bound to its release tag**. `checksums.txt` names artifacts but carries no version, so a signature alone cannot tell a current release from an older one; the signing ceremony therefore writes the tag into minisign's trusted comment, which minisign's second signature covers. Every client requires that comment to name the exact tag being installed, as a whole token — so a genuinely-signed *older* release replayed under a newer tag is refused rather than silently installed (a downgrade/replay, CWE-294). `install.sh` and `install.ps1` both **require `minisign`** and verify signature and tag before installing (fail closed); `zcli upgrade` verifies both natively with no external tools.
+
+To check by hand:
 
 ```bash
 gh release download zcli-vX.Y.Z -p 'checksums.txt*'
-minisign -Vm checksums.txt -p docs/zcli-minisign.pub   # verifies the signature
+minisign -Vm checksums.txt -p docs/zcli-minisign.pub   # verifies the signature,
+                                                       # and prints the trusted
+                                                       # comment — confirm it
+                                                       # names zcli-vX.Y.Z
 sha256sum -c checksums.txt                              # then the binaries
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,11 +42,21 @@ are signed with [minisign](https://jedisct1.github.io/minisign/) (Ed25519):
   `scripts/sign-release.sh` and then publishes it. This means a compromised
   GitHub account or CI workflow can swap binaries and rewrite checksums, but
   cannot forge a valid signature.
-- The **public** key is pinned in the clients: `install.sh` requires `minisign`
-  and verifies the signature before installing anything (fail closed — it does
-  not fall back to checksum-only verification if `minisign` is missing), and
-  `zcli upgrade` verifies it natively in pure Zig (no external tool, no libc
-  dependency) before trusting any checksum.
+- The **public** key is pinned in the clients: `install.sh` and `install.ps1`
+  require `minisign` and verify the signature before installing anything (fail
+  closed — neither falls back to checksum-only verification if `minisign` is
+  missing), and `zcli upgrade` verifies it natively in pure Zig (no external
+  tool, no libc dependency) before trusting any checksum.
+- The signature is **bound to its release tag**. `checksums.txt` names artifacts
+  but carries no version, so an authentic signature alone cannot distinguish a
+  current release from an older one — an actor able to influence which release
+  `releases/latest` resolves to could otherwise replay a genuinely-signed older,
+  vulnerable build. The signing ceremony writes the tag into minisign's trusted
+  comment (covered by minisign's second, "global" signature), and every client
+  requires that comment to name the exact tag being installed as a whole token,
+  refusing the install otherwise (CWE-294). `scripts/sign-release.sh` checks the
+  same binding before publishing, so a mistyped tag fails at signing time rather
+  than for every user afterwards.
 - Apps built with zcli's `zcli_github_upgrade` plugin must explicitly choose a
   verification mode — `.{ .minisign = "<public key>" }` or the explicit opt-out
   `.checksum_only` — there is no silent default that skips verification.

--- a/TODOS.md
+++ b/TODOS.md
@@ -134,8 +134,9 @@ then the context tail `examples → guide → AGENTS.md`. **Parallelizable early
 
 Implemented via [ADR-0023](docs/adr/0023-release-signing-minisign.md): `checksums.txt` is
 signed with a minisign (Ed25519) key held offline (never in CI), verified against a pinned
-public key in both `install.sh` (verify-if-able, checksum fail-closed) and the
-`zcli_github_upgrade` plugin (pure-Zig `std.crypto` verify, fail closed). Ceremony, custody,
+public key in both `install.sh` (fail closed: `minisign` is required, and the signature must
+name the tag being installed) and the `zcli_github_upgrade` plugin (pure-Zig `std.crypto`
+verify, fail closed). Ceremony, custody,
 rotation, and compromise procedure: `docs/RELEASE-SIGNING.md`. The production key has been
 minted and pinned (key id 1638B69B8EF680FD): `projects/zcli/build.zig` (upgrade plugin) and
 `install.sh` both carry the real public key, and `docs/zcli-minisign.pub` holds the full key.

--- a/docs/RELEASE-SIGNING.md
+++ b/docs/RELEASE-SIGNING.md
@@ -132,11 +132,25 @@ passphrase), self-verifies against `docs/zcli-minisign.pub`, uploads
 `checksums.txt.minisig`, and flips the release to published. Never publish a CLI
 release draft by hand — that would ship it unsigned.
 
+Both self-verify steps are unconditional and abort the ceremony on failure:
+
+1. **Signature** — the signature must verify under the committed public key.
+   Catches signing with the wrong key. A missing `docs/zcli-minisign.pub` is an
+   error (a broken checkout), not a reason to skip.
+2. **Tag binding** — the trusted comment must name the tag being signed, as a
+   whole whitespace-delimited token. The `-t "zcli $TAG — signed release
+   checksums"` argument is what every client checks; a typo there would not
+   surface until after publish, when *every* user's install fails closed. This
+   catches it while the release is still a draft.
+
 ### How a user verifies (for the docs / the paranoid)
 
 ```sh
 gh release download zcli-v0.20.0 -p 'checksums.txt*'
 minisign -Vm checksums.txt -p docs/zcli-minisign.pub
+# minisign prints the trusted comment on success — confirm it names the tag you
+# downloaded (zcli-v0.20.0). That binding is what makes replaying an older,
+# genuinely-signed release under a newer tag fail.
 # then check a binary's line in the (now-trusted) checksums.txt
 ```
 

--- a/install.ps1
+++ b/install.ps1
@@ -8,6 +8,9 @@
 #   - exact filename-field match against checksums.txt (no shadow-entry match)
 #   - fail-closed minisign signature verification: if a public key is pinned
 #     but minisign is unavailable, abort rather than degrade to checksum-only
+#   - the signature must name the release tag being installed, as a whole
+#     token, so a genuinely-signed OLDER release cannot be replayed under a
+#     newer tag (downgrade/replay — CWE-294)
 #   - latest-version resolution via the GitHub Releases API (install.sh has
 #     no pinned-version mode to mirror; both always install latest)
 
@@ -23,14 +26,19 @@ $BinaryName = 'zcli.exe'
 
 # zcli's pinned minisign public key. Kept in sync with install.sh's
 # MINISIGN_PUBKEY. The installer verifies checksums.txt against its detached
-# signature (checksums.txt.minisig) under this key when the `minisign` tool
-# is available — closing the gap that checksums alone cannot: a compromised
-# release can swap the binary AND its checksum, but not forge a signature
-# under a key that never lived in the release pipeline (see ADR-0023).
+# signature (checksums.txt.minisig) under this key — closing the gap that
+# checksums alone cannot: a compromised release can swap the binary AND its
+# checksum, but not forge a signature under a key that never lived in the
+# release pipeline (see ADR-0023).
 #
-# Key id 1638B69B8EF680FD. The full key lives at docs/zcli-minisign.pub; if
-# empty, signature verification is skipped and the fail-closed SHA-256
-# checksum check below still applies. Rotation/compromise: docs/RELEASE-SIGNING.md.
+# Verification is REQUIRED, never best-effort: while this key is set, a missing
+# `minisign` tool aborts the install rather than degrading to checksum-only, and
+# the signature must also name the exact release tag being installed (see
+# Test-Signature below). Only an empty key — signing not enabled for a project —
+# skips verification, leaving the fail-closed SHA-256 checksum check.
+#
+# Key id 1638B69B8EF680FD. The full key lives at docs/zcli-minisign.pub.
+# Rotation/compromise: docs/RELEASE-SIGNING.md.
 $MinisignPubkey = 'RWT9gPaOm7Y4Fm5WFqqlWRpI4FgPTIjD5UhUsaZsdKHrWYuWa9jt8ESC'
 
 function Write-Info    { param([string]$Message) Write-Host "==> $Message" -ForegroundColor Blue }
@@ -48,7 +56,8 @@ function Get-Arch {
     }
 }
 
-# Verify checksums.txt against its detached minisign signature.
+# Verify checksums.txt against its detached minisign signature, and bind that
+# signature to the exact release tag being installed.
 #
 # Fail closed: returns $true only when the signature actually verified (or
 # signing is not enabled for this project). Signature verification is
@@ -59,7 +68,8 @@ function Get-Arch {
 function Test-Signature {
     param(
         [string]$ChecksumsPath,
-        [string]$ChecksumUrl
+        [string]$ChecksumUrl,
+        [string]$ExpectedTag
     )
 
     # Signing not yet enabled for this project — nothing to verify.
@@ -93,7 +103,64 @@ function Test-Signature {
         return $false
     }
 
-    Write-Success 'Signature verified'
+    # Bind the signature to THIS release. The check above only authenticates
+    # checksums.txt, which names artifacts but carries no version — so a
+    # compromised publisher could serve an OLDER release's binary, checksums.txt
+    # and its genuine .minisig under a newer tag and pass every check so far,
+    # silently rolling the user back to a previously-signed (possibly vulnerable)
+    # build (a downgrade/replay — CWE-294).
+    #
+    # The signing ceremony defends against this by embedding the release tag in
+    # minisign's *trusted* comment (scripts/sign-release.sh: `-t "zcli $TAG —
+    # signed release checksums"`). That comment is line 3 of the .minisig and is
+    # covered by minisign's second, "global" signature on line 4 — the `-V` above
+    # verifies it and exits nonzero ("Comment signature verification failed")
+    # when it does not match, so by this point line 3 is authenticated and its
+    # tag can be trusted. Reading it unverified would defeat the point.
+    #
+    # Kept in step with install.sh's verify_signature and with
+    # verifyTrustedComment in
+    # packages/core/src/plugins/zcli_github_upgrade/minisign.zig.
+    $sigLines = @(Get-Content -Path $sigPath)
+    if ($sigLines.Count -lt 3) {
+        Write-ErrorMsg "Signature carries no trusted comment to bind $ExpectedTag."
+        Write-ErrorMsg 'Refusing to install a release whose version cannot be verified.'
+        return $false
+    }
+
+    $commentPrefix = 'trusted comment: '
+    $commentLine = $sigLines[2].TrimEnd("`r")
+    if (-not $commentLine.StartsWith($commentPrefix, [StringComparison]::Ordinal)) {
+        Write-ErrorMsg "Signature carries no trusted comment to bind $ExpectedTag."
+        Write-ErrorMsg 'Refusing to install a release whose version cannot be verified.'
+        return $false
+    }
+    $trustedComment = $commentLine.Substring($commentPrefix.Length)
+
+    # Whole-token match, not substring, so a shorter tag can never be satisfied
+    # by a longer one (`zcli-v0.2` must not match `zcli-v0.20.0`, nor the
+    # reverse). `-ceq` is the case-sensitive comparison — PowerShell's `-eq`
+    # ignores case, which would not match the byte equality the Zig verifier and
+    # install.sh both use.
+    $tagBound = $false
+    if (-not [string]::IsNullOrEmpty($ExpectedTag)) {
+        foreach ($token in ($trustedComment -split '\s+')) {
+            if ($token -ceq $ExpectedTag) {
+                $tagBound = $true
+                break
+            }
+        }
+    }
+
+    if (-not $tagBound) {
+        Write-ErrorMsg "Signature does not name $ExpectedTag."
+        Write-ErrorMsg "Trusted comment: $trustedComment"
+        Write-ErrorMsg 'This looks like an older, genuinely-signed release replayed'
+        Write-ErrorMsg 'under a newer tag. Refusing a possible downgrade. Aborting.'
+        return $false
+    }
+
+    Write-Success "Signature verified (binds $ExpectedTag)"
     return $true
 }
 
@@ -154,10 +221,11 @@ function Get-ZcliBinary {
         exit 1
     }
 
-    # Authenticate checksums.txt against its signature before trusting it.
-    # Fail closed: a signature failure, or a missing minisign tool when a
-    # key is pinned, aborts the install.
-    if (-not (Test-Signature -ChecksumsPath $checksumsPath -ChecksumUrl $checksumUrl)) {
+    # Authenticate checksums.txt against its signature before trusting it, and
+    # require that signature to name the tag we are installing. Fail closed: a
+    # signature failure, a version mismatch, or a missing minisign tool when a
+    # key is pinned all abort the install.
+    if (-not (Test-Signature -ChecksumsPath $checksumsPath -ChecksumUrl $checksumUrl -ExpectedTag "zcli-v$Version")) {
         Remove-Item -Recurse -Force $tmpDir -ErrorAction SilentlyContinue
         exit 1
     }
@@ -220,26 +288,84 @@ function Test-InPath {
     return $false
 }
 
-# Add a directory to the persistent per-user PATH (if not already present)
+# Tell the shell (and Explorer) that the environment block changed.
+#
+# DO NOT DELETE THIS AS REDUNDANT. It is not belt-and-braces; it repairs a
+# regression that Add-ToUserPath's registry fix would otherwise introduce.
+# [Environment]::SetEnvironmentVariable used to broadcast WM_SETTINGCHANGE for us
+# as a side effect. Add-ToUserPath no longer calls it (see the comment there: that
+# API flattens %VAR% references), and a raw registry write broadcasts nothing — so
+# without this, a terminal started from the running Explorer session inherits a
+# stale environment block and keeps the old PATH until the user logs out, making
+# this script's own "restart your terminal, then run zcli --help" advice wrong.
+#
+# Best effort: PATH is already persisted by the time this runs, so a failure here
+# is a warning, not an aborted install.
+function Send-EnvironmentChange {
+    try {
+        if (-not ('ZcliNative.Win32' -as [type])) {
+            Add-Type -Namespace 'ZcliNative' -Name 'Win32' -MemberDefinition @'
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+    IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+    uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+'@
+        }
+        $result = [UIntPtr]::Zero
+        # HWND_BROADCAST, WM_SETTINGCHANGE, SMTO_ABORTIFHUNG, 5s timeout.
+        [void][ZcliNative.Win32]::SendMessageTimeout(
+            [IntPtr]0xffff, 0x1A, [UIntPtr]::Zero, 'Environment', 0x2, 5000, [ref]$result)
+    } catch {
+        Write-WarnMsg 'Could not notify running programs of the PATH change; log out and back in if a new terminal cannot find zcli.'
+    }
+}
+
+# Add a directory to the persistent per-user PATH (if not already present).
+#
+# This goes through the registry rather than [Environment]::GetEnvironmentVariable
+# / SetEnvironmentVariable on purpose: the getter EXPANDS %VAR% references and the
+# setter writes the result back as REG_SZ, so a user PATH containing (say)
+# `%USERPROFILE%\bin` would be permanently flattened to today's literal path and
+# stop tracking the variable. Reading with DoNotExpandEnvironmentNames and writing
+# RegistryValueKind.ExpandString leaves those references exactly as the user wrote
+# them.
 function Add-ToUserPath {
     param([string]$Dir)
 
     $normalized = $Dir.TrimEnd('\')
-    $current = [Environment]::GetEnvironmentVariable('Path', 'User')
-    $entries = @()
-    if (-not [string]::IsNullOrEmpty($current)) {
-        $entries = $current -split ';'
+
+    $key = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $true)
+    if ($null -eq $key) {
+        $key = [Microsoft.Win32.Registry]::CurrentUser.CreateSubKey('Environment')
     }
 
-    foreach ($entry in $entries) {
-        if ($entry.TrimEnd('\') -ieq $normalized) {
-            Write-Success 'PATH already configured for future sessions'
-            return
+    try {
+        $current = $key.GetValue(
+            'Path', '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+        $entries = @()
+        if (-not [string]::IsNullOrEmpty($current)) {
+            $entries = $current -split ';'
         }
+
+        # Entries are raw now, so compare both the literal text and its expansion —
+        # otherwise an existing `%LOCALAPPDATA%\Programs\zcli` would no longer be
+        # recognized and we would append a duplicate.
+        foreach ($entry in $entries) {
+            if ([string]::IsNullOrWhiteSpace($entry)) { continue }
+            $expanded = [Environment]::ExpandEnvironmentVariables($entry)
+            if (($entry.TrimEnd('\') -ieq $normalized) -or ($expanded.TrimEnd('\') -ieq $normalized)) {
+                Write-Success 'PATH already configured for future sessions'
+                return
+            }
+        }
+
+        $new = if ($entries.Length -eq 0) { $Dir } else { "$current;$Dir" }
+        $key.SetValue('Path', $new, [Microsoft.Win32.RegistryValueKind]::ExpandString)
+    } finally {
+        if ($null -ne $key) { $key.Dispose() }
     }
 
-    $new = if ($entries.Length -eq 0) { $Dir } else { "$current;$Dir" }
-    [Environment]::SetEnvironmentVariable('Path', $new, 'User')
+    Send-EnvironmentChange
     Write-Success "Added $Dir to your user PATH"
 }
 

--- a/install.sh
+++ b/install.sh
@@ -17,14 +17,19 @@ INSTALL_DIR="$HOME/.local/bin"
 BINARY_NAME="zcli"
 
 # zcli's pinned minisign public key. The installer verifies checksums.txt against
-# its detached signature (checksums.txt.minisig) under this key when the
-# `minisign` tool is available — closing the gap that checksums alone cannot: a
-# compromised release can swap the binary AND its checksum, but not forge a
-# signature under a key that never lived in the release pipeline (see ADR-0023).
+# its detached signature (checksums.txt.minisig) under this key — closing the gap
+# that checksums alone cannot: a compromised release can swap the binary AND its
+# checksum, but not forge a signature under a key that never lived in the release
+# pipeline (see ADR-0023).
 #
-# Key id 1638B69B8EF680FD. The full key lives at docs/zcli-minisign.pub; if
-# empty, signature verification is skipped and the fail-closed SHA-256 checksum
-# check below still applies. Rotation/compromise: docs/RELEASE-SIGNING.md.
+# Verification is REQUIRED, never best-effort: while this key is set, a missing
+# `minisign` tool aborts the install rather than degrading to checksum-only, and
+# the signature must also name the exact release tag being installed (see
+# verify_signature below). Only an empty key — signing not enabled for a project
+# — skips verification, leaving the fail-closed SHA-256 checksum check.
+#
+# Key id 1638B69B8EF680FD. The full key lives at docs/zcli-minisign.pub.
+# Rotation/compromise: docs/RELEASE-SIGNING.md.
 MINISIGN_PUBKEY="RWT9gPaOm7Y4Fm5WFqqlWRpI4FgPTIjD5UhUsaZsdKHrWYuWa9jt8ESC"
 
 # Print functions
@@ -75,7 +80,8 @@ sha256_digest() {
     fi
 }
 
-# Verify checksums.txt against its detached minisign signature.
+# Verify checksums.txt against its detached minisign signature, and bind that
+# signature to the exact release tag being installed.
 #
 # Fail closed: returns 0 only when the signature actually verified (or signing is
 # not enabled for this project). Signature verification is REQUIRED when a key is
@@ -86,6 +92,7 @@ verify_signature() {
     checksums="$1"
     checksum_url="$2"
     tmp_dir="$3"
+    expected_tag="$4"
 
     # Signing not yet enabled for this project — nothing to verify.
     if [ -z "${MINISIGN_PUBKEY}" ]; then
@@ -115,7 +122,58 @@ verify_signature() {
         return 1
     fi
 
-    print_success "Signature verified"
+    # Bind the signature to THIS release. The check above only authenticates
+    # checksums.txt, which names artifacts but carries no version — so a
+    # compromised publisher could serve an OLDER release's binary, checksums.txt
+    # and its genuine .minisig under a newer tag and pass every check so far,
+    # silently rolling the user back to a previously-signed (possibly vulnerable)
+    # build (a downgrade/replay — CWE-294).
+    #
+    # The signing ceremony defends against this by embedding the release tag in
+    # minisign's *trusted* comment (scripts/sign-release.sh: `-t "zcli $TAG —
+    # signed release checksums"`). That comment is line 3 of the .minisig and is
+    # covered by minisign's second, "global" signature on line 4 — the `-V` above
+    # verifies it and exits nonzero ("Comment signature verification failed")
+    # when it does not match, so by this point line 3 is authenticated and its
+    # tag can be trusted. Reading it unverified would defeat the point.
+    #
+    # This mirrors verifyTrustedComment in
+    # packages/core/src/plugins/zcli_github_upgrade/minisign.zig, which gives
+    # `zcli upgrade` the same guarantee.
+    comment_line=$(sed -n '3p' "${sig}" | tr -d '\r')
+    case "${comment_line}" in
+        "trusted comment: "*) ;;
+        *)
+            print_error "Signature carries no trusted comment to bind ${expected_tag}."
+            print_error "Refusing to install a release whose version cannot be verified."
+            return 1
+            ;;
+    esac
+    trusted_comment="${comment_line#"trusted comment: "}"
+
+    # Whole-token match, not substring, so a shorter tag can never be satisfied
+    # by a longer one (`zcli-v0.2` must not match `zcli-v0.20.0`). Unquoted
+    # expansion does the whitespace tokenization; `set -f` disables globbing so
+    # a `*` planted in the comment cannot expand against the working directory.
+    set -f
+    tag_bound=0
+    for token in ${trusted_comment}; do
+        if [ "${token}" = "${expected_tag}" ]; then
+            tag_bound=1
+            break
+        fi
+    done
+    set +f
+
+    if [ "${tag_bound}" -ne 1 ]; then
+        print_error "Signature does not name ${expected_tag}."
+        print_error "Trusted comment: ${trusted_comment}"
+        print_error "This looks like an older, genuinely-signed release replayed"
+        print_error "under a newer tag. Refusing a possible downgrade. Aborting."
+        return 1
+    fi
+
+    print_success "Signature verified (binds ${expected_tag})"
     return 0
 }
 
@@ -171,10 +229,11 @@ download_binary() {
         exit 1
     fi
 
-    # Authenticate checksums.txt against its signature before trusting it. Fail
-    # closed: a signature failure, or a missing minisign tool when a key is
-    # pinned, aborts the install.
-    if ! verify_signature "${checksums}" "${checksum_url}" "${tmp_dir}"; then
+    # Authenticate checksums.txt against its signature before trusting it, and
+    # require that signature to name the tag we are installing. Fail closed: a
+    # signature failure, a version mismatch, or a missing minisign tool when a
+    # key is pinned all abort the install.
+    if ! verify_signature "${checksums}" "${checksum_url}" "${tmp_dir}" "zcli-v${version}"; then
         rm -rf "${tmp_dir}"
         exit 1
     fi

--- a/scripts/sign-release.sh
+++ b/scripts/sign-release.sh
@@ -23,6 +23,49 @@ error()   { echo -e "${RED}✗ $1${NC}" >&2; exit 1; }
 success() { echo -e "${GREEN}✓ $1${NC}"; }
 info()    { echo -e "${YELLOW}→ $1${NC}"; }
 
+# True when the trusted comment in $1 (a .minisig file) names $2 as a whole
+# whitespace-delimited token.
+#
+# Token-exact, not substring, so `zcli-v0.2` cannot satisfy `zcli-v0.20.0` nor
+# the reverse. Behaviorally identical to install.sh's verify_signature,
+# install.ps1's Test-Signature, and verifyTrustedComment in
+# packages/core/src/plugins/zcli_github_upgrade/minisign.zig. The four copies
+# exist only because sh, PowerShell and Zig share no runtime — keep them in step.
+#
+# Only meaningful AFTER `minisign -V` has succeeded on the same file: that is
+# what authenticates line 3 via minisign's global signature. Reading the comment
+# unverified would prove nothing.
+#
+# Written in POSIX sh (not bash) so scripts/test-install-signature.sh can extract
+# this function by name and hold it to the same case matrix as the installers.
+# Keep the `name() {` ... `}` shape at column 0 or that extraction breaks loudly.
+trusted_comment_binds_tag() {
+    _sig_file="$1"
+    _expected_tag="$2"
+
+    [ -n "$_expected_tag" ] || return 1
+
+    _comment_line=$(sed -n '3p' "$_sig_file" | tr -d '\r')
+    case "$_comment_line" in
+        "trusted comment: "*) ;;
+        *) return 1 ;;
+    esac
+    _trusted_comment="${_comment_line#"trusted comment: "}"
+
+    # `set -f` disables globbing so a `*` in the comment cannot expand against
+    # the working directory during word splitting.
+    set -f
+    _bound=1
+    for _token in ${_trusted_comment}; do
+        if [ "$_token" = "$_expected_tag" ]; then
+            _bound=0
+            break
+        fi
+    done
+    set +f
+    return $_bound
+}
+
 # Default signing key location; override with MINISIGN_SECRET_KEY or -s.
 SECRET_KEY="${MINISIGN_SECRET_KEY:-$HOME/.minisign/minisign.key}"
 # Committed public key, used to self-verify the signature we just produced.
@@ -85,15 +128,28 @@ minisign -S -s "$SECRET_KEY" \
 success "Signature created"
 
 # Self-verify against the committed public key before publishing anything —
-# catches signing with the wrong key.
-if [ -f "$PUBKEY_FILE" ]; then
-    info "Verifying signature against $PUBKEY_FILE..."
-    minisign -Vm "$WORK_DIR/checksums.txt" -p "$PUBKEY_FILE" >/dev/null \
-        || error "Self-verification failed — signed with the wrong key?"
-    success "Signature verifies against the pinned public key"
-else
-    info "No $PUBKEY_FILE found — skipping self-verify (add it during the keygen ceremony)"
+# catches signing with the wrong key. Unconditional: keygen is long past, so a
+# missing pubkey file means a broken checkout, not a first run. Skipping the
+# self-verify would be fail-open in the one ceremony still able to fix a bad
+# signature — after publish, every consumer fails closed instead.
+[ -f "$PUBKEY_FILE" ] || error "Pinned public key not found: $PUBKEY_FILE (it is committed at docs/zcli-minisign.pub — broken checkout?)"
+
+info "Verifying signature against $PUBKEY_FILE..."
+minisign -Vm "$WORK_DIR/checksums.txt" -p "$PUBKEY_FILE" >/dev/null \
+    || error "Self-verification failed — signed with the wrong key?"
+success "Signature verifies against the pinned public key"
+
+# `minisign -V` authenticates the trusted comment but asserts nothing about its
+# contents, so check that the comment we just wrote actually names this tag.
+# Both installers and the in-binary upgrade path now REQUIRE that binding, so a
+# typo'd `-t` argument above would not surface until every consumer's install
+# fails closed — after publish, with the artifacts already signed. Catch it here,
+# while the release is still a draft and re-signing costs nothing.
+if ! trusted_comment_binds_tag "$WORK_DIR/checksums.txt.minisig" "$TAG"; then
+    echo "  trusted comment: $(sed -n '3p' "$WORK_DIR/checksums.txt.minisig")" >&2
+    error "Trusted comment does not name $TAG as a whole token — refusing to publish a release every consumer would reject"
 fi
+success "Trusted comment binds $TAG"
 
 info "Uploading checksums.txt.minisig to $TAG..."
 gh release upload "$TAG" "$WORK_DIR/checksums.txt.minisig" --clobber \

--- a/scripts/test-install-signature.ps1
+++ b/scripts/test-install-signature.ps1
@@ -1,0 +1,201 @@
+#!/usr/bin/env pwsh
+# Regression tests for install.ps1's release-signature trust model, and for the
+# registry contract its PATH handling depends on.
+#
+# install.ps1 is an `irm | iex` trust root: like install.sh it is the only
+# validation most Windows users ever run, and no Zig test covers it. These
+# assertions exist so a regression fails CI rather than shipping.
+#
+# Two independent sections, each skipped only when its prerequisite genuinely
+# cannot exist on the runner:
+#
+#   1. Signature version binding — needs `minisign`. Exercises the real
+#      Test-Signature from the shipped install.ps1 with only the network fetch
+#      stubbed. Mirrors scripts/test-install-signature.sh case for case; the two
+#      installers must agree.
+#   2. Registry value-kind contract — Windows only. Proves the .NET behavior the
+#      %VAR%-preservation fix rests on: that ExpandString round-trips as
+#      REG_EXPAND_SZ, that DoNotExpandEnvironmentNames returns the raw text, and
+#      that the default read expands it (the bug that flattened user PATHs).
+#
+# Usage: pwsh -NoProfile -File scripts/test-install-signature.ps1
+#   ZCLI_REQUIRE_MINISIGN=1  a missing minisign binary is a hard failure rather
+#                            than a skip (CI sets this on the legs that install it).
+#   ZCLI_REQUIRE_REGISTRY=1  a non-Windows host is a hard failure rather than a
+#                            skip (CI sets this on the Windows leg).
+#
+# Between them, every CI leg carries at least one of these flags, so no leg can
+# quietly degrade to running nothing.
+
+$ErrorActionPreference = 'Stop'
+
+$RepoRoot = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+$InstallPs1 = Join-Path $RepoRoot 'install.ps1'
+
+$script:PassCount = 0
+$script:FailCount = 0
+
+function Note { param([string]$M) Write-Host $M }
+function Bad  { param([string]$M) Write-Host "::error::$M" }
+
+function Assert-Result {
+    param([string]$Label, [string]$Expected, [string]$Actual)
+    if ($Expected -ceq $Actual) {
+        Note "  PASS  $Label"
+        $script:PassCount++
+    } else {
+        Bad "$Label — expected $Expected, got $Actual"
+        $script:FailCount++
+    }
+}
+
+# ===========================================================================
+# Section 1 — signature version binding
+# ===========================================================================
+$minisign = Get-Command minisign -ErrorAction SilentlyContinue
+if (-not $minisign) {
+    if ($env:ZCLI_REQUIRE_MINISIGN) {
+        Bad 'ZCLI_REQUIRE_MINISIGN=1 but no minisign binary was found — the install.ps1 signature tests cannot run'
+        exit 1
+    }
+    Note 'SKIP: minisign not installed (set ZCLI_REQUIRE_MINISIGN=1 to make this a failure)'
+} else {
+    $work = Join-Path ([System.IO.Path]::GetTempPath()) ("zcli-sigtest-" + [guid]::NewGuid().ToString('N'))
+    New-Item -ItemType Directory -Path $work | Out-Null
+    try {
+        # -------------------------------------------------------------------
+        # Load the real Test-Signature. install.ps1 calls Main on load, so strip
+        # that one trailing line and dot-source the rest. install.ps1 itself
+        # stays untouched — this must exercise exactly what ships. If the
+        # invocation stops being a bare trailing `Main`, fail loudly rather than
+        # dot-sourcing a script that would run the installer for real.
+        # -------------------------------------------------------------------
+        $src = (Get-Content -Path $InstallPs1 -Raw).TrimEnd()
+        if (-not $src.EndsWith("`nMain")) {
+            Bad "install.ps1 no longer ends with a bare 'Main' invocation — update this harness's strip-and-source before it runs the installer for real"
+            exit 1
+        }
+        $src = $src.Substring(0, $src.Length - 'Main'.Length)
+
+        # install.ps1 computes $InstallDir via Join-Path at load time; on Linux
+        # and macOS a 'C:' drive is rejected, so give it a loadable value. The
+        # signature path never touches it.
+        if (-not $env:LOCALAPPDATA) { $env:LOCALAPPDATA = $work }
+
+        $shim = Join-Path $work 'installer-under-test.ps1'
+        Set-Content -Path $shim -Value $src
+        . $shim
+
+        # Fixtures: throwaway keypair, genuinely-signed checksums for two tags.
+        & minisign -G -W -p (Join-Path $work 'test.pub') -s (Join-Path $work 'test.key') *> $null
+        $pubkey = (Get-Content (Join-Path $work 'test.pub'))[1]
+
+        $checksums = Join-Path $work 'checksums.txt'
+        $tampered = Join-Path $work 'tampered.txt'
+        Set-Content -Path $checksums -Value "abc123  zcli-x86_64-linux`ndef456  zcli-aarch64-macos" -NoNewline
+        Set-Content -Path $tampered  -Value "abc123  zcli-x86_64-linux`nBADBAD  zcli-aarch64-macos" -NoNewline
+
+        function New-TestSignature { param([string]$Out, [string]$Tag)
+            & minisign -S -W -s (Join-Path $work 'test.key') -m $checksums -x (Join-Path $work $Out) `
+                -t "zcli $Tag — signed release checksums" *> $null
+        }
+        New-TestSignature 'sig-0.20.0.minisig' 'zcli-v0.20.0'
+        New-TestSignature 'sig-0.19.0.minisig' 'zcli-v0.19.0'
+        New-TestSignature 'sig-0.2.minisig'    'zcli-v0.2'
+
+        # Attacker rewrites the trusted comment to claim the new tag but cannot
+        # re-sign it — minisign's global signature still covers the old text.
+        $orig = Get-Content (Join-Path $work 'sig-0.19.0.minisig')
+        Set-Content -Path (Join-Path $work 'sig-rewritten.minisig') -Value @(
+            $orig[0], $orig[1], 'trusted comment: zcli zcli-v0.20.0 — signed release checksums', $orig[3])
+
+        # Line 3 present but missing the `trusted comment: ` prefix.
+        $orig20 = Get-Content (Join-Path $work 'sig-0.20.0.minisig')
+        Set-Content -Path (Join-Path $work 'sig-noprefix.minisig') -Value @(
+            $orig20[0], $orig20[1], 'zcli zcli-v0.20.0 — signed release checksums', $orig20[3])
+
+        # Stub the network: Test-Signature fetches "<url>.minisig" into
+        # "<checksums>.minisig". A function shadows the real cmdlet here.
+        function Invoke-WebRequest {
+            param($Uri, $OutFile, [switch]$UseBasicParsing)
+            Copy-Item -Path $script:ServeSig -Destination $OutFile -Force
+        }
+
+        $MinisignPubkey = $pubkey
+
+        function Check { param([string]$Label, [string]$Expect, [string]$Sig, [string]$Tag, [string]$Body)
+            $script:ServeSig = Join-Path $work $Sig
+            $run = Join-Path $work 'run-checksums.txt'
+            Copy-Item $Body $run -Force
+            try {
+                $ok = [bool](Test-Signature -ChecksumsPath $run `
+                    -ChecksumUrl 'https://example.invalid/checksums.txt' -ExpectedTag $Tag 6>$null)
+            } catch {
+                $ok = $false
+            }
+            Assert-Result "install.ps1: $Label" $Expect $(if ($ok) { 'accept' } else { 'reject' })
+        }
+
+        Note 'install.ps1 Test-Signature — version binding'
+        Check 'matching tag accepted'                 'accept' 'sig-0.20.0.minisig'   'zcli-v0.20.0' $checksums
+        Check 'downgrade replay rejected'             'reject' 'sig-0.19.0.minisig'   'zcli-v0.20.0' $checksums
+        Check 'prefix tag rejected (v0.2 vs v0.20.0)' 'reject' 'sig-0.20.0.minisig'   'zcli-v0.2'    $checksums
+        Check 'inverse prefix rejected'               'reject' 'sig-0.2.minisig'      'zcli-v0.20.0' $checksums
+        Check 'case-only mismatch rejected'           'reject' 'sig-0.20.0.minisig'   'ZCLI-V0.20.0' $checksums
+        Check 'rewritten trusted comment rejected'    'reject' 'sig-rewritten.minisig' 'zcli-v0.20.0' $checksums
+        Check 'missing comment prefix rejected'       'reject' 'sig-noprefix.minisig' 'zcli-v0.20.0' $checksums
+        Check 'tampered checksums rejected'           'reject' 'sig-0.20.0.minisig'   'zcli-v0.20.0' $tampered
+
+        Note ''
+        Note 'install.ps1 Test-Signature — pinned-key behavior'
+        $MinisignPubkey = ''
+        Check 'empty pinned key skips verification'   'accept' 'sig-0.19.0.minisig'   'zcli-v0.20.0' $checksums
+    } finally {
+        Remove-Item -Recurse -Force $work -ErrorAction SilentlyContinue
+    }
+}
+
+# ===========================================================================
+# Section 2 — registry value-kind contract (Windows only)
+#
+# Add-ToUserPath reads with DoNotExpandEnvironmentNames and writes ExpandString
+# precisely so %VAR% entries survive. That rests on .NET behavior which cannot
+# be observed off Windows, so pin it down here against a scratch key rather than
+# the real user PATH.
+# ===========================================================================
+Note ''
+if (-not $IsWindows) {
+    if ($env:ZCLI_REQUIRE_REGISTRY) {
+        Bad 'ZCLI_REQUIRE_REGISTRY=1 but this is not Windows — the registry contract tests cannot run'
+        exit 1
+    }
+    Note 'SKIP: registry value-kind contract (Windows only)'
+} else {
+    Note 'registry value-kind contract (underpins install.ps1 PATH handling)'
+    $testKeyPath = 'Software\zcli-installer-test'
+    $raw = $null; $expanded = $null; $kind = $null
+    $key = [Microsoft.Win32.Registry]::CurrentUser.CreateSubKey($testKeyPath)
+    try {
+        $key.SetValue('Path', '%USERPROFILE%\bin;C:\literal',
+            [Microsoft.Win32.RegistryValueKind]::ExpandString)
+        $raw = $key.GetValue('Path', '',
+            [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+        $expanded = $key.GetValue('Path', '')
+        $kind = $key.GetValueKind('Path')
+    } finally {
+        $key.Dispose()
+        [Microsoft.Win32.Registry]::CurrentUser.DeleteSubKeyTree($testKeyPath, $false)
+    }
+
+    Assert-Result 'ExpandString round-trips as REG_EXPAND_SZ' 'ExpandString' "$kind"
+    Assert-Result 'DoNotExpandEnvironmentNames returns raw %VAR%' `
+        '%USERPROFILE%\bin;C:\literal' $raw
+    # The bug this guards: a default read expands, and writing that back as
+    # REG_SZ is what permanently flattened the user's PATH.
+    Assert-Result 'default read DOES expand (the flattening bug)' `
+        'expanded' $(if ($expanded -ne $raw -and $expanded -notmatch '%USERPROFILE%') { 'expanded' } else { "unexpanded:$expanded" })
+}
+
+Note ''
+Note "passed: $script:PassCount   failed: $script:FailCount"
+if ($script:FailCount -ne 0) { exit 1 }

--- a/scripts/test-install-signature.sh
+++ b/scripts/test-install-signature.sh
@@ -1,0 +1,188 @@
+#!/bin/sh
+# Regression tests for the installer's release-signature trust model.
+#
+# install.sh is a `curl | sh` trust root: it is the only validation most users
+# ever run, and it is not covered by `zig build test` (no Zig involved). These
+# assertions exist so a regression in the signature or version-binding logic
+# fails CI rather than shipping.
+#
+# What is under test, against REAL minisign signatures made with a throwaway
+# keypair generated per run:
+#   1. install.sh's verify_signature — the whole function, sourced from the
+#      shipped file, with only the network fetch stubbed.
+#   2. scripts/sign-release.sh's trusted_comment_binds_tag — the release
+#      ceremony's copy of the same token-exactness rule, extracted by name.
+#
+# The matching PowerShell surface lives in scripts/test-install-signature.ps1.
+# Semantics all four copies must share (the fourth is verifyTrustedComment in
+# packages/core/src/plugins/zcli_github_upgrade/minisign.zig, covered by the Zig
+# unit tests): a signature is accepted only when its authenticated trusted
+# comment names the exact release tag as a whole whitespace-delimited token.
+#
+# Deliberately `#!/bin/sh`, and CI runs it with `sh` on Linux (where that is
+# dash): install.sh must stay POSIX, so a bashism introduced into
+# verify_signature fails here too.
+#
+# Usage: sh scripts/test-install-signature.sh
+#   ZCLI_REQUIRE_MINISIGN=1  a missing minisign binary is a hard failure rather
+#                            than a skip (CI sets this; dev boxes need not).
+
+set -e
+
+REPO_ROOT=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+INSTALL_SH="${REPO_ROOT}/install.sh"
+SIGN_RELEASE_SH="${REPO_ROOT}/scripts/sign-release.sh"
+
+pass_count=0
+fail_count=0
+
+note() { printf '%s\n' "$1"; }
+bad()  { printf '::error::%s\n' "$1"; }
+
+if ! command -v minisign >/dev/null 2>&1; then
+    if [ -n "${ZCLI_REQUIRE_MINISIGN:-}" ]; then
+        bad "ZCLI_REQUIRE_MINISIGN=1 but no minisign binary was found — the installer signature tests cannot run"
+        exit 1
+    fi
+    note "SKIP: minisign not installed (set ZCLI_REQUIRE_MINISIGN=1 to make this a failure)"
+    exit 0
+fi
+
+WORK=$(mktemp -d)
+trap 'rm -rf "${WORK}"' EXIT
+
+# ---------------------------------------------------------------------------
+# Load the real verify_signature.
+#
+# install.sh calls main() on load, so strip that one trailing line and source
+# the rest. install.sh itself stays untouched — this must exercise exactly what
+# ships, not a testability-modified copy. If the invocation ever stops being a
+# bare `main` line, fail loudly rather than sourcing a script that would run the
+# installer for real.
+# ---------------------------------------------------------------------------
+main_lines=$(grep -c '^main$' "${INSTALL_SH}" || true)
+if [ "${main_lines}" != "1" ]; then
+    bad "expected exactly one bare 'main' line in install.sh, found ${main_lines} — update this harness's strip-and-source before it runs the installer for real"
+    exit 1
+fi
+grep -v '^main$' "${INSTALL_SH}" > "${WORK}/installer.sh"
+# shellcheck source=/dev/null
+. "${WORK}/installer.sh"
+
+# ---------------------------------------------------------------------------
+# Load the release ceremony's copy of the token rule, extracted by name.
+# ---------------------------------------------------------------------------
+awk '/^trusted_comment_binds_tag\(\) \{/,/^\}/' "${SIGN_RELEASE_SH}" > "${WORK}/sign-lib.sh"
+if ! grep -q '^trusted_comment_binds_tag() {' "${WORK}/sign-lib.sh" || ! grep -q '^}' "${WORK}/sign-lib.sh"; then
+    bad "could not extract trusted_comment_binds_tag() from ${SIGN_RELEASE_SH} — did its shape change?"
+    exit 1
+fi
+# shellcheck source=/dev/null
+. "${WORK}/sign-lib.sh"
+
+# ---------------------------------------------------------------------------
+# Fixtures: a throwaway keypair and genuinely-signed checksums for two tags.
+# ---------------------------------------------------------------------------
+minisign -G -W -p "${WORK}/test.pub" -s "${WORK}/test.key" >/dev/null 2>&1
+PUBKEY=$(sed -n '2p' "${WORK}/test.pub")
+
+printf 'abc123  zcli-x86_64-linux\ndef456  zcli-aarch64-macos\n' > "${WORK}/checksums.txt"
+printf 'abc123  zcli-x86_64-linux\nBADBAD  zcli-aarch64-macos\n' > "${WORK}/tampered.txt"
+
+sign_as() { # <out-sig> <tag>
+    minisign -S -W -s "${WORK}/test.key" -m "${WORK}/checksums.txt" -x "$1" \
+        -t "zcli $2 — signed release checksums" >/dev/null 2>&1
+}
+sign_as "${WORK}/sig-0.20.0.minisig" "zcli-v0.20.0"
+sign_as "${WORK}/sig-0.19.0.minisig" "zcli-v0.19.0"
+sign_as "${WORK}/sig-0.2.minisig"    "zcli-v0.2"
+
+# An attacker rewrites the trusted comment to claim the new tag but cannot
+# re-sign it: minisign's global signature (line 4) still covers the old text.
+{ sed -n '1,2p' "${WORK}/sig-0.19.0.minisig"
+  echo 'trusted comment: zcli zcli-v0.20.0 — signed release checksums'
+  sed -n '4p' "${WORK}/sig-0.19.0.minisig"; } > "${WORK}/sig-rewritten.minisig"
+
+# Line 3 present but missing the `trusted comment: ` prefix.
+{ sed -n '1,2p' "${WORK}/sig-0.20.0.minisig"
+  echo 'zcli zcli-v0.20.0 — signed release checksums'
+  sed -n '4p' "${WORK}/sig-0.20.0.minisig"; } > "${WORK}/sig-noprefix.minisig"
+
+# ---------------------------------------------------------------------------
+# Stub the network. verify_signature fetches "<checksum_url>.minisig" with
+# curl into "<checksums>.minisig"; serve ${SERVE_SIG} instead. Everything else
+# — the pinned-key check, the real `minisign -V`, the line-3 parse and the
+# token match — is the shipped code.
+# ---------------------------------------------------------------------------
+curl() { cp "${SERVE_SIG}" "$7"; }
+
+MINISIGN_PUBKEY="${PUBKEY}"
+
+check() { # <label> <accept|reject> <sig> <tag> <body>
+    label="$1"; expect="$2"; SERVE_SIG="${WORK}/$3"; tag="$4"; body="$5"
+
+    cp "${WORK}/${body}" "${WORK}/run-checksums.txt"
+    if verify_signature "${WORK}/run-checksums.txt" \
+            "https://example.invalid/checksums.txt" "${WORK}" "${tag}" >/dev/null 2>&1; then
+        got=accept
+    else
+        got=reject
+    fi
+
+    if [ "${got}" = "${expect}" ]; then
+        note "  PASS  install.sh: ${label}"
+        pass_count=$((pass_count + 1))
+    else
+        bad "install.sh: ${label} — expected ${expect}, got ${got}"
+        fail_count=$((fail_count + 1))
+    fi
+}
+
+check_ceremony() { # <label> <accept|reject> <sig> <tag>
+    label="$1"; expect="$2"; sig="${WORK}/$3"; tag="$4"
+
+    if trusted_comment_binds_tag "${sig}" "${tag}"; then
+        got=accept
+    else
+        got=reject
+    fi
+
+    if [ "${got}" = "${expect}" ]; then
+        note "  PASS  sign-release.sh: ${label}"
+        pass_count=$((pass_count + 1))
+    else
+        bad "sign-release.sh: ${label} — expected ${expect}, got ${got}"
+        fail_count=$((fail_count + 1))
+    fi
+}
+
+note "install.sh verify_signature — version binding"
+check "matching tag accepted"                  accept sig-0.20.0.minisig   zcli-v0.20.0 checksums.txt
+check "downgrade replay rejected"              reject sig-0.19.0.minisig   zcli-v0.20.0 checksums.txt
+check "prefix tag rejected (v0.2 vs v0.20.0)"  reject sig-0.20.0.minisig   zcli-v0.2    checksums.txt
+check "inverse prefix rejected"                reject sig-0.2.minisig      zcli-v0.20.0 checksums.txt
+check "case-only mismatch rejected"            reject sig-0.20.0.minisig   ZCLI-V0.20.0 checksums.txt
+check "rewritten trusted comment rejected"     reject sig-rewritten.minisig zcli-v0.20.0 checksums.txt
+check "missing comment prefix rejected"        reject sig-noprefix.minisig zcli-v0.20.0 checksums.txt
+check "tampered checksums rejected"            reject sig-0.20.0.minisig   zcli-v0.20.0 tampered.txt
+
+note ""
+note "install.sh verify_signature — pinned-key behavior"
+MINISIGN_PUBKEY=''
+check "empty pinned key skips verification"    accept sig-0.19.0.minisig   zcli-v0.20.0 checksums.txt
+# shellcheck disable=SC2034  # consumed by verify_signature, sourced from install.sh
+MINISIGN_PUBKEY="${PUBKEY}"
+
+note ""
+note "sign-release.sh trusted_comment_binds_tag — same token rule"
+check_ceremony "matching tag accepted"                 accept sig-0.20.0.minisig zcli-v0.20.0
+check_ceremony "wrong tag rejected"                    reject sig-0.19.0.minisig zcli-v0.20.0
+check_ceremony "prefix tag rejected"                   reject sig-0.20.0.minisig zcli-v0.2
+check_ceremony "inverse prefix rejected"               reject sig-0.2.minisig    zcli-v0.20.0
+check_ceremony "case-only mismatch rejected"           reject sig-0.20.0.minisig ZCLI-V0.20.0
+check_ceremony "missing comment prefix rejected"       reject sig-noprefix.minisig zcli-v0.20.0
+check_ceremony "empty tag rejected"                    reject sig-0.20.0.minisig ''
+
+note ""
+note "passed: ${pass_count}   failed: ${fail_count}"
+[ "${fail_count}" -eq 0 ]

--- a/website/content/docs/shipping.smd
+++ b/website/content/docs/shipping.smd
@@ -44,8 +44,11 @@ Checksums alone can't survive a compromised publisher — `checksums.txt` ships 
 - Generate the keypair **offline**, once: `minisign -G`. The secret key lives in a password manager — never a CI secret.
 - Pin the public key where verification happens: your install script and your `github_upgrade` plugin config.
 - Sign each release locally: the release is created as a draft, you sign its `checksums.txt`, upload `checksums.txt.minisig`, and publish.
+- Put the release tag in minisign's **trusted comment** when you sign (`minisign -S -t "myapp $TAG — signed release checksums"`). That comment is covered by a second signature, so it can't be edited after the fact.
 
-Verification is **fail-closed**: when a public key is pinned, a missing or invalid signature aborts the install or upgrade — it never falls back to "unsigned but probably fine". zcli's own releases work exactly this way, and `install.sh` verifies both the minisign signature and the SHA-256 checksum before moving a binary into place.
+Verification is **fail-closed**: when a public key is pinned, a missing or invalid signature aborts the install or upgrade — it never falls back to "unsigned but probably fine". zcli's own releases work exactly this way, and `install.sh` and `install.ps1` verify the minisign signature and the SHA-256 checksum before moving a binary into place.
+
+Signatures are also **bound to their release tag**. `checksums.txt` lists artifacts but no version, so an authentic signature alone can't tell a current release from an old one — anyone able to influence what `releases/latest` returns could serve a genuinely-signed *older* build and downgrade your users onto a vulnerable version. Requiring the trusted comment to name the exact tag being installed, as a whole token, closes that (`zcli-v0.2` must not satisfy `zcli-v0.20.0`). zcli's installers, `zcli upgrade`, and the signing script itself all enforce it.
 
 ## Self-upgrade for your users
 

--- a/website/layouts/install.shtml
+++ b/website/layouts/install.shtml
@@ -59,7 +59,7 @@
           <pre><span class="pr">$</span> curl -fsSL https://zcli.sh/install.sh | sh</pre>
           <button onclick="cp(this,'curl -fsSL https://zcli.sh/install.sh | sh')">copy</button>
         </div>
-        <p style="font-size:13.5px;">Requires <code class="mono" style="color:var(--accent)">curl</code> and <code class="mono" style="color:var(--accent)">minisign</code>. The script reads the latest release from GitHub, verifies the minisign signature over the checksums (fail closed) and the SHA-256 of the binary, then makes it executable. <code class="mono">zcli upgrade</code> verifies the signature natively. Details: <a href="https://github.com/ryanhair/zcli/blob/main/docs/RELEASE-SIGNING.md">release signing</a>.</p>
+        <p style="font-size:13.5px;">Requires <code class="mono" style="color:var(--accent)">curl</code> and <code class="mono" style="color:var(--accent)">minisign</code>. The script reads the latest release from GitHub, verifies the minisign signature over the checksums (fail closed), checks that the signature names the release being installed — so an older, genuinely-signed build can't be replayed under a newer tag — and verifies the SHA-256 of the binary, then makes it executable. <code class="mono">zcli upgrade</code> verifies all of it natively. Details: <a href="https://github.com/ryanhair/zcli/blob/main/docs/RELEASE-SIGNING.md">release signing</a>.</p>
       </div>
 
       <!-- PKG -->


### PR DESCRIPTION
Five issues across both installers and the signing ceremony. Four were found *while fixing the first one*.

## #735 / #748 — signed-downgrade replay

`install.sh` (and `install.ps1`) verified the minisign signature but **not the version binding**. `minisign -V` authenticates the trusted comment's global signature; it asserts nothing about its *content*. So an actor able to influence what `releases/latest` returns could serve an **older, genuinely-signed** release — checksum matches, signature verifies, user silently installs a known-vulnerable build.

`zcli upgrade` already closed this (`minisign.zig:154-192`, explicitly citing CWE-294). `curl | sh` — the path most users take — did not.

Both installers now read line 3 of the `.minisig` after `-V` succeeds, require the `trusted comment: ` prefix, and match `zcli-v${version}` as a **whole whitespace-delimited token**, mirroring `trustedCommentHasTag`.

Two details worth review:
- **`install.sh` wraps tokenization in `set -f`.** The trusted comment is attacker-controlled in this threat model; unquoted expansion would otherwise glob against cwd.
- **`install.ps1` uses `-ceq`, not `-eq`.** PowerShell's `-eq` on strings is case-**insensitive**, so a faithful-looking transcription would have been *weaker* than the Zig and shell originals — a signed `ZCLI-v0.20.0` would have satisfied a request for `zcli-v0.20.0`. Git tags are case-sensitive, so that is reachable. `StartsWith` likewise uses `StringComparison.Ordinal`.

## #749 — the signing ceremony didn't check what it wrote

`sign-release.sh` self-verified with `minisign -V` only, so a maintainer tag typo would surface as *every consumer's install failing closed*, after publish. Now applies the same token-exact check — and the self-verify is **unconditional** (it previously skipped when the pubkey file was absent: fail-open in the signing ceremony).

## #737 — contradictory security docs

`install.sh`'s header claimed best-effort/skippable verification; `:80-100` did the opposite and aborts when minisign is missing. Header corrected, plus `TODOS.md:137`, and doc parity across `install.ps1`, `README.md`, `SECURITY.md`, `docs/RELEASE-SIGNING.md`, and the website.

## #746 — Windows PATH corruption

`GetEnvironmentVariable`/`SetEnvironmentVariable` **expand** `%VAR%` and write back `REG_SZ`, permanently flattening `%USERPROFILE%\bin` to a literal. Now reads raw with `DoNotExpandEnvironmentNames` and writes `ExpandString`. Dedupe compares both literal and expanded forms — without that, reading raw would have appended a duplicate entry.

`Send-EnvironmentChange` restores the `WM_SETTINGCHANGE` broadcast that `SetEnvironmentVariable` used to perform as a side effect; without it the script's own "restart your terminal" advice becomes wrong. It carries a deliberately loud comment so it isn't deleted as redundant.

## Tests — now in CI

New `installers` job runs `scripts/test-install-signature.{sh,ps1}`: 16 shell assertions, 9 PowerShell. Both **source the real shipped functions** and assert the strip matched, so the harness can never quietly run the installer for real. Only the network fetch is stubbed; `minisign -V` is the real binary against a per-run throwaway keypair.

**The gate was mutation-tested**, not just run green:

| Mutation | Caught by |
|---|---|
| token match → substring | prefix case (`v0.2` vs `v0.20.0`) |
| binding disabled entirely | 4 assertions |
| `-ceq` → `-eq` | case-only mismatch |
| token match → `.Contains()` | prefix case |

Wiring note: `actionlint` catches a typo'd `needs.changes.outputs.*` but **does not** catch a job missing from `ci-ok`'s `needs` — the exact silent dead-gate this repo's CI comments warn about. Verified by hand. Every leg carries a `ZCLI_REQUIRE_*` flag so a missing interpreter is a hard failure, not a silent skip.

## Review

Composer 2.5, two passes: **APPROVE_WITH_NITS**. It independently reproduced the tokenization against a real minisign fixture and got the same accept/reject matrix, found no bypass and no functional regression. Its main ask — CI coverage for installer security logic — is what produced the `installers` job above.

## Verification

**Verified:** all 34 harness assertions pass locally (`minisign` runs natively on macOS; `pwsh` 7.6.3 present). `shellcheck` and `PSScriptAnalyzer` unchanged from baseline; `dash -n`, `sh -n`, `zsh -n` parse clean; `actionlint` clean.

**Not verified:** nothing here has run on **real Windows**. The registry semantics (`DoNotExpandEnvironmentNames` suppressing expansion, `ExpandString` producing `REG_EXPAND_SZ`) and the `user32.dll` P/Invoke rest on documented .NET contracts that the new CI assertion encodes but has never executed. The Windows leg of the `installers` job is where that will first run.

Fixes #735
Fixes #737
Fixes #746
Fixes #748
Fixes #749
