### PR TITLE
Stop echoing config values; enforce HTTPS on every request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to zcli are documented here.
 
 **Versioning policy:** zcli follows [semver](https://semver.org). Until 1.0, breaking changes may land in minor versions and are called out below; patch versions are always safe to take. Releases target **stable Zig** — moving to a new Zig version is at least a minor bump and is stated in the entry. Each release is tagged twice in lockstep: `vX.Y.Z` is the framework library (the tag for your `build.zig.zon`), `zcli-vX.Y.Z` carries the prebuilt meta-CLI binaries.
 
+## Unreleased
+
+### Changed (breaking)
+- **`zcli.http.Client` is HTTPS-only for *every* request, not just credentialed ones** (#745). A plain `http://` URL now fails with `error.InsecureTransport` before a connection is opened — the same rule the client already enforced on redirect targets (`error.InsecureRedirect`), and the one its module doc already promised. A request that also carried an `Authorization`/`Cookie`/`Proxy-Authorization` header still reports the more specific `error.InsecureCredentialTransport`. Loopback (`127.0.0.0/8`, `::1`, `localhost`) remains the sole carve-out, so local servers and test fixtures are unaffected.
+
+### Fixed
+- **`zcli_config` no longer echoes a rejected config value** (#736) — a value that fails to parse is now reported by size, not content (`config 'app.json' has an invalid value (22 bytes) for 'api_key' — ignoring`). A config file is where a user puts a secret precisely to keep it off the command line, so a typo or a field's type changing must not print the token into CI logs or scrollback. Every config path the plugin prints — the apply-pass warnings, the project-local `note:`, the unreadable/unrecognized-file warnings, the not-found error — now renders through the diagnostic control-byte sanitizer.
+- **`zcli_config` no longer leaks a multi-value option's buffer on a lenient skip** (#750) — a config list with one element that fails to coerce (`tags = ["ok", "!!bad"]` for a `[]SomeEnum`) skipped the option without freeing the buffer it had already allocated. Masked by the arena-per-command in framework use; real on any path that supplies a plain allocator.
+
 ## v0.22.0 — 2026-07-22
 
 ### Changed (breaking)

--- a/packages/core/src/http.zig
+++ b/packages/core/src/http.zig
@@ -28,13 +28,16 @@
 //!   are kept across all redirects. (This is why the wrapper follows redirects
 //!   itself: as of 0.16, `std.http.Client`'s auto-follow re-sends every extra
 //!   header to the redirect target regardless of origin.)
-//! - **Credential headers never ride cleartext to a remote host.** A request
-//!   that carries one of those credential headers over a non-`https` scheme
-//!   fails with `error.InsecureCredentialTransport` — checked on every hop, so a
-//!   same-origin `http`→`http` redirect cannot smuggle a token onto the wire
-//!   either. The sole carve-out is loopback (`127.0.0.0/8`, `::1`, `localhost`),
-//!   which is a secure transport in practice (nothing on the wire) and is what
-//!   the loopback integration tests exercise; every real caller uses `https`.
+//! - **Every request is HTTPS.** A request to a non-`https` URL fails with
+//!   `error.InsecureTransport` before a connection is opened, and a redirect to
+//!   one fails with `error.InsecureRedirect` — one rule checked on every hop, so
+//!   the client never *starts* from a destination it would refuse to follow to.
+//!   A hop that would have carried a credential header gets the more specific
+//!   `error.InsecureCredentialTransport`, because a token about to go on the
+//!   wire in cleartext is worth naming. The sole carve-out is loopback
+//!   (`127.0.0.0/8`, `::1`, `localhost`), which is a secure transport in
+//!   practice (nothing on the wire) and is what the loopback integration tests
+//!   exercise; every real caller uses `https`.
 //! - **Each request has an overall timeout** (default `default_timeout`) so a
 //!   hung or dead server cannot make a command hang forever. See "Timeouts".
 //!
@@ -89,10 +92,14 @@ pub const Error = error{
     Timeout,
     /// A redirect chain exceeded `max_redirects`.
     TooManyRedirects,
-    /// A request carrying a credential header (`authorization`, `cookie`, or
-    /// `proxy-authorization`) targeted a non-`https` origin that is not
-    /// loopback. Refused fail-closed so a bearer token / cookie is never put on
-    /// the wire in cleartext to a remote host.
+    /// A request targeted a non-`https` origin that is not loopback. This client
+    /// is HTTPS-only: refused fail-closed, before a connection is opened, rather
+    /// than putting the request on the wire in cleartext.
+    InsecureTransport,
+    /// The same refusal as `InsecureTransport`, for a request that was also
+    /// carrying a credential header (`authorization`, `cookie`, or
+    /// `proxy-authorization`). Reported distinctly because the cleartext hop
+    /// would have leaked a bearer token / cookie, not just the request.
     InsecureCredentialTransport,
     /// A redirect pointed to a non-`https` URL. This client is HTTPS-only at
     /// request time, and redirects must stay on HTTPS. Loopback is the sole
@@ -137,8 +144,8 @@ fn sameOrigin(a: std.Uri, b: std.Uri) bool {
     return (a.port orelse defaultPort(a.scheme)) == (b.port orelse defaultPort(b.scheme));
 }
 
-/// True when `host` is a loopback address — the one carve-out where a credential
-/// header may travel over cleartext `http`, because nothing leaves the machine.
+/// True when `host` is a loopback address — the one carve-out where this client
+/// speaks cleartext `http` at all, because nothing leaves the machine.
 /// Covers the IPv4 loopback block `127.0.0.0/8`, the IPv6 loopback `::1` (with or
 /// without brackets), and the literal name `localhost`.
 fn isLoopbackHost(host: []const u8) bool {
@@ -153,10 +160,12 @@ fn isLoopbackHost(host: []const u8) bool {
     } else |_| return false;
 }
 
-/// A credential-bearing request may go out only over `https`, or to a loopback
-/// host over any scheme. Returns false for anything else (cleartext to a remote
-/// host), which the request loop turns into `error.InsecureCredentialTransport`.
-fn credentialTransportOk(uri: std.Uri) bool {
+/// A request may go out only over `https`, or to a loopback host over any
+/// scheme. Returns false for anything else (cleartext to a remote host), which
+/// the request loop turns into `error.InsecureTransport` — or
+/// `error.InsecureCredentialTransport` when the hop carried a credential header,
+/// and `error.InsecureRedirect` when it was a redirect target.
+fn transportOk(uri: std.Uri) bool {
     if (std.ascii.eqlIgnoreCase(uri.scheme, "https")) return true;
     var host_buf: [256]u8 = undefined;
     const host = (uri.host orelse return false).toRaw(&host_buf) catch return false;
@@ -412,13 +421,19 @@ pub const Client = struct {
         while (true) {
             const uri = try std.Uri.parse(current_url);
 
-            // Fail closed before opening the connection: a credential header must
-            // never travel in cleartext to a remote host. This covers the initial
-            // request and every same-origin `http`→`http` redirect hop (a hop that
-            // leaves the origin has already cleared `send_credentials`). `https`
-            // and loopback are the only origins allowed to carry credentials.
-            if (send_credentials and has_credentials and !credentialTransportOk(uri)) {
-                return Error.InsecureCredentialTransport;
+            // Fail closed before opening the connection: this client is
+            // HTTPS-only, so nothing goes out in cleartext to a remote host —
+            // the same rule the redirect check below applies, held here too so
+            // the client cannot start from a destination it would refuse to
+            // follow to. `https` and loopback are the only origins allowed.
+            // A hop that would have carried a credential header says so
+            // specifically (a hop that left the origin has already cleared
+            // `send_credentials`, so its token is gone by then).
+            if (!transportOk(uri)) {
+                return if (has_credentials and send_credentials)
+                    Error.InsecureCredentialTransport
+                else
+                    Error.InsecureTransport;
             }
 
             const hop_headers = headers.items[0..if (send_credentials)
@@ -470,7 +485,7 @@ pub const Client = struct {
                     // host. Integrity is already protected by minisign + checksum,
                     // but belt-and-suspenders: a server-controlled redirect must
                     // never silently move a connection off TLS.
-                    if (!credentialTransportOk(next_uri)) return Error.InsecureRedirect;
+                    if (!transportOk(next_uri)) return Error.InsecureRedirect;
 
                     if (!sameOrigin(uri, next_uri)) send_credentials = false;
                     // A 303 means "GET the result of what you sent".
@@ -679,18 +694,43 @@ test "isLoopbackHost recognizes loopback names and addresses only" {
     try testing.expect(!isLoopbackHost("::2"));
 }
 
-test "credentialTransportOk allows https and loopback, refuses cleartext to a remote host" {
+test "transportOk allows https and loopback, refuses cleartext to a remote host" {
     const parse = std.Uri.parse;
     // https anywhere is fine.
-    try testing.expect(credentialTransportOk(try parse("https://api.example.com/")));
-    try testing.expect(credentialTransportOk(try parse("https://127.0.0.1:8443/")));
+    try testing.expect(transportOk(try parse("https://api.example.com/")));
+    try testing.expect(transportOk(try parse("https://127.0.0.1:8443/")));
     // http only on loopback.
-    try testing.expect(credentialTransportOk(try parse("http://127.0.0.1:8080/")));
-    try testing.expect(credentialTransportOk(try parse("http://localhost:8080/")));
-    try testing.expect(credentialTransportOk(try parse("http://[::1]:8080/")));
+    try testing.expect(transportOk(try parse("http://127.0.0.1:8080/")));
+    try testing.expect(transportOk(try parse("http://localhost:8080/")));
+    try testing.expect(transportOk(try parse("http://[::1]:8080/")));
     // http to a remote host is refused — this is the leak the guard closes.
-    try testing.expect(!credentialTransportOk(try parse("http://api.example.com/")));
-    try testing.expect(!credentialTransportOk(try parse("http://10.0.0.5/")));
+    try testing.expect(!transportOk(try parse("http://api.example.com/")));
+    try testing.expect(!transportOk(try parse("http://10.0.0.5/")));
+    try testing.expect(!transportOk(try parse("http://192.168.1.1/file")));
+    try testing.expect(!transportOk(try parse("http://cdn.example.com/file")));
+}
+
+test "a plain-http request to a remote host is refused before connecting" {
+    var client = Client.init(testing.allocator, testing.io, .{});
+    defer client.deinit();
+
+    // No credential header anywhere: the HTTPS-only rule still fires, so the
+    // client never opens a cleartext connection to these hosts (nothing here
+    // touches the network).
+    try testing.expectError(
+        Error.InsecureTransport,
+        client.get("http://api.example.com/data"),
+    );
+    try testing.expectError(
+        Error.InsecureTransport,
+        client.post("http://10.0.0.5/ingest", .{ .body = "payload", .content_type = "text/plain" }),
+    );
+    // A non-credential header does not change the verdict.
+    const plain = [_]Header{.{ .name = "accept", .value = "application/json" }};
+    try testing.expectError(
+        Error.InsecureTransport,
+        client.request(.GET, "http://api.example.com/", .{ .headers = &plain }),
+    );
 }
 
 test "a credentialed request over cleartext to a remote host is refused before connecting" {
@@ -698,7 +738,7 @@ test "a credentialed request over cleartext to a remote host is refused before c
     defer client.deinit();
 
     // An authorization header over plain http to a non-loopback host must fail
-    // closed with InsecureCredentialTransport, without any network work.
+    // closed with the credential-specific error, without any network work.
     const creds = [_]Header{.{ .name = "authorization", .value = "Bearer secret-token" }};
     try testing.expectError(
         Error.InsecureCredentialTransport,
@@ -721,20 +761,10 @@ test "redirectTarget follows only real redirect statuses" {
     try testing.expect(redirectTarget(.found, null) == null);
 }
 
-test "a credentialed request with an https-to-http redirect to a remote host is refused" {
-    // credentialTransportOk is already unit-tested above; this test proves the
-    // same guard fires on redirect targets that are not HTTPS and not loopback,
-    // without opening a real connection.
-    const parse = std.Uri.parse;
-    // HTTPS is allowed.
-    try testing.expect(credentialTransportOk(try parse("https://cdn.example.com/file")));
-    // HTTP on loopback is the test carve-out.
-    try testing.expect(credentialTransportOk(try parse("http://127.0.0.1:8080/file")));
-    try testing.expect(credentialTransportOk(try parse("http://localhost/file")));
-    // HTTP to a remote host is the downgrade we block.
-    try testing.expect(!credentialTransportOk(try parse("http://cdn.example.com/file")));
-    try testing.expect(!credentialTransportOk(try parse("http://192.168.1.1/file")));
-}
+// The redirect guard itself is exercised end-to-end, against a real loopback
+// server, by http_loopback_test.zig ("a redirect to a non-https remote host…"
+// and its credentialed sibling) — a predicate re-assertion here would only
+// restate the `transportOk` test above without touching the redirect path.
 
 test "an invalid URL fails before any network work" {
     var client = Client.init(testing.allocator, testing.io, .{});

--- a/packages/core/src/http_loopback_test.zig
+++ b/packages/core/src/http_loopback_test.zig
@@ -301,6 +301,36 @@ test "a redirect to a non-https remote host fails with InsecureRedirect" {
     try testing.expectError(Error.InsecureRedirect, client.get(url));
 }
 
+test "a credentialed request refuses the same redirect, with the token in flight" {
+    const io = testing.io;
+
+    var addr = try std.Io.net.IpAddress.parse("127.0.0.1", 0);
+    var server = try addr.listen(io, .{});
+    defer server.deinit(io);
+    const port = server.socket.address.getPort();
+
+    // Same downgrade, but the request carries `authorization`: the first hop is
+    // loopback (the carve-out, so the header legitimately goes out) and the
+    // server then points at plain http on a remote host. The guard must fire on
+    // the redirect *target*, before the client dials it — the case that matters
+    // most, since the destination is entirely server-controlled and a bearer
+    // token is in flight.
+    const http_remote = "http://cdn.example.com/file";
+    var future = try io.concurrent(serveOneRedirect, .{ io, &server, @as([]const u8, http_remote) });
+    defer future.await(io);
+
+    var client = Client.init(testing.allocator, io, .{});
+    defer client.deinit();
+
+    const url = try loopbackUrl(port);
+    defer testing.allocator.free(url);
+
+    try testing.expectError(
+        Error.InsecureRedirect,
+        client.request(.GET, url, .{ .headers = &redirect_test_headers }),
+    );
+}
+
 test "a request that outlives its timeout fails with error.Timeout" {
     const io = testing.io;
 

--- a/packages/core/src/plugins/zcli_config/plugin.zig
+++ b/packages/core/src/plugins/zcli_config/plugin.zig
@@ -31,7 +31,10 @@ const zcli = @import("zcli");
 /// all int widths, floats, enums (incl. optionals), custom `parse` types, and
 /// arrays/multi-value (from a config list). Config stays lenient: a value that
 /// won't parse (bad format, out of range, unknown enum variant) is skipped with
-/// a warning, never injected — see docs/DESIGN.md.
+/// a warning, never injected — see docs/DESIGN.md. That warning names the field
+/// and the value's size but never the value itself: a config file is where a
+/// user puts a secret to keep it off the command line, so a rejected `api_key`
+/// must not end up echoed into CI logs or scrollback (#736).
 ///
 /// Consumer note — cwd-controlled defaults: case 2 above means anyone who can
 /// get a victim to run the CLI inside a directory they control (a cloned repo,
@@ -48,6 +51,24 @@ const zcli = @import("zcli");
 pub const plugin_id = "zcli_config";
 
 pub const Format = enum { json, toml, yaml };
+
+/// A config path rendered through the shared diagnostic sanitizer: `{f}` on this
+/// drops control bytes, so a path can never smuggle a raw ANSI/OSC sequence into
+/// a warning line. Every path this plugin prints is user-controlled — `--config`
+/// is argv, and discovery walks a cwd an attacker may own (see the note above) —
+/// and `context.fail` takes a comptime format string, so a wrapper is what makes
+/// one rule reachable from every site.
+const SafePath = struct {
+    path: []const u8,
+
+    pub fn format(self: SafePath, writer: anytype) !void {
+        try zcli.writeSanitized(writer, self.path);
+    }
+};
+
+fn safe(path: []const u8) SafePath {
+    return .{ .path = path };
+}
 
 pub const ContextData = struct {
     custom_path: ?[]const u8 = null,
@@ -94,18 +115,18 @@ pub fn preExecute(context: anytype, args: zcli.ParsedArgs) !?zcli.ParsedArgs {
     var path_allocated = false;
     var is_project_local = false;
     const path = (findConfigFile(allocator, context.io, context.environ, context.app_name, data.custom_path, stderr, &path_allocated, &is_project_local) catch |err| switch (err) {
-        error.ConfigFileNotFound => return context.fail("Error: config file '{s}' not found", .{data.custom_path.?}),
+        error.ConfigFileNotFound => return context.fail("Error: config file '{f}' not found", .{safe(data.custom_path.?)}),
     }) orelse return args;
 
     const format = detectFormat(path) orelse {
         // Unrecognized extension — warn and skip
-        try stderr.print("Warning: Config file '{s}' has unrecognized extension. Use .json, .toml, .yaml, or .yml\n", .{path});
+        try stderr.print("Warning: Config file '{f}' has unrecognized extension. Use .json, .toml, .yaml, or .yml\n", .{safe(path)});
         if (path_allocated) allocator.free(path);
         return args;
     };
 
     const content = std.Io.Dir.cwd().readFileAlloc(context.io, path, allocator, .limited(1024 * 1024)) catch |err| {
-        try stderr.print("Warning: Could not read config file '{s}': {s}\n", .{ path, @errorName(err) });
+        try stderr.print("Warning: Could not read config file '{f}': {s}\n", .{ safe(path), @errorName(err) });
         if (path_allocated) allocator.free(path);
         return args;
     };
@@ -121,7 +142,7 @@ pub fn preExecute(context: anytype, args: zcli.ParsedArgs) !?zcli.ParsedArgs {
     // themselves and stays silent, as does an explicit --config (already visible
     // on the command line). One line, once per invocation — not per option.
     if (is_project_local) {
-        try stderr.print("note: applied config from ./{s}\n", .{path});
+        try stderr.print("note: applied config from ./{f}\n", .{safe(path)});
     }
 
     return args;
@@ -294,7 +315,10 @@ fn applyFromYamlScoped(comptime OptionsType: type, options: *OptionsType, conten
 }
 
 fn warnParse(ctx: ApplyCtx, err: anyerror) void {
-    ctx.stderr.print("Warning: Could not parse config file '{s}': {s}\n", .{ ctx.path, @errorName(err) }) catch {};
+    ctx.stderr.print(
+        "Warning: Could not parse config file '{f}': {s}\n",
+        .{ safe(ctx.path), @errorName(err) },
+    ) catch {};
 }
 
 // ---------------------------------------------------------------------------
@@ -427,7 +451,12 @@ fn applyField(comptime T: type, dest: *T, field_name: []const u8, fv: FieldVal, 
                 for (items, 0..) |s, idx| {
                     out[idx] = zcli.plugin_abi.config_coerce.parseOptionValue(Child, s) catch {
                         warnValue(ctx, field_name, s);
-                        return false; // Lenient: one bad element skips the whole option.
+                        // Lenient: one bad element skips the whole option — and
+                        // the buffer goes back, since nothing ever sees it
+                        // (#750). Under the arena this is a no-op; on a plain
+                        // allocator it is the difference between a leak and not.
+                        ctx.allocator.free(out);
+                        return false;
                     };
                 }
                 dest.* = out;
@@ -493,17 +522,23 @@ fn applyField(comptime T: type, dest: *T, field_name: []const u8, fv: FieldVal, 
     }
 }
 
+/// A rejected value is described, never echoed (#736). A config file is exactly
+/// where a user puts a secret to keep it *off* the command line, so a typo or a
+/// field's type changing under an `api_key` must not print the token into CI
+/// logs, scrollback, or a screen share — unlike argv, which is already visible
+/// in `ps` and shell history. The field name plus the value's size is enough to
+/// find the offending entry in a file the user can just open.
 fn warnValue(ctx: ApplyCtx, field_name: []const u8, value: []const u8) void {
     ctx.stderr.print(
-        "Warning: config '{s}' has an invalid value '{s}' for '{s}' — ignoring\n",
-        .{ ctx.path, value, field_name },
+        "Warning: config '{f}' has an invalid value ({d} bytes) for '{s}' — ignoring\n",
+        .{ safe(ctx.path), value.len, field_name },
     ) catch {};
 }
 
 fn warnShape(ctx: ApplyCtx, field_name: []const u8) void {
     ctx.stderr.print(
-        "Warning: config '{s}' has an unsupported value shape for '{s}' — ignoring\n",
-        .{ ctx.path, field_name },
+        "Warning: config '{f}' has an unsupported value shape for '{s}' — ignoring\n",
+        .{ safe(ctx.path), field_name },
     ) catch {};
 }
 
@@ -610,8 +645,8 @@ fn firstExisting(
     if (chosen) |c| {
         if (extra_count > 0) {
             stderr.print(
-                "Warning: multiple config files found; using '{s}' (found {d} more)\n",
-                .{ c, extra_count },
+                "Warning: multiple config files found; using '{f}' (found {d} more)\n",
+                .{ safe(c), extra_count },
             ) catch {};
         }
         allocated.* = true;
@@ -1067,7 +1102,9 @@ test "JSON: out-of-range int is skipped (no panic), warns" {
 
     applyJson(Opts, &opts, "{\"count\": 300}", ctx, &data, &cmd_path, &provided);
     try testing.expectEqual(@as(u8, 7), opts.count); // unchanged
-    try testing.expect(std.mem.indexOf(u8, aw.written(), "invalid value") != null);
+    // Specific enough to fail if the value itself came back into the message.
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "invalid value (3 bytes) for 'count'") != null);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "300") == null);
 }
 
 test "JSON: negative into unsigned is skipped (no panic)" {
@@ -1098,7 +1135,156 @@ test "JSON: unknown enum variant is skipped, warns" {
 
     applyJson(Opts, &opts, "{\"color\": \"purple\"}", ctx, &data, &cmd_path, &provided);
     try testing.expect(opts.color == .red);
-    try testing.expect(std.mem.indexOf(u8, aw.written(), "invalid value") != null);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "invalid value (6 bytes) for 'color'") != null);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "purple") == null);
+}
+
+// --- A rejected value is described, never echoed (#736) ---
+
+test "JSON: a rejected value is not echoed to stderr" {
+    // The classic leak: an `api_key` the app models as an enum (or any parsed
+    // type), holding a real token. The warning must say enough to find the entry
+    // and nothing more — the secret stays in the file the user put it in.
+    const Opts = struct { api_key: Color = .red };
+    const allocator = testing.allocator;
+    var data = ContextData{};
+    defer deinitContextData(&data, allocator);
+    var opts = Opts{};
+    const provided = [_]bool{false};
+    const cmd_path = [_][]const u8{};
+
+    var aw = std.Io.Writer.Allocating.init(allocator);
+    defer aw.deinit();
+    var ctx = testCtx(allocator);
+    ctx.stderr = &aw.writer;
+
+    const secret = "sk-live-51H9xQe3ZbTvKp";
+    applyJson(Opts, &opts, "{\"api_key\": \"" ++ secret ++ "\"}", ctx, &data, &cmd_path, &provided);
+
+    try testing.expect(opts.api_key == .red); // still skipped, as before
+    const written = aw.written();
+    try testing.expect(std.mem.indexOf(u8, written, secret) == null);
+    // Not even a prefix of it: a short secret would be mostly given away.
+    try testing.expect(std.mem.indexOf(u8, written, "sk-live") == null);
+    // What the user does get: the field, the size, and the file.
+    try testing.expect(std.mem.indexOf(u8, written, "api_key") != null);
+    try testing.expect(std.mem.indexOf(u8, written, "(22 bytes)") != null);
+    try testing.expect(std.mem.indexOf(u8, written, "test.cfg") != null);
+}
+
+test "TOML: a rejected value is not echoed to stderr" {
+    // Every format funnels through the same applyMap/applyField pair, but the
+    // adapters differ — so each one gets the same guarantee asserted directly.
+    const Opts = struct { api_key: Color = .red };
+    const allocator = testing.allocator;
+    var data = ContextData{};
+    defer deinitContextData(&data, allocator);
+    var opts = Opts{};
+    const provided = [_]bool{false};
+    const cmd_path = [_][]const u8{};
+
+    var aw = std.Io.Writer.Allocating.init(allocator);
+    defer aw.deinit();
+    var ctx = testCtx(allocator);
+    ctx.stderr = &aw.writer;
+
+    const secret = "sk-live-51H9xQe3ZbTvKp";
+    applyToml(Opts, &opts, "api_key = \"" ++ secret ++ "\"\n", ctx, &data, &cmd_path, &provided);
+
+    try testing.expect(opts.api_key == .red);
+    const written = aw.written();
+    try testing.expect(std.mem.indexOf(u8, written, secret) == null);
+    try testing.expect(std.mem.indexOf(u8, written, "sk-live") == null);
+    try testing.expect(std.mem.indexOf(u8, written, "invalid value (22 bytes) for 'api_key'") != null);
+}
+
+test "YAML: a rejected value is not echoed to stderr" {
+    const Opts = struct { api_key: Color = .red };
+    const allocator = testing.allocator;
+    var data = ContextData{};
+    defer deinitContextData(&data, allocator);
+    var opts = Opts{};
+    const provided = [_]bool{false};
+    const cmd_path = [_][]const u8{};
+
+    var aw = std.Io.Writer.Allocating.init(allocator);
+    defer aw.deinit();
+    var ctx = testCtx(allocator);
+    ctx.stderr = &aw.writer;
+
+    const secret = "sk-live-51H9xQe3ZbTvKp";
+    // Plain (unquoted) scalar, matching the YAML the other tests in this file use.
+    applyYaml(Opts, &opts, "api_key: " ++ secret ++ "\n", ctx, &data, &cmd_path, &provided);
+
+    try testing.expect(opts.api_key == .red);
+    const written = aw.written();
+    try testing.expect(std.mem.indexOf(u8, written, secret) == null);
+    try testing.expect(std.mem.indexOf(u8, written, "sk-live") == null);
+    try testing.expect(std.mem.indexOf(u8, written, "invalid value (22 bytes) for 'api_key'") != null);
+}
+
+test "a rejected element of a multi-value option is not echoed either" {
+    // The array branch of applyField has its own warnValue call site (one bad
+    // element skips the whole option), so a secret in a list is covered too.
+    const allocator = testing.allocator;
+    var ctx = testCtx(allocator);
+
+    var aw = std.Io.Writer.Allocating.init(allocator);
+    defer aw.deinit();
+    ctx.stderr = &aw.writer;
+
+    var dest: []const Color = &.{};
+    const items = [_][]const u8{ "red", "sk-live-51H9xQe3ZbTvKp" };
+    try testing.expect(!applyField([]const Color, &dest, "keys", FieldVal{ .list = &items }, ctx));
+
+    const written = aw.written();
+    try testing.expect(std.mem.indexOf(u8, written, "sk-live") == null);
+    try testing.expect(std.mem.indexOf(u8, written, "invalid value (22 bytes) for 'keys'") != null);
+}
+
+test "applyField frees the array buffer when an element fails to coerce (#750)" {
+    // `testing.allocator` is the point of this test: under the framework's
+    // arena the leak is invisible, so the lenient-skip path is driven with a
+    // plain allocator, which fails the test if the buffer escapes.
+    const allocator = testing.allocator;
+    const ctx = testCtx(allocator);
+
+    var dest: []const Color = &.{};
+    const items = [_][]const u8{ "red", "chartreuse" };
+    try testing.expect(!applyField([]const Color, &dest, "colors", FieldVal{ .list = &items }, ctx));
+    // Nothing applied, and nothing left allocated (the leak check runs at exit).
+    try testing.expectEqual(@as(usize, 0), dest.len);
+}
+
+test "JSON: control bytes in the config path are stripped from warnings" {
+    // `--config` is argv and discovery is cwd-driven, so the path is
+    // user-controlled text reaching a terminal — an ESC byte in it must not be
+    // able to run an OSC sequence out of a warning line.
+    const Opts = struct { count: u8 = 7 };
+    const allocator = testing.allocator;
+    // One ContextData per apply: each parse installs its own arena.
+    var data = ContextData{};
+    defer deinitContextData(&data, allocator);
+    var shape_data = ContextData{};
+    defer deinitContextData(&shape_data, allocator);
+    var opts = Opts{};
+    const provided = [_]bool{false};
+    const cmd_path = [_][]const u8{};
+
+    var aw = std.Io.Writer.Allocating.init(allocator);
+    defer aw.deinit();
+    var ctx = testCtx(allocator);
+    ctx.stderr = &aw.writer;
+    ctx.path = "co\x1b]0;pwned\x07nf.json";
+
+    // Both the invalid-value warning and the shape warning share the prefix.
+    applyJson(Opts, &opts, "{\"count\": 300}", ctx, &data, &cmd_path, &provided);
+    applyJson(Opts, &opts, "{\"count\": {\"a\": 1}}", ctx, &shape_data, &cmd_path, &provided);
+
+    const written = aw.written();
+    try testing.expect(std.mem.indexOfScalar(u8, written, 0x1b) == null);
+    try testing.expect(std.mem.indexOfScalar(u8, written, 0x07) == null);
+    try testing.expect(std.mem.indexOf(u8, written, "co]0;pwnednf.json") != null);
 }
 
 // --- Malformed config warns (but the run continues) ---

--- a/website/content/docs/http.smd
+++ b/website/content/docs/http.smd
@@ -1,6 +1,6 @@
 ---
 .title = "zcli — HTTP client",
-.description = "zcli.http.Client — an HTTP client with safe defaults baked in: enforced TLS verification, request timeouts, bounded response bodies, redirect limits, and credential stripping on cross-origin redirects.",
+.description = "zcli.http.Client — an HTTP client with safe defaults baked in: HTTPS-only requests, enforced TLS verification, request timeouts, bounded response bodies, redirect limits, and credential stripping on cross-origin redirects.",
 .date = @date("2026-07-12"),
 .author = "Ryan Hair",
 .layout = "guide.shtml",
@@ -11,6 +11,7 @@
 CLIs talk to APIs, and hand-rolled HTTP code tends to skip the unglamorous parts — timeouts, response limits, redirect hygiene. `zcli.http.Client` wraps `std.http` with **safe defaults you can't accidentally lose**:
 
 - **TLS verification is mandatory.** There is no knob to disable it.
+- **Every request is HTTPS.** A plain `http://` URL is refused before a connection is opened (`error.InsecureTransport`, or `error.InsecureCredentialTransport` when the request carried a credential header), and a redirect to one is refused too (`error.InsecureRedirect`). Loopback (`127.0.0.0/8`, `::1`, `localhost`) is the sole carve-out, so local dev servers still work.
 - **Requests time out** — 30 seconds by default, configurable per client or per request.
 - **Response bodies are bounded** — 10 MiB by default (`error.ResponseTooLarge` beyond it), so a misbehaving server can't balloon your process.
 - **Redirects are bounded** (3) and only followed for bodyless requests — and `Authorization`, `Cookie`, and `Proxy-Authorization` headers are **stripped on cross-origin redirects**, so a redirect can't exfiltrate a token.


### PR DESCRIPTION
Two security fixes plus one pre-existing leak the review surfaced.

## #736 — config values were echoed verbatim to stderr

```zig
"Warning: config '{s}' has an invalid value '{s}' for '{s}' — ignoring"
```

If an app declares `api_key` as an enum or custom-parse type and the user's config holds a real secret, a typo or a type change printed it into CI logs and scrollback. That is a **new** exposure, unlike argv values which are already in `ps` and shell history — the user deliberately put it in a file to keep it off the command line.

Now reports size, never content: `invalid value (22 bytes) for 'api_key'`. No prefix either — an 8-char prefix gives away most of a short secret.

Path sanitization was extended to **every** stderr site via a `SafePath` formatter (`{f}` renders through `writeSanitized`), following the repo's existing `pub fn format` idiom. Six sites: apply-pass value/shape warnings, parse failures, unrecognized extension, unreadable file, the project-local `note:`, the ambiguity warning, and the not-found `context.fail`. The formatter is what made the `fail` site reachable at all — it takes a comptime format string.

## #745 — HTTPS was enforced only on credentialed requests

`http.zig`'s module doc said "HTTPS-only at request time"; the code only checked when a credential header was present, so uncredentialed `http://` went out in cleartext — inconsistent with the redirect rule one hop later, which *was* unconditional.

The check is now unconditional at the top of the hop loop. A hop that would have carried a credential still returns the sharper `InsecureCredentialTransport`, so the "a token was about to go on the wire" signal isn't lost. Loopback carve-out untouched. Doc and code now agree, which was the point.

## #750 — pre-existing leak, found by the reviewer

`applyField`'s array branch allocated `out` then hit the lenient `return false` without freeing. Masked by the arena in framework use — same shape as #747. Now freed, with a test driving `applyField` **directly** under `std.testing.allocator`: going through `applyJson` would not catch it, because `applyFromJsonScoped` swaps in the parse arena, which is exactly why this hid.

## Review

Composer 2.5: **APPROVE_WITH_NITS**, confirming both fixes land at the right layer with no allocation regressions in new code. It found #750, and three test defects now fixed:

- **A vacuous test.** `http.zig:762` was named "credentialed request with https-to-http redirect" but only re-asserted `transportOk` on parsed URIs — no `Client`, no redirect. Replaced with a real loopback test that builds a `Client`, sends credentials, and asserts `InsecureRedirect` on a server-controlled target. (Shipping a no-op test in the same batch as #744 would have been self-undermining.)
- **#736 tests covered only JSON.** Added TOML and YAML cases plus the array-element path, and strengthened two pre-existing tests that asserted only on the substring `"invalid value"` — they would have passed against the old echoing format.
- **Sibling stderr sites** still printed paths raw; hence the `SafePath` formatter.

## Verification

**Verified:** `zig ast-check` and `zig fmt --check` clean on all touched files. The pre-review version of this branch passed a full `zig build test` including the 21-test loopback suite.

**Not verified:** everything added in the review pass — `syspolicyd` wedged this machine and newly-linked binaries hang in `_dyld_start`. Residual risk: type-level resolution of the new `SafePath.format` call sites, and the exact byte-count assertions (`(3 bytes)`, `(22 bytes)`) if a parser hands back a differently-quoted scalar — those fail loudly and are a one-line fix.

**Note this is breaking** for anyone hitting an internal `http://` endpoint. CHANGELOG updated.

Fixes #736
Fixes #745
Fixes #750
