### PR TITLE
Remove the incoherent option cap; route bare '--'; fix suggestion leak

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -518,9 +518,34 @@ pub fn execute(args: Args, options: Options, context: *Context) !void {
 
 **Special Handling:**
 
-- `--` stops option parsing (everything after is positional)
+- `--` stops option parsing (everything after is positional). It terminates the
+  option namespace it appears in: written before the command name it is consumed
+  by routing, so `myapp -- list` runs `list` and the `myapp -- "$@"` wrapper idiom
+  works; written after the command name it reaches that command's own parser, so
+  `myapp add -- --weird` stores `--weird` as a positional. An app with a root
+  `index.zig` shares the top-level namespace, so `myapp -- -x` hands the root
+  command `-x` as a positional.
 - Unknown options: compile-time error if possible, runtime error otherwise
 - Case sensitive (no automatic case conversion)
+
+**Parsing Limits:**
+
+There is exactly one, and it is a sanity bound rather than memory protection:
+
+- **Option name length — 256 bytes.** An option name (`--<name>`) longer than
+  this is rejected with a `ResourceLimitExceeded` diagnostic before any lookup
+  or "did you mean" scoring runs.
+
+Nothing else about a command line is capped — not how many options it carries,
+not how many times a flag repeats, not how many comma-separated values one flag
+holds. A `docker run --env` or `cc -I`/`-D` shaped CLI can repeat a flag as many
+times as the shell allows. What makes that safe is that parsing work and
+allocation are **linear** in the input, and values are borrowed slices rather
+than copies; the only superlinear step is the suggestion scoring
+(O(name × fields)), which is exactly what the name cap bounds. Note the
+reasoning deliberately does not rest on `ARG_MAX`: that bounds a real process's
+argv, but `parseOptions` is public API and a library caller can pass a slice
+built in memory, where no OS limit applies.
 
 **Value Types and Parsing:**
 

--- a/packages/core/src/diagnostic_errors.zig
+++ b/packages/core/src/diagnostic_errors.zig
@@ -43,6 +43,33 @@ pub const ZcliError = error{
     ResourceLimitExceeded,
 };
 
+/// Most near-miss option names an `OptionUnknown` diagnostic offers.
+pub const max_option_suggestions = 3;
+
+/// The "did you mean" list for an unknown option, stored inline.
+///
+/// The names are comptime literals with static lifetime — the same contract as
+/// `nearestEnumValue` — so a diagnostic never owns an allocation and nothing
+/// has to free it. This replaced a heap slice that had no owner: `parseOptions`
+/// allocated it and `cleanupOptions` walks only the Options struct, so every
+/// caller supplying its own (non-arena) allocator leaked it (#747).
+pub const OptionSuggestions = struct {
+    names: [max_option_suggestions][]const u8 = [_][]const u8{""} ** max_option_suggestions,
+    count: usize = 0,
+
+    pub fn fromNames(names: []const []const u8) OptionSuggestions {
+        var result: OptionSuggestions = .{};
+        result.count = @min(names.len, max_option_suggestions);
+        for (0..result.count) |i| result.names[i] = names[i];
+        return result;
+    }
+
+    /// The populated prefix. Borrows from `self`, which must outlive the slice.
+    pub fn slice(self: *const OptionSuggestions) []const []const u8 {
+        return self.names[0..self.count];
+    }
+};
+
 pub const ZcliDiagnostic = union(enum) {
     // Argument parsing errors
     ArgumentMissingRequired: struct {
@@ -86,7 +113,9 @@ pub const ZcliDiagnostic = union(enum) {
     OptionUnknown: struct {
         option_name: []const u8,
         is_short: bool,
-        suggestions: []const []const u8,
+        /// Near-miss long option names, closest first. Inline and unowned —
+        /// see `OptionSuggestions`.
+        suggestions: OptionSuggestions = .{},
     },
     OptionMissingValue: struct {
         option_name: []const u8,
@@ -360,13 +389,13 @@ pub fn formatDiagnostic(diagnostic: ZcliDiagnostic, allocator: std.mem.Allocator
         .OptionUnknown => |ctx| blk: {
             const base_msg = try std.fmt.allocPrint(allocator, "Unknown option '{s}{s}'", .{ if (ctx.is_short) "-" else "--", ctx.option_name });
 
-            if (ctx.suggestions.len > 0) {
+            if (ctx.suggestions.count > 0) {
                 var full_msg = std.ArrayList(u8).empty;
                 defer full_msg.deinit(allocator);
                 try full_msg.appendSlice(allocator, base_msg);
                 allocator.free(base_msg);
                 try full_msg.appendSlice(allocator, "\nDid you mean:\n");
-                for (ctx.suggestions) |suggestion| {
+                for (ctx.suggestions.slice()) |suggestion| {
                     const line = try std.fmt.allocPrint(allocator, "  --{s}\n", .{suggestion});
                     defer allocator.free(line);
                     try full_msg.appendSlice(allocator, line);
@@ -483,7 +512,7 @@ test "diagnostic formatting" {
     const opt_diag = ZcliDiagnostic{ .OptionUnknown = .{
         .option_name = "verbose",
         .is_short = false,
-        .suggestions = &.{ "verbosity", "version" },
+        .suggestions = OptionSuggestions.fromNames(&.{ "verbosity", "version" }),
     } };
 
     const opt_msg = try formatDiagnostic(opt_diag, allocator);

--- a/packages/core/src/options/parser.zig
+++ b/packages/core/src/options/parser.zig
@@ -11,9 +11,7 @@ const type_utils = @import("../type_utils.zig");
 const levenshtein = @import("../levenshtein.zig");
 const ZcliError = diagnostic_errors.ZcliError;
 const ZcliDiagnostic = diagnostic_errors.ZcliDiagnostic;
-const ResourceLimits = @import("../resource_limits.zig").ResourceLimits;
-const ResourceTracker = @import("../resource_limits.zig").ResourceTracker;
-const ResourceLimitError = @import("../resource_limits.zig").ResourceLimitError;
+const resource_limits = @import("../resource_limits.zig");
 
 /// Parse command-line options into a struct using default field names.
 ///
@@ -136,9 +134,6 @@ pub fn parseOptionsWithMeta(
     const struct_info = type_info.@"struct";
     var result: OptionsType = undefined;
 
-    // Initialize resource tracker with default limits
-    var resource_tracker = ResourceTracker.init(ResourceLimits.getDefault());
-
     // Track array accumulation for each field
     var array_lists: [struct_info.fields.len]?array_utils.ArrayListUnion = [_]?array_utils.ArrayListUnion{null} ** struct_info.fields.len;
     defer {
@@ -217,41 +212,31 @@ pub fn parseOptionsWithMeta(
             // Stop parsing options at "--"
             .terminator => break :parse,
             .positional => {},
-            .long, .shorts => {
-                // Check resource limits before processing option
-                resource_tracker.checkOptionCount() catch {
+            // How many options one command line may carry is deliberately
+            // NOT capped (#741): each occurrence costs linear work and borrows
+            // its value from `args` rather than copying, and `--env`/`-I`-style
+            // CLIs legitimately repeat a flag hundreds of times. The name-length
+            // check below is the one limit, and it guards the suggestion
+            // scoring — the only superlinear path here. See resource_limits.zig.
+            .long => |long| {
+                resource_limits.checkOptionNameLength(long.name) catch {
                     if (diag) |d| d.* = .{ .ResourceLimitExceeded = .{
-                        .limit_type = "total options",
-                        .limit_value = resource_tracker.limits.max_total_options,
-                        .actual_value = resource_tracker.option_count,
-                        .suggestion = null,
+                        .limit_type = "option name length",
+                        .limit_value = resource_limits.max_option_name_length,
+                        .actual_value = long.name.len,
+                        .suggestion = "Option names are capped at 256 bytes — this is almost certainly a value that lost its separating space or quotes, not a flag.",
                     } };
                     return ZcliError.ResourceLimitExceeded;
                 };
 
-                switch (token) {
-                    .long => |long| {
-                        resource_tracker.checkOptionNameLength(long.name) catch {
-                            if (diag) |d| d.* = .{ .ResourceLimitExceeded = .{
-                                .limit_type = "option name length",
-                                .limit_value = resource_tracker.limits.max_option_name_length,
-                                .actual_value = long.name.len,
-                                .suggestion = null,
-                            } };
-                            return ZcliError.ResourceLimitExceeded;
-                        };
-
-                        applyLongOption(OptionsType, meta, &result, &option_counts, long, &array_lists, allocator, &resource_tracker, diag) catch |err| {
-                            return convertLongOptionError(err);
-                        };
-                    },
-                    .shorts => |shorts| {
-                        applyShortBundle(OptionsType, meta, &result, &option_counts, shorts, &array_lists, allocator, &resource_tracker, diag) catch |err| {
-                            return convertShortOptionError(err);
-                        };
-                    },
-                    else => unreachable,
-                }
+                applyLongOption(OptionsType, meta, &result, &option_counts, long, &array_lists, allocator, diag) catch |err| {
+                    return convertLongOptionError(err);
+                };
+            },
+            .shorts => |shorts| {
+                applyShortBundle(OptionsType, meta, &result, &option_counts, shorts, &array_lists, allocator, diag) catch |err| {
+                    return convertShortOptionError(err);
+                };
             },
         }
     }
@@ -304,10 +289,6 @@ fn convertLongOptionError(err: anyerror) ZcliError {
         error.BooleanOptionWithValue => ZcliError.OptionBooleanWithValue,
         error.DuplicateOption => ZcliError.OptionDuplicate,
         error.OutOfMemory => ZcliError.SystemOutOfMemory,
-        // CSV array elements are counted against the option budget; overflow
-        // surfaces as the same resource-limit error as the per-token check, its
-        // diagnostic already set at the counting site.
-        error.TooManyOptions => ZcliError.ResourceLimitExceeded,
         // The helpers' error sets are hand-listed above; anything new must be
         // mapped (and given a diagnostic) rather than silently misclassified.
         else => ZcliError.OptionInvalidValue,
@@ -323,9 +304,6 @@ fn convertShortOptionError(err: anyerror) ZcliError {
         error.BooleanOptionWithValue => ZcliError.OptionBooleanWithValue,
         error.DuplicateOption => ZcliError.OptionDuplicate,
         error.OutOfMemory => ZcliError.SystemOutOfMemory,
-        // See convertLongOptionError: CSV element overflow maps to the
-        // resource-limit error with its diagnostic already set.
-        error.TooManyOptions => ZcliError.ResourceLimitExceeded,
         // See convertLongOptionError: map new helper errors explicitly.
         else => ZcliError.OptionInvalidValue,
     };
@@ -409,21 +387,24 @@ fn applyEnvValue(comptime T: type, target: *T, env_value: []const u8) bool {
 
 /// Nearest-match long option names for an unknown `--option`, for the
 /// OptionUnknown diagnostic's "did you mean" list. Uses the same edit-distance
-/// engine as the command not-found plugin. Returns up to `max` names within a
-/// small distance, closest first; an empty slice when nothing is close.
+/// engine as the command not-found plugin. Returns up to
+/// `diagnostic_errors.max_option_suggestions` names within a small distance,
+/// closest first; count 0 when nothing is close.
 ///
-/// Allocated on `allocator` (the run's arena) — the diagnostic is rendered
-/// before that arena is freed, so callers do not free the result.
+/// Deliberately allocation-free: the names are comptime literals with static
+/// lifetime, and the diagnostic stores them inline. An earlier version handed
+/// the diagnostic a heap slice that nothing owned — `cleanupOptions` walks only
+/// the Options struct — so every caller passing its own (non-arena) allocator
+/// leaked it (#747).
 fn suggestLongOptions(
     comptime OptionsType: type,
     comptime meta: anytype,
     unknown: []const u8,
-    allocator: std.mem.Allocator,
-) []const []const u8 {
-    const max = 3;
+) diagnostic_errors.OptionSuggestions {
+    const max = diagnostic_errors.max_option_suggestions;
     const max_distance = 3;
     const field_count = std.meta.fields(OptionsType).len;
-    if (field_count == 0) return &.{};
+    if (field_count == 0) return .{};
 
     const Scored = struct { name: []const u8, distance: usize };
     var scored: [field_count]Scored = undefined;
@@ -437,7 +418,7 @@ fn suggestLongOptions(
             count += 1;
         }
     }
-    if (count == 0) return &.{};
+    if (count == 0) return .{};
 
     std.sort.pdq(Scored, scored[0..count], {}, struct {
         fn lessThan(_: void, a: Scored, b: Scored) bool {
@@ -445,9 +426,9 @@ fn suggestLongOptions(
         }
     }.lessThan);
 
-    const limit = @min(count, max);
-    const result = allocator.alloc([]const u8, limit) catch return &.{};
-    for (0..limit) |i| result[i] = scored[i].name;
+    var result: diagnostic_errors.OptionSuggestions = .{};
+    result.count = @min(count, max);
+    for (0..result.count) |i| result.names[i] = scored[i].name;
     return result;
 }
 
@@ -492,34 +473,6 @@ fn markBooleanFlagOnce(
     try option_counts.put(field_name, 1);
 }
 
-/// Count each additional comma-separated element of an array-option value
-/// against the option budget. The option token itself was already counted once
-/// by `checkOptionCount` at the top of the parse loop, but `--tags a,b,c`
-/// expands to N accumulated elements — so the remaining N-1 must also be
-/// counted. Without this a single CSV flag could push an array option past
-/// `max_total_options` unbounded, violating the invariant documented in
-/// resource_limits.zig ("grow by one element per flag occurrence"). On overflow
-/// it records the ResourceLimitExceeded diagnostic and returns the error;
-/// callers map `TooManyOptions` to `ZcliError.ResourceLimitExceeded`.
-fn countCsvArrayElements(
-    resource_tracker: *ResourceTracker,
-    value: []const u8,
-    diag: ?*?ZcliDiagnostic,
-) ResourceLimitError!void {
-    const extra = std.mem.count(u8, value, ",");
-    for (0..extra) |_| {
-        resource_tracker.checkOptionCount() catch {
-            if (diag) |d| d.* = .{ .ResourceLimitExceeded = .{
-                .limit_type = "total options",
-                .limit_value = resource_tracker.limits.max_total_options,
-                .actual_value = resource_tracker.option_count,
-                .suggestion = null,
-            } };
-            return ResourceLimitError.TooManyOptions;
-        };
-    }
-}
-
 /// Apply a tokenized long option (`--option`, `--option=value`) to the result
 /// struct. Field matching uses the shared resolution rules (options/utils.zig)
 /// that the tokenizer's spec classifies with, so the tokenizer's value decision
@@ -532,7 +485,6 @@ fn applyLongOption(
     long: anytype,
     array_lists: anytype,
     allocator: std.mem.Allocator,
-    resource_tracker: *ResourceTracker,
     diag: ?*?ZcliDiagnostic,
 ) !void {
     const option_name = long.name;
@@ -580,8 +532,6 @@ fn applyLongOption(
                 // Handle array accumulation
                 const element_type = @typeInfo(field.type).pointer.child;
                 if (array_lists[i]) |*list_union| {
-                    // CSV elements each count against the option budget.
-                    try countCsvArrayElements(resource_tracker, value, diag);
                     try array_utils.appendCsvToArrayListUnion(element_type, allocator, list_union, value, option_name);
                 }
             } else {
@@ -619,7 +569,7 @@ fn applyLongOption(
         if (diag) |d| d.* = .{ .OptionUnknown = .{
             .option_name = option_name,
             .is_short = false,
-            .suggestions = suggestLongOptions(OptionsType, meta, option_name, allocator),
+            .suggestions = suggestLongOptions(OptionsType, meta, option_name),
         } };
         return error.UnknownOption;
     }
@@ -639,7 +589,6 @@ fn applyShortBundle(
     shorts: anytype,
     array_lists: anytype,
     allocator: std.mem.Allocator,
-    resource_tracker: *ResourceTracker,
     diag: ?*?ZcliDiagnostic,
 ) !void {
     const chars = shorts.chars;
@@ -649,7 +598,6 @@ fn applyShortBundle(
             if (diag) |d| d.* = .{ .OptionUnknown = .{
                 .option_name = chars[ci .. ci + 1],
                 .is_short = true,
-                .suggestions = &.{},
             } };
             return error.UnknownOption;
         },
@@ -697,8 +645,6 @@ fn applyShortBundle(
                                 // For array types, accumulate values
                                 if (array_lists.*[i]) |*list_union| {
                                     const element_type = @typeInfo(field.type).pointer.child;
-                                    // CSV elements each count against the option budget.
-                                    try countCsvArrayElements(resource_tracker, value, diag);
                                     try array_utils.appendCsvToArrayListUnionShort(element_type, allocator, list_union, value, char);
                                 }
                             } else {
@@ -1242,30 +1188,32 @@ test "parseOptions comma-separated rejects empty segments" {
     }
 }
 
-test "parseOptions CSV array elements count against the option budget" {
-    // #515: a single `--opt a,b,c,...` token expands to one accumulated element
-    // per segment, so every segment must count against max_total_options — one
-    // flag must not add unbounded elements.
+test "parseOptions does not cap how many values one option carries (#741)" {
+    // There is no `max_total_options` any more: a single `--opt a,b,c,…` token
+    // and a repeated flag are both bounded by argv, which the OS already caps.
+    // #515 used to charge every CSV segment against a 100-option budget, so one
+    // flag with 150 tags failed outright.
     const TestOptions = struct {
         nums: []i32 = &.{},
     };
 
     const allocator = std.testing.allocator;
 
-    // Build a single --nums token with 101 comma-separated elements. The default
-    // max_total_options is 100, so this one flag must trip the resource limit.
+    // 500 comma-separated elements on one flag.
     var buf = std.ArrayList(u8).empty;
     defer buf.deinit(allocator);
-    for (0..101) |k| {
+    for (0..500) |k| {
         if (k != 0) try buf.append(allocator, ',');
         try buf.append(allocator, '1');
     }
     {
         const args = [_][]const u8{ "--nums", buf.items };
-        try std.testing.expectError(ZcliError.ResourceLimitExceeded, parseOptions(TestOptions, allocator, &args, null));
+        const parsed = try parseOptions(TestOptions, allocator, &args, null);
+        defer cleanupOptions(TestOptions, parsed.options, allocator);
+        try std.testing.expectEqual(@as(usize, 500), parsed.options.nums.len);
     }
 
-    // The same overflow via the attached short form.
+    // The same via the attached short form.
     {
         const short = try std.fmt.allocPrint(allocator, "-n{s}", .{buf.items});
         defer allocator.free(short);
@@ -1274,15 +1222,22 @@ test "parseOptions CSV array elements count against the option budget" {
             nums: []i32 = &.{},
         };
         const meta = .{ .options = .{ .nums = .{ .short = 'n' } } };
-        try std.testing.expectError(ZcliError.ResourceLimitExceeded, parseOptionsWithMeta(NumOpts, meta, allocator, null, &args, null));
+        const parsed = try parseOptionsWithMeta(NumOpts, meta, allocator, null, &args, null);
+        defer cleanupOptions(NumOpts, parsed.options, allocator);
+        try std.testing.expectEqual(@as(usize, 500), parsed.options.nums.len);
     }
 
-    // A CSV comfortably under the limit still parses fine.
+    // And via repetition — the `docker run --env` / `cc -I` shape.
     {
-        const args = [_][]const u8{ "--nums", "1,2,3" };
-        const parsed = try parseOptions(TestOptions, allocator, &args, null);
+        var argv = std.ArrayList([]const u8).empty;
+        defer argv.deinit(allocator);
+        for (0..500) |_| {
+            try argv.append(allocator, "--nums");
+            try argv.append(allocator, "1");
+        }
+        const parsed = try parseOptions(TestOptions, allocator, argv.items, null);
         defer cleanupOptions(TestOptions, parsed.options, allocator);
-        try std.testing.expectEqual(@as(usize, 3), parsed.options.nums.len);
+        try std.testing.expectEqual(@as(usize, 500), parsed.options.nums.len);
     }
 }
 
@@ -1753,6 +1708,56 @@ test "diagnostics: option error sites fill precise context" {
         try std.testing.expectError(ZcliError.OptionBooleanWithValue, parseOptions(Options, allocator, &args, &diag));
         try std.testing.expectEqualStrings("verbose", diag.?.OptionBooleanWithValue.option_name);
         try std.testing.expectEqualStrings("yes", diag.?.OptionBooleanWithValue.provided_value);
+    }
+}
+
+test "diagnostics: unknown-option suggestions allocate nothing (#747)" {
+    // The suggestion path only runs with a non-null `diag`, which is why the
+    // leak it used to carry went unnoticed: every other test passed null.
+    // `std.testing.allocator` fails the test on any unfreed allocation, so this
+    // is the regression guard — the near-miss below MUST produce suggestions.
+    const allocator = std.testing.allocator;
+    const Options = struct {
+        count: u32 = 0,
+        mount: u32 = 0,
+        verbose: bool = false,
+    };
+
+    // A near miss of two fields: `count` (distance 1) and `mount` (2).
+    {
+        var diag: ?ZcliDiagnostic = null;
+        const args = [_][]const u8{"--cont"};
+        try std.testing.expectError(ZcliError.OptionUnknown, parseOptions(Options, allocator, &args, &diag));
+        try std.testing.expectEqualStrings("cont", diag.?.OptionUnknown.option_name);
+        const suggestions = diag.?.OptionUnknown.suggestions.slice();
+        try std.testing.expectEqual(@as(usize, 2), suggestions.len);
+        try std.testing.expectEqualStrings("count", suggestions[0]); // closest first
+        try std.testing.expectEqualStrings("mount", suggestions[1]);
+    }
+
+    // Nothing close: an empty list, still no allocation.
+    {
+        var diag: ?ZcliDiagnostic = null;
+        const args = [_][]const u8{"--zzzzzzzz"};
+        try std.testing.expectError(ZcliError.OptionUnknown, parseOptions(Options, allocator, &args, &diag));
+        try std.testing.expectEqual(@as(usize, 0), diag.?.OptionUnknown.suggestions.count);
+    }
+
+    // The list is capped, and the surviving names are the closest ones.
+    {
+        const Many = struct {
+            alpha: bool = false,
+            alpho: bool = false,
+            alphi: bool = false,
+            alphu: bool = false,
+        };
+        var diag: ?ZcliDiagnostic = null;
+        const args = [_][]const u8{"--alph"};
+        try std.testing.expectError(ZcliError.OptionUnknown, parseOptions(Many, allocator, &args, &diag));
+        try std.testing.expectEqual(
+            @as(usize, diagnostic_errors.max_option_suggestions),
+            diag.?.OptionUnknown.suggestions.count,
+        );
     }
 }
 

--- a/packages/core/src/plugin_pipeline_test.zig
+++ b/packages/core/src/plugin_pipeline_test.zig
@@ -1384,3 +1384,88 @@ test "group index with positionals: exact subcommand wins, unmatched word is a v
     try run(App, &.{ "users", "123" });
     try testing.expectEqualStrings("123", UsersIndex.last_id.?);
 }
+
+// ---------------------------------------------------------------------------
+// The `--` terminator at the routing position (#743)
+// ---------------------------------------------------------------------------
+
+/// A command with both a positional and an option, so a test can tell a
+/// terminated `-x` (positional) from an un-terminated one (unknown option).
+const Dashy = struct {
+    var last: ?[]const u8 = null;
+    pub const meta = .{ .description = "dashy" };
+    pub const Args = struct { word: ?[]const u8 = null };
+    pub const Options = struct { loud: bool = false };
+    pub fn execute(args: Args, _: Options, _: anytype) !void {
+        last = args.word;
+    }
+};
+
+test "routing: a leading bare `--` is not a command name (#743)" {
+    const App = zcli.Registry.init(test_config)
+        .register("list", Greet)
+        .registerPlugin(NotFound)
+        .build();
+
+    // `myapp -- list` routes to `list` instead of reporting
+    // "Unknown command '-- list'".
+    Greet.executed = false;
+    try run(App, &.{ "--", "list" });
+    try testing.expect(Greet.executed);
+
+    // `myapp --` behaves exactly like a bare invocation, not
+    // "Unknown command '--'".
+    const cap = try runCapture(App, &.{"--"});
+    defer cap.deinit(testing.allocator);
+    const bare = try runCapture(App, &.{});
+    defer bare.deinit(testing.allocator);
+    try testing.expect(!contains(cap.stderr, "Unknown command"));
+    try testing.expectEqualStrings(bare.stderr, cap.stderr);
+    try testing.expectEqualStrings(bare.stdout, cap.stdout);
+    try testing.expectEqual(bare.err, cap.err);
+
+    // Only the leading one is consumed: a second `--` is an ordinary (bogus)
+    // command name again.
+    const cap2 = try runCapture(App, &.{ "--", "--", "list" });
+    defer cap2.deinit(testing.allocator);
+    try testing.expect(contains(cap2.stderr, "Unknown command"));
+}
+
+test "routing: `--` after the command name still terminates its options (#501)" {
+    const App = zcli.Registry.init(test_config)
+        .register("dashy", Dashy)
+        .build();
+
+    // The command's own parser still sees its terminator, so `-x` lands as a
+    // positional rather than as an unknown short option.
+    Dashy.last = null;
+    try run(App, &.{ "dashy", "--", "-x" });
+    try testing.expectEqualStrings("-x", Dashy.last.?);
+
+    // And the same after a leading routing `--`: that one is consumed, the
+    // command's own one is not.
+    Dashy.last = null;
+    try run(App, &.{ "--", "dashy", "--", "-x" });
+    try testing.expectEqualStrings("-x", Dashy.last.?);
+}
+
+test "routing: a root index still receives the `--` its own parser needs (#743)" {
+    const App = zcli.Registry.init(test_config)
+        .register("", RootWithPositional)
+        .register("greet", Greet)
+        .build();
+
+    // No command matched, so the whole argv — terminator included — belongs to
+    // the root command, whose option namespace is the top-level one.
+    RootWithPositional.reset();
+    try run(App, &.{ "--", "-weird-name" });
+    try testing.expect(RootWithPositional.ran);
+    try testing.expectEqualStrings("-weird-name", RootWithPositional.last_word.?);
+
+    // A named command still wins over the root's positional after a `--`.
+    RootWithPositional.reset();
+    Greet.executed = false;
+    try run(App, &.{ "--", "greet" });
+    try testing.expect(Greet.executed);
+    try testing.expect(!RootWithPositional.ran);
+}

--- a/packages/core/src/registry/compiled.zig
+++ b/packages/core/src/registry/compiled.zig
@@ -769,6 +769,12 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
             // lookahead the command parsers share. This layer only filters:
             // tokens that resolve to globals are consumed and dispatched,
             // everything else passes through verbatim.
+            //
+            // No resource limit is applied here, and none is missing (#741):
+            // option occurrences are no longer capped anywhere, and the option
+            // name-length cap is a guard for the O(name x fields) suggestion
+            // scoring that only the command parser runs — this layer does exact
+            // memcmp against a fixed global list and then hands the token on.
             var tok = tokenizer.Tokenizer(GlobalSpec){ .args = args };
             while (tok.next()) |token| {
                 switch (token) {
@@ -1245,6 +1251,24 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
         fn executeCommand(_: *Self, context: *Context, args: []const []const u8) !void {
             @setEvalBranchQuota(10000);
 
+            // A leading bare `--` is the conventional "nothing after this is an
+            // option" terminator, not a command name (#743). `parseGlobalOptions`
+            // deliberately forwards it (#501) so a command's own parser still
+            // sees its own terminator, but nothing consumed it at the routing
+            // layer, so `myapp -- list` reported "Unknown command '-- list'" and
+            // the `myapp -- "$@"` wrapper idiom failed unconditionally.
+            //
+            // Only the *leading* one is a routing artifact: once a command name
+            // has been matched, everything after it is passed through untouched,
+            // so `myapp cmd -- -x` still terminates `cmd`'s options. A second
+            // `--` (`myapp -- -- x`) is likewise left alone.
+            //
+            // The root-index fallback below is deliberately handed the untrimmed
+            // argv: the root command shares the top-level option namespace, so
+            // `myapp -- -x` must reach its parser with the terminator intact for
+            // `-x` to land as a positional.
+            const route_args = if (args.len > 0 and std.mem.eql(u8, args[0], "--")) args[1..] else args;
+
             // The root group's index (a top-level index.zig) registers at the
             // empty path (ADR-0029). It is deliberately NOT matched by the
             // longest-path loop below — an empty path matches any argv, which
@@ -1261,7 +1285,7 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
             // help plugin answers a bare --help here), then route through
             // CommandNotFound. With a root index, bare invocation falls
             // through to it below.
-            if (!root_index_exists and args.len == 0) {
+            if (!root_index_exists and route_args.len == 0) {
                 const parsed_args = try runPostParseHooks(context, zcli.ParsedArgs.init(context.allocator));
                 _ = (try runPreExecuteHooks(context, parsed_args)) orelse return; // plugin cancelled execution
                 if (try runOnErrorHooks(context, error.CommandNotFound)) return;
@@ -1272,16 +1296,16 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
             // Regular commands, longest path first so the longest match wins.
             const sorted_commands = comptime sortedByPathLengthDesc(cmd_entries);
             inline for (sorted_commands) |cmd| {
-                if (cmd.path.len > 0 and cmd.path.len <= args.len) {
+                if (cmd.path.len > 0 and cmd.path.len <= route_args.len) {
                     var parts_match = true;
                     for (cmd.path, 0..) |part, i| {
-                        if (!std.mem.eql(u8, part, args[i])) {
+                        if (!std.mem.eql(u8, part, route_args[i])) {
                             parts_match = false;
                             break;
                         }
                     }
                     if (parts_match) {
-                        return executeResolvedCommand(cmd.module, .regular, context, cmd.path, args[cmd.path.len..]);
+                        return executeResolvedCommand(cmd.module, .regular, context, cmd.path, route_args[cmd.path.len..]);
                     }
                 }
             }
@@ -1290,10 +1314,10 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
             var best_match_idx: ?usize = null;
             var best_match_len: usize = 0;
             inline for (plugin_command_entries, 0..) |plugin_cmd, idx| {
-                if (args.len >= plugin_cmd.path.len and plugin_cmd.path.len > best_match_len) {
+                if (route_args.len >= plugin_cmd.path.len and plugin_cmd.path.len > best_match_len) {
                     var matches = true;
                     for (plugin_cmd.path, 0..) |path_part, i| {
-                        if (!std.mem.eql(u8, path_part, args[i])) {
+                        if (!std.mem.eql(u8, path_part, route_args[i])) {
                             matches = false;
                             break;
                         }
@@ -1307,7 +1331,7 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
             if (best_match_idx) |match_idx| {
                 inline for (plugin_command_entries, 0..) |plugin_cmd, idx| {
                     if (idx == match_idx) {
-                        return executeResolvedCommand(plugin_cmd.module, .plugin, context, plugin_cmd.path, args[plugin_cmd.path.len..]);
+                        return executeResolvedCommand(plugin_cmd.module, .plugin, context, plugin_cmd.path, route_args[plugin_cmd.path.len..]);
                     }
                 }
             }
@@ -1332,7 +1356,7 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
             // A plugin that fully handles the error suppresses it (returns true);
             // otherwise the error propagates so the entry point exits non-zero.
             // No bare fallback line here: it would double-report over that block.
-            try setCommandPath(context, args);
+            try setCommandPath(context, route_args);
             if (try runOnErrorHooks(context, error.CommandNotFound)) return;
             return error.CommandNotFound;
         }

--- a/packages/core/src/resource_limits.zig
+++ b/packages/core/src/resource_limits.zig
@@ -1,86 +1,58 @@
-//! Policy caps applied to untrusted argv during option parsing.
+//! Policy cap applied to untrusted input during option parsing.
 //!
-//! These are sanity bounds, not memory protection — parsing work and
-//! allocation are linear in argv, which the OS already caps (ARG_MAX). The
-//! two limits below are the ones the options parser actually enforces;
-//! everything else is bounded transitively:
+//! There is exactly one, and it is a sanity bound rather than memory
+//! protection. The property that makes that safe is **linearity**: parsing
+//! work and allocation are linear in the input, and argument values are
+//! borrowed slices into it rather than copies. The one place that is not
+//! linear is the "did you mean" suggestion list, whose edit-distance scoring
+//! is O(name x fields) — so the option name is capped, and with it the only
+//! superlinear path. No real CLI has a flag anywhere near 256 bytes.
 //!
-//! - Accumulated array options grow by one element per flag occurrence, so
-//!   they can never exceed `max_total_options` elements.
-//! - Positional-argument count is bounded by argv itself (positionals are
-//!   borrowed slices; no per-argument allocation).
-//! - Command nesting depth is fixed at compile time by the registry; runtime
-//!   input cannot deepen it.
+//! Note the reasoning deliberately does **not** rest on ARG_MAX. That bounds a
+//! real process's argv, but `options/parser.zig` is public API and a library
+//! caller can hand it an arbitrarily long slice built in memory, where no OS
+//! limit applies at all — the same class of caller parser.zig already reasons
+//! about explicitly where it handles partial array conversion for
+//! caller-supplied allocators. Linear work is what holds for both.
 //!
-//! Earlier versions of this module advertised caps for those cases too, but
-//! never enforced them — a documented-vs-actual gap flagged in the security
-//! audit. What is declared here is what runs.
+//! A `max_total_options = 100` cap used to live here too. It was removed in
+//! #741 because it defended against nothing (option occurrences cost linear
+//! work, exactly like positionals) while breaking legitimate command lines: a
+//! `docker run --env`-style or compiler-style (`-I`, `-D`) invocation died at
+//! the 101st occurrence with no way for the app author to raise it. Worse,
+//! comma-separated array values were charged per element, so a *single*
+//! `--tags a,b,c,…` flag could trip it. It was never applied symmetrically
+//! either — the global-option layer (registry/compiled.zig) never counted, so
+//! globals repeated freely while command options capped.
+//!
+//! What is declared here is what runs.
 
 const std = @import("std");
 
-/// Limits enforced by the options parser on each parse.
-pub const ResourceLimits = struct {
-    /// Maximum length of an option name in argv (`--<name>`), rejecting
-    /// absurd flags before any lookup work.
-    max_option_name_length: usize = 256,
-
-    /// Maximum total number of option occurrences on one command line.
-    max_total_options: usize = 100,
-
-    pub fn getDefault() @This() {
-        return .{};
-    }
-};
+/// Maximum length of an option name (`--<name>`), rejecting absurd flags
+/// before the superlinear suggestion scoring runs over them. Documented in
+/// docs/DESIGN.md ("Option Parsing Behavior") and on the website's args &
+/// options guide.
+pub const max_option_name_length: usize = 256;
 
 /// Error types for resource limit violations
 pub const ResourceLimitError = error{
     OptionNameTooLong,
-    TooManyOptions,
 };
 
-/// Tracks resource usage across one parse.
-pub const ResourceTracker = struct {
-    limits: ResourceLimits,
-    option_count: usize = 0,
-
-    pub fn init(limits: ResourceLimits) @This() {
-        return .{ .limits = limits };
+/// Reject an option name that exceeds `max_option_name_length`.
+pub fn checkOptionNameLength(name: []const u8) ResourceLimitError!void {
+    if (name.len > max_option_name_length) {
+        return ResourceLimitError.OptionNameTooLong;
     }
-
-    pub fn checkOptionCount(self: *@This()) ResourceLimitError!void {
-        self.option_count += 1;
-        if (self.option_count > self.limits.max_total_options) {
-            return ResourceLimitError.TooManyOptions;
-        }
-    }
-
-    pub fn checkOptionNameLength(self: @This(), name: []const u8) ResourceLimitError!void {
-        if (name.len > self.limits.max_option_name_length) {
-            return ResourceLimitError.OptionNameTooLong;
-        }
-    }
-};
-
-test "ResourceLimits default values" {
-    const limits = ResourceLimits.getDefault();
-    try std.testing.expectEqual(@as(usize, 256), limits.max_option_name_length);
-    try std.testing.expectEqual(@as(usize, 100), limits.max_total_options);
 }
 
-test "ResourceTracker option counting" {
-    var tracker = ResourceTracker.init(ResourceLimits{ .max_total_options = 2 });
+test "option name length checking" {
+    try checkOptionNameLength("short"); // OK
+    try checkOptionNameLength("a" ** max_option_name_length); // OK (exactly at limit)
 
-    try tracker.checkOptionCount(); // 1st option - OK
-    try tracker.checkOptionCount(); // 2nd option - OK
-
-    try std.testing.expectError(ResourceLimitError.TooManyOptions, tracker.checkOptionCount()); // 3rd option - should fail
-}
-
-test "ResourceTracker option name length checking" {
-    const tracker = ResourceTracker.init(ResourceLimits{ .max_option_name_length = 10 });
-
-    try tracker.checkOptionNameLength("short"); // OK
-    try tracker.checkOptionNameLength("exactly10c"); // OK (exactly at limit)
-
-    try std.testing.expectError(ResourceLimitError.OptionNameTooLong, tracker.checkOptionNameLength("this-is-too-long")); // Should fail
+    try std.testing.expectError(
+        ResourceLimitError.OptionNameTooLong,
+        checkOptionNameLength("a" ** (max_option_name_length + 1)),
+    );
 }

--- a/packages/core/src/security_test.zig
+++ b/packages/core/src/security_test.zig
@@ -4,6 +4,7 @@ const zcli = @import("zcli.zig");
 const args_parser = @import("args.zig");
 const options_parser = @import("options.zig");
 const levenshtein = @import("levenshtein.zig");
+const resource_limits = @import("resource_limits.zig");
 
 // ============================================================================
 // Security Test Framework - Corrected Version
@@ -229,48 +230,82 @@ test "security: malicious input handling - format strings" {
 // Resource Exhaustion Tests
 // ============================================================================
 
-test "security: resource limits - option count cap is enforced at the boundary" {
+test "security: option occurrences cost linear work, so they carry no policy cap (#741)" {
     const allocator = testing.allocator;
 
-    // Exactly at the default cap (100 option occurrences): parses fine, and
-    // the accumulated array holds exactly what was passed.
-    var at_cap: std.ArrayList([]const u8) = .empty;
-    defer at_cap.deinit(allocator);
+    // There is deliberately no `max_total_options`. Repeating a flag far past
+    // the old 100-occurrence cap parses fine and accumulates every value: each
+    // occurrence costs linear work and borrows its value from the input rather
+    // than copying it, and `docker run --env` / `cc -I` shaped CLIs need this.
+    // (The bound is linearity, not ARG_MAX — this test is itself a library
+    // caller handing the parser a slice it built in memory, where no OS limit
+    // applies.) See resource_limits.zig.
+    var argv: std.ArrayList([]const u8) = .empty;
+    defer argv.deinit(allocator);
     var names: std.ArrayList([]u8) = .empty;
     defer {
         for (names.items) |n| allocator.free(n);
         names.deinit(allocator);
     }
-    for (0..100) |i| {
+    for (0..1000) |i| {
         const name = try std.fmt.allocPrint(allocator, "file{d}.txt", .{i});
         try names.append(allocator, name);
-        try at_cap.append(allocator, "--files");
-        try at_cap.append(allocator, name);
+        try argv.append(allocator, "--files");
+        try argv.append(allocator, name);
     }
 
-    const parsed = try options_parser.parseOptions(TestOptions, allocator, at_cap.items, null);
+    const parsed = try options_parser.parseOptions(TestOptions, allocator, argv.items, null);
     defer options_parser.cleanupOptions(TestOptions, parsed.options, allocator);
-    try testing.expectEqual(@as(usize, 100), parsed.options.files.len);
-
-    // One past the cap: hard failure, not a truncated success.
-    try at_cap.append(allocator, "--enabled");
-    try testing.expectError(
-        zcli.ZcliError.ResourceLimitExceeded,
-        options_parser.parseOptions(TestOptions, allocator, at_cap.items, null),
-    );
+    try testing.expectEqual(@as(usize, 1000), parsed.options.files.len);
 }
 
-test "security: resource limits - absurd option names are rejected" {
+// Names built at container scope so the `**` repeats are unambiguously comptime.
+const name_at_cap = "--" ++ ("a" ** resource_limits.max_option_name_length);
+const name_one_over_cap = "--" ++ ("a" ** (resource_limits.max_option_name_length + 1));
+const name_far_over_cap = "--" ++ ("a" ** 300);
+
+test "security: the option-name cap is a boundary, not a blanket rejection" {
     const allocator = testing.allocator;
 
-    // An option name longer than the 256-byte cap fails fast instead of
-    // being fed through lookup and suggestion machinery.
-    const long_name = "--" ++ ("a" ** 300);
-    const args = [_][]const u8{long_name};
-    try testing.expectError(
-        zcli.ZcliError.ResourceLimitExceeded,
-        options_parser.parseOptions(TestOptions, allocator, &args, null),
-    );
+    // Well past the cap: fails fast instead of being fed through lookup and
+    // the O(name x fields) suggestion scoring that the cap exists to bound.
+    {
+        const args = [_][]const u8{name_far_over_cap};
+        try testing.expectError(
+            zcli.ZcliError.ResourceLimitExceeded,
+            options_parser.parseOptions(TestOptions, allocator, &args, null),
+        );
+    }
+
+    // One byte over: the first name that trips it.
+    {
+        const args = [_][]const u8{name_one_over_cap};
+        try testing.expectError(
+            zcli.ZcliError.ResourceLimitExceeded,
+            options_parser.parseOptions(TestOptions, allocator, &args, null),
+        );
+    }
+
+    // Exactly at the cap: NOT a resource-limit failure. No field is named this,
+    // so it lands as an ordinary unknown option. This is what pins the cap as a
+    // boundary rather than just "something got rejected".
+    {
+        const args = [_][]const u8{name_at_cap};
+        try testing.expectError(
+            zcli.ZcliError.OptionUnknown,
+            options_parser.parseOptions(TestOptions, allocator, &args, null),
+        );
+    }
+
+    // And ordinary option names still parse: the cap rejects only the offending
+    // token, it does not make the parser hostile to normal input.
+    {
+        const args = [_][]const u8{ "--count", "7", "--enabled" };
+        const parsed = try options_parser.parseOptions(TestOptions, allocator, &args, null);
+        defer options_parser.cleanupOptions(TestOptions, parsed.options, allocator);
+        try testing.expectEqual(@as(u32, 7), parsed.options.count);
+        try testing.expect(parsed.options.enabled);
+    }
 }
 
 test "security: resource exhaustion - processing bounded regardless of input" {

--- a/website/content/docs/args-options.smd
+++ b/website/content/docs/args-options.smd
@@ -34,6 +34,8 @@ pub const Options = struct {
 
 Parsing is GNU-style: options and positionals interleave freely, `--option value` and `--option=value` both work, and `--` ends option parsing so everything after it is positional.
 
+`--` ends the option namespace it appears in. Before the command name it is consumed by routing — `myapp -- deploy` runs `deploy`, so the `myapp -- "$@"` wrapper idiom is safe for user data that starts with a dash. After the command name it reaches that command's own parser: `myapp add -- --weird` stores `--weird` as a positional. (A single-command app shares the top-level namespace, so `myapp -- -x` hands its root command `-x` as a positional.)
+
 ## Positional args
 
 `Args` fields bind positionals in declaration order:
@@ -74,6 +76,8 @@ myapp deploy --tag a,b --tag c   # [a, b, c]
 ```
 
 Element types beyond strings parse too: `[]u32`, `[]f64`, and friends. Greedy space-separated lists (`--tag a b c`) are deliberately not supported — they're ambiguous with interleaved positionals. Empty segments (`--tag a,,b`) are rejected. Help marks these options `(repeatable)`.
+
+Nothing caps how many values accumulate or how often a flag repeats — a `docker run --env` or `cc -I` shaped CLI can repeat a flag as many times as the shell allows. Parsing cost is linear in the input and values are borrowed, not copied, so there is nothing to protect against. (The one parsing limit is on the *name*: an option name longer than 256 bytes is rejected before lookup, which bounds the only superlinear step — the "did you mean" scoring.)
 
 ### Enums: only valid values, helpful failures
 


### PR DESCRIPTION
Three parser/routing defects.

## #741 — the option cap is removed, not made configurable

`max_total_options = 100` was hardcoded at the only construction site with no config path, and broke real command lines three ways at once:

- a `docker run --env` / `cc -I` style CLI died at occurrence 101, with no author-side escape;
- CSV elements were charged per element, so **one** `--tags a,b,c,…` flag could trip it alone;
- `parseGlobalOptions` never counted at all, so globals repeated freely while command options capped — the limit wasn't even coherent with itself.

`resource_limits.zig`'s own docstring already conceded these were "sanity bounds, not memory protection." Making it configurable would have kept all the machinery (`ResourceLimits`, `ResourceTracker`, `countCsvArrayElements`, `TooManyOptions`, the CSV-counting invariant) to defend a boundary that isn't real — **and** would still have needed the asymmetry fixed. Removing it makes both layers consistent by construction.

The 256-byte **option-name** cap stays: that is the one place a single oversized token buys superlinear work (O(name × fields) suggestion scoring). It is now documented in `docs/DESIGN.md` and the website, and its diagnostic carries an actionable suggestion instead of `.suggestion = null`.

**The rationale was corrected during review.** The comment originally leaned partly on ARG_MAX bounding argv. That is true for a real process but *not* for the library callers this file already reasons about explicitly — `parseOptions` is public API and a caller can hand it an arbitrarily long in-memory slice. The reasoning now rests on **linearity** (work and allocation are linear; values are borrowed slices, not copies) with ARG_MAX explicitly disclaimed at all three sites that mention it.

## #743 — bare `--` was routed as a command name

`notes -- list` → `Unknown command '-- list'`, exit 3. The `myapp -- "$@"` wrapper idiom failed unconditionally.

`executeCommand` now consumes a **leading** `--` into `route_args`. Only the leading one, and `parseGlobalOptions` still forwards it, so #501 behavior is preserved. The root-index fallback is deliberately handed the **untrimmed** argv, since a root command shares the top-level option namespace.

```
notes -- list            → No notes yet.                      [0]
notes --                 → app help                           [0]
notes add -- --weird b   → Saved note '--weird'               [0]   (#501 preserved)
notes -- -- list         → Unknown command '-- list'          [3]   (only leading consumed)
myapp -- -weird-name     → Hello, -weird-name!                [0]   (root index)
```

## #747 — suggestion-path leak

`suggestLongOptions` no longer allocates at all. Option names are comptime literals with static lifetime, so the diagnostic stores them inline in a new `OptionSuggestions` — matching the contract `nearestEnumValue` already documents. Test under `std.testing.allocator` with a non-null `diag` on a near-miss, which is the path every existing test missed by passing `null`.

**Breaking:** `OptionUnknown`'s shape changed (`.suggestions.slice()` / `.count` instead of indexing a slice). Anyone pattern-matching that diagnostic in a plugin or `onError` hook is affected. Recorded in the commit body for the CHANGELOG at release time.

## Review

Composer 2.5: **APPROVE_WITH_NITS**, explicitly endorsing the #741 call — "removing the option cap is the right product call given the old cap's bugs and non-configurability; work stays linear with the 256-byte name cap guarding the only former superlinear path." It called the `--` routing split carefully done and the #747 fix clean and test-backed. Its nits (ARG_MAX rationale, boundary-test strength, breaking-change visibility) are all addressed — the name-cap test now pins the boundary at exactly 256 (`OptionUnknown`) vs 257 (`ResourceLimitExceeded`), rather than just "something got rejected."

## Verification

**Verified:** `zig build test` exit 0 on the three fixes, and #743 confirmed behaviorally against built binaries (transcript above). `zig ast-check` and `zig fmt --check` clean on all six touched files.

**Not verified:** the review-pass additions — `syspolicyd` wedged this machine and newly-linked binaries hang in `_dyld_start`. Risk is concentrated in the new `security_test.zig` boundary assertions. **CI is the gate.**

Fixes #741
Fixes #743
Fixes #747
