### PR TITLE
Fix 8x Levenshtein memcpy, a real OOM leak, and five vacuous tests

### DIFF
--- a/packages/core/src/command_parser.zig
+++ b/packages/core/src/command_parser.zig
@@ -109,7 +109,14 @@ pub fn parseCommandLine(
     // Parse positional arguments
     // Note: We need to keep positional_args.items alive for the lifetime of the result
     // because parseArgs may create references to the input slice (for varargs)
-    const positional_slice = positional_args.toOwnedSlice(allocator) catch return ZcliError.SystemOutOfMemory;
+    const positional_slice = positional_args.toOwnedSlice(allocator) catch {
+        // Same contract as the parseArgs failure below: options were already
+        // parsed, so their accumulated arrays must be freed before bailing out
+        // — under a plain (non-arena) allocator they would otherwise leak on
+        // the out-of-memory path (#744).
+        options_parser.cleanupOptions(OptionsType, options, allocator);
+        return ZcliError.SystemOutOfMemory;
+    };
     const parsed_args = args_parser.parseArgs(ArgsType, positional_slice, diag) catch |err| {
         // parseArgs failed AFTER options were parsed: free the accumulated
         // option arrays as well as the slice we allocated — under a plain

--- a/packages/core/src/levenshtein.zig
+++ b/packages/core/src/levenshtein.zig
@@ -59,8 +59,12 @@ pub fn editDistance(a: []const u8, b: []const u8) usize {
     const shorter = if (a_len <= b_len) a_buf[0..a_len] else b_buf[0..b_len];
     const longer = if (a_len <= b_len) b_buf[0..b_len] else a_buf[0..a_len];
 
-    var prev_row: [max_practical_len + 1]usize = undefined; // +1 for initialization
-    var curr_row: [max_practical_len + 1]usize = undefined;
+    // Two DP rows held in one backing array so the per-row swap below is a
+    // pointer swap. Swapping the arrays by value would memcpy 2 KB per row
+    // regardless of how short the real strings are (#742).
+    var rows: [2][max_practical_len + 1]usize = undefined; // +1 for initialization
+    var prev_row: *[max_practical_len + 1]usize = &rows[0];
+    var curr_row: *[max_practical_len + 1]usize = &rows[1];
 
     // Initialize first row
     for (0..shorter_len + 1) |j| {
@@ -80,10 +84,8 @@ pub fn editDistance(a: []const u8, b: []const u8) usize {
             );
         }
 
-        // Swap rows
-        const temp = prev_row;
-        prev_row = curr_row;
-        curr_row = temp;
+        // Swap rows (by pointer — see the `rows` declaration above)
+        std.mem.swap(*[max_practical_len + 1]usize, &prev_row, &curr_row);
     }
 
     return prev_row[shorter_len];

--- a/packages/core/src/property_test.zig
+++ b/packages/core/src/property_test.zig
@@ -3,6 +3,7 @@ const testing = std.testing;
 const zcli = @import("zcli.zig");
 const args_parser = @import("args.zig");
 const options_parser = @import("options.zig");
+const command_parser = @import("command_parser.zig");
 
 // ============================================================================
 // Randomized property tests for zcli parser security
@@ -37,7 +38,6 @@ pub const PropertyTesting = struct {
     pub fn checkArgumentParsing(random: std.Random, iterations: usize, allocator: std.mem.Allocator) !void {
         var successful_parses: usize = 0;
         var failed_parses: usize = 0;
-        const crashes: usize = 0;
 
         for (0..iterations) |_| {
             // Generate random number of arguments (1-10)
@@ -76,15 +76,27 @@ pub const PropertyTesting = struct {
         }
 
         // Report statistics
-        std.log.info("Argument property results: {} successful, {} failed, {} crashes out of {} iterations", .{
+        std.log.info("Argument property results: {} successful, {} failed out of {} iterations", .{
             successful_parses,
             failed_parses,
-            crashes,
             iterations,
         });
 
-        // Should have very few or no crashes
-        try testing.expect(crashes < iterations / 100); // Less than 1% crash rate
+        // There is deliberately no "crash rate" gate here. A crash cannot be
+        // tallied from inside the process — a panic or UB takes the whole test
+        // binary down — so reaching this line at all IS the crash check, and
+        // testing.allocator turns any leak into a failure. (This used to read
+        // `try expect(crashes < iterations / 100)` over a `const crashes = 0`,
+        // i.e. `0 < N` — always true. #744.)
+        //
+        // What is worth asserting is that the generator still reaches both
+        // outcomes. If it degenerated into all-reject (or all-accept) every
+        // iteration above would go on exercising one path while looking like
+        // full coverage. PropertyTestArgs takes at most 4 positionals and this
+        // loop generates 1-10 of them, so a healthy run produces both parses
+        // and ArgumentTooMany rejections.
+        try testing.expect(successful_parses > 0);
+        try testing.expect(failed_parses > 0);
     }
 
     /// Exercise option parsing with seeded random inputs
@@ -170,8 +182,16 @@ pub const PropertyTesting = struct {
             iterations,
         });
 
-        // Should handle memory exhaustion gracefully
-        try testing.expect(memory_errors < iterations); // All memory errors should be handled
+        // `memory_errors < iterations` was vacuous — under testing.allocator
+        // nothing ever runs out of memory, so it read `0 < N` (#744). Assert
+        // the invariant that actually holds: with memory available, no input
+        // may be reported as SystemOutOfMemory. That error is only ever
+        // produced by mapping a real allocator failure (see the
+        // convertLongOptionError/convertShortOptionError tables), so a nonzero
+        // count means an unrelated failure was misclassified as exhaustion.
+        // Genuine exhaustion behaviour is covered by the
+        // checkAllAllocationFailures tests at the bottom of this file.
+        try testing.expectEqual(@as(usize, 0), memory_errors);
     }
 
     /// Exercise the parsers with malicious patterns specifically
@@ -188,8 +208,8 @@ pub const PropertyTesting = struct {
             "../{}", // Relative path
         };
 
-        var dangerous_parses: usize = 0;
-        var safe_rejections: usize = 0;
+        var parsed_verbatim: usize = 0;
+        var rejections: usize = 0;
 
         for (0..iterations) |_| {
             // Pick a random malicious template
@@ -212,64 +232,78 @@ pub const PropertyTesting = struct {
             const args = [_][]const u8{malicious_input};
 
             if (args_parser.parseArgs(PropertyTestArgs, &args, null)) |parsed| {
-                // If it parsed, verify it's treated as literal string
+                // The property: a hostile payload is data. It must come back
+                // byte-for-byte — neither interpreted (no substitution, no
+                // escape processing) nor silently truncated at the first NUL.
                 try testing.expectEqualStrings(malicious_input, parsed.name);
-
-                // Check that it doesn't contain obvious signs of code execution
-                if (std.mem.indexOf(u8, parsed.name, "$(") != null or
-                    std.mem.indexOf(u8, parsed.name, "`") != null)
-                {
-                    dangerous_parses += 1;
-                }
-            } else |err| {
-                switch (err) {
-                    zcli.ZcliError.ArgumentInvalidValue => {
-                        safe_rejections += 1; // Good - rejected malicious input
-                    },
-                    else => {
-                        // Other errors are also acceptable for malicious input
-                        safe_rejections += 1;
-                    },
-                }
+                parsed_verbatim += 1;
+            } else |_| {
+                rejections += 1;
             }
         }
 
-        std.log.info("Malicious pattern results: {} dangerous parses, {} safe rejections", .{
-            dangerous_parses,
-            safe_rejections,
+        std.log.info("Malicious pattern results: {} parsed verbatim, {} rejected", .{
+            parsed_verbatim,
+            rejections,
         });
 
-        // Most malicious patterns should be treated as literal strings (not executed)
-        // This is actually OK - we want the parser to accept them as literal strings
-        // The danger would be if they were interpreted/executed later
+        // Every one of these is a single positional bound to a []const u8
+        // field, so the parser has nothing to reject: the pass-through above
+        // must hold for all of them. (This block previously counted
+        // "dangerous parses" — payloads containing `$(` or a backtick — and
+        // asserted nothing about the count, which was doubly misleading: a
+        // literal `$(` in a string is the *expected* result, not a danger.
+        // #744.)
+        try testing.expectEqual(iterations, parsed_verbatim);
+        try testing.expectEqual(@as(usize, 0), rejections);
     }
 
-    /// Stress the parser with many small and a few large random inputs. This is a
-    /// stability check — `testing.allocator` catches leaks and any crash/UB fails
-    /// the test. It deliberately does not assert wall-clock budgets: those only
-    /// measure the CI runner's load, not the parser, and were flaky in CI.
-    pub fn checkPerformanceStress(random: std.Random, allocator: std.mem.Allocator) !void {
+    /// Stress the parser with many small and a few large random inputs. This is
+    /// a stability check, NOT a performance measurement — `testing.allocator`
+    /// catches leaks and any crash/UB fails the test. It deliberately does not
+    /// assert wall-clock budgets: those only measure the CI runner's load, not
+    /// the parser, and were flaky in CI. (Named for what it does since #744;
+    /// it was `checkPerformanceStress`, which promised timing it never took.)
+    pub fn checkStabilityUnderLoad(random: std.Random, allocator: std.mem.Allocator) !void {
         // Many small parses.
         const small_iterations = 10000;
         for (0..small_iterations) |_| {
             const arg = try generateRandomString(random, allocator, 10);
             defer allocator.free(arg);
 
-            const args = [_][]const u8{arg};
-            _ = args_parser.parseArgs(PropertyTestArgs, &args, null) catch {};
+            try expectSinglePositionalRoundTrips(arg);
         }
 
-        // A few large parses.
+        // A few large parses. Length is not supposed to change the outcome —
+        // a 1000-byte positional round-trips exactly like a 10-byte one.
         const large_iterations = 10;
         for (0..large_iterations) |_| {
             const arg = try generateRandomString(random, allocator, 1000);
             defer allocator.free(arg);
 
-            const args = [_][]const u8{arg};
-            _ = args_parser.parseArgs(PropertyTestArgs, &args, null) catch {};
+            try expectSinglePositionalRoundTrips(arg);
         }
     }
 };
+
+/// The invariant every single-positional parse must satisfy, whatever the
+/// bytes are: `PropertyTestArgs` binds one positional to `name` and leaves the
+/// fields behind it at their declared defaults, and `[]const u8` values are
+/// returned as-is (args.zig parseValue), so the parse must succeed and hand
+/// back a *view* of the caller's buffer — same pointer, same length, same
+/// bytes. Copying, truncating at an interior NUL, or reinterpreting the
+/// payload all fail here.
+fn expectSinglePositionalRoundTrips(arg: []const u8) !void {
+    const args = [_][]const u8{arg};
+    const parsed = try args_parser.parseArgs(PropertyTestArgs, &args, null);
+
+    try testing.expectEqual(arg.ptr, parsed.name.ptr);
+    try testing.expectEqual(arg.len, parsed.name.len);
+    try testing.expectEqualStrings(arg, parsed.name);
+    try testing.expectEqual(@as(?u32, null), parsed.count);
+    try testing.expectEqual(@as(?[]const u8, null), parsed.file);
+    try testing.expectEqual(false, parsed.enabled);
+}
 
 /// Generate a random string of specified length
 fn generateRandomString(random: std.Random, allocator: std.mem.Allocator, len: usize) ![]u8 {
@@ -308,12 +342,12 @@ test "property: malicious pattern handling" {
     try PropertyTesting.checkMaliciousPatterns(random, 200, allocator);
 }
 
-test "property: performance stress testing" {
+test "property: parser stability under load" {
     var prng = std.Random.DefaultPrng.init(99999);
     const random = prng.random();
     const allocator = testing.allocator;
 
-    try PropertyTesting.checkPerformanceStress(random, allocator);
+    try PropertyTesting.checkStabilityUnderLoad(random, allocator);
 }
 
 // ============================================================================
@@ -348,10 +382,12 @@ test "property: unicode and encoding edge cases" {
         }
 
         const valid_string = unicode_string[0..utf8_len];
-        const args = [_][]const u8{valid_string};
 
-        // Should handle Unicode without crashing
-        _ = args_parser.parseArgs(PropertyTestArgs, &args, null) catch {};
+        // Multi-byte codepoints must survive the parse intact: the parser is
+        // byte-transparent, so nothing here may be split, re-encoded, or
+        // rejected. (This loop used to be `_ = parseArgs(...) catch {}` — a
+        // crash detector wearing the name of an encoding test. #744.)
+        try expectSinglePositionalRoundTrips(valid_string);
     }
 }
 
@@ -386,24 +422,63 @@ test "property: memory boundary conditions" {
     }
 }
 
-test "property: concurrent parsing stress" {
-    // Test that parsing is thread-safe by running concurrent randomized parses
-    const allocator = testing.allocator;
+/// One worker of the concurrent stress test below: parses its own seeded
+/// random inputs on its own thread and records the first failure, if any.
+const ParseWorker = struct {
+    allocator: std.mem.Allocator,
+    seed: u64,
+    iterations: usize,
+    result: anyerror!void = {},
 
-    // Run multiple parsing operations "concurrently" (simulated)
-    // In real concurrent testing, these would be on separate threads
-    for (0..10) |thread_id| {
-        var thread_prng = std.Random.DefaultPrng.init(@intCast(thread_id + 1000));
-        const thread_random = thread_prng.random();
+    fn run(self: *ParseWorker) void {
+        self.result = self.parseLoop();
+    }
 
-        for (0..50) |_| {
-            const test_string = try generateRandomString(thread_random, allocator, 20);
-            defer allocator.free(test_string);
+    fn parseLoop(self: *ParseWorker) !void {
+        var prng = std.Random.DefaultPrng.init(self.seed);
+        const random = prng.random();
 
-            const args = [_][]const u8{test_string};
-            _ = args_parser.parseArgs(PropertyTestArgs, &args, null) catch {};
+        for (0..self.iterations) |_| {
+            const test_string = try generateRandomString(random, self.allocator, 20);
+            defer self.allocator.free(test_string);
+
+            // The pointer identity in this invariant is what makes the test
+            // concurrent rather than merely parallel: the parse must be a view
+            // of THIS thread's buffer, never a copy and never another thread's
+            // string.
+            try expectSinglePositionalRoundTrips(test_string);
         }
     }
+};
+
+test "property: concurrent parsing stress" {
+    // parseArgs takes no allocator and holds no state — it slices the argv it
+    // is handed — so parsing must be safe from several threads at once. Run it
+    // on real threads and assert each thread's results (this test used to run
+    // 10 sequential batches with zero assertions — #744).
+    //
+    // Sharing testing.allocator across the workers is deliberate and safe: it
+    // is a std.heap.DebugAllocator whose `thread_safe` config defaults to
+    // `!builtin.single_threaded`, so it takes its mutex here — and sharing it
+    // keeps its leak accounting whole across every thread.
+    const allocator = testing.allocator;
+
+    var workers: [10]ParseWorker = undefined;
+    for (&workers, 0..) |*worker, i| {
+        worker.* = .{ .allocator = allocator, .seed = @intCast(i + 1000), .iterations = 50 };
+    }
+
+    var threads: [workers.len]std.Thread = undefined;
+    var spawned: usize = 0;
+    for (&threads, &workers) |*thread, *worker| {
+        thread.* = std.Thread.spawn(.{}, ParseWorker.run, .{worker}) catch break;
+        spawned += 1;
+    }
+    for (threads[0..spawned]) |thread| thread.join();
+
+    // A platform with no threads at all would make this test meaningless.
+    try testing.expect(spawned > 0);
+    for (workers[0..spawned]) |worker| try worker.result;
 }
 
 // ============================================================================
@@ -439,4 +514,120 @@ test "property: regression tests for past vulnerabilities" {
         // Verify input was handled as literal string
         try testing.expectEqualStrings(input, result.name);
     }
+}
+
+// ============================================================================
+// Allocation-failure tests (#744)
+//
+// `std.testing.checkAllAllocationFailures` replays a parse once per allocation
+// site with that one allocation forced to fail, and reports either a swallowed
+// OOM (the parser returned success even though an allocation failed) or a leak
+// (bytes allocated before the failure were never released). zcli maps allocator
+// failure onto `ZcliError.SystemOutOfMemory`, so each wrapper below translates
+// it back to `error.OutOfMemory`, which is the contract the helper asserts on.
+// ============================================================================
+
+/// `checkAllAllocationFailures` is a no-op when the workload never allocates —
+/// it iterates over the allocations the first run made. Prove there is at least
+/// one before leaning on it: with the very first allocation forced to fail, the
+/// workload must report out of memory.
+fn expectWorkloadAllocates(comptime workload: anytype, args: []const []const u8) !void {
+    var failing = testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 0 });
+    try testing.expectError(error.OutOfMemory, workload(failing.allocator(), args));
+}
+
+const OomOptions = struct {
+    output: []const u8 = "stdout",
+    files: []const []const u8 = &.{},
+    tags: []const []const u8 = &.{},
+    counts: []const u32 = &.{},
+    verbose: bool = false,
+};
+
+const OomArgs = struct {
+    command: []const u8,
+    rest: []const []const u8,
+};
+
+/// Every allocation the options parser makes must be released on the failure
+/// path, and a failed allocation must surface as SystemOutOfMemory.
+fn parseOptionsUnderOom(allocator: std.mem.Allocator, args: []const []const u8) !void {
+    const result = options_parser.parseOptions(OomOptions, allocator, args, null) catch |err| switch (err) {
+        zcli.ZcliError.SystemOutOfMemory => return error.OutOfMemory,
+        else => return err,
+    };
+    defer options_parser.cleanupOptions(OomOptions, result.options, allocator);
+
+    try testing.expectEqualStrings("out.txt", result.options.output);
+    try testing.expectEqual(@as(usize, 2), result.options.files.len);
+    try testing.expectEqual(@as(usize, 3), result.options.counts.len);
+    try testing.expect(result.options.verbose);
+}
+
+test "property: option parsing under allocation failure" {
+    const args = [_][]const u8{
+        "--output",  "out.txt",
+        "--files",   "a.txt",
+        "--files",   "b.txt",
+        "--tags",    "alpha",
+        "--counts",  "1",
+        "--counts",  "2",
+        "--counts",  "3",
+        "--verbose",
+    };
+    try expectWorkloadAllocates(parseOptionsUnderOom, &args);
+    try testing.checkAllAllocationFailures(testing.allocator, parseOptionsUnderOom, .{&args});
+}
+
+/// The combined split-then-parse path: it allocates the option/positional
+/// piles, the owned positional slice, and the option arrays.
+fn parseCommandLineUnderOom(allocator: std.mem.Allocator, args: []const []const u8) !void {
+    const result = command_parser.parseCommandLine(OomArgs, OomOptions, .{}, allocator, null, args, null) catch |err| switch (err) {
+        zcli.ZcliError.SystemOutOfMemory => return error.OutOfMemory,
+        else => return err,
+    };
+    defer result.deinit();
+
+    try testing.expectEqualStrings("build", result.args.command);
+    try testing.expectEqual(@as(usize, 2), result.args.rest.len);
+    try testing.expectEqual(@as(usize, 2), result.options.files.len);
+}
+
+test "property: command-line parsing under allocation failure" {
+    const args = [_][]const u8{
+        "build",    "--files", "a.txt",  "--files",
+        "b.txt",    "target",  "--tags", "alpha",
+        "--counts", "7",       "extra",
+    };
+    try expectWorkloadAllocates(parseCommandLineUnderOom, &args);
+    try testing.checkAllAllocationFailures(testing.allocator, parseCommandLineUnderOom, .{&args});
+}
+
+/// The arena-per-command shape from ADR-0001: the command's allocations all go
+/// into a per-invocation arena that is released wholesale, so a mid-parse
+/// allocation failure must still leave the backing allocator balanced once the
+/// arena is torn down — and must not be swallowed on the way out.
+fn parseInArenaUnderOom(backing: std.mem.Allocator, args: []const []const u8) !void {
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+
+    const result = command_parser.parseCommandLine(OomArgs, OomOptions, .{}, arena.allocator(), null, args, null) catch |err| switch (err) {
+        zcli.ZcliError.SystemOutOfMemory => return error.OutOfMemory,
+        else => return err,
+    };
+    // No deinit(): the arena owns everything the parse allocated. That is the
+    // property under test — the teardown above must reclaim it regardless.
+
+    try testing.expectEqualStrings("build", result.args.command);
+    try testing.expectEqual(@as(usize, 2), result.options.files.len);
+}
+
+test "property: arena-per-command path under allocation failure" {
+    const args = [_][]const u8{
+        "build",    "--files", "a.txt",  "--files",
+        "b.txt",    "target",  "--tags", "alpha",
+        "--counts", "7",       "extra",
+    };
+    try expectWorkloadAllocates(parseInArenaUnderOom, &args);
+    try testing.checkAllAllocationFailures(testing.allocator, parseInArenaUnderOom, .{&args});
 }


### PR DESCRIPTION
## #742 — Levenshtein copied 2 KB per DP row

`prev_row`/`curr_row` were `[257]usize` **value** arrays swapped by value, so each row cost three 2 KB memcpys regardless of the actual string length. A 3-char typo against `"version"` copied 42 KB to do 21 cells of work.

Now pointers into a single `[2][257]usize`, swapped with `std.mem.swap`.

**Measured** (same binary, both variants compiled side by side, ReleaseFast, identical result checksums):

| Workload | before | after | speedup |
|---|---|---|---|
| `"lst"` vs 7 commands × 200k | 786.8 ms | 96.2 ms | **8.2x** |
| 4000-char argv vs 7 commands × 2k | 353.3 ms | 48.6 ms | **7.3x** |

The 256-codepoint DoS cap is untouched and `security_test.zig`'s truncation lock-in still passes; the pointer swap also works at comptime.

## #744 — a real leak, and a suite that overstated itself

**The leak.** `checkAllAllocationFailures` coverage found `command_parser.zig:112` leaking option arrays on the OOM path: options were already parsed when `toOwnedSlice` failed, and unlike the `parseArgs` failure path on the very next line, this one didn't call `cleanupOptions`. 52 bytes at `fail_index 9/10`. Under the framework arena it was masked; `parseCommandLine` is public and documented for direct use with a plain allocator, where it leaked.

OOM coverage now spans three paths: `parseOptions` (array options), `parseCommandLine`, and the ADR-0001 arena shape. A small `expectWorkloadAllocates` guard prevents the helper passing vacuously if a workload ever stops allocating — that failure mode is precisely what this issue is about.

**The vacuous assertions.** `const crashes: usize = 0` was never incremented, so the "<1% crash rate" gate was `0 < N`. My first replacement — `expectEqual(iterations, successful + failed)` — was flagged in review as *also* a tautology, correctly: the `if/else` guarantees exactly one counter increments per iteration. It is now removed, with the comment explaining that a crash cannot be tallied in-process (a panic takes the binary down) so reaching the line **is** the check. Replaced with something the loop does not give for free: `successful_parses > 0` **and** `failed_parses > 0`, which catches a generator degenerating to one branch while still looking like full coverage.

Four more in the same file:
- `:178` `expect(memory_errors < iterations)` — vacuous when 0, the normal case. Now `expectEqual(0, memory_errors)`, a real invariant: `SystemOutOfMemory` is only produced by mapping an actual allocator failure, so nonzero means a misclassification.
- `checkMaliciousPatterns` counted payloads containing `$(` — the expected result, not a danger — and asserted nothing. Now asserts the real security property: every hostile payload parses **byte-for-byte verbatim**.
- `checkPerformanceStress` → `checkStabilityUnderLoad` (it measured no time by design; its own comment said so), with its 10,010 parses now checked rather than `catch {}`-discarded.
- unicode test: `_ = parseArgs(...) catch {}` → asserts multi-byte codepoints survive intact.

Every test in the file now carries a real assertion.

## Review

Composer 2.5: **APPROVE_WITH_NITS**. #742 confirmed correct, complete, comptime-safe, DoS cap intact; the leak fix and `parseCommandLineUnderOom` called strong. Its central finding — that the replacement assertion was still always-true — is what produced the rework above. It also verified the shared `testing.allocator` across threads is safe (`DebugAllocator` with `thread_safe` defaulting to `!single_threaded`), which also keeps leak accounting whole.

## Verification

**Verified on the pre-review commit** (content-identical apart from the `property_test.zig` rework): `zig build test` exit **0**, zero failures across all packages, examples and projects — so the Levenshtein fix, the `command_parser` leak fix, and the three OOM tests are confirmed by a real run.

**Not verified:** the review-pass rework. `syspolicyd` wedged this machine; newly-linked binaries hang in `_dyld_start`. `zig fmt --check` and `zig ast-check` clean. Residual risk, descending: the `>0` assertions (reasoned from `args.zig:238` plus the fixed seed, not observed), `expectEqual(0, memory_errors)`, and the verbatim round-trip.

**CI is the gate.**

Fixes #742
Fixes #744
