### PR TITLE
Harden the installers: PATH detection, release selection, minisign resolution, TLS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,12 +330,21 @@ jobs:
   # misses. Case matrix and rationale: scripts/test-install-signature.sh.
   #
   # Both harnesses run on Linux and macOS, where minisign is one package away.
-  # Windows deliberately runs only the PowerShell one, for the registry
-  # value-kind contract that install.ps1's %VAR%-preserving PATH handling rests
-  # on and that cannot be observed on any other OS; its signature section skips
-  # there because the identical PowerShell code is already exercised on two
-  # other legs. So no leg silently runs nothing, each sets a ZCLI_REQUIRE_*
-  # flag that turns its own missing prerequisite into a hard failure.
+  # Windows deliberately runs only the PowerShell one, and only the parts that
+  # need no minisign: the registry value-kind contract that install.ps1's
+  # %VAR%-preserving PATH handling rests on and that cannot be observed on any
+  # other OS, plus the release-selection and TLS-floor sections, which are pure.
+  # So no leg silently runs nothing, each sets a ZCLI_REQUIRE_* flag that turns
+  # its own missing prerequisite into a hard failure.
+  #
+  # WHAT THE WINDOWS TICK DOES NOT MEAN. Everything gated on minisign is skipped
+  # there, including the whole signature/version-binding matrix and the
+  # hostile-`minisign`-function case that covers Test-Signature's tool
+  # resolution (#772). That is the identical PowerShell exercised on the Linux
+  # and macOS legs, so it IS covered — but by those two legs, not this one. A
+  # green Windows run says nothing about it. Closing that gap means packaging
+  # minisign for the Windows runner image; until then, do not read this leg as
+  # coverage it does not provide.
   installers:
     name: installer signature binding (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -386,9 +395,10 @@ jobs:
           ZCLI_REQUIRE_MINISIGN: "1"
         run: pwsh -NoProfile -File scripts/test-install-signature.ps1
 
-      # Windows runs the same harness for its registry half only: minisign is
-      # not packaged on the runner image, and the signature section it would
-      # gate is the identical PowerShell exercised on the two legs above.
+      # Windows runs the same harness minus its signature section: minisign is
+      # not packaged on the runner image, and the section it would gate is the
+      # identical PowerShell exercised on the two legs above. Everything else —
+      # registry contract, release selection, TLS floor — still runs here.
       - name: install.ps1 registry + PATH contract
         if: runner.os == 'Windows'
         env:

--- a/install.ps1
+++ b/install.ps1
@@ -11,18 +11,45 @@
 #   - the signature must name the release tag being installed, as a whole
 #     token, so a genuinely-signed OLDER release cannot be replayed under a
 #     newer tag (downgrade/replay — CWE-294)
-#   - latest-version resolution via the GitHub Releases API (install.sh has
-#     no pinned-version mode to mirror; both always install latest)
+#   - latest-version resolution from the GitHub release LIST, taking the newest
+#     `zcli-v*` tag, so the library tag that publishes ahead of the still-draft
+#     CLI tag cannot derail an install (install.sh has no pinned-version mode to
+#     mirror; both always install latest)
 
 $ErrorActionPreference = 'Stop'
 
 # Require TLS 1.2 or newer for every request this script makes.
-[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+#
+# ASSIGN the protocol set; do not -bor into whatever was already there. OR-ing
+# only *permits* TLS 1.2, leaving SSL 3.0 / TLS 1.0 / TLS 1.1 enabled and still
+# negotiable — which is not what "require" means, and left the comment on this
+# line describing something the code did not do.
+#
+# The set is computed from the enum rather than written as `Tls12 -bor Tls13`
+# because `Tls13` does not exist on older .NET Framework, where naming it would
+# throw. Everything at or above Tls12 is allowed in, so a future protocol the
+# runtime knows about is picked up without another edit.
+#
+# Windows PowerShell 5.1 is where this matters: it defaults to SSL3|TLS1.0.
+# PowerShell 6+ (.NET Core) ignores the property in favour of the OS defaults,
+# so setting it there is harmless and inert.
+$tls12 = [int][Net.SecurityProtocolType]::Tls12
+$modernProtocols = 0
+foreach ($protocol in [Enum]::GetValues([Net.SecurityProtocolType])) {
+    if ([int]$protocol -ge $tls12) { $modernProtocols = $modernProtocols -bor [int]$protocol }
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]$modernProtocols
 
 # Configuration
 $Repo = 'ryanhair/zcli'
 $InstallDir = Join-Path $env:LOCALAPPDATA 'Programs\zcli'
 $BinaryName = 'zcli.exe'
+
+# How many releases Get-LatestVersion asks the API for in one page. Named
+# because it appears three times: in the request, in the "did we see every
+# release?" test, and in the message that test produces. Kept in step with
+# install.sh's RELEASES_PAGE_SIZE.
+$ReleasesPageSize = 100
 
 # zcli's pinned minisign public key. Kept in sync with install.sh's
 # MINISIGN_PUBKEY. The installer verifies checksums.txt against its detached
@@ -77,7 +104,19 @@ function Test-Signature {
         return $true
     }
 
-    if (-not (Get-Command minisign -ErrorAction SilentlyContinue)) {
+    # -CommandType Application: only a real executable counts. A bare
+    # `Get-Command minisign` also resolves aliases, functions and cmdlets, and
+    # `& minisign` would then prefer the alias or function over the binary —
+    # so a hostile PowerShell profile could define `function minisign {}`,
+    # satisfy this presence check, and have the "verification" below run its
+    # own no-op. A function sets no exit code, so $LASTEXITCODE would still
+    # hold whatever an earlier command left there (a 0, most likely) and an
+    # unverified release would pass.
+    #
+    # Keep the resolved path and invoke THAT, not the bare name: resolving and
+    # invoking by name separately would just reopen the same hole.
+    $minisign = @(Get-Command minisign -CommandType Application -ErrorAction SilentlyContinue)[0]
+    if (-not $minisign) {
         Write-ErrorMsg 'minisign is required to verify this release but was not found.'
         Write-ErrorMsg 'Install it and re-run:'
         Write-ErrorMsg '  winget:        winget install minisign'
@@ -96,8 +135,15 @@ function Test-Signature {
         return $false
     }
 
-    & minisign -Vm $ChecksumsPath -x $sigPath -P $MinisignPubkey *> $null
-    if ($LASTEXITCODE -ne 0) {
+    # Decide on THIS invocation's exit code. $LASTEXITCODE is ambient and
+    # sticky — nothing clears it, and it is only written by external processes
+    # — so clear it to a sentinel first and capture it immediately after. If
+    # the call somehow does not run a process, the sentinel ($null, which is
+    # -ne 0) fails closed instead of a stale 0 passing verification.
+    $global:LASTEXITCODE = $null
+    & $minisign.Source -Vm $ChecksumsPath -x $sigPath -P $MinisignPubkey *> $null
+    $verifyExit = $LASTEXITCODE
+    if ($verifyExit -ne 0) {
         Write-ErrorMsg 'Signature verification FAILED for checksums.txt'
         Write-ErrorMsg 'The release may have been tampered with. Aborting.'
         return $false
@@ -164,25 +210,85 @@ function Test-Signature {
     return $true
 }
 
-# Get latest release version from GitHub
+# Resolve the newest installable CLI release. Mirrors install.sh's
+# get_latest_version, including why it reads the release LIST rather than
+# /releases/latest: this repo publishes library tags (`v0.22.0`, immediately)
+# and CLI tags (`zcli-v0.22.0`, draft until their checksums are signed offline)
+# from one workflow, so between those two moments — every release — `latest`
+# is the library tag and an installer trusting it fails on an unparseable tag.
+#
+# The list is newest-first and hides drafts from anonymous callers, so the first
+# `zcli-v*` entry is the newest CLI release a user can actually install. Same
+# rule as selectVersion in
+# packages/core/src/plugins/zcli_github_upgrade/plugin.zig.
 function Get-LatestVersion {
     $headers = @{ 'User-Agent' = 'zcli-installer' }
     try {
-        $release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" -Headers $headers
+        # Assign, do NOT `@(...)`. Invoke-RestMethod emits a JSON array as ONE
+        # pipeline object, so `@(Invoke-RestMethod …)` yields a one-element array
+        # whose single element is the whole release list — and `$releases[0].tag_name`
+        # then member-enumerates into every tag at once. Plain assignment binds
+        # the array itself, which `foreach` iterates correctly.
+        $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases?per_page=$ReleasesPageSize" -Headers $headers
     } catch {
-        Write-ErrorMsg "Failed to get latest version: $($_.Exception.Message)"
+        Write-ErrorMsg "Could not fetch the release list for $Repo from the GitHub API: $($_.Exception.Message)"
+        Write-ErrorMsg "Check your network connection (or GitHub's status) and try again."
+        exit 1
+    }
+
+    # StartsWith(..., Ordinal) rather than -like/-eq: PowerShell's string
+    # comparisons are case-INSENSITIVE by default, and the tag family is
+    # literally `zcli-v`.
+    #
+    # $scanned is counted here rather than via `@($releases).Count` afterwards:
+    # `@(…)` on some collection types throws "Argument types do not match", and
+    # `foreach` already visits exactly what needs counting. It is only read on
+    # the no-tag path below, where the loop necessarily ran to completion, so
+    # the early `break` cannot leave it short.
+    $tag = $null
+    $scanned = 0
+    foreach ($release in $releases) {
+        $scanned++
+        if (($release.tag_name -is [string]) -and
+            $release.tag_name.StartsWith('zcli-v', [StringComparison]::Ordinal)) {
+            $tag = $release.tag_name
+            break
+        }
+    }
+
+    if ($null -eq $tag) {
+        # One page holds $ReleasesPageSize releases. A short page means we saw
+        # every release there is, so no CLI tag really does mean "none published
+        # yet" — the mid-publish window, which clears on its own. A FULL page
+        # means we may simply not have looked far enough back; telling that user
+        # to wait would send them off after something that will never happen.
+        if ($scanned -ge $ReleasesPageSize) {
+            Write-ErrorMsg "No zcli-v* tag in the newest $ReleasesPageSize releases of $Repo."
+            Write-ErrorMsg 'The CLI release is older than one page of the API, so this installer'
+            Write-ErrorMsg 'cannot find it. Download the binary for your platform directly from'
+            Write-ErrorMsg "  https://github.com/$Repo/releases"
+            exit 1
+        }
+
+        Write-ErrorMsg "No published zcli-v* release found for $Repo."
+        Write-ErrorMsg 'A release may be mid-publish: CLI releases stay drafts until their'
+        Write-ErrorMsg 'checksums are signed offline, so there is a short window with nothing'
+        Write-ErrorMsg 'installable. Wait a few minutes and re-run, or pick a release from'
+        Write-ErrorMsg "  https://github.com/$Repo/releases"
         exit 1
     }
 
     # Defense-in-depth: validate the version against a strict charset before it
     # is interpolated into download URLs, mirroring the in-binary isValidVersionArg
-    # check. Rejects '/', '..' and other path-traversal characters.
-    if ($release.tag_name -notmatch '^zcli-v([A-Za-z0-9._-]+)$') {
-        Write-ErrorMsg "Unexpected release tag format: $($release.tag_name)"
-        exit 1
+    # check. Rejects '/', '..' and other path-traversal characters. Fail closed
+    # rather than skipping to an older release — a malformed newest tag is an
+    # anomaly worth surfacing, which is also what the Zig verifier does.
+    if ($tag -cmatch '^zcli-v([A-Za-z0-9._-]+)$') {
+        return $Matches[1]
     }
 
-    return $Matches[1]
+    Write-ErrorMsg "Unexpected release tag format: $tag"
+    exit 1
 }
 
 # Download binary, verify it, and return the local path to the verified file.

--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,11 @@ REPO="ryanhair/zcli"
 INSTALL_DIR="$HOME/.local/bin"
 BINARY_NAME="zcli"
 
+# How many releases get_latest_version asks the API for in one page. Named
+# because it appears three times: in the request, in the "did we see every
+# release?" test, and in the message that test produces.
+RELEASES_PAGE_SIZE=100
+
 # zcli's pinned minisign public key. The installer verifies checksums.txt against
 # its detached signature (checksums.txt.minisig) under this key — closing the gap
 # that checksums alone cannot: a compromised release can swap the binary AND its
@@ -177,16 +182,80 @@ verify_signature() {
     return 0
 }
 
-# Get latest release version from GitHub
+# Resolve the newest installable CLI release.
+#
+# This asks for the release LIST, not /releases/latest, because this repo
+# publishes two tag families from one workflow (.github/workflows/release.yml):
+# library releases tagged `v0.22.0`, published immediately, and CLI releases
+# tagged `zcli-v0.22.0`, created as drafts and published only once their
+# checksums have been signed offline. Between those two moments — a normal,
+# recurring part of every release, not an error — `/releases/latest` returns the
+# LIBRARY tag, and an installer that trusts it fails on a tag whose shape it
+# cannot parse, with a message about nothing the user did.
+#
+# The list endpoint is ordered newest-first and omits drafts for anonymous
+# callers, so the first `zcli-v*` entry is precisely "the newest CLI release a
+# user can actually install". That is the same rule selectVersion applies in
+# packages/core/src/plugins/zcli_github_upgrade/plugin.zig, so `curl | sh` and
+# `zcli upgrade` resolve identically.
 get_latest_version() {
     if ! command -v curl >/dev/null 2>&1; then
         print_error "curl is required but not found"
         exit 1
     fi
 
-    version=$(curl -fsSL --proto '=https' --tlsv1.2 "https://api.github.com/repos/${REPO}/releases/latest" | \
-        grep '"tag_name":' | \
-        sed -E 's/.*"tag_name": "zcli-v([^"]+)".*/\1/')
+    releases=$(curl -fsSL --proto '=https' --tlsv1.2 \
+        "https://api.github.com/repos/${REPO}/releases?per_page=${RELEASES_PAGE_SIZE}") || releases=''
+
+    if [ -z "${releases}" ]; then
+        print_error "Could not fetch the release list for ${REPO} from the GitHub API."
+        print_error "Check your network connection (or GitHub's status) and try again."
+        exit 1
+    fi
+
+    # Put every "tag_name" key at the start of its own line, so the extraction
+    # below can anchor at ^. Without the anchor, sed's greedy `.*` would skip
+    # past an earlier match to a later one on the same line, and the API's
+    # compact spelling puts many releases on one line.
+    #
+    # `sed`, not `grep -o`: -o is a GNU extension, and this file is piped into
+    # whatever /bin/sh the user has — busybox and the BSDs included. The literal
+    # backslash-newline in the replacement is the POSIX way to insert a newline.
+    tag_lines=$(printf '%s\n' "${releases}" | sed 's/"tag_name"/\
+&/g')
+
+    # First matching tag wins; document order is release order (newest first).
+    # Tolerates both the API's pretty-printed `"tag_name": "…"` and a compact
+    # `"tag_name":"…"`. Case-sensitive, like every other tag comparison here.
+    version=$(printf '%s\n' "${tag_lines}" \
+        | sed -n 's/^"tag_name"[[:space:]]*:[[:space:]]*"zcli-v\([^"]*\)".*/\1/p' \
+        | head -n 1)
+
+    if [ -z "${version}" ]; then
+        # One page holds RELEASES_PAGE_SIZE releases. A short page means we saw
+        # every release there is, so no CLI tag really does mean "none published
+        # yet" — the mid-publish window. A FULL page means we may simply not
+        # have looked far enough back, which is a different problem and deserves
+        # a different answer; saying "mid-publish" there would send the user off
+        # to wait for something that is never going to happen.
+        tag_count=$(printf '%s\n' "${tag_lines}" \
+            | grep -cE '^"tag_name"[[:space:]]*:') || tag_count=0
+
+        if [ "${tag_count}" -ge "${RELEASES_PAGE_SIZE}" ]; then
+            print_error "No zcli-v* tag in the newest ${RELEASES_PAGE_SIZE} releases of ${REPO}."
+            print_error "The CLI release is older than one page of the API, so this installer"
+            print_error "cannot find it. Download the binary for your platform directly from"
+            print_error "  https://github.com/${REPO}/releases"
+            exit 1
+        fi
+
+        print_error "No published zcli-v* release found for ${REPO}."
+        print_error "A release may be mid-publish: CLI releases stay drafts until their"
+        print_error "checksums are signed offline, so there is a short window with nothing"
+        print_error "installable. Wait a few minutes and re-run, or pick a release from"
+        print_error "  https://github.com/${REPO}/releases"
+        exit 1
+    fi
 
     # Defense-in-depth: validate the version against a strict charset before it
     # is interpolated into download URLs, mirroring the in-binary isValidVersionArg
@@ -358,7 +427,28 @@ get_shell_config() {
     esac
 }
 
-# Check if PATH export already exists in config file
+# Does this config file already put ${INSTALL_DIR} on PATH?
+#
+# This has to match the mechanism, not a mention of the string. The old check
+# was a bare `grep '.local/bin'`: unanchored, with `.` as a regex wildcard, so a
+# comment ("# TODO: add ~/.local/bin to PATH"), an unrelated entry
+# (`$HOME/mylocal/binaries`) or any incidental `X` + `local/bin` convinced the
+# installer PATH was already configured. It then skipped the append and printed
+# success while leaving zcli off PATH.
+#
+# The two error directions are not symmetric. A false positive is the bug above:
+# a silently broken install. A false negative just appends a second export line
+# on a repeat install. So this errs strict — three conditions, all required:
+#
+#   1. the line is not a shell comment;
+#   2. the line actually sets PATH (an assignment, or fish's fish_add_path);
+#   3. the install dir appears as a WHOLE path component — `~/.local/bin`
+#      followed by a separator or end of line, never `~/.local/binaries`.
+#
+# Spellings accepted for (3): `$HOME/.local/bin`, `${HOME}/.local/bin`,
+# `~/.local/bin`, and ${INSTALL_DIR} written out absolutely. All four are in
+# the wild — Debian's stock ~/.profile uses the first — and every one of them
+# genuinely works, so recognizing them keeps repeat installs idempotent.
 path_already_configured() {
     config_file="$1"
 
@@ -366,11 +456,41 @@ path_already_configured() {
         return 1
     fi
 
-    # Check for various patterns that would add ~/.local/bin to PATH
-    if grep -q '\$HOME/.local/bin' "${config_file}" 2>/dev/null || \
-       grep -q '~/.local/bin' "${config_file}" 2>/dev/null || \
-       grep -q '.local/bin' "${config_file}" 2>/dev/null; then
+    # (1) drop comments, using sh's own rule: `#` at the start of the line or
+    #     preceded by whitespace. `abc#def` is not a comment and is left alone.
+    # (2) keep only lines that put something on PATH:
+    #       PATH=…            sh/bash/zsh/ksh assignment, with or without export
+    #       path=(…)          zsh's lowercase array, which is tied to $PATH —
+    #       path+=(…)         and zsh is the macOS default shell, so this form
+    #                         is common enough that missing it would double-append
+    #       fish_add_path …   fish
+    #       set -gx PATH …    fish, and `setenv PATH …` in csh — PATH is a
+    #                         separate word rather than the target of an `=`
+    #     The leading `(^|[^[:alnum:]_])` guard keeps `MYPATH=` and `mypath=(`
+    #     out. Prose that merely ends in "…on your PATH" has none of these.
+    path_lines=$(sed -e 's/^#.*$//' -e 's/[[:space:]]#.*$//' "${config_file}" \
+        | grep -E '(^|[^[:alnum:]_])(PATH=|path\+?=\(|fish_add_path)|set.*[[:space:]]PATH[[:space:]]') \
+        || path_lines=''
+
+    if [ -z "${path_lines}" ]; then
+        return 1
+    fi
+
+    # (3) symbolic spellings of $HOME.
+    if printf '%s\n' "${path_lines}" \
+        | grep -qE '(\$HOME|\$\{HOME\}|~)/\.local/bin([^[:alnum:]_./-]|$)'; then
         return 0
+    fi
+
+    # (3, cont.) the same directory written out absolutely. ${INSTALL_DIR} is
+    # data, not a pattern, so escape every ERE metacharacter it could contain
+    # before splicing it in — a `+` or `(` in $HOME must match itself.
+    if [ -n "${INSTALL_DIR}" ]; then
+        install_dir_re=$(printf '%s' "${INSTALL_DIR}" | sed 's/[][\\^$.|?*+(){}]/\\&/g')
+        if printf '%s\n' "${path_lines}" \
+            | grep -qE "${install_dir_re}([^[:alnum:]_./-]|\$)"; then
+            return 0
+        fi
     fi
 
     return 1

--- a/scripts/test-install-signature.ps1
+++ b/scripts/test-install-signature.ps1
@@ -1,19 +1,27 @@
 #!/usr/bin/env pwsh
-# Regression tests for install.ps1's release-signature trust model, and for the
-# registry contract its PATH handling depends on.
+# Regression tests for install.ps1: its release-signature trust model, the
+# release it resolves, the TLS floor it sets, and the registry contract its
+# PATH handling depends on.
 #
 # install.ps1 is an `irm | iex` trust root: like install.sh it is the only
 # validation most Windows users ever run, and no Zig test covers it. These
 # assertions exist so a regression fails CI rather than shipping.
 #
-# Two independent sections, each skipped only when its prerequisite genuinely
-# cannot exist on the runner:
+# Sections, each skipped only when its prerequisite genuinely cannot exist on
+# the runner:
 #
 #   1. Signature version binding — needs `minisign`. Exercises the real
 #      Test-Signature from the shipped install.ps1 with only the network fetch
 #      stubbed. Mirrors scripts/test-install-signature.sh case for case; the two
-#      installers must agree.
-#   2. Registry value-kind contract — Windows only. Proves the .NET behavior the
+#      installers must agree. Includes the hostile-`minisign`-function case
+#      (#772): tool resolution must find an executable, not a profile-defined
+#      function whose "success" would be a stale $LASTEXITCODE.
+#   2. Release selection — no external tools. Get-LatestVersion must take the
+#      newest `zcli-v*` from the release LIST, so a library tag published ahead
+#      of the still-draft CLI tag cannot derail an install (#774).
+#   3. TLS floor — no external tools. The protocol set must EXCLUDE TLS 1.0/1.1,
+#      not merely include 1.2 (#773).
+#   4. Registry value-kind contract — Windows only. Proves the .NET behavior the
 #      %VAR%-preservation fix rests on: that ExpandString round-trips as
 #      REG_EXPAND_SZ, that DoNotExpandEnvironmentNames returns the raw text, and
 #      that the default read expands it (the bug that flattened user PATHs).
@@ -49,43 +57,50 @@ function Assert-Result {
     }
 }
 
-# ===========================================================================
-# Section 1 — signature version binding
-# ===========================================================================
-$minisign = Get-Command minisign -ErrorAction SilentlyContinue
-if (-not $minisign) {
-    if ($env:ZCLI_REQUIRE_MINISIGN) {
-        Bad 'ZCLI_REQUIRE_MINISIGN=1 but no minisign binary was found — the install.ps1 signature tests cannot run'
+$minisign = Get-Command minisign -CommandType Application -ErrorAction SilentlyContinue
+
+$work = Join-Path ([System.IO.Path]::GetTempPath()) ("zcli-sigtest-" + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $work | Out-Null
+try {
+    # =======================================================================
+    # Load the real install.ps1. It calls Main on load, so strip that one
+    # trailing line and dot-source the rest. install.ps1 itself stays untouched
+    # — this must exercise exactly what ships. If the invocation stops being a
+    # bare trailing `Main`, fail loudly rather than dot-sourcing a script that
+    # would run the installer for real.
+    # =======================================================================
+    $src = (Get-Content -Path $InstallPs1 -Raw).TrimEnd()
+    if (-not $src.EndsWith("`nMain")) {
+        Bad "install.ps1 no longer ends with a bare 'Main' invocation — update this harness's strip-and-source before it runs the installer for real"
         exit 1
     }
-    Note 'SKIP: minisign not installed (set ZCLI_REQUIRE_MINISIGN=1 to make this a failure)'
-} else {
-    $work = Join-Path ([System.IO.Path]::GetTempPath()) ("zcli-sigtest-" + [guid]::NewGuid().ToString('N'))
-    New-Item -ItemType Directory -Path $work | Out-Null
-    try {
-        # -------------------------------------------------------------------
-        # Load the real Test-Signature. install.ps1 calls Main on load, so strip
-        # that one trailing line and dot-source the rest. install.ps1 itself
-        # stays untouched — this must exercise exactly what ships. If the
-        # invocation stops being a bare trailing `Main`, fail loudly rather than
-        # dot-sourcing a script that would run the installer for real.
-        # -------------------------------------------------------------------
-        $src = (Get-Content -Path $InstallPs1 -Raw).TrimEnd()
-        if (-not $src.EndsWith("`nMain")) {
-            Bad "install.ps1 no longer ends with a bare 'Main' invocation — update this harness's strip-and-source before it runs the installer for real"
+    $src = $src.Substring(0, $src.Length - 'Main'.Length)
+
+    # install.ps1 computes $InstallDir via Join-Path at load time; on Linux and
+    # macOS a 'C:' drive is rejected, so give it a loadable value. Nothing under
+    # test touches it.
+    if (-not $env:LOCALAPPDATA) { $env:LOCALAPPDATA = $work }
+
+    # Put the process on a deliberately WEAK TLS floor before loading, so
+    # section 3 can tell "install.ps1 assigned a modern-only set" apart from
+    # "install.ps1 OR-ed TLS 1.2 into whatever was already permitted".
+    [Net.ServicePointManager]::SecurityProtocol =
+        [Net.SecurityProtocolType]::Tls -bor [Net.SecurityProtocolType]::Tls11
+
+    $shim = Join-Path $work 'installer-under-test.ps1'
+    Set-Content -Path $shim -Value $src
+    . $shim
+
+    # =======================================================================
+    # Section 1 — signature version binding
+    # =======================================================================
+    if (-not $minisign) {
+        if ($env:ZCLI_REQUIRE_MINISIGN) {
+            Bad 'ZCLI_REQUIRE_MINISIGN=1 but no minisign binary was found — the install.ps1 signature tests cannot run'
             exit 1
         }
-        $src = $src.Substring(0, $src.Length - 'Main'.Length)
-
-        # install.ps1 computes $InstallDir via Join-Path at load time; on Linux
-        # and macOS a 'C:' drive is rejected, so give it a loadable value. The
-        # signature path never touches it.
-        if (-not $env:LOCALAPPDATA) { $env:LOCALAPPDATA = $work }
-
-        $shim = Join-Path $work 'installer-under-test.ps1'
-        Set-Content -Path $shim -Value $src
-        . $shim
-
+        Note 'SKIP: minisign not installed (set ZCLI_REQUIRE_MINISIGN=1 to make this a failure)'
+    } else {
         # Fixtures: throwaway keypair, genuinely-signed checksums for two tags.
         & minisign -G -W -p (Join-Path $work 'test.pub') -s (Join-Path $work 'test.key') *> $null
         $pubkey = (Get-Content (Join-Path $work 'test.pub'))[1]
@@ -150,13 +165,162 @@ if (-not $minisign) {
         Note 'install.ps1 Test-Signature — pinned-key behavior'
         $MinisignPubkey = ''
         Check 'empty pinned key skips verification'   'accept' 'sig-0.19.0.minisig'   'zcli-v0.20.0' $checksums
-    } finally {
-        Remove-Item -Recurse -Force $work -ErrorAction SilentlyContinue
+        $MinisignPubkey = $pubkey
+
+        # -------------------------------------------------------------------
+        # #772: a hostile PowerShell profile defines `minisign` as a FUNCTION.
+        #
+        # A bare `Get-Command minisign` resolves it, and `& minisign` prefers a
+        # function over an executable — so the "verification" would run the
+        # hijack, which sets no exit code, leaving $LASTEXITCODE holding
+        # whatever an earlier command left there. Seed that with the most
+        # likely stale value, 0, and hand Test-Signature a TAMPERED
+        # checksums.txt: the only thing that can reject it is a real minisign
+        # actually running.
+        # -------------------------------------------------------------------
+        Note ''
+        Note 'install.ps1 Test-Signature — hostile minisign function (#772)'
+        function minisign { $script:HijackCalled = $true }
+        try {
+            $script:HijackCalled = $false
+            $global:LASTEXITCODE = 0
+            Check 'tampered release still rejected under a minisign function' `
+                'reject' 'sig-0.20.0.minisig' 'zcli-v0.20.0' $tampered
+            Assert-Result 'install.ps1: hostile minisign function never invoked' `
+                'not-called' $(if ($script:HijackCalled) { 'called' } else { 'not-called' })
+        } finally {
+            Remove-Item -Path 'Function:\minisign' -ErrorAction SilentlyContinue
+        }
     }
+
+    # =======================================================================
+    # Section 2 — release selection (#774)
+    #
+    # release.yml publishes two tag families: library tags (`v0.22.0`) go out
+    # immediately, CLI tags (`zcli-v0.22.0`) stay drafts until their checksums
+    # are signed offline. `/releases/latest` therefore returns the LIBRARY tag
+    # for the whole of that window, which happens on every single release.
+    # Get-LatestVersion must read the release list and take the newest
+    # `zcli-v*` — and when there genuinely isn't one yet, say so in those words.
+    #
+    # Get-LatestVersion ends its failure paths with `exit`, which would take
+    # this harness down with it. Calling it from a separate script FILE with `&`
+    # contains that: the exit terminates only that file and surfaces as
+    # $LASTEXITCODE here. The driver dot-sources the same shim, so it is still
+    # the shipped function under test.
+    # =======================================================================
+    $driver = Join-Path $work 'run-latest-version.ps1'
+    Set-Content -Path $driver -Value @'
+param([string]$Shim, [string]$ReleasesFile, [switch]$Fail)
+$ErrorActionPreference = 'Stop'
+. $Shim
+function Invoke-RestMethod {
+    param($Uri, $Headers)
+    if ($Fail) { throw 'simulated network failure' }
+    # Emit an Object[] as ONE pipeline object, which is the shape the real
+    # cmdlet produces. A stub that enumerated instead would quietly hide the
+    # `@(Invoke-RestMethod …)` bug, where the wrap produces a one-element array
+    # holding the whole list and every tag member-enumerates into one string.
+    #
+    # `@(…)` then `,` — NOT `Write-Output -NoEnumerate`, which since PowerShell
+    # 7.4 hands back a List[Object] rather than an Object[]. That is a different
+    # wrong shape, and it behaves differently enough that `@(…).Count` on it
+    # throws — so the stub would have been testing something the installer will
+    # never see.
+    $parsed = @(Get-Content -Raw -Path $ReleasesFile | ConvertFrom-Json)
+    return ,$parsed
+}
+Write-Output "version:$(Get-LatestVersion)"
+exit 0
+'@
+
+    $releasesFile = Join-Path $work 'releases.json'
+
+    # Returns the combined output text; sets $script:LatestVersion to the
+    # resolved version, or 'reject' when the driver exited nonzero.
+    function Invoke-LatestVersion { param([string]$Json, [switch]$Fail)
+        Set-Content -Path $releasesFile -Value $Json
+        # 6>&1 folds Write-Host (stream 6) in, so the diagnostics are visible
+        # to the caller and not just to the console.
+        $out = if ($Fail) { & $driver -Shim $shim -ReleasesFile $releasesFile -Fail 6>&1 }
+               else       { & $driver -Shim $shim -ReleasesFile $releasesFile 6>&1 }
+        $text = ($out | ForEach-Object { "$_" }) -join "`n"
+        $script:LatestVersion = 'reject'
+        if ($LASTEXITCODE -eq 0 -and $text -cmatch '(?m)^version:(.+)$') {
+            $script:LatestVersion = $Matches[1]
+        }
+        return $text
+    }
+
+    function Check-Version { param([string]$Label, [string]$Expect, [string]$Json)
+        Invoke-LatestVersion -Json $Json | Out-Null
+        Assert-Result "install.ps1: $Label" $Expect $script:LatestVersion
+    }
+
+    Note ''
+    Note 'install.ps1 Get-LatestVersion — newest installable zcli-v* release'
+    Check-Version 'newest CLI tag wins over the library tag above it' '0.22.0' `
+        '[{"tag_name":"v0.22.0"},{"tag_name":"zcli-v0.22.0"},{"tag_name":"v0.21.0"},{"tag_name":"zcli-v0.21.0"}]'
+    Check-Version 'library tag published ahead of a draft CLI tag skipped' '0.21.0' `
+        '[{"tag_name":"v0.22.0"},{"tag_name":"zcli-v0.21.0"},{"tag_name":"v0.21.0"}]'
+    Check-Version 'case-variant tag family not accepted' 'reject' `
+        '[{"tag_name":"ZCLI-V0.22.0"}]'
+    Check-Version 'path-traversal tag rejected, not skipped over' 'reject' `
+        '[{"tag_name":"zcli-v../../evil/releases/download/other-v9.9.9"},{"tag_name":"zcli-v0.21.0"}]'
+
+    # A FULL page with no zcli-v tag is a different condition from a short one:
+    # not "nothing is published yet" but "we may not have looked far enough
+    # back". Sized from install.ps1's own constant so the fixture cannot drift.
+    $fullPage = '[' + ((0..($ReleasesPageSize - 1) | ForEach-Object {
+        "{`"tag_name`":`"v0.$_.0`"}" }) -join ',') + ']'
+    Check-Version 'full page with no CLI tag rejected' 'reject' $fullPage
+
+    # The two no-release outcomes get different advice, so they have to be told
+    # apart: the mid-publish window clears on its own and the user should wait;
+    # an exhausted page never will, and telling them to wait sends them after
+    # something that is not going to happen.
+    function Check-VersionMessage {
+        param([string]$Label, [string]$Json, [string]$Want, [string]$Unwanted)
+        $text = Invoke-LatestVersion -Json $Json
+        $got = if ($text -notmatch [regex]::Escape($Want)) { "does not say '$Want': $text" }
+               elseif ($text -match [regex]::Escape($Unwanted)) { "also says '$Unwanted': $text" }
+               else { 'explained' }
+        Assert-Result "install.ps1: $Label" 'explained' $got
+    }
+
+    $text = Invoke-LatestVersion -Json '[{"tag_name":"v0.22.0"},{"tag_name":"v0.21.0"}]'
+    Assert-Result 'install.ps1: no zcli-v* release yet rejected' 'reject' $script:LatestVersion
+    Check-VersionMessage 'mid-publish window explained to the user' `
+        '[{"tag_name":"v0.22.0"},{"tag_name":"v0.21.0"}]' 'mid-publish' 'older than one page'
+    Check-VersionMessage 'exhausted page distinguished from mid-publish' `
+        $fullPage 'older than one page' 'mid-publish'
+
+    $text = Invoke-LatestVersion -Json '[]' -Fail
+    Assert-Result 'install.ps1: unreachable API rejected' 'reject' $script:LatestVersion
+
+    # =======================================================================
+    # Section 3 — TLS floor (#773)
+    #
+    # The load above ran install.ps1's protocol block on top of a deliberately
+    # weak floor (TLS 1.0 | 1.1). OR-ing TLS 1.2 in would leave those two
+    # enabled; assigning removes them. That difference is the whole issue.
+    # =======================================================================
+    Note ''
+    Note 'install.ps1 TLS floor (set at load)'
+    $sp = [Net.ServicePointManager]::SecurityProtocol
+    Assert-Result 'install.ps1: TLS 1.2 permitted' 'yes' `
+        $(if ($sp.HasFlag([Net.SecurityProtocolType]::Tls12)) { 'yes' } else { "no: $sp" })
+    foreach ($weak in @('Ssl3', 'Tls', 'Tls11')) {
+        $flag = [Net.SecurityProtocolType]$weak
+        Assert-Result "install.ps1: $weak excluded, not merely deprioritized" 'excluded' `
+            $(if ($sp.HasFlag($flag)) { "still permitted: $sp" } else { 'excluded' })
+    }
+} finally {
+    Remove-Item -Recurse -Force $work -ErrorAction SilentlyContinue
 }
 
 # ===========================================================================
-# Section 2 — registry value-kind contract (Windows only)
+# Section 4 — registry value-kind contract (Windows only)
 #
 # Add-ToUserPath reads with DoNotExpandEnvironmentNames and writes ExpandString
 # precisely so %VAR% entries survive. That rests on .NET behavior which cannot

--- a/scripts/test-install-signature.sh
+++ b/scripts/test-install-signature.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-# Regression tests for the installer's release-signature trust model.
+# Regression tests for the installer's release-signature trust model, and for
+# the two other ways install.sh can silently hand a user a broken install.
 #
 # install.sh is a `curl | sh` trust root: it is the only validation most users
 # ever run, and it is not covered by `zig build test` (no Zig involved). These
@@ -12,6 +13,19 @@
 #      shipped file, with only the network fetch stubbed.
 #   2. scripts/sign-release.sh's trusted_comment_binds_tag — the release
 #      ceremony's copy of the same token-exactness rule, extracted by name.
+#   3. install.sh's get_latest_version — that it selects the newest `zcli-v*`
+#      release from the release LIST, so a library tag published ahead of the
+#      still-draft CLI tag cannot derail an install (#774), and that its two
+#      no-release outcomes (mid-publish window vs. a CLI release older than one
+#      API page) are told apart, because the advice differs.
+#   4. install.sh's path_already_configured — that it recognizes a real PATH
+#      export and only a real one, so an incidental mention of the string
+#      cannot make the installer skip the append and report success while
+#      leaving zcli off PATH (#771). Includes a round-trip: what add_to_path
+#      writes must satisfy the check, or repeat installs double-append.
+#   5. install.sh's POSIX-ness as a static property — a deny-list for GNU-only
+#      options like `grep -o`, which parse everywhere and only fail at run time
+#      on the busybox/BSD systems this script most needs to work on.
 #
 # The matching PowerShell surface lives in scripts/test-install-signature.ps1.
 # Semantics all four copies must share (the fourth is verifyTrustedComment in
@@ -109,14 +123,47 @@ sign_as "${WORK}/sig-0.2.minisig"    "zcli-v0.2"
   sed -n '4p' "${WORK}/sig-0.20.0.minisig"; } > "${WORK}/sig-noprefix.minisig"
 
 # ---------------------------------------------------------------------------
-# Stub the network. verify_signature fetches "<checksum_url>.minisig" with
-# curl into "<checksums>.minisig"; serve ${SERVE_SIG} instead. Everything else
-# — the pinned-key check, the real `minisign -V`, the line-3 parse and the
-# token match — is the shipped code.
+# Stub the network for both of install.sh's curl call sites, using curl's own
+# rule to tell them apart: `-o <file>` downloads to that file, otherwise the
+# body goes to stdout.
+#
+#   verify_signature   fetches "<checksum_url>.minisig" with -o; serve ${SERVE_SIG}.
+#   get_latest_version reads the releases API from stdout; serve ${SERVE_RELEASES},
+#                      or fail like curl's --fail when ${SERVE_RELEASES_FAILS}=1.
+#
+# Everything else — the pinned-key check, the real `minisign -V`, the line-3
+# parse, the token match, the tag selection — is the shipped code.
 # ---------------------------------------------------------------------------
-curl() { cp "${SERVE_SIG}" "$7"; }
+curl() {
+    curl_out=''
+    curl_prev=''
+    for curl_arg in "$@"; do
+        if [ "${curl_prev}" = "-o" ]; then curl_out="${curl_arg}"; fi
+        curl_prev="${curl_arg}"
+    done
+
+    if [ -n "${curl_out}" ]; then
+        cp "${SERVE_SIG}" "${curl_out}"
+        return 0
+    fi
+
+    if [ "${SERVE_RELEASES_FAILS:-0}" = "1" ]; then
+        return 22
+    fi
+    printf '%s\n' "${SERVE_RELEASES}"
+}
 
 MINISIGN_PUBKEY="${PUBKEY}"
+
+report() { # <label> <expected> <actual>
+    if [ "$2" = "$3" ]; then
+        note "  PASS  $1"
+        pass_count=$((pass_count + 1))
+    else
+        bad "$1 — expected $2, got $3"
+        fail_count=$((fail_count + 1))
+    fi
+}
 
 check() { # <label> <accept|reject> <sig> <tag> <body>
     label="$1"; expect="$2"; SERVE_SIG="${WORK}/$3"; tag="$4"; body="$5"
@@ -129,13 +176,7 @@ check() { # <label> <accept|reject> <sig> <tag> <body>
         got=reject
     fi
 
-    if [ "${got}" = "${expect}" ]; then
-        note "  PASS  install.sh: ${label}"
-        pass_count=$((pass_count + 1))
-    else
-        bad "install.sh: ${label} — expected ${expect}, got ${got}"
-        fail_count=$((fail_count + 1))
-    fi
+    report "install.sh: ${label}" "${expect}" "${got}"
 }
 
 check_ceremony() { # <label> <accept|reject> <sig> <tag>
@@ -147,13 +188,7 @@ check_ceremony() { # <label> <accept|reject> <sig> <tag>
         got=reject
     fi
 
-    if [ "${got}" = "${expect}" ]; then
-        note "  PASS  sign-release.sh: ${label}"
-        pass_count=$((pass_count + 1))
-    else
-        bad "sign-release.sh: ${label} — expected ${expect}, got ${got}"
-        fail_count=$((fail_count + 1))
-    fi
+    report "sign-release.sh: ${label}" "${expect}" "${got}"
 }
 
 note "install.sh verify_signature — version binding"
@@ -182,6 +217,277 @@ check_ceremony "inverse prefix rejected"               reject sig-0.2.minisig   
 check_ceremony "case-only mismatch rejected"           reject sig-0.20.0.minisig ZCLI-V0.20.0
 check_ceremony "missing comment prefix rejected"       reject sig-noprefix.minisig zcli-v0.20.0
 check_ceremony "empty tag rejected"                    reject sig-0.20.0.minisig ''
+
+# ---------------------------------------------------------------------------
+# install.sh get_latest_version — release selection (#774).
+#
+# release.yml publishes two tag families: library tags (`v0.22.0`) go out
+# immediately, CLI tags (`zcli-v0.22.0`) stay drafts until their checksums are
+# signed offline. `/releases/latest` therefore returns the LIBRARY tag for the
+# whole of that window, which happens on every single release. The installer
+# must read the release list and take the newest `zcli-v*` instead — and when
+# there genuinely isn't one yet, say so in those words rather than complaining
+# about a malformed version.
+#
+# Bodies below are shaped like the real API response (pretty-printed, newest
+# first); one case uses the compact spelling to pin that both parse.
+# ---------------------------------------------------------------------------
+LIST_BOTH='[
+  { "tag_name": "v0.22.0" },
+  { "tag_name": "zcli-v0.22.0" },
+  { "tag_name": "v0.21.0" },
+  { "tag_name": "zcli-v0.21.0" }
+]'
+LIST_MID_PUBLISH='[
+  { "tag_name": "v0.22.0" },
+  { "tag_name": "zcli-v0.21.0" },
+  { "tag_name": "v0.21.0" }
+]'
+LIST_NO_CLI='[
+  { "tag_name": "v0.22.0" },
+  { "tag_name": "v0.21.0" }
+]'
+LIST_COMPACT='[{"tag_name":"v0.22.0"},{"tag_name":"zcli-v0.22.0"}]'
+LIST_TRAVERSAL='[{"tag_name":"zcli-v../../evil/releases/download/other-v9.9.9"}]'
+LIST_CASE_VARIANT='[{"tag_name":"ZCLI-V0.22.0"}]'
+
+# A FULL page with no zcli-v tag means something different from a short one:
+# not "nothing is published yet" but "we may not have looked far enough back".
+# Sized from install.sh's own constant so the fixture cannot drift from it.
+LIST_FULL_PAGE=$(
+    printf '['
+    i=0
+    while [ "${i}" -lt "${RELEASES_PAGE_SIZE}" ]; do
+        if [ "${i}" -gt 0 ]; then printf ','; fi
+        printf '{"tag_name":"v0.%d.0"}' "${i}"
+        i=$((i + 1))
+    done
+    printf ']'
+)
+
+check_version() { # <label> <expected-version|reject> <releases-json>
+    label="$1"; expect="$2"; SERVE_RELEASES="$3"
+
+    got=$(get_latest_version 2>/dev/null) || got=reject
+    report "install.sh: ${label}" "${expect}" "${got}"
+}
+
+# Runs get_latest_version for its DIAGNOSTIC, not its result: <must-contain> has
+# to appear on stderr and <must-not-contain> must not. The two no-release cases
+# are different problems with different advice, so telling them apart is the
+# point — a "wait a few minutes" message for a condition that will never clear
+# is worse than no message.
+check_version_message() { # <label> <releases-json> <must-contain> <must-not-contain>
+    label="$1"; SERVE_RELEASES="$2"; want="$3"; unwanted="$4"
+
+    msg=$(get_latest_version 2>&1 >/dev/null) || true
+    case "${msg}" in
+        *"${want}"*)
+            case "${msg}" in
+                *"${unwanted}"*) got="also says '${unwanted}': ${msg}" ;;
+                *)               got=explained ;;
+            esac
+            ;;
+        *) got="does not say '${want}': ${msg}" ;;
+    esac
+
+    report "install.sh: ${label}" explained "${got}"
+}
+
+note ""
+note "install.sh get_latest_version — newest installable zcli-v* release"
+SERVE_RELEASES_FAILS=0
+check_version "newest CLI tag wins over the library tag above it" 0.22.0 "${LIST_BOTH}"
+check_version "library tag published ahead of a draft CLI tag skipped" 0.21.0 "${LIST_MID_PUBLISH}"
+check_version "compact JSON parses too"                          0.22.0 "${LIST_COMPACT}"
+check_version "no zcli-v* release yet rejected"                  reject "${LIST_NO_CLI}"
+check_version "path-traversal tag rejected, not skipped over"    reject "${LIST_TRAVERSAL}"
+check_version "case-variant tag family not accepted"             reject "${LIST_CASE_VARIANT}"
+check_version "full page with no CLI tag rejected"               reject "${LIST_FULL_PAGE}"
+
+# The mid-publish window is a normal, recurring condition, so the diagnostic has
+# to name it — a user who hits it should be told to wait, not sent hunting for a
+# fault on their machine. A full page of non-CLI tags must NOT claim that:
+# waiting will not help, the release is simply off the end of the page.
+check_version_message "mid-publish window explained to the user" \
+    "${LIST_NO_CLI}" 'mid-publish' 'older than one page'
+check_version_message "exhausted page distinguished from mid-publish" \
+    "${LIST_FULL_PAGE}" 'older than one page' 'mid-publish'
+
+SERVE_RELEASES_FAILS=1
+SERVE_RELEASES=''
+check_version "unreachable API rejected" reject '(unused)'
+SERVE_RELEASES_FAILS=0
+
+# ---------------------------------------------------------------------------
+# install.sh must stay POSIX. It is piped into whatever /bin/sh the user has —
+# busybox ash on Alpine, a real Bourne-ish sh on the BSDs. `dash -n` and the
+# dash leg of this harness catch syntax-level bashisms, but NOT a GNU-only
+# option to a POSIX utility: `grep -o` parses fine everywhere and simply does
+# not exist on some systems, so it would fail at run time on the machines least
+# able to debug it. Deny-list the ones this file has actually reached for.
+#
+# Comments are stripped first, so the prose explaining why `grep -o` is absent
+# does not itself trip the check.
+# ---------------------------------------------------------------------------
+note ""
+note "install.sh — POSIX-only utilities and syntax"
+INSTALL_SH_CODE=$(sed -e 's/^[[:space:]]*#.*$//' -e 's/[[:space:]]#.*$//' "${INSTALL_SH}")
+
+deny() { # <label> <ere>
+    hit=$(printf '%s\n' "${INSTALL_SH_CODE}" | grep -nE "$2" | head -n 1) || hit=''
+    if [ -n "${hit}" ]; then
+        got="present: ${hit}"
+    else
+        got=absent
+    fi
+    report "install.sh: $1" absent "${got}"
+}
+
+deny "no 'grep -o' (GNU extension)"        'grep[[:space:]]+-[[:alnum:]]*o'
+deny "no 'grep -P' (GNU extension)"        'grep[[:space:]]+-[[:alnum:]]*P'
+deny "no 'sed -E' / 'sed -r' (not POSIX)"  'sed[[:space:]]+-[[:alnum:]]*[Er]'
+deny "no 'echo -n' / 'echo -e'"            'echo[[:space:]]+-[[:alnum:]]'
+deny "no '[[ ]]' (bashism)"                '\[\[[[:space:]]'
+deny "no 'local' (not POSIX)"              '(^|[[:space:];])local[[:space:]]'
+deny "no 'readarray' / 'mapfile'"          '(readarray|mapfile)'
+
+# ---------------------------------------------------------------------------
+# install.sh path_already_configured — PATH detection (#771).
+#
+# The old check was `grep '.local/bin'`: unanchored, `.` a wildcard, so any
+# incidental mention convinced the installer PATH was already set up. It then
+# skipped the append and printed success over a binary that was not on PATH.
+#
+# Both directions matter. A false positive is that silent breakage; a false
+# negative double-appends on a repeat install. So the accept cases below are
+# the spellings that genuinely work (Debian's stock ~/.profile uses the first)
+# and the reject cases are near-misses that do not.
+# ---------------------------------------------------------------------------
+FAKE_HOME="${WORK}/home"
+mkdir -p "${FAKE_HOME}/.local/bin"
+
+check_path() { # <label> <configured|not-configured> <config-body>
+    label="$1"; expect="$2"; body="$3"
+    cfg="${WORK}/rc"
+    printf '%s\n' "${body}" > "${cfg}"
+
+    if ( HOME="${FAKE_HOME}"; INSTALL_DIR="${FAKE_HOME}/.local/bin"
+         path_already_configured "${cfg}" ); then
+        got=configured
+    else
+        got=not-configured
+    fi
+
+    report "install.sh: ${label}" "${expect}" "${got}"
+}
+
+note ""
+note "install.sh path_already_configured — real PATH exports"
+check_path "the line the installer itself writes" configured \
+    'export PATH="$HOME/.local/bin:$PATH"'
+check_path "Debian stock ~/.profile form"        configured \
+    'PATH="$HOME/.local/bin:$PATH"'
+check_path "tilde form"                          configured \
+    'export PATH=~/.local/bin:$PATH'
+check_path "braced \${HOME} form"                configured \
+    'export PATH="${HOME}/.local/bin:$PATH"'
+check_path "absolute path form"                  configured \
+    "export PATH=\"${FAKE_HOME}/.local/bin:\$PATH\""
+check_path "fish_add_path form"                  configured \
+    'fish_add_path $HOME/.local/bin'
+check_path "fish set -gx form"                   configured \
+    'set -gx PATH $HOME/.local/bin $PATH'
+# zsh's lowercase `path` array is tied to $PATH, and zsh is the macOS default
+# shell — missing this form would double-append for a large share of users.
+check_path "zsh path=() array form"              configured \
+    'path=(~/.local/bin $path)'
+check_path "zsh path+=() array form"             configured \
+    'path+=($HOME/.local/bin)'
+
+note ""
+note "install.sh path_already_configured — mentions that configure nothing"
+check_path "whole-line comment"                  not-configured \
+    '# TODO: add ~/.local/bin to PATH one day'
+check_path "trailing comment on another export"  not-configured \
+    'export PATH="$HOME/bin:$PATH"  # not ~/.local/bin'
+check_path "prose mentioning PATH"               not-configured \
+    'echo "remember to put ~/.local/bin on your PATH"'
+check_path "longer sibling directory"            not-configured \
+    'export PATH="$HOME/.local/binaries:$PATH"'
+check_path "wildcard-only match (old .local/bin regex)" not-configured \
+    'export PATH="$HOME/mylocal/binaries:$PATH"'
+check_path "suffixed directory"                  not-configured \
+    'export PATH="$HOME/.local/bin.old:$PATH"'
+check_path "subdirectory, not the dir itself"    not-configured \
+    'export PATH="$HOME/.local/bin/extra:$PATH"'
+check_path "alias that is not a PATH change"     not-configured \
+    'alias lb="ls ~/.local/bin"'
+check_path "unrelated lowercase array"           not-configured \
+    'mypath=(~/.local/bin)'
+
+# A missing config file is the common case on a fresh machine, and the check
+# runs mid-install with the user's terminal attached. Asserting the return value
+# alone would be vacuous — every plausible implementation returns 1 here, guard
+# or no guard. What is NOT free is doing it quietly: drop the `[ -f ]` guard and
+# sed prints "no such file or directory" straight into the install output. So
+# assert the silence, which is the part that can actually regress.
+missing_err=$( ( HOME="${FAKE_HOME}"; INSTALL_DIR="${FAKE_HOME}/.local/bin"
+                 path_already_configured "${WORK}/does-not-exist" ) 2>&1 >/dev/null ) \
+    && missing_rc=configured || missing_rc=not-configured
+
+report "install.sh: missing config file" not-configured "${missing_rc}"
+if [ -n "${missing_err}" ]; then
+    got="noisy: ${missing_err}"
+else
+    got=silent
+fi
+report "install.sh: missing config file probed silently" silent "${got}"
+
+# The absolute-path branch splices ${INSTALL_DIR} into an ERE, so a $HOME
+# carrying regex metacharacters has to match itself and nothing else. `a+b.c`
+# unescaped means "one or more a, then b, then any char, then c" — which fails
+# to match its own literal text and does match `aab_c`. Both directions here.
+ODD_HOME="${WORK}/a+b.c"
+check_path_odd() { # <label> <configured|not-configured> <config-body>
+    printf '%s\n' "$3" > "${WORK}/rc"
+    if ( HOME="${ODD_HOME}"; INSTALL_DIR="${ODD_HOME}/.local/bin"
+         path_already_configured "${WORK}/rc" ); then
+        got=configured
+    else
+        got=not-configured
+    fi
+    report "install.sh: $1" "$2" "${got}"
+}
+check_path_odd "regex metacharacters in \$HOME match literally" configured \
+    "export PATH=\"${ODD_HOME}/.local/bin:\$PATH\""
+check_path_odd "regex metacharacters in \$HOME are not wildcards" not-configured \
+    "export PATH=\"${WORK}/aab_c/.local/bin:\$PATH\""
+
+# ---------------------------------------------------------------------------
+# Round-trip: whatever add_to_path writes must satisfy path_already_configured.
+# Without this, tightening the matcher could silently make every repeat install
+# append another export block.
+# ---------------------------------------------------------------------------
+note ""
+note "install.sh add_to_path — its own output is recognized on re-run"
+for shell_type in bash zsh ksh fish; do
+    rt_home="${WORK}/roundtrip-${shell_type}"
+    mkdir -p "${rt_home}"
+
+    rt_cfg=$( HOME="${rt_home}"; INSTALL_DIR="${rt_home}/.local/bin"
+              add_to_path "${shell_type}" 2>/dev/null )
+
+    # shellcheck disable=SC2034  # consumed by path_already_configured, sourced from install.sh
+    if ( HOME="${rt_home}"; INSTALL_DIR="${rt_home}/.local/bin"
+         path_already_configured "${rt_cfg}" ); then
+        got=configured
+    else
+        got=not-configured
+    fi
+
+    report "install.sh: add_to_path ${shell_type} output re-detected" configured "${got}"
+done
 
 note ""
 note "passed: ${pass_count}   failed: ${fail_count}"


### PR DESCRIPTION
Four defects in the `curl | sh` / `irm | iex` trust root, plus the harness coverage to keep them fixed. Follow-up to #754, which added the minisign trusted-comment version binding these build on.

## #771 — an unanchored grep could silently skip the PATH append

`grep -q '.local/bin'` is unanchored, and `.` is a regex metacharacter. Any incidental mention — a comment, `~/.local/binaries`, even `Xlocalybin` — made the installer believe PATH was already configured, leaving a working binary off PATH with a success message.

Replaced with three required conditions: the line is not a shell comment (stripped with sh's own rule), it actually sets PATH (`PATH=`, `fish_add_path`, `set …PATH…`, or zsh's `path=(`/`path+=(` array form), and the install dir appears as a **whole path component**. Accepts `$HOME/`, `${HOME}/`, `~/` and absolute forms, escaping ERE metacharacters out of `$INSTALL_DIR` before splicing.

Strictness is itself gated: a round-trip test asserts that what `add_to_path` *writes* satisfies `path_already_configured` for all four shell types — without it, a stricter matcher double-appends on every repeat install.

## #774 — `releases/latest` can return the library tag mid-publish

Library releases (`v0.22.0`) publish immediately while CLI releases (`zcli-v*`) stay `draft: true` until offline signing, so `releases/latest` can return the wrong tag during every release. Verified against the live API: `/releases` currently returns `v0.22.0` **first**.

Both installers now page `/releases` and take the first `zcli-v*` — the same rule `selectVersion` already applies for `zcli upgrade`. Two distinct failure messages rather than one: a short page means "may be mid-publish, wait"; a full page means "older than one page of the API, download directly". Telling a user to wait for something that will never clear is worse than saying nothing, so the harness asserts each message contains its own wording and *not* the other's.

## #772 — `Get-Command minisign` matched functions and aliases

A hostile profile function satisfied the presence check, and because a function sets no `$LASTEXITCODE`, a later check could read a stale `0` and treat verification as passed. Now `-CommandType Application`, invoked via the resolved `.Source`, with `$LASTEXITCODE` cleared to `$null` before the call and captured immediately after — so a call that runs no process fails closed on the sentinel.

## #773 — the TLS comment did not describe its code

`-bor Tls12` *permits* TLS 1.2; the comment claimed it *requires* it. Now assigns a set computed from the enum (`>= Tls12`) rather than naming `Tls13`, which does not exist on older .NET Framework — so the fix neither caps TLS at 1.2 nor throws.

## POSIX

`grep -o` is not POSIX, and `install.sh` is piped straight into `/bin/sh`. Replaced with a `sed` extraction anchored at `^` — without the anchor, sed's greedy `.*` skips past an earlier match to a later one on the same line, which the API's compact JSON makes reachable. A **static deny-list** in the harness now rejects `grep -o/-P`, `sed -E/-r`, `echo -n/-e`, `[[`, `local`, `readarray`/`mapfile`, checked with comments stripped. That turns a one-time fix into a standing gate.

## Verification — fully green, no Zig linked

`sh` and `dash scripts/test-install-signature.sh` → **59/59** (was 45). `pwsh scripts/test-install-signature.ps1` → **24/24** (was 22). `shellcheck -s sh -S warning` clean; `dash -n`, `zsh -n`, `bash -n`; PowerShell AST parse clean. `actionlint` byte-identical to the `origin/main` baseline. Live end-to-end: `get_latest_version` → `0.22.0` under dash, `Get-LatestVersion` → `0.22.0`, `SecurityProtocol` → `Tls12, Tls13`.

**13 mutations, all caught.** Each fix was reverted individually and the harness had to fail:

| Mutation | Gate that fired |
|---|---|
| #771 → original unanchored grep | 10 failures |
| #771 → over-strict (exact snippet) | 7, incl. the fish round-trip |
| #771 → drop regex escaping | 2 (literal match + wildcard) |
| #772 → bare `Get-Command` + ambient `$LASTEXITCODE` | 2 — tampered release **accepted**, hijack **called** |
| #773 → `-bor` | 2 (`Tls`, `Tls11` still permitted) |
| #774 sh/ps1 → `/releases/latest` | 4 / 5 |
| reintroduce `grep -o` | 4, incl. the deny-list |
| drop full-page branch (sh/ps1) | 1 each |
| drop zsh `path=(` alternative | 2 |
| remove `[ -f ]` guard | 1 — probe no longer silent |
| case-insensitive sh tag match | 1 |

## Three bugs found *during* verification

1. **A harness that passed while the real code was broken.** `@(Invoke-RestMethod ...)` wrapped the entire release list into one element, so `$release.tag_name` member-enumerated all 45 tags into a single string. The stub used `return (… | ConvertFrom-Json)`, which enumerates where the real cmdlet does not — caught only by a **live API call**.
2. **The fix for (1) was wrong in a new way.** `Write-Output -NoEnumerate` returns a `List[Object]` since PowerShell 7.4, not `Object[]`, and `@($list).Count` throws outright. `install.ps1` now counts during the `foreach` it already runs instead of calling `@(…).Count`.
3. The pre-existing `-notmatch` tag check was case-**insensitive**; the rewrite uses `-cmatch` + `StringComparison.Ordinal`, preserving #754's discipline. Gated by a case-variant test on both sides.

## Review

Composer 2.5: **APPROVE_WITH_NITS**, confirming all four fixes correct and #754's tag binding **not weakened**. Its five nits (the `grep -o` POSIX break, the `per_page` ceiling, a missing shell-side case-variant test, one vacuous case, and the zsh array form) are all addressed above.

Fixes #771
Fixes #772
Fixes #773
Fixes #774
