### PR TITLE
Add a no_config marker, an ADR rule for plugin_abi, and close three docs/build gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,36 @@ jobs:
           fi
           echo "shared-offset contract holds: no positional stdio writers/readers in library source"
 
+      # vterm's public API is what every consumer test assertion is written
+      # against (`result.term.hasAttribute(...)`), and it sat at 1 of 50
+      # declarations documented until #786 — a package README mitigates that but
+      # does not replace it. Now that the file is at 100%, this keeps it there:
+      # the failure mode being guarded is not "someone documents nothing", it is
+      # the slow slide back as declarations get added one at a time.
+      #
+      # Scoped to this one file deliberately. The repo-wide number (56%) is not a
+      # target to enforce — a doc comment written to satisfy a gate is worse than
+      # none — so the gate covers only the surface where the value per word is
+      # highest and the file is already clean. Widening it means bringing another
+      # file to 100% first, on purpose, not padding one to clear a bar.
+      #
+      # A declaration counts as documented when the nearest preceding non-blank
+      # line is a `///` comment, which is exactly what `zig fmt` produces.
+      - name: vterm's public API is documented
+        shell: bash
+        run: |
+          file=packages/vterm/src/vterm.zig
+          bare=$(awk '
+            /^ *pub (fn|const) / { if (prev !~ /^ *\/\/\//) print FILENAME":"NR": "$0 }
+            { if ($0 ~ /^[ \t]*$/) next; prev=$0 }
+          ' "$file")
+          if [ -n "$bare" ]; then
+            echo "::error::public declarations in $file must carry a /// doc comment — explain WHY it exists or what it costs, not just what it does:"
+            echo "$bare"
+            exit 1
+          fi
+          echo "$file: every public declaration is documented"
+
   # The framework (root build.zig.zon) and the CLI (projects/zcli/build.zig.zon)
   # ship in lockstep and MUST declare the same version — the CLI's `--version`
   # reads its own zon, the website + library tag read the root's. The README's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to zcli are documented here.
 
 ## Unreleased
 
+### Added
+- **`meta.options.<field>.no_config` — lock a field against config files** (#788, [ADR-0032](docs/adr/0032-no-config-field-marker.md)). `zcli_config` discovers project-local config from the working directory, so a cloned repo or extracted archive can set the *default* for any option. For fields whose value is a trust decision — skipping a verification step, naming a trusted URL or repo — declare `.no_config = true` and the field is never filled from a config file; the CLI flag, the `env` fallback and the struct default are unaffected. The marker is comptime-checked (a typo or a non-bool value is a build error) and enforced in the registry rather than in the plugin, so no `applyConfigDefaults` hook — bundled or third-party — can populate a marked field. A marked *required* option is not satisfied by a config file naming it: the user gets "missing required option", which is the safe answer. This replaces guidance that previously lived only in a doc comment.
+
 ### Changed (breaking)
 - **`zcli.http.Client` is HTTPS-only for *every* request, not just credentialed ones** (#745). A plain `http://` URL now fails with `error.InsecureTransport` before a connection is opened — the same rule the client already enforced on redirect targets (`error.InsecureRedirect`), and the one its module doc already promised. A request that also carried an `Authorization`/`Cookie`/`Proxy-Authorization` header still reports the more specific `error.InsecureCredentialTransport`. Loopback (`127.0.0.0/8`, `::1`, `localhost`) remains the sole carve-out, so local servers and test fixtures are unaffected.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ zig build test
 | job | what it covers |
 | --- | --- |
 | `classify changed paths` | Path filters that gate the jobs below. PR-only: pushes to `main` always run everything, and the `ci-full` label forces the full matrix. |
-| `zig fmt check` | `zig fmt --check packages projects examples build.zig`, plus the output-contract grep (no `std.debug.print` / `std.process.exit` outside the command context). |
+| `zig fmt check` | `zig fmt --check packages projects examples build.zig`, the output-contract grep (no `std.debug.print` / `std.process.exit` outside the command context), and a doc-comment gate on `packages/vterm/src/vterm.zig` (every `pub` declaration needs a `///`). |
 | `version consistency` | The three `build.zig.zon` versions and the README dependency tag agree; the website transcript injects its version instead of hardcoding one; install URLs use the branded host. |
 | `unit tests` | `zig build test` — the whole battery, on **ubuntu, macos and windows**. |
 | `zcli end-to-end tests` | `zig build e2e` on **ubuntu, macos and windows**. |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,7 @@ From the repo root:
 - `zig build build-examples` / `build-cli` — compile the examples / the zcli binary
 - `zig build e2e` — the meta-CLI's end-to-end suite (scaffolds real projects in temp dirs and drives the binary through a PTY; slow, not part of `test`; run it after prompt/render/help changes). Forwards to `projects/zcli`'s own `e2e` step; `cd projects/zcli && zig build e2e -De2e-filter=<substring>` to narrow it while iterating.
 - `zig build test-secrets` — compile+link the host's native secrets backend (forwarded from `packages/core`, like `benchmark`/`regression`; not part of `test`)
+- `zig build build-all` — everything above that CI also gates: `test` + `build-examples` + `build-cli` + `e2e`. Slow, by design; it is the step whose name means all of it.
 
 `-Dtarget=` and `-Doptimize=` at the root propagate into the package test builds.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@
 ```
 packages/    the framework, as standalone Zig packages
   core/        parsing, registry, plugins, build-time codegen (the framework)
+  ui/          the terminal-native layout engine (ADR-0013) prompts/progress render on
   theme/ markdown/ terminal/ prompts/ progress/   the terminal stack
   vterm/       virtual-terminal emulator (used by tests)
   testing/     the three-tier testing framework
@@ -40,9 +41,31 @@ zig fmt packages projects examples build.zig
 zig build test
 ```
 
+### What CI runs
+
+`.github/workflows/ci.yml`, on every PR and every push to `main`. Keep this list in sync when you add a job — it drifted silently once.
+
+| job | what it covers |
+| --- | --- |
+| `classify changed paths` | Path filters that gate the jobs below. PR-only: pushes to `main` always run everything, and the `ci-full` label forces the full matrix. |
+| `zig fmt check` | `zig fmt --check packages projects examples build.zig`, plus the output-contract grep (no `std.debug.print` / `std.process.exit` outside the command context). |
+| `version consistency` | The three `build.zig.zon` versions and the README dependency tag agree; the website transcript injects its version instead of hardcoding one; install URLs use the branded host. |
+| `unit tests` | `zig build test` — the whole battery, on **ubuntu, macos and windows**. |
+| `zcli end-to-end tests` | `zig build e2e` on **ubuntu, macos and windows**. |
+| `windows release build` | The CLI built natively on Windows in ReleaseSafe — the only ReleaseSafe Windows coverage on PRs. |
+| `linux musl release build` | Both static-musl targets, byte-for-byte the release's build command; x86_64 is smoke-run. |
+| `zcli_secrets backend` | The native secrets backend on all three OSes (ADR-0003/ADR-0010). |
+| `installer signature binding` | `install.sh` / `install.ps1` signature + version binding on all three OSes (`scripts/test-install-signature.{sh,ps1}`). |
+| `canonical examples compile` | `zig build build-examples` (ADR-0004), plus a real `zig build docs` run against `examples/tasks` with content assertions. |
+| `registry comptime scaling` | A generated 120-command app compiled **and run**, so the comptime branch-quota ceiling can't silently come back (#730). |
+| `performance budgets` | `zig build regression` — parsing hot path, startup time, binary size. Fail-closed: no skip path. |
+| `CI OK` | Aggregates all of the above. This is the **only** required status check; adding a job needs no ruleset edit, only an entry in its `needs`. |
+
+Most jobs are path-gated, so a docs-only PR runs just `zig fmt check`, `version consistency` and `CI OK`.
+
 ## Change conventions
 
-- **One focused PR per change**, branched off `main`. CI runs the unit battery on ubuntu/macos, e2e on ubuntu/macos, a Windows build + portable-package tests, the secrets backends on all three OSes, and compiles every example.
+- **One focused PR per change**, branched off `main` — see [What CI runs](#what-ci-runs) for the gate it has to clear.
 - **Tests ride with the change.** A behavioral fix wants a regression test that fails without it; if you add a command file to the meta-CLI with tests in it, wire it into `command_test_files` in `projects/zcli/build.zig` (unit tests there are opt-in per file).
 - **The examples are load-bearing** (ADR-0004): if a framework change breaks `zig build build-examples`, update the examples in the same PR — they're the canonical idiom source.
 - **Docs live next to decisions**: significant design choices get an ADR in `docs/adr/`; user-facing behavior changes update the relevant `docs/*.md` (and the scaffolding templates in `projects/zcli/src/commands/init.zig`, which generate what users see first).

--- a/build.zig
+++ b/build.zig
@@ -255,11 +255,23 @@ pub fn build(b: *std.Build) void {
     e2e_run.setCwd(b.path("projects/zcli"));
     e2e_step.dependOn(&e2e_run.step);
 
-    // Create a comprehensive build step that builds and tests everything
-    const build_all_step = b.step("build-all", "Build and test all subprojects");
+    // The pre-push step: everything a PR is gated on that also runs locally.
+    // Its name promises "all", so it has to mean it — `e2e` was omitted (#789),
+    // which made this a trap rather than a convenience. Nothing was actually
+    // ungated (CI runs `e2e` on all three OSes), but a contributor running
+    // `build-all` before pushing reasonably believed they had run it, and the
+    // suite it silently skipped is the one that catches prompt/render/help
+    // regressions no unit test can see.
+    //
+    // The description names the cost, so nobody reaches for this expecting
+    // `test`'s runtime. Deliberately still out: `test-secrets` (touches the
+    // host keychain) and `benchmark`/`regression` (build ReleaseFast) — the
+    // same reasons they are excluded from the aggregate `test` step above.
+    const build_all_step = b.step("build-all", "Build and test everything: unit suites, examples, the CLI, and the end-to-end suite (slow — e2e scaffolds real projects and drives a PTY)");
     build_all_step.dependOn(test_step);
     build_all_step.dependOn(build_examples_step);
     build_all_step.dependOn(build_cli_step);
+    build_all_step.dependOn(e2e_step);
 
     // Make the default install step build everything important
     const install_step = b.getInstallStep();

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -52,9 +52,14 @@ pub fn execute(args: Args, options: Options, context: anytype) !void {
   [ADR-0026](adr/0026-dynamic-shell-completion.md)). Options additionally
   accept `short` (single-char flag alias), `name` (override the flag's long
   name — e.g. `.output_dir = .{ .name = "out" }` makes the flag `--out`
-  instead of `--output-dir`), `env` (fallback environment variable), and
+  instead of `--output-dir`), `env` (fallback environment variable),
   `requires` (this option, if supplied, requires another option to also be
-  supplied; see ADR-0022). For values that don't map onto a plain scalar
+  supplied; see ADR-0022), and `no_config` (`.no_config = true` — the field is
+  never filled from a config file, only from the CLI, `env`, or its default;
+  use it for anything a config file discovered in the current directory must
+  not be able to decide, such as skipping a verification step or naming a
+  trusted URL — [ADR-0032](adr/0032-no-config-field-marker.md)).
+  For values that don't map onto a plain scalar
   (`u16`, `enum`, `[]const u8`, …), a field's type can itself declare
   `pub fn parse(s: []const u8) E!@This()` instead of relying on `validate` —
   see ADR-0025.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -276,6 +276,37 @@ Exactly-one-of-a-mode needs no constraint: an enum with no default
 (`format: enum { json, yaml, xml }`) is already exactly-one, and `?enum … = null`
 is at-most-one.
 
+**Locking a field against config files:**
+
+`zcli_config` discovers project-local config from the process's cwd, so a
+directory an attacker controls (a cloned repo, an extracted archive) can set the
+*default* for any option — bounded (typed parsing, size-capped, CLI/env always
+win) but attacker-influenced. A field whose value is a trust decision says so in
+its metadata (ADR-0032):
+
+```zig
+pub const Options = struct { skip_verification: bool = false };
+
+pub const meta = .{
+    .options = .{ .skip_verification = .{ .no_config = true } },
+};
+```
+
+`.no_config = true` means the field is never filled from a config file. The CLI,
+the `env` fallback and the struct default are unaffected — it locks the one
+source the user does not necessarily control. The marker joins the same
+comptime-checked metadata allowlist as `requires`/`validate` (a typo is a build
+error, and a non-bool value is rejected with a message).
+
+Enforcement lives in the registry rather than in `zcli_config`, so it covers
+*any* `applyConfigDefaults` hook: the registry forces the field's `provided` flag
+true in the view it hands the hooks — so they skip it through the same check that
+already enforces CLI > env > config — and restores the pre-config value
+afterwards, so a hook that ignores `provided` cannot defeat the marker. The real
+`options_provided` bitset is untouched, so a locked *required* option that only a
+config file supplied still reports as missing rather than silently taking the
+file's value.
+
 **Per-field validation:**
 
 A field whose *type* is right but whose *value* needs a further rule declares a
@@ -885,7 +916,7 @@ const cmd_registry = try zcli.generate(b, exe, zcli_dep, .{
 5. Command resolution routes to the matched command, then all `postParse` hooks called, threading each plugin's replacement `ParsedArgs`
 6. All `preExecute` hooks called before command execution (a plugin may cancel execution by returning `null`)
 7. Argv is parsed into the command's `Args`/`Options`
-8. All `applyConfigDefaults` hooks called after CLI/env parse — filling options no higher-precedence source set — then required/dependency/exclusive/per-field validation runs
+8. All `applyConfigDefaults` hooks called after CLI/env parse — filling options no higher-precedence source set, and skipping any field marked `.no_config` (ADR-0032; the registry masks it into the `provided` view the hooks see, and restores it afterwards) — then required/dependency/exclusive/per-field validation runs
 9. Command executes
 10. All `postExecute` hooks called after execution (success or a handled failure)
 11. On error at any stage above, `onError` hooks called until one handles the error

--- a/docs/adr/0027-plugins-are-compile-time.md
+++ b/docs/adr/0027-plugins-are-compile-time.md
@@ -63,7 +63,10 @@ plugins usually serve are covered another way:
   enough (`build_utils/plugin_system.zig` `scanLocalPlugins`, ADR-0006). No
   `build.zig` array to splice.
 - **`zcli add plugin <name>` scaffolds one** as a guided skeleton, auto-discovered
-  on the next build (ADR-0006).
+  on the next build (ADR-0006). The framework's own bundled plugins compile under
+  the same single-`"zcli"`-import rule as a local or third-party one, so they stay
+  readable as worked examples — ADR-0031 records why, and what may be exported
+  through `zcli.plugin_abi` to serve them.
 - **Rebuilds are fast**, and `zcli dev` watches and rebuilds on change — the
   edit-plugin/see-result loop is measured in the same seconds as editing a command.
 - **The single static binary is the distribution advantage.** The thing you ship

--- a/docs/adr/0031-plugin-abi-boundary.md
+++ b/docs/adr/0031-plugin-abi-boundary.md
@@ -1,0 +1,119 @@
+# Bundled plugins keep the single-import rule; `plugin_abi` gets an admission test
+
+Status: accepted
+
+Bundled plugins — `zcli_help`, `zcli_config`, `zcli_completions`, `zcli_docs`
+and the rest under `packages/core/src/plugins/` — compile against exactly one
+import, `"zcli"`, the same as a third-party plugin package or a
+`plugins_dir` local. They are **not** given a private door into framework
+internals. `zcli.plugin_abi` stays the single, named place where an internal
+becomes reachable from a plugin, and it now carries a written admission test
+(below) that says which internals qualify.
+
+**Nothing was removed from `plugin_abi`.** Issue #787 framed the work as
+shrinking it, so this is worth stating plainly rather than leaving a reader to
+notice: all five groups remain, because on review all five pass the admission
+test this ADR introduces. The change here is a rule where there was none, not a
+smaller surface — and if the rule is right, the surface being unchanged is the
+expected result, not a dodge. What would have shrunk it is the rejected design
+(a private import for bundled plugins), and the "Decision" section is the
+argument for why that trade is bad.
+
+## Context
+
+`plugin_abi` re-exports five groups of framework internals purely so bundled
+plugins can reach them: `isNegativeNumber`, the serde `config_parse` shims,
+`usage`, `custom_type`, and `config_coerce`. Every consumer today is a bundled
+plugin; no third-party plugin uses any of it.
+
+The tension is structural and was raised in #787. ADR-0027 makes plugins
+compile-time participants in the registry, and bundled plugins live *inside*
+core — the same repository, the same release, the same reviewer. Yet
+`addPluginModulesToRegistry` gives a built-in exactly the module set it gives a
+consumer's local plugin: `zcli` and nothing else. So core reaches its own
+internals through a public re-export on its own umbrella, and that re-export
+list only ever grows.
+
+The obvious fix is to let bundled plugins import internals directly — an
+additional `zcli_internal` module wired only for built-ins (they cannot use
+relative imports; their module root is the plugin file, so `../../` escapes it).
+That would shrink `plugin_abi` to whatever genuine third-party plugins need,
+which today is nothing.
+
+## Decision
+
+**Keep the constraint.** Three reasons, in order of weight:
+
+1. **Bundled plugins are the reference implementations.** A `plugins_dir`
+   local plugin and a built-in are compiled by the *same branch* of
+   `addPluginModulesToRegistry`, differing only in where the root source file
+   resolves. That is not an accident of the build code; it is the property that
+   makes "read `zcli_help` to see how a plugin does it" a true answer. Give the
+   built-ins a private door and every such answer becomes "with a mechanism you
+   don't have" — and the framework loses its most honest set of worked examples
+   at exactly the moment ADR-0027 is asking users to accept compile-time-only
+   plugins.
+
+2. **The constraint is the only thing making the surface visible.** The
+   complaint is that `plugin_abi` grows monotonically. It does — but it grows
+   *in a reviewed, documented, greppable list*. Replace it with
+   `@import("zcli_internal")` and the growth does not stop; it stops being
+   observable. The leak gets worse and quieter. A boundary you can see people
+   crossing is worth more than a boundary nobody crosses because it isn't there.
+
+3. **Each crossing is a forcing function.** Adding to `plugin_abi` costs a
+   deliberate act, which is what makes someone ask whether the thing being
+   exported is *shared vocabulary* or just convenient. Four of the five current
+   groups are shared vocabulary: `usage` exists so help and the doc generator
+   render the same synopsis, `isNegativeNumber` so the completions cursor walk
+   counts positionals exactly as the parser does, `custom_type` and
+   `config_coerce` so config coerces a value identically to CLI and env. A
+   divergent private copy of any of them would be a *behavioral bug*, not
+   duplication. That is not leakage; it is single-source-of-truth, and it should
+   be somewhere visible.
+
+There is no ABI cost either way — everything resolves at comptime and links into
+one binary (ADR-0027) — so the whole question is conceptual surface, and the
+visible-boundary answer wins.
+
+## The admission test
+
+A declaration may join `plugin_abi` only if it passes **at least one** of:
+
+- **Shared agreement.** Two or more independently-compiled units must agree on
+  it, such that a divergent copy would be a behavioral bug rather than
+  duplication. (`usage`, `isNegativeNumber`, `custom_type`, `config_coerce`.)
+- **Dependency containment.** It is a narrow shim that exists to keep a
+  third-party dependency *out* of zcli's public contract. (`config_parse`
+  re-exports four serde names instead of serde.)
+
+and **all** of:
+
+- **In-lockstep ownership.** You would fix the bundled plugins yourself when it
+  changes. If a change here would require coordinating with code you don't own,
+  it is a public API question, not a `plugin_abi` one.
+- **Named for the job, not the internal.** It goes under a named group that
+  says what need it serves (`config_parse`, `config_coerce`), so the entry
+  documents the requirement rather than advertising the internal.
+
+And the negative rule, which is the one that matters: **`plugin_abi` is not for
+convenience.** If a bundled plugin wants an internal only for itself, and
+nothing in core has to agree with it, the answer is to copy the logic into the
+plugin or move it there — not to widen the surface. A sixth group that is not
+like the five above is the signal that this ADR is being violated.
+
+## Consequences
+
+- The rule lives in three places on purpose: here, as a comment on `plugin_abi`
+  in `packages/core/src/zcli.zig` (the point of temptation), and by example in
+  the five existing groups. A reviewer can apply it without reading this file.
+- `plugin_abi` will keep growing, and that is now an intended, bounded outcome
+  rather than an unexamined one. It stays small because the test is narrow, not
+  because nobody is looking.
+- The `zcli_internal`-module design is written down as **rejected**, so the next
+  person to have the idea can see it was considered and why it lost, instead of
+  re-deriving it.
+- If a genuine third-party plugin ever needs one of these groups, nothing has to
+  change — that is the point of exporting them under a documented name in the
+  first place. What would reopen this ADR is the opposite: sustained pressure to
+  add entries that pass neither arm of the admission test.

--- a/docs/adr/0032-no-config-field-marker.md
+++ b/docs/adr/0032-no-config-field-marker.md
@@ -1,0 +1,159 @@
+# `meta.options.<field>.no_config`: config trust as a field declaration
+
+Status: accepted (implemented)
+
+An Options field may declare `.no_config = true`. A marked field is never filled
+from a config file — no `applyConfigDefaults` hook can populate it — while the
+CLI, the env fallback, and the struct default keep working exactly as before.
+The marker is comptime-validated and enforced in the registry, not requested of
+the plugin.
+
+## Context
+
+`zcli_config` discovers project-local config from the process's cwd
+(`.{app}.config.toml` and friends). That is a real, bounded exposure, documented
+at length on the plugin: anyone who can get a victim to run the CLI inside a
+directory they control — a cloned repo, an extracted archive, a shared build
+dir — sets the *default* for every Option the plugin covers, for that
+invocation. Values still flow through the typed parser, content is capped, and
+CLI/env always win, so it is an attacker-influenced default rather than code
+execution. The plugin's doc comment therefore gave concrete guidance:
+
+> do not model security-sensitive behavior (e.g. "skip verification", "disable
+> a safety check", a trusted path/URL/repo) as a plain config-overridable Option
+> field.
+
+Good advice, correctly reasoned, and followed by the framework's own upgrade
+plugin (its repo and signing key are comptime). But it is a **doc comment**.
+Nothing stopped an app author from declaring `--skip-verification` as an
+ordinary `bool` Option, and nothing warned them. The one class of field where
+the guidance matters most is the one where "I read the plugin's doc comment"
+is the weakest possible control (#788).
+
+Meanwhile the framework already expresses field-level policy at comptime
+everywhere else: `meta.exclusive` and `meta.options.<field>.requires` for
+cross-field constraints (ADR-0022), a per-field `validate` hook for value rules
+(ADR-0025). "This field is never settable from a config file" is exactly that
+shape of statement, and there was no way to say it.
+
+## Decision
+
+A comptime marker in the place every other per-field policy lives:
+
+```zig
+pub const Options = struct {
+    skip_verification: bool = false,
+    registry: []const u8 = "https://registry.example",
+};
+
+pub const meta = .{
+    .options = .{
+        .skip_verification = .{ .no_config = true },
+        .registry = .{ .no_config = true },
+    },
+};
+```
+
+Following ADR-0022/ADR-0025 exactly: it sits on `meta.options.<field>`, it joins
+the `valid_option_fields` allowlist so a neighbouring typo is a build error, and
+its type is checked (`bool`) at comptime with a message that says what the
+marker does. `false` is a legitimate no-op, so a comptime-computed marker reads
+the way it looks.
+
+### Enforced in the registry, not in the plugin
+
+The obvious implementation — teach `zcli_config` to read the marker — was
+rejected for two reasons.
+
+**It would still be advisory.** `applyConfigDefaults` is a public plugin hook.
+Any plugin can implement it, and a second config source that didn't check the
+marker would silently defeat it. A security marker that only the *bundled*
+implementation honors is barely stronger than the doc comment it replaces.
+
+**It would grow the hook contract.** Passing `meta` (or a locked mask) to the
+hook makes honoring it an obligation every implementer has to remember — which
+is the same failure mode one level down.
+
+So the registry enforces it, around the hook loop, in two layers:
+
+1. **`maskNoConfig`** hands the hooks a `provided` view with every marked
+   field's flag forced true. Every hook *already* owes the framework "skip any
+   field whose `provided` flag is true" — that single check is what makes
+   CLI > env > config hold — so a locked field is skipped by machinery a
+   conforming hook has already implemented. No new obligation, and third-party
+   config sources get the guarantee for free.
+2. **`restoreNoConfig`** afterwards restores the pre-hook value of every marked
+   field and clears its `config_applied` flag. A conforming hook makes this a
+   no-op; a hook that ignores `provided` cannot make the marker a lie. This is
+   what turns the marker from advice into a guarantee.
+
+The *real* provided bitset is untouched, so the required-option and ADR-0022
+constraint checks still see the truth: a marked **required** option that only a
+config file supplied correctly reports "missing" rather than silently taking the
+file's value — the safe outcome, and the one an author who marked the field
+would expect.
+
+### Cost
+
+The mask is comptime, so with no marker every flag is false and every guarded
+branch folds away. The snapshot needed more care than that: an unconditional
+`const before = options` would copy the whole options struct on *every*
+invocation of *every* command, and no amount of dead-branch folding removes it —
+the copy happens before the branch that would have ignored it. On a path this
+repo gates with startup-time and binary-size budgets (#738/#739), that is not a
+cost to wave through on behalf of a marker almost no command uses.
+
+So the snapshot's **type** is conditional: `NoConfigSnapshot` is `OptionsType`
+when some field is marked and `void` when none is. The unmarked case does not
+take a cheap copy — there is nothing to copy. `captureNoConfig` compiles to
+nothing and `restoreNoConfig` returns before reading `before`. Commands that
+actually use the marker pay one struct copy per invocation, which is the honest
+price of a guarantee that survives a hook ignoring its contract. `.no_config =
+false` is a no-op here too: it does not flip the snapshot type, so mentioning the
+marker inertly costs nothing either.
+
+Restoring **orphans** rather than frees whatever a rogue hook wrote. It must: a
+slice field's current value may be the hook's allocation or the struct's own
+comptime default, and nothing at that point can tell them apart, so freeing
+risks an invalid free. Under the arena-per-command (ADR-0001) the orphan is
+reclaimed wholesale, and a conforming hook never allocates for a locked field at
+all, because layer 1 made it skip.
+
+### Why a per-field opt-out rather than a per-field opt-in
+
+An allowlist (`.config = true`, nothing settable from config unless marked)
+would be the stricter default, and was considered. It was rejected because it
+inverts the plugin's entire value proposition: `zcli_config` exists so that
+adding one plugin makes *every* option config-overridable with no per-field
+work. Requiring an annotation per field would make the common, harmless case
+(a default output format) pay for the rare, sensitive one, and an annotation
+tax that fires constantly is an annotation people apply mechanically — which
+is how it stops meaning anything. Opt-out keeps the marker rare, which keeps it
+readable as a signal.
+
+### Why the marker names config, not "trust"
+
+`no_config` says precisely what it does — this field is not populated from a
+config file — rather than implying a general trust level the framework cannot
+enforce. Env vars are not covered: the environment belongs to the user's own
+process, not to a directory they happened to `cd` into, and conflating the two
+would make the marker mean something vaguer than it can deliver.
+
+## Consequences
+
+- The plugin's threat-model doc comment now ends in a mechanism instead of an
+  instruction: it shows the marker, and keeps recommending the stronger option
+  (comptime/build-time config, as the upgrade plugin uses) where it fits. A
+  security note that terminates in something you can *write* is worth more than
+  one that terminates in something you must remember.
+- The `applyConfigDefaults` contract in `plugin_types.zig` documents that
+  `provided` now carries the marker, and that ignoring `provided` gets a hook's
+  writes to marked fields undone. Hooks that were already correct need no change.
+- Help output is unchanged: a marked field looks like any other option. Marking
+  it in `--help` was considered and deferred — the marker is a statement about
+  where a value may come from, not about how to use the flag, and no other
+  source-level policy (`.env`) is surfaced there either. Easy to add if asked for.
+- Deliberately not covered, in keeping with the ADR-0022 habit of deferring
+  primitives until something needs them: a command-level "no config at all"
+  switch, and any marker for `meta.args.<field>` (positionals are never
+  config-sourced, so there is nothing to lock).

--- a/packages/core/src/command_parser.zig
+++ b/packages/core/src/command_parser.zig
@@ -194,6 +194,133 @@ pub fn firstMissingRequiredOption(
     return null;
 }
 
+/// One flag per Options field (field-declaration order — the same keying as
+/// `options_provided`), true where `meta.options.<field>.no_config` locks the
+/// field against config files (ADR-0032). Fully comptime; all false, and every
+/// branch guarded by it folded away, unless a field carries the marker.
+pub fn noConfigMask(
+    comptime OptionsType: type,
+    comptime meta: anytype,
+) [options_parser.optionFieldCount(OptionsType)]bool {
+    // `return comptime blk:` rather than a `comptime { … }` body, matching
+    // `option_utils.exclusiveSets` — the established idiom here for a helper
+    // whose whole result is folded at compile time.
+    return comptime blk: {
+        var mask = [_]bool{false} ** options_parser.optionFieldCount(OptionsType);
+        const info = @typeInfo(OptionsType);
+        if (info == .@"struct") {
+            for (info.@"struct".fields, 0..) |field, i| {
+                mask[i] = option_utils.isNoConfig(meta, field.name);
+            }
+        }
+        break :blk mask;
+    };
+}
+
+/// The `provided` view to hand `applyConfigDefaults` hooks: the real CLI/env
+/// bitset with every `no_config` field forced true (ADR-0032).
+///
+/// This is the *primary* enforcement of the marker, and it deliberately adds no
+/// new obligation: every hook already owes the framework "skip any field whose
+/// `provided` flag is true" — that single check is what makes CLI > env > config
+/// hold — so a locked field is skipped by the machinery a conforming hook has
+/// already implemented. A third-party config source gets the guarantee for free,
+/// which is why this lives here and not inside `zcli_config`.
+///
+/// The caller keeps the real bitset for the required/constraint checks, so a
+/// locked field still reads as unsupplied unless the CLI or env truly supplied
+/// it — a locked *required* option correctly reports "missing" rather than
+/// silently taking a config value.
+pub fn maskNoConfig(
+    comptime OptionsType: type,
+    comptime meta: anytype,
+    provided: [options_parser.optionFieldCount(OptionsType)]bool,
+) [options_parser.optionFieldCount(OptionsType)]bool {
+    const mask = comptime noConfigMask(OptionsType, meta);
+    var masked = provided;
+    inline for (mask, 0..) |locked, i| {
+        if (locked) masked[i] = true;
+    }
+    return masked;
+}
+
+/// Does any field of `OptionsType` carry the `no_config` marker? Comptime, and
+/// false for the overwhelming majority of commands — which is what lets
+/// `NoConfigSnapshot` erase the backstop's cost entirely rather than merely
+/// making its branches dead.
+pub fn anyNoConfig(comptime OptionsType: type, comptime meta: anytype) bool {
+    return comptime blk: {
+        for (noConfigMask(OptionsType, meta)) |locked| {
+            if (locked) break :blk true;
+        }
+        break :blk false;
+    };
+}
+
+/// What `captureNoConfig` hands `restoreNoConfig`: the options struct when some
+/// field is marked, and `void` when none is.
+///
+/// The `void` case is the point. An unconditional `const before = options` would
+/// copy the whole struct on every command invocation to serve a marker almost no
+/// command uses — a real cost on a path this repo gates with a startup-time and
+/// binary-size budget, and not something a dead `if` removes, since the copy
+/// happens before any branch. Making the *type* zero-sized removes the copy
+/// itself.
+pub fn NoConfigSnapshot(comptime OptionsType: type, comptime meta: anytype) type {
+    return if (anyNoConfig(OptionsType, meta)) OptionsType else void;
+}
+
+/// Take the pre-config snapshot `restoreNoConfig` restores from. Compiles to
+/// nothing when no field is marked (the snapshot type is `void`); otherwise it
+/// is one copy of the options struct, paid only by commands that use the marker.
+pub fn captureNoConfig(
+    comptime OptionsType: type,
+    comptime meta: anytype,
+    options: OptionsType,
+) NoConfigSnapshot(OptionsType, meta) {
+    if (comptime !anyNoConfig(OptionsType, meta)) return {};
+    return options;
+}
+
+/// Undo any write an `applyConfigDefaults` hook made to a `no_config` field:
+/// restore the pre-hook value from `before` and clear its `config_applied` flag.
+///
+/// The backstop to `maskNoConfig`. A hook that honors `provided` never touches a
+/// locked field and this is a no-op; a hook that ignores it cannot make the
+/// marker a lie. Without this the marker would be advisory — exactly the
+/// weakness in relying on a doc comment that #788 set out to remove.
+///
+/// `before` comes from `captureNoConfig` and holds the options as they stood
+/// after CLI/env parsing, so restoring is a plain assignment of the value that
+/// was already correct. Clearing the applied flag matters as much as the value:
+/// leaving it set would tell the required-option check that a locked field had
+/// been supplied.
+///
+/// Restoring *orphans* rather than frees whatever a rogue hook wrote. It has to:
+/// a slice field's current value may be the hook's allocation or the struct's
+/// own comptime default, and nothing here can tell them apart, so freeing risks
+/// an invalid free. Under the framework's arena-per-command (ADR-0001) — which
+/// is what the registry always uses, and what the config plugin allocates
+/// coerced arrays from — the orphan is reclaimed wholesale. A conforming hook
+/// never allocates for a locked field in the first place, because `maskNoConfig`
+/// made it skip.
+pub fn restoreNoConfig(
+    comptime OptionsType: type,
+    comptime meta: anytype,
+    options: *OptionsType,
+    before: NoConfigSnapshot(OptionsType, meta),
+    config_applied: *[options_parser.optionFieldCount(OptionsType)]bool,
+) void {
+    if (comptime !anyNoConfig(OptionsType, meta)) return;
+    const mask = comptime noConfigMask(OptionsType, meta);
+    inline for (@typeInfo(OptionsType).@"struct".fields, 0..) |field, i| {
+        if (mask[i]) {
+            @field(options, field.name) = @field(before, field.name);
+            config_applied[i] = false;
+        }
+    }
+}
+
 /// The field index of `name` in `OptionsType` (comptime). Constraint names are
 /// validated with `@hasField` at build time, so this always resolves here.
 fn fieldIndex(comptime OptionsType: type, comptime name: []const u8) usize {
@@ -1329,6 +1456,215 @@ test "firstExclusiveViolation: overlapping sets are checked independently" {
         try std.testing.expectEqualStrings("b", ex.?.first);
         try std.testing.expectEqualStrings("c", ex.?.second);
     }
+}
+
+test "noConfigMask: marks exactly the fields carrying meta.<field>.no_config" {
+    const Options = struct {
+        verbose: bool = false,
+        skip_verification: bool = false,
+        registry: []const u8 = "default",
+    };
+    const meta = .{
+        .options = .{
+            .skip_verification = .{ .no_config = true },
+            // `false` is a legitimate no-op, not a lock — a computed marker has to
+            // read the way it looks.
+            .registry = .{ .description = "registry URL", .no_config = false },
+        },
+    };
+
+    const mask = noConfigMask(Options, meta);
+    try std.testing.expectEqual(false, mask[0]);
+    try std.testing.expectEqual(true, mask[1]);
+    try std.testing.expectEqual(false, mask[2]);
+
+    // A command with no meta at all locks nothing.
+    const bare = noConfigMask(Options, null);
+    for (bare) |locked| try std.testing.expectEqual(false, locked);
+}
+
+test "maskNoConfig: hides a locked field from the hook without touching the real bitset" {
+    const Options = struct {
+        verbose: bool = false,
+        skip_verification: bool = false,
+    };
+    const meta = .{ .options = .{ .skip_verification = .{ .no_config = true } } };
+
+    const provided = [_]bool{ false, false }; // neither supplied by CLI/env
+    const masked = maskNoConfig(Options, meta, provided);
+
+    // The hook sees the locked field as already supplied, so its precedence
+    // check skips it; the unlocked field is still fair game.
+    try std.testing.expectEqual(false, masked[0]);
+    try std.testing.expectEqual(true, masked[1]);
+
+    // The caller's bitset is untouched — the required/constraint checks must
+    // keep seeing that nothing was actually supplied.
+    try std.testing.expectEqual(false, provided[1]);
+}
+
+test "restoreNoConfig: undoes a hook that wrote to a locked field anyway" {
+    const Options = struct {
+        verbose: bool = false,
+        skip_verification: bool = false,
+    };
+    const meta = .{ .options = .{ .skip_verification = .{ .no_config = true } } };
+
+    const before = captureNoConfig(Options, meta, .{ .verbose = false, .skip_verification = false });
+    // A non-conforming hook that ignored `provided` and set both fields.
+    var options: Options = .{ .verbose = true, .skip_verification = true };
+    var applied = [_]bool{ true, true };
+
+    restoreNoConfig(Options, meta, &options, before, &applied);
+
+    // The locked field is back to its pre-config value and no longer counts as
+    // supplied; the unlocked field's config value stands.
+    try std.testing.expectEqual(false, options.skip_verification);
+    try std.testing.expectEqual(false, applied[1]);
+    try std.testing.expectEqual(true, options.verbose);
+    try std.testing.expectEqual(true, applied[0]);
+}
+
+test "restoreNoConfig: no-op when nothing is marked, and the snapshot is zero-sized" {
+    const Options = struct { count: u32 = 1 };
+
+    // The cost claim, pinned as a type-level fact rather than asserted in prose:
+    // with no marker the snapshot is `void`, so the registry takes no copy at
+    // all (as opposed to taking one that a dead branch then ignores).
+    try std.testing.expectEqual(void, NoConfigSnapshot(Options, .{}));
+    try std.testing.expectEqual(@as(usize, 0), @sizeOf(NoConfigSnapshot(Options, .{})));
+    try std.testing.expectEqual(false, anyNoConfig(Options, .{}));
+
+    const before = captureNoConfig(Options, .{}, .{ .count = 1 });
+    var options: Options = .{ .count = 7 };
+    var applied = [_]bool{true};
+
+    restoreNoConfig(Options, .{}, &options, before, &applied);
+
+    // A config-sourced value on an unmarked field survives untouched.
+    try std.testing.expectEqual(@as(u32, 7), options.count);
+    try std.testing.expectEqual(true, applied[0]);
+}
+
+test "NoConfigSnapshot: a marked field makes the snapshot the options struct" {
+    const Options = struct {
+        verbose: bool = false,
+        skip_verification: bool = false,
+    };
+    const meta = .{ .options = .{ .skip_verification = .{ .no_config = true } } };
+
+    try std.testing.expectEqual(true, anyNoConfig(Options, meta));
+    try std.testing.expectEqual(Options, NoConfigSnapshot(Options, meta));
+
+    // `.no_config = false` is a no-op, so it must NOT make the command pay for
+    // the snapshot — the marker's cost tracks real use, not mere mention.
+    const inert = .{ .options = .{ .skip_verification = .{ .no_config = false } } };
+    try std.testing.expectEqual(false, anyNoConfig(Options, inert));
+    try std.testing.expectEqual(void, NoConfigSnapshot(Options, inert));
+}
+
+/// A deliberately non-conforming `applyConfigDefaults`: it ignores `provided`
+/// entirely and stamps every field it can. Exists so the backstop is proven by
+/// RUNNING a hook like this, not by reading `restoreNoConfig` and believing it —
+/// nothing in the hook contract can stop such a plugin being written, which is
+/// the whole reason layer 2 exists.
+///
+/// It lives here rather than in plugin_config_integration_test.zig for a module
+/// reason: that file imports the config plugin's source, so it is built with the
+/// "zcli" module, and `zcli.zig` already contains this file — importing this
+/// file relatively from there would put one file in two modules, which Zig
+/// rejects outright. The rogue hook needs no plugin anyway, only the helpers it
+/// must not be able to defeat.
+const RogueConfigHook = struct {
+    fn applyConfigDefaults(
+        comptime OptionsType: type,
+        options: *OptionsType,
+        provided: []const bool,
+        applied: []bool,
+    ) void {
+        _ = provided; // the bug being modelled
+        inline for (@typeInfo(OptionsType).@"struct".fields, 0..) |field, i| {
+            if (field.type == bool) {
+                @field(options, field.name) = true;
+                applied[i] = true;
+            } else if (field.type == []const u8) {
+                @field(options, field.name) = "https://evil.example";
+                applied[i] = true;
+            }
+        }
+    }
+};
+
+test "no_config: a rogue hook that ignores `provided` cannot write a locked field" {
+    const Options = struct {
+        skip_verification: bool = false,
+        registry: []const u8 = "https://trusted.example",
+        verbose: bool = false,
+    };
+    const meta = .{ .options = .{
+        .skip_verification = .{ .no_config = true },
+        .registry = .{ .no_config = true },
+    } };
+
+    var options: Options = .{};
+    var applied = [_]bool{false} ** 3;
+    const provided = [_]bool{false} ** 3;
+
+    // The registry's exact sequence, with the rogue hook standing in.
+    const hook_provided = maskNoConfig(Options, meta, provided);
+    const before = captureNoConfig(Options, meta, options);
+    RogueConfigHook.applyConfigDefaults(Options, &options, &hook_provided, &applied);
+
+    // Layer 1 did not save us — this hook never looked at `provided`.
+    try std.testing.expectEqual(true, options.skip_verification);
+    try std.testing.expectEqualStrings("https://evil.example", options.registry);
+
+    restoreNoConfig(Options, meta, &options, before, &applied);
+
+    // Layer 2 did: values back to the pre-config ones, and the applied flags
+    // cleared so nothing downstream believes the fields were supplied.
+    try std.testing.expectEqual(false, options.skip_verification);
+    try std.testing.expectEqualStrings("https://trusted.example", options.registry);
+    try std.testing.expect(!applied[0]);
+    try std.testing.expect(!applied[1]);
+
+    // The unmarked field keeps the hook's write — the backstop is targeted, not
+    // a blanket rollback of everything a misbehaving plugin did.
+    try std.testing.expectEqual(true, options.verbose);
+    try std.testing.expect(applied[2]);
+}
+
+test "no_config: a locked REQUIRED option supplied only by config still reports missing" {
+    // The subtlest interaction in ADR-0032. Both options are required (no
+    // default, non-optional, non-bool, non-array); only `signing_key` is locked.
+    const Options = struct {
+        signing_key: []const u8,
+        project: []const u8,
+    };
+    const meta = .{ .options = .{ .signing_key = .{ .no_config = true } } };
+
+    // Nothing came from CLI or env. This is the REAL bitset — the registry never
+    // overwrites it with the masked view, precisely so this check sees the truth.
+    const provided = [_]bool{ false, false };
+
+    // A config pass that filled the unlocked field and (correctly) skipped the
+    // locked one: exactly the report the masked view produces.
+    const config_applied = [_]bool{ false, true };
+
+    const missing = firstMissingRequiredOption(Options, meta, provided, config_applied);
+    try std.testing.expect(missing != null);
+    // Reported by effective long name, so the user sees the flag they would type.
+    try std.testing.expectEqualStrings("signing-key", missing.?.name);
+
+    // Control: had the field not been locked, that same config value would have
+    // satisfied it — so the marker is what changes the outcome, not the fixture.
+    const both_applied = [_]bool{ true, true };
+    try std.testing.expect(firstMissingRequiredOption(Options, meta, provided, both_applied) == null);
+
+    // And CLI/env still satisfy a locked required option, which is the point:
+    // the value has to come from somewhere the user controls.
+    const from_cli = [_]bool{ true, false };
+    try std.testing.expect(firstMissingRequiredOption(Options, meta, from_cli, config_applied) == null);
 }
 
 test "firstOptionValidationError: reports the first field the hook rejects" {

--- a/packages/core/src/options/utils.zig
+++ b/packages/core/src/options/utils.zig
@@ -787,6 +787,25 @@ pub fn hasValidate(comptime meta: anytype, comptime field_name: []const u8) bool
     return @hasField(@TypeOf(field_meta), "validate");
 }
 
+/// Whether `meta.options.<field>.no_config` locks this field against config
+/// files (ADR-0032): a marked field is never filled by an `applyConfigDefaults`
+/// hook, so its value can only come from the CLI, the env, or the struct
+/// default. Exists because project-local config is discovered from cwd, which an
+/// attacker may control — a field whose value is a trust decision must not be
+/// settable by a file that arrives with a cloned repo.
+///
+/// `validateCommand` checks the marker is a bool. Only `true` locks: `false`
+/// means "no policy", so a comptime-computed marker reads the way it looks.
+pub fn isNoConfig(comptime meta: anytype, comptime field_name: []const u8) bool {
+    if (@TypeOf(meta) == @TypeOf(null)) return false;
+    if (!@hasField(@TypeOf(meta), "options")) return false;
+    if (!@hasField(@TypeOf(meta.options), field_name)) return false;
+    const field_meta = @field(meta.options, field_name);
+    if (@typeInfo(@TypeOf(field_meta)) != .@"struct") return false;
+    if (!@hasField(@TypeOf(field_meta), "no_config")) return false;
+    return field_meta.no_config;
+}
+
 /// Whether `meta.args.<field>` declares a `validate` hook. The struct form of
 /// args metadata (a bare string carries none) may carry the same `fn(Base)
 /// ?[]const u8` hook as options; `validateCommand` verifies its signature.

--- a/packages/core/src/plugin_config_integration_test.zig
+++ b/packages/core/src/plugin_config_integration_test.zig
@@ -9,6 +9,20 @@ const zcli = @import("zcli");
 const config = @import("plugins/zcli_config/plugin.zig");
 const testing = std.testing;
 
+// NOTE on module boundaries: this file may NOT relatively import framework
+// internals (`command_parser.zig`, …). It imports the config plugin's source,
+// which imports the "zcli" MODULE, so this test target is built with that module
+// — and `zcli.zig` already contains `command_parser.zig`. Reaching it relatively
+// as well puts one file in two modules, which Zig rejects outright:
+// "file exists in modules 'root' and 'zcli'".
+//
+// That is why the `no_config` split below is what it is: the ADR-0032 helpers
+// (`noConfigMask`/`maskNoConfig`/`captureNoConfig`/`restoreNoConfig`, and their
+// interaction with `firstMissingRequiredOption`) are unit-tested next to their
+// implementation in command_parser.zig, where no plugin — and so no "zcli"
+// module — is needed. What belongs HERE is the other half: the real plugin,
+// reading a real file, honoring the masked bitset the registry hands it.
+
 /// The slice of `context` the config plugin reads. `plugins.zcli_config` is the
 /// per-command ContextData the framework threads; the rest are plain accessors.
 const FakeContext = struct {
@@ -174,6 +188,220 @@ test "integration: required option satisfied by config (through parseCommandLine
     // registry's required-option check treats as "supplied".
     try testing.expectEqualStrings("secret123", opts.token);
     try testing.expect(applied[0]);
+
+    config.deinitContextData(&ctx.plugins.zcli_config, alloc);
+}
+
+test "integration: a no_config field is not set from a config file that supplies it (ADR-0032)" {
+    var a = arena();
+    defer a.deinit();
+    const alloc = a.allocator();
+    const io = testing.io;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // The threat this marker exists for: a config file that arrived with a
+    // cloned repo tries to turn off signature verification, and to prove the
+    // lock is per-field rather than per-file, sets an ordinary option too.
+    try tmp.dir.writeFile(io, .{
+        .sub_path = "myapp.toml",
+        .data = "skip_verification = true\nregistry = \"https://evil.example\"\ncount = 9\n",
+    });
+    const abs = try tmp.dir.realPathFileAlloc(io, "myapp.toml", alloc);
+
+    var environ = std.process.Environ.Map.init(alloc);
+    const cmd_path = [_][]const u8{};
+    var ctx = makeCtx(alloc, &environ, &cmd_path, &discard.writer);
+    ctx.plugins.zcli_config.custom_path = abs;
+    const args = zcli.ParsedArgs.init(alloc);
+    _ = try config.preExecute(&ctx, args);
+
+    const Opts = struct {
+        skip_verification: bool = false,
+        registry: []const u8 = "https://trusted.example",
+        count: u32 = 1,
+    };
+    const meta = .{ .options = .{
+        .skip_verification = .{ .no_config = true },
+        .registry = .{ .no_config = true },
+    } };
+
+    const result = try zcli.parseCommandLine(struct {}, Opts, meta, alloc, &environ, &.{}, null);
+    defer result.deinit();
+
+    var opts = result.options;
+    var applied = [_]bool{false} ** @typeInfo(Opts).@"struct".fields.len;
+
+    // The bitset the registry hands the hook: nothing was supplied by CLI/env,
+    // but the two marked fields read as provided. This is precisely what
+    // `command_parser.maskNoConfig(Opts, meta, result.options_provided)` returns
+    // — asserted against the real helper in command_parser.zig's own tests (see
+    // the module-boundary note at the top of this file for why it cannot be
+    // called from here). What this test pins is the half that is genuinely the
+    // plugin's: given that bitset, and a file that names all three keys, the
+    // real plugin must not write the marked fields.
+    for (result.options_provided) |p| try testing.expect(!p);
+    const hook_provided = [_]bool{ true, true, false };
+
+    config.applyConfigDefaults(&ctx, Opts, &opts, &hook_provided, &applied);
+
+    // Both marked fields keep their struct defaults even though the file names
+    // them, and neither counts as supplied — so a marked *required* option would
+    // correctly report "missing" rather than silently take the file's value
+    // (pinned in command_parser.zig against firstMissingRequiredOption).
+    try testing.expectEqual(false, opts.skip_verification);
+    try testing.expectEqualStrings("https://trusted.example", opts.registry);
+    try testing.expect(!applied[0]);
+    try testing.expect(!applied[1]);
+
+    // The lock is per-field: the unmarked option still loads normally, so this
+    // is a targeted policy rather than "ignore the config file".
+    try testing.expectEqual(@as(u32, 9), opts.count);
+    try testing.expect(applied[2]);
+
+    config.deinitContextData(&ctx.plugins.zcli_config, alloc);
+}
+
+test "integration: no_config does not block the CLI or env from setting the field" {
+    var a = arena();
+    defer a.deinit();
+    const alloc = a.allocator();
+
+    var environ = std.process.Environ.Map.init(alloc);
+    try environ.put("MYAPP_REGISTRY", "https://from-env.example");
+
+    const Opts = struct {
+        skip_verification: bool = false,
+        registry: []const u8 = "https://trusted.example",
+    };
+    const meta = .{ .options = .{
+        .skip_verification = .{ .no_config = true },
+        .registry = .{ .no_config = true, .env = "MYAPP_REGISTRY" },
+    } };
+
+    // No config plugin in play at all — the marker governs file-sourced values
+    // only, and must leave the two sources the user genuinely controls alone.
+    const result = try zcli.parseCommandLine(struct {}, Opts, meta, alloc, &environ, &.{"--skip-verification"}, null);
+    defer result.deinit();
+
+    const opts = result.options;
+
+    // Both marked, both still set — from the CLI and from env respectively — and
+    // both flagged provided, which is what makes them satisfy a required option
+    // and what makes config skip them.
+    try testing.expectEqual(true, opts.skip_verification);
+    try testing.expectEqualStrings("https://from-env.example", opts.registry);
+    try testing.expect(result.options_provided[0]);
+    try testing.expect(result.options_provided[1]);
+}
+
+test "integration: a no_config REQUIRED option is left unset by the real plugin" {
+    var a = arena();
+    defer a.deinit();
+    const alloc = a.allocator();
+    const io = testing.io;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // The subtlest interaction in the feature: config supplies the required
+    // option, and must NOT count. Two required options so the "unmarked one is
+    // still satisfied" half is proven by the same run. That the registry then
+    // REPORTS it missing is pinned against firstMissingRequiredOption in
+    // command_parser.zig; what this proves is that the plugin leaves it unset
+    // and, crucially, does not mark it applied.
+    try tmp.dir.writeFile(io, .{
+        .sub_path = "myapp.yaml",
+        .data = "signing_key: attacker-key\nproject: acme\n",
+    });
+    const abs = try tmp.dir.realPathFileAlloc(io, "myapp.yaml", alloc);
+
+    var environ = std.process.Environ.Map.init(alloc);
+    const cmd_path = [_][]const u8{};
+    var ctx = makeCtx(alloc, &environ, &cmd_path, &discard.writer);
+    ctx.plugins.zcli_config.custom_path = abs;
+    const args = zcli.ParsedArgs.init(alloc);
+    _ = try config.preExecute(&ctx, args);
+
+    // Both required (no default, non-optional, non-bool, non-array).
+    const Opts = struct {
+        signing_key: []const u8,
+        project: []const u8,
+    };
+    const meta = .{ .options = .{ .signing_key = .{ .no_config = true } } };
+
+    const result = try zcli.parseCommandLine(struct {}, Opts, meta, alloc, &environ, &.{}, null);
+    defer result.deinit();
+
+    var opts = result.options;
+    var applied = [_]bool{false} ** @typeInfo(Opts).@"struct".fields.len;
+
+    const hook_provided = [_]bool{ true, false }; // signing_key masked by the registry
+    config.applyConfigDefaults(&ctx, Opts, &opts, &hook_provided, &applied);
+
+    // The unmarked required option is satisfied by the file, as always.
+    try testing.expectEqualStrings("acme", opts.project);
+    try testing.expect(applied[1]);
+
+    // The marked one is not, and is not marked applied — which is exactly the
+    // input that makes the registry's required-option check report it missing
+    // rather than silently running with a value a directory chose.
+    try testing.expect(!applied[0]);
+
+    config.deinitContextData(&ctx.plugins.zcli_config, alloc);
+}
+
+test "integration: a no_config multi-value option is not filled from a config list" {
+    var a = arena();
+    defer a.deinit();
+    const alloc = a.allocator();
+    const io = testing.io;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(io, .{
+        .sub_path = "myapp.json",
+        .data = "{\"trusted_hosts\": [\"evil.example\", \"evil2.example\"], \"tags\": [\"a\", \"b\"]}",
+    });
+    const abs = try tmp.dir.realPathFileAlloc(io, "myapp.json", alloc);
+
+    var environ = std.process.Environ.Map.init(alloc);
+    const cmd_path = [_][]const u8{};
+    var ctx = makeCtx(alloc, &environ, &cmd_path, &discard.writer);
+    ctx.plugins.zcli_config.custom_path = abs;
+    const args = zcli.ParsedArgs.init(alloc);
+    _ = try config.preExecute(&ctx, args);
+
+    // Arrays are the case where a config write ALLOCATES, so they are where the
+    // marker has to hold at the coercion path rather than at a scalar store.
+    const Opts = struct {
+        trusted_hosts: []const []const u8 = &.{},
+        tags: []const []const u8 = &.{},
+    };
+    const meta = .{ .options = .{ .trusted_hosts = .{ .no_config = true } } };
+
+    // Routed through the real parser so the marker itself is exercised: an
+    // unknown key in `meta.options.<field>` is a @compileError, so this failing
+    // to build is how a renamed or dropped marker would surface here.
+    const result = try zcli.parseCommandLine(struct {}, Opts, meta, alloc, &environ, &.{}, null);
+    defer result.deinit();
+
+    var opts = result.options;
+    var applied = [_]bool{false} ** @typeInfo(Opts).@"struct".fields.len;
+    const hook_provided = [_]bool{ true, false }; // trusted_hosts masked by the registry
+
+    config.applyConfigDefaults(&ctx, Opts, &opts, &hook_provided, &applied);
+
+    // Marked: still the empty default. Because the mask made the plugin skip the
+    // field, the element buffer is never allocated in the first place — there is
+    // nothing for the registry's restore to undo, which is the cheap path by
+    // construction and the reason a locked array cannot leak.
+    try testing.expectEqual(@as(usize, 0), opts.trusted_hosts.len);
+    try testing.expect(!applied[0]);
+
+    // Unmarked: the list loads normally, so the lock is per-field here too.
+    try testing.expectEqual(@as(usize, 2), opts.tags.len);
+    try testing.expectEqualStrings("a", opts.tags[0]);
+    try testing.expect(applied[1]);
 
     config.deinitContextData(&ctx.plugins.zcli_config, alloc);
 }

--- a/packages/core/src/plugin_types.zig
+++ b/packages/core/src/plugin_types.zig
@@ -218,7 +218,14 @@ pub fn getPriority(comptime T: type) i32 {
 ///     declaration order, true when the CLI or the field's env fallback already
 ///     set it. The precedence obligation: the hook MUST skip any field whose
 ///     `provided` flag is true — this single check is what makes
-///     CLI > env > hook hold. `applied` (same keying, caller-zeroed) is the
+///     CLI > env > hook hold. It also carries the `no_config` marker
+///     (ADR-0032): the registry forces the flag true for any field marked
+///     `meta.options.<field>.no_config`, so honoring `provided` is the whole of
+///     what a hook must do to respect a field the app author put off-limits to
+///     file-sourced values. (A hook that ignores `provided` has its writes to
+///     those fields undone afterwards — the marker is a guarantee to the app
+///     author, not a request to the hook.)
+///     `applied` (same keying, caller-zeroed) is the
 ///     hook's report back: it MUST mark every field it fills — the registry's
 ///     required-option and constraint checks treat `provided[i] or applied[i]`
 ///     as "supplied", with no value diffing (#388). `options` is mutated in

--- a/packages/core/src/plugin_types.zig
+++ b/packages/core/src/plugin_types.zig
@@ -148,23 +148,41 @@ pub fn hasHandleGlobalOption(comptime T: type) bool {
     return @hasDecl(T, "handleGlobalOption");
 }
 
-/// Check if a type has lifecycle hooks
+/// Does plugin `T` implement a given lifecycle hook?
+///
+/// Every hook is optional, so the generated registry asks before it calls: each
+/// of these is one `@hasDecl`, folded at comptime, and a plugin that declares
+/// nothing costs nothing at every stage it sits out. `hook_names` below is the
+/// authoritative list, with each hook's signature and contract — a hook is
+/// detected by *exact name*, which is why `validatePlugin` flags near-misses
+/// (`applyConfigDefualts`) rather than letting them silently never run.
+///
+/// Plugin authors do not call these; they exist for the registry and for the
+/// build-time validator.
 pub fn hasPreParse(comptime T: type) bool {
     return @hasDecl(T, "preParse");
 }
 
+/// See `hasPreParse`. `postParse` runs after routing, and may replace the
+/// `ParsedArgs` threaded to the next plugin.
 pub fn hasPostParse(comptime T: type) bool {
     return @hasDecl(T, "postParse");
 }
 
+/// See `hasPreParse`. `preExecute` runs immediately before the command body,
+/// and may cancel execution by returning null.
 pub fn hasPreExecute(comptime T: type) bool {
     return @hasDecl(T, "preExecute");
 }
 
+/// See `hasPreParse`. `postExecute` runs after the command body, on success and
+/// on a handled failure alike.
 pub fn hasPostExecute(comptime T: type) bool {
     return @hasDecl(T, "postExecute");
 }
 
+/// See `hasPreParse`. `onError` runs on a failure at any stage, until one
+/// plugin reports the error handled.
 pub fn hasOnError(comptime T: type) bool {
     return @hasDecl(T, "onError");
 }
@@ -181,12 +199,20 @@ pub fn hasApplyConfigDefaults(comptime T: type) bool {
     return @hasDecl(T, "applyConfigDefaults");
 }
 
-/// Check if a type has command extensions
+/// Does the plugin contribute commands of its own (`pub const commands`)? This
+/// is how `zcli_help` supplies `help` and `zcli_completions` supplies
+/// `__complete` without the app author creating a file for them — plugin
+/// commands merge into the same comptime registry as `commands_dir` ones, and a
+/// real command file always wins the name.
 pub fn hasCommands(comptime T: type) bool {
     return @hasDecl(T, "commands");
 }
 
-/// Get plugin priority (default 50)
+/// The plugin's execution priority (`pub const priority: i32`, default 50).
+/// Higher runs first at every hook; ties keep registration order, so the
+/// declared list is the tiebreak and ordering is fully determined at compile
+/// time. The default sits mid-range on purpose — a plugin that must wrap the
+/// others can go either side without renumbering anything.
 pub fn getPriority(comptime T: type) i32 {
     if (@hasDecl(T, "priority")) {
         return T.priority;

--- a/packages/core/src/plugins/zcli_config/plugin.zig
+++ b/packages/core/src/plugins/zcli_config/plugin.zig
@@ -45,9 +45,26 @@ const zcli = @import("zcli");
 /// but it is still an attacker-influenced default. Consequently: do not model
 /// security-sensitive behavior (e.g. "skip verification", "disable a safety
 /// check", a trusted path/URL/repo) as a plain config-overridable Option field.
-/// Either keep it out of Options entirely (comptime/build-time config, as the
-/// upgrade plugin does for its repo and signing key), or gate it so config
-/// alone cannot flip it.
+///
+/// Say that in the type rather than remembering it (ADR-0032):
+///
+///     pub const Options = struct { skip_verification: bool = false };
+///     pub const meta = .{
+///         .options = .{ .skip_verification = .{ .no_config = true } },
+///     };
+///
+/// A field marked `.no_config = true` is never filled from a config file. The
+/// registry forces its `provided` flag true in the view it hands this plugin —
+/// so the skip runs through the very check that already enforces CLI > env >
+/// config — and restores the pre-config value afterwards, so no
+/// `applyConfigDefaults` hook can populate it whatever it does. CLI and env
+/// still set it normally, and the marker is comptime-validated, so it cannot rot
+/// into a silently-meaningless typo.
+///
+/// The stronger option remains available and is still better where it fits:
+/// keep the switch out of Options entirely as comptime/build-time config, as the
+/// upgrade plugin does for its repo and signing key — things no invocation
+/// should be able to choose at all.
 pub const plugin_id = "zcli_config";
 
 pub const Format = enum { json, toml, yaml };

--- a/packages/core/src/registry/compiled.zig
+++ b/packages/core/src/registry/compiled.zig
@@ -1219,12 +1219,37 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
             // in `config_applied` — an explicit report, not a value diff, so a
             // config value equal to a field's placeholder still counts as
             // supplied (#388).
+            //
+            // `meta.options.<field>.no_config` (ADR-0032) rides on exactly that
+            // mechanism: `maskNoConfig` forces a locked field's flag true in the
+            // view the hooks see, so they skip it via the check they already
+            // make. The REAL bitset is what the required/constraint checks below
+            // read, so a locked field still reads as unsupplied unless CLI or env
+            // truly supplied it. `restoreNoConfig` afterwards is the backstop
+            // that keeps the marker from being advisory: a hook that ignores
+            // `provided` gets its write undone rather than quietly winning.
+            //
+            // Both are enforced here rather than inside zcli_config so the
+            // guarantee covers ANY applyConfigDefaults hook — a third-party
+            // config source cannot opt out of a security marker — and so the
+            // hook signature stays free of a policy argument every implementer
+            // would have to remember to honor. When no field is marked the mask
+            // is all-false at comptime, every branch here folds away, and
+            // `before_config` is a ZERO-SIZED `void` — the snapshot is not a
+            // struct copy that a dead branch later ignores, it is not taken at
+            // all. That distinction is the difference between "free" and "one
+            // struct copy per invocation" on a path gated by a startup-time and
+            // binary-size budget.
+            const hook_provided = command_parser.maskNoConfig(OptionsType, cmd_meta, parse_result.options_provided);
+            const before_config = command_parser.captureNoConfig(OptionsType, cmd_meta, options_instance);
+
             var config_applied = [_]bool{false} ** command_parser.optionFieldCount(OptionsType);
             inline for (sorted_plugins) |Plugin| {
                 if (@hasDecl(Plugin, "applyConfigDefaults")) {
-                    Plugin.applyConfigDefaults(context, OptionsType, &options_instance, &parse_result.options_provided, &config_applied);
+                    Plugin.applyConfigDefaults(context, OptionsType, &options_instance, &hook_provided, &config_applied);
                 }
             }
+            command_parser.restoreNoConfig(OptionsType, cmd_meta, &options_instance, before_config, &config_applied);
 
             // Required options: a non-optional, defaultless, non-bool, non-array
             // Options field must be supplied by SOME source — CLI, env, or config.

--- a/packages/core/src/zcli.zig
+++ b/packages/core/src/zcli.zig
@@ -106,10 +106,18 @@ pub const plugin_abi = struct {
         /// Dynamic (untyped) YAML value; a document root is the `.mapping` variant.
         pub const YamlValue = serde.yaml.Value;
 
+        /// Parse TOML into a dynamic table. Every string in the result borrows
+        /// from `content` and from `allocator`, so both must outlive the tree —
+        /// the config plugin parses into an arena it keeps on its ContextData
+        /// for exactly that reason. Errors are serde's; the plugin turns any of
+        /// them into one warning-and-skip, since a config typo must not brick
+        /// every command.
         pub fn parseToml(allocator: std.mem.Allocator, content: []const u8) !TomlTable {
             return serde.toml.parse(allocator, content);
         }
 
+        /// Parse YAML into a dynamic value; a document root is the `.mapping`
+        /// variant. Same lifetime and error contract as `parseToml`.
         pub fn parseYaml(allocator: std.mem.Allocator, content: []const u8) !YamlValue {
             return serde.yaml.parseValue(allocator, content);
         }

--- a/packages/core/src/zcli.zig
+++ b/packages/core/src/zcli.zig
@@ -873,7 +873,7 @@ pub fn validateMeta(
             const option_meta_info = @typeInfo(@TypeOf(option_meta));
 
             if (option_meta_info == .@"struct") {
-                const valid_option_fields = .{ "description", "short", "name", "env", "requires", "validate", "complete" };
+                const valid_option_fields = .{ "description", "short", "name", "env", "requires", "validate", "complete", "no_config" };
 
                 inline for (option_meta_info.@"struct".fields) |opt_field| {
                     const opt_is_valid = comptime blk: {
@@ -885,7 +885,23 @@ pub fn validateMeta(
                         break :blk false;
                     };
                     if (!opt_is_valid) {
-                        @compileError(loc ++ "unknown option metadata field '" ++ opt_field.name ++ "' in option '" ++ field.name ++ "'. Valid fields are: description, short, name, env, requires, validate, complete");
+                        @compileError(loc ++ "unknown option metadata field '" ++ opt_field.name ++ "' in option '" ++ field.name ++ "'. Valid fields are: description, short, name, env, requires, validate, complete, no_config");
+                    }
+                }
+
+                // `no_config`: the config opt-out marker (ADR-0032). A field
+                // carrying `.no_config = true` is never filled from a config
+                // file — the registry masks it out of the `provided` view it
+                // hands every applyConfigDefaults hook and restores it after.
+                // Must be a bool, so a typo'd value is a build error rather than
+                // a marker that silently means nothing; `false` is a legitimate
+                // no-op ("no policy") so a comptime-computed marker reads the
+                // way it looks.
+                if (@hasField(@TypeOf(option_meta), "no_config")) {
+                    if (@TypeOf(option_meta.no_config) != bool) {
+                        @compileError(loc ++ "option '" ++ field.name ++ "' declares `no_config` as " ++
+                            @typeName(@TypeOf(option_meta.no_config)) ++ ", but it must be a bool — " ++
+                            "`.no_config = true` blocks config files from setting the field (CLI and env still work)");
                     }
                 }
 

--- a/packages/core/src/zcli.zig
+++ b/packages/core/src/zcli.zig
@@ -56,6 +56,30 @@ pub const completion = @import("completion.zig");
 /// not consumer API; an app building a CLI never needs `plugin_abi`. Grouping
 /// these here keeps the top-level surface reading as genuine consumer API
 /// (`parseCommandLine`, `Context`, `option`, …) instead of plugin plumbing.
+///
+/// Bundled plugins live inside core but compile with the SAME single `"zcli"`
+/// import as a third-party or `plugins_dir` plugin — deliberately, so they stay
+/// copyable reference implementations and so every internal a plugin reaches
+/// for lands in this one reviewable list instead of an invisible private
+/// import. ADR-0031 records that decision and rejects the `zcli_internal`-module
+/// alternative.
+///
+/// BEFORE ADDING A SIXTH GROUP it must pass the ADR-0031 admission test — at
+/// least one of:
+///
+///   - Shared agreement: two independently-compiled units must agree on it, so
+///     a divergent private copy would be a behavioral bug rather than mere
+///     duplication (`usage`, `isNegativeNumber`, `custom_type`, `config_coerce`).
+///   - Dependency containment: a narrow shim that keeps a third-party
+///     dependency out of zcli's public contract (`config_parse`, vs. exporting
+///     serde).
+///
+/// and all of: you would fix the bundled plugins yourself when it changes, and
+/// it is grouped under a name describing the NEED rather than the internal.
+///
+/// The negative rule is the load-bearing one: this is not somewhere to put an
+/// internal because it is convenient. If one plugin wants it and nothing in
+/// core has to agree with it, copy or move the logic into the plugin.
 pub const plugin_abi = struct {
     /// Is this `-`-prefixed token actually a negative number (`-5`, `-.5`, `-1e9`,
     /// `-inf`, `-nan`) rather than an option flag? The single source of truth

--- a/packages/vterm/src/vterm.zig
+++ b/packages/vterm/src/vterm.zig
@@ -1,3 +1,28 @@
+//! A virtual terminal emulator: feed it the bytes a program wrote, ask it what
+//! a real terminal would be showing.
+//!
+//! This is what makes terminal output *testable*. Rendered output is a stream of
+//! interleaved text and escape sequences — asserting on those bytes means
+//! asserting on an implementation detail (`\x1b[2K\x1b[1G` vs. `\r\x1b[K` paint
+//! the same thing), and any change to how a frame is drawn breaks tests that
+//! were never about drawing. `VTerm` collapses the stream to the state it
+//! produces, so a test says "row 3 reads `Done`, and it is bold" instead of
+//! naming the sequences that got it there.
+//!
+//! **The grid.** Cells live in a circular buffer holding `scrollback_lines`
+//! rows, not just the visible ones. A *logical line* is an absolute line number
+//! (line 0 = the first line ever written) and occupies ring row
+//! `line % scrollback_lines`, so the mapping survives any number of laps and any
+//! resize. The **viewport** is the `height` rows currently on screen; every
+//! public read and write below (`getCell`, `moveCursor`, `containsText`, …) is
+//! viewport-relative, and the scrollback is reached by moving the viewport
+//! (`scrollViewportUp`, `pageUp`) rather than by addressing it directly.
+//!
+//! **The model is deliberately narrow.** One cell per codepoint (wide CJK/emoji
+//! glyphs claim a second continuation cell), the eight basic ANSI colors, and
+//! bold/italic/underline. It is built to answer questions test authors actually
+//! ask, not to be a conformant DEC terminal.
+
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const DisplayWidth = @import("DisplayWidth");
@@ -5,21 +30,40 @@ const DisplayWidth = @import("DisplayWidth");
 const CellModule = @import("cell.zig");
 const PositionModule = @import("position.zig");
 
+/// One grid cell: a codepoint plus the colors and attributes in force when it
+/// was written. `char == 0` is an empty cell; `wide_continuation` marks the
+/// second half of a wide glyph (it carries no codepoint of its own, so text
+/// extraction skips it rather than emitting a stray space).
 pub const Cell = CellModule.Cell;
+
+/// A viewport-relative `(x, y)` coordinate: column from the left edge, row from
+/// the top of the visible area — the same frame `getCell` and `moveCursor` use.
 pub const Position = PositionModule.Position;
 
-// Testing API structures
+/// A snapshot of the screen taken by `captureState`, for comparing "before" and
+/// "after" without holding two live terminals. `content` is `getAllText`'s flat
+/// `width * height` run with no row breaks — use `getAllLines` if the snapshot
+/// needs to preserve row structure. Owns `content`; call `deinit`.
 pub const TerminalState = struct {
     content: []u8, // All text as single string
     cursor: Position,
     dimensions: struct { width: u16, height: u16 },
 
+    /// Frees `content`. Pass the same allocator `captureState` was given — the
+    /// snapshot does not store one.
     pub fn deinit(self: *TerminalState, allocator: Allocator) void {
         allocator.free(self.content);
     }
 };
 
-// Input generation types
+/// A keystroke to send *to* the program under test, named rather than spelled.
+/// `inputKey` turns it into the bytes a real terminal would emit, so a test
+/// writes `.arrow_up` instead of `"\x1b[A"` and does not encode which of the
+/// several legal encodings this harness happens to use.
+///
+/// Deliberately small: ASCII characters, arrows, enter/escape, F1-F12, and
+/// Ctrl+A..Ctrl+Z (as the control codes 1-26). Anything outside that — Alt
+/// combinations, bracketed paste, mouse reports — is written as raw bytes.
 pub const Key = union(enum) {
     char: u8, // ASCII character input only
     arrow_up,
@@ -32,7 +76,16 @@ pub const Key = union(enum) {
     ctrl_char: u8, // Ctrl+A through Ctrl+Z (1-26)
 };
 
-// Attribute testing types
+/// The eight basic ANSI colors, plus `default` for "never set". Values are the
+/// SGR *foreground* codes (30-37) so the enum reads like the sequences it
+/// models; cells store the 0-7 index, and `getTextColor`/`getBackgroundColor`
+/// translate.
+///
+/// `default` is genuinely ambiguous in one direction each way, because a cell
+/// cannot record "no color was set" separately from the color it defaults to:
+/// a white foreground reports `.default` (7 is the default fg), and a black
+/// background reports `.default` (0 is the default bg). Assert on the other six
+/// when a test needs to prove a color was applied.
 pub const Color = enum(u8) {
     default = 0,
     black = 30,
@@ -45,16 +98,21 @@ pub const Color = enum(u8) {
     white = 37,
 };
 
+/// The text attributes the emulator tracks, for `hasAttribute`. Styling that
+/// does not survive into a cell (reverse video, blink, dim, strikethrough) is
+/// parsed and discarded — this is the set worth asserting on.
 pub const TextAttribute = enum {
     bold,
     italic,
     underline,
 };
 
-// Character width detection for wide characters (CJK, emojis, etc.).
-// vterm uses a fixed one-cell-per-codepoint model, so only the wide/narrow
-// distinction matters here; the underlying Unicode data comes from zg's
-// DisplayWidth table rather than a hand-maintained list of ranges.
+/// Cells occupied by one codepoint: 2 for wide glyphs (CJK, emoji), 1 for
+/// everything else.
+///
+/// vterm uses a fixed one-cell-per-codepoint model, so only the wide/narrow
+/// distinction matters here; the underlying Unicode data comes from zg's
+/// DisplayWidth table rather than a hand-maintained list of ranges.
 pub fn charWidth(codepoint: u21) u8 {
     return if (DisplayWidth.codePointWidth(codepoint) == 2) 2 else 1;
 }
@@ -68,13 +126,18 @@ const ParserState = enum {
     osc_escape, // Inside an OSC payload, just saw ESC (maybe ST)
 };
 
-// Scrollback position info
+/// Where the viewport sits in history, from `getScrollbackPosition`. `at_bottom`
+/// is the one to assert on: any `write` snaps the viewport back to the present,
+/// so a test that scrolled up and expects to still be there is asserting on a
+/// terminal nobody wrote to in between.
 pub const ScrollPosition = struct {
     current_line: u32, // Current viewport position in history
     total_lines: u32, // Total lines in scrollback
     at_bottom: bool, // Whether viewport is at bottom
 };
 
+/// The emulator itself: `write` the bytes a program produced, then read the
+/// resulting screen. See the module doc for the grid/viewport model.
 pub const VTerm = struct {
     allocator: Allocator,
 
@@ -119,15 +182,25 @@ pub const VTerm = struct {
     cursor_visible: bool,
     autowrap: bool, // DECAWM (CSI ?7 h/l); off = clamp at the last column
 
-    // Circular buffer coordinate translation. Logical lines are ABSOLUTE
-    // line numbers (line 0 = first line ever written); the ring holds the
-    // most recent `scrollback_lines` of them at row `line % scrollback_lines`.
-    // Writes and reads share this one mapping, so the viewport stays in sync
-    // no matter how many times the ring laps (#393).
+    /// Circular buffer coordinate translation. Logical lines are ABSOLUTE
+    /// line numbers (line 0 = first line ever written); the ring holds the
+    /// most recent `scrollback_lines` of them at row `line % scrollback_lines`.
+    /// Writes and reads share this one mapping, so the viewport stays in sync
+    /// no matter how many times the ring laps (#393).
+    ///
+    /// Public for the scrollback tests, which assert the mapping directly rather
+    /// than inferring it from rendered output; ordinary use goes through
+    /// `getCell`/`getLine`, which apply it for you.
     pub fn bufferLineIndex(self: *VTerm, logical_line: u32) u16 {
         return @intCast(logical_line % self.scrollback_lines);
     }
 
+    /// The ring row backing viewport row `viewport_y`, honoring the user's
+    /// scrollback offset — or null when that row has no content: above the
+    /// first line, past the last, or old enough that the ring has overwritten
+    /// it. Callers must treat null as "empty", never as row 0; reading through
+    /// the raw `% scrollback_lines` mapping instead would return the *newer*
+    /// line that overwrote it.
     pub fn viewportToBuffer(self: *VTerm, viewport_y: u16) ?u16 {
         // Convert viewport Y to buffer line index
 
@@ -158,6 +231,10 @@ pub const VTerm = struct {
         return self.bufferLineIndex(logical_line);
     }
 
+    /// The absolute logical line number of the newest line written — the line
+    /// at the bottom of the viewport when it is at the present. Uncapped by
+    /// `scrollback_lines` on purpose: capping it desynced reads from writes once
+    /// the ring lapped (#393).
     pub fn getBottomLine(self: *VTerm) u32 {
         // The absolute logical line number at the bottom of the viewport —
         // always the newest line written, however many times the ring lapped.
@@ -193,16 +270,27 @@ pub const VTerm = struct {
     // Initialization and Cleanup
     const DEFAULT_SCROLLBACK = 1000;
 
+    /// A `width` x `height` terminal with 1000 lines of scrollback. `deinit`
+    /// frees the cell buffer. The whole scrollback is allocated up front
+    /// (`scrollback_lines * width` cells), so a huge scrollback costs memory
+    /// immediately — `initWithScrollback` exists for tests that want it small.
     pub fn init(allocator: Allocator, width: u16, height: u16) !VTerm {
         return initWithScrollback(allocator, width, height, .{
             .scrollback_lines = DEFAULT_SCROLLBACK,
         });
     }
 
+    /// Options for `initWithScrollback`. `scrollback_lines` is the ring's total
+    /// capacity, not extra rows above the viewport: a value below `height`
+    /// leaves the viewport unable to show a full screen of history.
     pub const InitOptions = struct {
         scrollback_lines: u16,
     };
 
+    /// `init` with an explicit ring capacity. Worth reaching for when a test
+    /// needs to exercise ring *wraparound* — set it just above `height` and a
+    /// handful of writes will lap the buffer, which is where line-mapping bugs
+    /// live (#393).
     pub fn initWithScrollback(allocator: Allocator, width: u16, height: u16, options: InitOptions) !VTerm {
         const total_cells = @as(usize, options.scrollback_lines) * @as(usize, width);
         const cells = try allocator.alloc(Cell, total_cells);
@@ -245,11 +333,14 @@ pub const VTerm = struct {
         };
     }
 
+    /// Frees the cell buffer. Text returned by `getAllText`/`getLine`/`getRegion`
+    /// was allocated separately by the caller's allocator and is not freed here.
     pub fn deinit(self: *VTerm) void {
         self.allocator.free(self.cells);
     }
 
     // Scrollback navigation
+    /// Where the viewport currently sits in history — see `ScrollPosition`.
     pub fn getScrollbackPosition(self: *VTerm) ScrollPosition {
         return ScrollPosition{
             .current_line = if (self.total_lines_written > 0) self.total_lines_written - 1 else 0,
@@ -258,6 +349,9 @@ pub const VTerm = struct {
         };
     }
 
+    /// Scroll the viewport back into history by `lines`, clamped so it can never
+    /// pass the oldest line the ring still holds. Saturates rather than erroring:
+    /// scrolling further than there is history leaves you at the top.
     pub fn scrollViewportUp(self: *VTerm, lines: u16) void {
         // Scroll viewport up in history (user scrollback). Only the most
         // recent `scrollback_lines` are retained — older lines have been
@@ -271,25 +365,35 @@ pub const VTerm = struct {
         self.viewport_offset = @max(-max_scroll, self.viewport_offset - @as(i32, @intCast(lines)));
     }
 
+    /// Scroll the viewport `lines` toward the present, clamped at the live
+    /// bottom.
     pub fn scrollViewportDown(self: *VTerm, lines: u16) void {
         // Scroll viewport down toward present
         self.viewport_offset = @min(0, self.viewport_offset + @as(i32, @intCast(lines)));
     }
 
+    /// Jump the viewport to the present. `write` does this implicitly — new
+    /// output always pulls the view back to the bottom, as a real terminal does.
     pub fn scrollToBottom(self: *VTerm) void {
         // Jump to bottom (present)
         self.viewport_offset = 0;
     }
 
+    /// `scrollViewportUp` by one full screen.
     pub fn pageUp(self: *VTerm) void {
         self.scrollViewportUp(self.height);
     }
 
+    /// `scrollViewportDown` by one full screen.
     pub fn pageDown(self: *VTerm) void {
         self.scrollViewportDown(self.height);
     }
 
     // Basic Cell Operations (viewport-relative)
+    /// The cell at viewport row `y`, column `x`. Out of bounds — or a row the
+    /// ring no longer holds — reads as an empty cell rather than erroring, so a
+    /// test asserting on a region larger than the content still gets spaces
+    /// instead of a crash.
     pub fn getCell(self: *VTerm, x: u16, y: u16) Cell {
         if (!self.isValidPos(x, y)) return Cell.empty();
         const buffer_line = self.viewportToBuffer(y) orelse return Cell.empty();
@@ -297,6 +401,9 @@ pub const VTerm = struct {
         return self.cells[idx];
     }
 
+    /// Overwrite the cell at viewport row `y`, column `x`; silently ignored out
+    /// of bounds. Paints the grid directly without touching the cursor or the
+    /// parser — for seeding a fixture. Use `write` to model what a program did.
     pub fn setCell(self: *VTerm, x: u16, y: u16, cell: Cell) void {
         if (!self.isValidPos(x, y)) return;
         const buffer_line = self.viewportToBuffer(y) orelse return;
@@ -324,6 +431,11 @@ pub const VTerm = struct {
         self.cells[idx] = cell;
     }
 
+    /// Write one codepoint at the cursor and advance it, honoring wide glyphs
+    /// (a second continuation cell) and DECAWM (wrap vs. clamp at the right
+    /// edge). This is the text path `write` funnels into once the parser has
+    /// decoded a character — call it directly only to bypass escape-sequence
+    /// parsing entirely.
     pub fn putChar(self: *VTerm, char: u21) void {
         var width = charWidth(char);
 
@@ -409,10 +521,17 @@ pub const VTerm = struct {
     }
 
     // Cursor Management
+    /// The cursor's viewport-relative position. Note this is where the *next*
+    /// character lands, which after filling a row may be one column past the
+    /// last one written (delayed wrap) — `cursorAt` compares against exactly
+    /// this value.
     pub fn getCursor(self: VTerm) Position {
         return self.cursor;
     }
 
+    /// Move the cursor to viewport row `y`, column `x`, clamped to the grid.
+    /// Models CSI CUP; the write position follows, so output after a move lands
+    /// on the row the viewport shows even once the buffer has scrolled (#504).
     pub fn moveCursor(self: *VTerm, x: u16, y: u16) void {
         // Clamp to valid bounds
         self.cursor.x = @min(x, self.width - 1);
@@ -424,6 +543,9 @@ pub const VTerm = struct {
     }
 
     // Screen Operations
+    /// Blank every cell — the whole ring, not just the viewport — and home the
+    /// cursor. Scrollback does not survive this, so it is a harder reset than
+    /// the `ESC[2J` a program would send.
     pub fn clear(self: *VTerm) void {
         @memset(self.cells, Cell.empty());
         self.cursor = Position.init(0, 0);
@@ -434,6 +556,11 @@ pub const VTerm = struct {
     }
 
     // Resize Support
+    /// Change the terminal's dimensions, keeping every retained line. Content is
+    /// **not** reflowed: a line longer than the new width is truncated, and
+    /// narrowing then widening does not restore it — matching what a terminal
+    /// without reflow does, and keeping the absolute line→ring-row mapping
+    /// intact across the resize. Use it to model SIGWINCH.
     pub fn resize(self: *VTerm, new_width: u16, new_height: u16) !void {
         // The cell buffer holds the whole scrollback (scrollback_lines ×
         // width), not just the viewport — the new buffer must too, or every
@@ -469,6 +596,19 @@ pub const VTerm = struct {
     // ===== Parser Implementation =====
 
     // Main parsing interface
+    /// Feed the terminal the bytes a program wrote: text is laid into cells,
+    /// escape sequences update cursor/attributes/modes. **The** entry point —
+    /// everything else here reads the state this produces.
+    ///
+    /// Chunk boundaries don't matter. Parser state (and a UTF-8 sequence split
+    /// across the boundary) carries between calls, so `write("\x1b[")` then
+    /// `write("31mred")` is identical to one call — which is what makes it safe
+    /// to feed whatever a pipe or PTY happened to hand you.
+    ///
+    /// Never fails: an unknown or malformed sequence is consumed and dropped,
+    /// as a real terminal does. It has no back channel, so a program's queries
+    /// (cursor-position reports, DA) are parsed and silently discarded rather
+    /// than answered.
     pub fn write(self: *VTerm, bytes: []const u8) void {
         // Auto-scroll to bottom when writing new content
         if (self.viewport_offset != 0) {
@@ -948,6 +1088,16 @@ pub const VTerm = struct {
 
     // ===== Input Generation =====
 
+    /// The bytes a real terminal emits for `key` — send these to the program
+    /// under test. Lets an interactive test say `.arrow_up` rather than hardcode
+    /// `"\x1b[A"`, so it does not depend on which of several legal encodings
+    /// this harness picked.
+    ///
+    /// The returned slice points at a static per-key buffer, not the caller's
+    /// memory: it stays valid, but a later call with the *same* key overwrites
+    /// it. Copy it if two keystrokes must be held at once. An out-of-range
+    /// function key (outside 1-12) or control char (outside 1-26) yields an
+    /// empty slice rather than an error.
     pub fn inputKey(self: *VTerm, key: Key) []const u8 {
         _ = self; // VTerm not needed for key generation, kept for API consistency
 
@@ -1007,6 +1157,10 @@ pub const VTerm = struct {
 
     // ===== Testing API =====
 
+    /// Snapshot the screen (text, cursor, dimensions) so a later state can be
+    /// compared against it — the "before" half of a before/after assertion when
+    /// keeping two live terminals around for `diff` would be overkill. Caller
+    /// owns the result; call `TerminalState.deinit`.
     pub fn captureState(self: *VTerm, allocator: Allocator) !TerminalState {
         const content = try self.getAllText(allocator);
         return TerminalState{
@@ -1016,6 +1170,16 @@ pub const VTerm = struct {
         };
     }
 
+    /// Is `text` visible anywhere on screen? The workhorse assertion, and
+    /// deliberately forgiving: the match walks the grid cell-by-cell and
+    /// continues onto the next row at the right edge, so a string that wrapped
+    /// mid-word is still found. That is usually what you want — a test about
+    /// *what* was printed should not fail because the terminal was narrow.
+    ///
+    /// Consequences to know: it compares bytes to codepoints, so it only finds
+    /// ASCII; it is allocation-free; and because it crosses row boundaries it
+    /// can match two unrelated rows that happen to abut. When exact placement is
+    /// the point, use `getLine` or `getRegion` instead.
     pub fn containsText(self: *VTerm, text: []const u8) bool {
         for (0..self.height) |y| {
             for (0..self.width) |x| {
@@ -1049,10 +1213,19 @@ pub const VTerm = struct {
         return true;
     }
 
+    /// Is the cursor exactly at viewport `(x, y)`? Remember it sits where the
+    /// *next* character goes, so after writing `n` characters on an empty row
+    /// the cursor is at column `n`, not `n - 1`.
     pub fn cursorAt(self: *VTerm, x: u16, y: u16) bool {
         return self.cursor.x == x and self.cursor.y == y;
     }
 
+    /// The whole viewport as one flat `width * height` run of UTF-8 with **no
+    /// row breaks** — empty cells become spaces, wide-glyph continuation cells
+    /// contribute nothing. Row boundaries are implicit at multiples of `width`,
+    /// which is what makes it the right substrate for substring search
+    /// (`containsPattern`, `findPattern`) and the wrong one for reading output
+    /// back: use `getAllLines` for that. Caller owns the result.
     pub fn getAllText(self: *VTerm, allocator: Allocator) ![]u8 {
         var result: std.ArrayList(u8) = .empty;
         errdefer result.deinit(allocator);
@@ -1103,6 +1276,10 @@ pub const VTerm = struct {
         return result.toOwnedSlice(allocator);
     }
 
+    /// One viewport row as UTF-8, with trailing spaces trimmed — the exact-
+    /// placement counterpart to `containsText`. A row past the bottom yields an
+    /// empty slice rather than an error, so iterating `0..height` is always
+    /// safe. Caller owns the result.
     pub fn getLine(self: *VTerm, allocator: Allocator, line_y: u16) ![]u8 {
         if (line_y >= self.height) return allocator.alloc(u8, 0);
 
@@ -1145,6 +1322,22 @@ pub const VTerm = struct {
     }
 
     // Pattern matching methods
+    /// Substring search with a few wildcards, for output whose exact text is
+    /// not stable — a duration, a temp path, a generated id.
+    ///
+    /// Not a regex engine; the supported forms are checked in this order and do
+    /// not compose:
+    ///   - `.*`  — the parts either side must appear, in order (`"Error.*retry"`)
+    ///   - `?`   — matches any single character
+    ///   - `*`   — same as `.*`
+    ///   - `^…`  — the pattern starts some row
+    ///   - `…$`  — the pattern ends some row, ignoring trailing spaces
+    ///   - otherwise, a plain substring
+    ///
+    /// The anchored forms work per row; every other form searches `getAllText`'s
+    /// flat run, so a match may straddle a row boundary. Non-ASCII cells become
+    /// `?` under the anchored forms. Allocates internally from the terminal's own
+    /// allocator and cleans up; an allocation failure reports "no match".
     pub fn containsPattern(self: *VTerm, pattern: []const u8) bool {
         // Simplified pattern matching - supports * wildcard and basic patterns
         // For now, we'll do simple substring matching with * wildcard support
@@ -1303,6 +1496,16 @@ pub const VTerm = struct {
         return std.mem.indexOf(u8, text, pattern) != null;
     }
 
+    /// Where a pattern appears, as grid positions — for asserting *placement*
+    /// rather than presence (a label in the right column, a spinner on the last
+    /// row).
+    ///
+    /// Two limits worth knowing before you rely on it: it reports the **first**
+    /// occurrence only (the returned slice holds at most one position, despite
+    /// the plural), and for a `.*` pattern it searches only the fixed part
+    /// *before* the `.*`. Byte offsets are mapped back through the same per-cell
+    /// accounting `getAllText` uses, so positions stay cell-accurate for wide
+    /// and multibyte content. Caller owns the returned slice.
     pub fn findPattern(self: *VTerm, allocator: Allocator, pattern: []const u8) ![]Position {
         // Simplified implementation - find first occurrence
         var positions: std.ArrayList(Position) = .empty;
@@ -1360,6 +1563,10 @@ pub const VTerm = struct {
         };
     }
 
+    /// `containsText` with ASCII case folding — for text whose capitalization is
+    /// not the thing under test (an "Error:"/"error:" prefix, a theme that
+    /// upcases headings). Unlike `containsText` this searches the flat text run,
+    /// so it also matches across a wrap. Non-ASCII case is not folded.
     pub fn containsTextIgnoreCase(self: *VTerm, text: []const u8) bool {
         // For testing purposes, use a temporary allocator
         var arena = std.heap.ArenaAllocator.init(self.allocator);
@@ -1392,6 +1599,10 @@ pub const VTerm = struct {
     }
 
     // Region testing methods
+    /// Assert a rectangle of the screen renders exactly `expected` (rows joined
+    /// by `\n`, as `getRegion` produces). Fails through
+    /// `std.testing.expectEqualStrings`, so a mismatch prints a character-level
+    /// diff — which is why this beats comparing `getRegion`'s output yourself.
     pub fn expectRegionEquals(self: *VTerm, x: u16, y: u16, width: u16, height: u16, expected: []const u8) !void {
         const testing = std.testing;
 
@@ -1405,6 +1616,14 @@ pub const VTerm = struct {
         try testing.expectEqualStrings(expected, actual);
     }
 
+    /// A `width` x `height` rectangle anchored at viewport `(x, y)`, rows joined
+    /// by `\n`. The natural unit for a boxed widget or a panel: assert the box
+    /// and ignore whatever else shares the screen.
+    ///
+    /// Rows keep their full width — trailing spaces are **not** trimmed here (a
+    /// region's shape is the point), which is the difference from `getLine`.
+    /// Cells outside the grid render as spaces, so a region may safely overhang.
+    /// Caller owns the result.
     pub fn getRegion(self: *VTerm, allocator: Allocator, x: u16, y: u16, width: u16, height: u16) ![]u8 {
         var result: std.ArrayList(u8) = .empty;
         errdefer result.deinit(allocator);
@@ -1442,6 +1661,13 @@ pub const VTerm = struct {
         return result.toOwnedSlice(allocator);
     }
 
+    /// `containsText` scoped to a rectangle — "the error is in the status bar",
+    /// not merely "somewhere on screen".
+    ///
+    /// One sharp edge: only the match's *start* is constrained to the region.
+    /// The match itself runs on across the full grid (and onto following rows),
+    /// so a long string beginning inside the box still matches. Use
+    /// `expectRegionEquals` when the region must contain it entirely.
     pub fn containsTextInRegion(self: *VTerm, text: []const u8, x: u16, y: u16, width: u16, height: u16) bool {
         for (0..height) |row| {
             for (0..width) |col| {
@@ -1458,19 +1684,36 @@ pub const VTerm = struct {
     }
 
     // Terminal comparison
+    /// The result of `diff`: which viewport rows differ, in ascending order.
+    /// Row granularity, not cell — the question it answers is "did the renderer
+    /// repaint more than it had to", and rows are the unit a diffing renderer
+    /// works in. Owns `changedLines`; call `deinit`.
     pub const TerminalDiff = struct {
         changedLines: []u16,
         allocator: Allocator,
 
+        /// Frees `changedLines`. Takes the allocator as a parameter and ignores
+        /// the `allocator` field, so pass the same one `diff` was given.
         pub fn deinit(self: *TerminalDiff, allocator: Allocator) void {
             allocator.free(self.changedLines);
         }
 
+        /// Did any row change? False here means the two frames render the same
+        /// *text* — `diff` does not compare color or attributes.
         pub fn hasDifferences(self: *const TerminalDiff) bool {
             return self.changedLines.len > 0;
         }
     };
 
+    /// Which viewport rows differ between two terminals of the same size.
+    /// Written for the layout engine's diffed live region (ADR-0013): render a
+    /// frame into each, and this says whether an update touched only the rows it
+    /// claimed to.
+    ///
+    /// Compares **codepoints only** — two rows differing solely in color or
+    /// bold are reported as identical. Assert styling with `hasAttribute` /
+    /// `getTextColor`. Mismatched dimensions return `error.DifferentDimensions`.
+    /// Caller owns the result.
     pub fn diff(self: *VTerm, other: *VTerm, allocator: Allocator) !TerminalDiff {
         if (self.width != other.width or self.height != other.height) {
             return error.DifferentDimensions;
@@ -1503,6 +1746,10 @@ pub const VTerm = struct {
     }
 
     // Attribute testing methods
+    /// Does the cell at viewport `(x, y)` carry `attr`? The way to assert
+    /// *styling* without asserting on SGR bytes — `hasAttribute(0, 0, .bold)`
+    /// holds whether the renderer emitted `\x1b[1m` or `\x1b[0;1m`. Out of
+    /// bounds is false, not an error.
     pub fn hasAttribute(self: *VTerm, x: u16, y: u16, attr: TextAttribute) bool {
         if (!self.isValidPos(x, y)) return false;
         const cell = self.getCell(x, y);
@@ -1514,6 +1761,9 @@ pub const VTerm = struct {
         };
     }
 
+    /// The foreground color of the cell at viewport `(x, y)`; `.default` out of
+    /// bounds. An explicitly-white foreground also reports `.default`, because 7
+    /// *is* the default — see `Color`.
     pub fn getTextColor(self: *VTerm, x: u16, y: u16) Color {
         if (!self.isValidPos(x, y)) return .default;
         const cell = self.getCell(x, y);
@@ -1534,6 +1784,9 @@ pub const VTerm = struct {
         };
     }
 
+    /// The background color of the cell at viewport `(x, y)`; `.default` out of
+    /// bounds. An explicitly-black background also reports `.default`, because 0
+    /// *is* the default — the mirror of `getTextColor`'s white, see `Color`.
     pub fn getBackgroundColor(self: *VTerm, x: u16, y: u16) Color {
         if (!self.isValidPos(x, y)) return .default;
         const cell = self.getCell(x, y);
@@ -1555,6 +1808,12 @@ pub const VTerm = struct {
     }
 
     // Test helper functions
+    /// One-liner for the common parser assertion: write `input` into a fresh
+    /// 80x24 terminal and expect the whole screen to read `expected`. Because
+    /// that is `getAllText`, `expected` must be the full flat 80*24 run —
+    /// padding and all — so this suits short sequences whose *entire* effect is
+    /// under test. Anything longer wants `getLine` or `expectRegionEquals`.
+    /// Uses `std.testing.allocator`, so it also catches a leak in the path.
     pub fn expectOutput(input: []const u8, expected: []const u8) !void {
         const testing = std.testing;
         var term = try VTerm.init(testing.allocator, 80, 24);

--- a/website/content/docs/config.smd
+++ b/website/content/docs/config.smd
@@ -59,6 +59,32 @@ A value set on the command line — or read from an option's `env` fallback — 
 
 Config can satisfy a [required option]($link.page('docs/args-options')) and participates in [validation and constraints]($link.page('docs/validation')) like any other source — a `validate` hook runs on the final value wherever it came from, and a config value counts as "supplied" for `exclusive`/`requires` checks.
 
+## Locking a field against config
+
+Discovery tier 2 reads from the **working directory**, which the person running your CLI does not always control — a cloned repo, an extracted archive, or a shared build dir can ship a `.myapp.config.toml`. That is bounded: values still go through the typed parser (no code execution), the file is size-capped, a CLI flag or env var always wins, and the plugin prints a `note:` naming the file it applied. But it does mean a directory can set the *default* for any option, for that invocation.
+
+So for anything whose value is a **trust decision** — skipping a verification step, disabling a safety check, naming a trusted URL, path, or repo — say so on the field:
+
+```zig
+pub const Options = struct {
+    skip_verification: bool = false,
+    registry: []const u8 = "https://registry.example",
+};
+
+pub const meta = .{
+    .options = .{
+        .skip_verification = .{ .no_config = true },
+        .registry = .{ .no_config = true },
+    },
+};
+```
+
+`.no_config = true` means the field is **never filled from a config file**. The CLI flag, the `env` fallback, and the struct default all keep working — it locks only the source the user may not control. The marker is checked at compile time (a typo, or a non-bool value, is a build error), and it is enforced by the framework rather than by the plugin, so no config source can opt out of it.
+
+If a marked field is also required, a config file naming it does *not* satisfy it: the CLI or env has to. That is the safe outcome — the user gets a "missing required option" error instead of a value chosen by a directory.
+
+Stronger still, where it fits: keep the switch out of `Options` entirely and make it build-time config. The bundled upgrade plugin does that for its repo and signing key — values no single invocation should be able to choose at all.
+
 ## Next
 
 - [Args & options]($link.page('docs/args-options')) — the full value cascade


### PR DESCRIPTION
Five issues: two documentation fixes, one build fix, and two architecture decisions that needed deciding rather than patching.

## #788 — `no_config`, a comptime marker config cannot override (ADR-0032)

`zcli_config`'s doc comment already carried excellent threat modelling: project-local config is discovered from cwd, so a cloned repo can set defaults, and therefore *"do not model security-sensitive behavior as a plain config-overridable Option field."* But it was a **doc comment** — nothing stopped an author from making `--skip-verification` config-overridable, and nothing warned them.

Now `meta.options.<field>.no_config` is a real marker, following ADR-0022/0025 exactly: in the `valid_option_fields` allowlist so a typo is a build error, and type-checked with an explanatory message.

**Enforced in the registry, not in the plugin.** Teaching `zcli_config` leaves it advisory — `applyConfigDefaults` is public, and a second config source that didn't check would defeat it; passing `meta` to the hook just moves "remember to honour this" one level down. Two layers instead:

- `maskNoConfig` forces the marked field's flag true in the `provided` view hooks see, so a locked field is skipped by the precedence check every conforming hook **already** implements — no new obligation, and third-party config sources are covered for free.
- `restoreNoConfig` undoes any write and clears the applied flag, so a non-conforming hook cannot make the marker a lie.

The real bitset is untouched, so a marked *required* option supplied only by config still correctly reports missing.

## #787 — `plugin_abi` keeps its constraint; the missing thing was a rule (ADR-0031)

**Decision: bundled plugins keep the single-`"zcli"`-import rule.** A shrink is possible but loses more than it gains — built-ins and `plugins_dir` locals go through the *same* branch of `addPluginModulesToRegistry`, which is what makes "read `zcli_help` to see how a plugin does it" true, and behind a private import the growth would continue while ceasing to be observable.

Reviewing the five existing groups, four are shared vocabulary where a divergent copy would be a **behavioural bug** (`usage`: help vs. doc generator; `isNegativeNumber`: completions vs. parser; `custom_type` + `config_coerce`: config vs. CLI/env). So the real gap was never the size — it was that no rule governed additions.

ADR-0031 adds an admission test (shared agreement **or** dependency containment, plus lockstep ownership and named-for-the-need) with the load-bearing negative rule: **not for convenience**. Nothing currently fails it, deliberately — the rule describes the five that belong and rejects the sixth that doesn't. Stated in three places including a comment on `plugin_abi` itself, at the point of temptation. The ADR says plainly that nothing was removed, and why an unchanged surface is the expected outcome of a correct rule rather than a dodge.

## #784 — CONTRIBUTING vs. reality

The one-line CI claim was wrong four ways: unit tests **and** e2e run on all three OSes (both matrices include `windows-latest`), the "portable-package tests" job has never existed, and it predated `registry-scale`, `installers` and `perf`. Replaced with a table of all 13 jobs in `ci.yml` order — a table because the failure mode is drift, and a missing row is more visible than a missing clause. Cross-checking the rest found one further drift: the layout block omitted `packages/ui` entirely, i.e. the ADR-0013 layout engine.

## #789 — `build-all` now includes e2e

`dependOn(e2e_step)` rather than a rename. Redescribing documents the gap instead of closing it, and the gap is worst-placed: e2e is the tier that catches prompt/render/help regressions, so the developer most misled is the one who just changed rendering.

## #786 — vterm doc coverage: 1/50 → 50/50

Aimed at what signatures cannot answer: a module header on why the package exists and the ring/viewport model, then the sharp edges — `Color.default` is ambiguous in both directions, `diff` compares codepoints only, `containsText` matches across a wrap, `containsTextInRegion` only constrains where the match *starts*, `findPattern` returns one position and searches only a `.*` pattern's fixed prefix, `inputKey` returns a shared static buffer, and the getAllText/getAllLines/getLine/getRegion distinction. Plus `parseToml`/`parseYaml` lifetime and error contracts, and the `plugin_types.zig` `has*` helpers.

## Review

Composer 2.5: **APPROVE_WITH_NITS**, confirming #788's registry placement is "the right call", #787's reasoning a "sound documented tradeoff, not rationalizing", the CONTRIBUTING table accurate against `ci.yml`, and the vterm docs accurate on spot-check. Three nits, all closed:

1. **ADR-0032 overclaimed the elision** — `const before_config = options_instance` ran unconditionally, and no dead-branch folding removes it because the copy happens *before* the branch that would ignore it. Fixed **in code**: `NoConfigSnapshot(OptionsType, meta)` is `OptionsType` when a field is marked and `void` when none is. The unmarked path does not take a cheap copy; there is nothing to copy. (`if (comptime ...)` was rejected because the value still needs somewhere to live, and `else undefined` passes an undefined struct by value — in Debug, a copy of 0xAA bytes, exactly what was being avoided.) Pinned as a type-level assertion: `expectEqual(void, NoConfigSnapshot(Options, .{}))` and `@sizeOf == 0`.
2. **Required-only-from-config and multi-value cases now tested.** On leaks: `restoreNoConfig` **orphans** rather than frees, and must — a slice field's current value may be the hook's allocation or the struct's comptime default, and nothing there can distinguish them, so freeing risks an invalid free. Under arena-per-command (ADR-0001) the orphan is reclaimed wholesale. Documented rather than glossed.
3. **Rogue-hook backstop now driven, not inspected** — a real `applyConfigDefaults` that discards `provided` and stamps every field. Asserts layer 1 fails, then that restore fixes both marked fields while the unmarked field keeps the hook's write, so the backstop is targeted rather than a blanket rollback.

#788's test count went 6 → 10.

## Verification

**Verified:** `zig ast-check` on all 11 changed `.zig` files; `zig fmt --check` clean; `ci.yml` re-parses with the new step in the right job; the new CI doc gate's script **extracted from the parsed YAML and executed** — passes on the tree, and fails with the offending line when a bare `pub fn` is appended.

**Not verified:** `syspolicyd` has this machine wedged, so no `zig build`/`zig test`. Every `#788` runtime path and all 10 new tests are unrun. Two specific things a build would catch immediately: `captureNoConfig`'s comptime-dead branch with a divergent return type, and `restoreNoConfig`'s `@field` never instantiating against a `void` snapshot. Both either compile or fail loudly — neither can fail silently at runtime. **`zig build test` and `zig build e2e` should be green before merge.**

Fixes #784
Fixes #786
Fixes #787
Fixes #788
Fixes #789
