### PR TITLE
Single-pass plugin dispatch and allocation-free suggestion scoring

### DIFF
--- a/packages/core/src/plugins/zcli_not_found/plugin.zig
+++ b/packages/core/src/plugins/zcli_not_found/plugin.zig
@@ -165,20 +165,12 @@ fn generateCommandNotFoundHelp(
         return;
     }
 
-    // Convert hierarchical commands to flat strings for suggestion processing.
-    // Both the suggestion list and the returned strings live in the arena-per-
-    // command allocator, so nothing here needs an explicit free.
-    var flat_commands = std.ArrayList([]const u8).empty;
-    defer flat_commands.deinit(context.allocator);
-    for (available_commands) |cmd_parts| {
-        const joined_cmd = try std.mem.join(context.allocator, " ", cmd_parts);
-        try flat_commands.append(context.allocator, joined_cmd);
-    }
-
-    // Find similar commands.
+    // Find similar commands. The hierarchical paths are scored as-is —
+    // `findBestSuggestions` flattens each candidate through one reused
+    // scratch buffer and only allocates the handful it actually returns.
     const suggestions = try findBestSuggestions(
         attempted_command,
-        flat_commands.items,
+        available_commands,
         context.allocator,
         3, // max suggestions
         3, // max edit distance
@@ -212,8 +204,14 @@ fn printAvailableCommands(
 ) !void {
     try writer.print("Available commands:\n", .{});
     for (available_commands) |cmd_parts| {
-        const joined = try std.mem.join(context.allocator, " ", cmd_parts);
-        try writer.print("    {s}\n", .{joined});
+        // Written segment-by-segment rather than joined into the arena first:
+        // the joined form existed only to be printed immediately.
+        try writer.writeAll("    ");
+        for (cmd_parts, 0..) |part, i| {
+            if (i != 0) try writer.writeAll(" ");
+            try writer.writeAll(part);
+        }
+        try writer.writeAll("\n");
     }
     try writer.print("\nRun '{s} --help' to see all available commands.\n", .{context.app_name});
 }
@@ -229,7 +227,7 @@ fn printAvailableCommands(
 /// noise, so neither is offered.
 fn findBestSuggestions(
     input: []const u8,
-    commands: []const []const u8,
+    commands: []const []const []const u8,
     allocator: std.mem.Allocator,
     max_suggestions: usize,
     max_distance: usize,
@@ -238,8 +236,18 @@ fn findBestSuggestions(
         return allocator.alloc([]const u8, 0);
     }
 
+    // A candidate is scored against its flattened form, but that form is only
+    // ever read by `editDistance` — so every candidate is flattened through
+    // one scratch buffer sized to the longest, instead of one allocation per
+    // candidate. Only the few suggestions actually returned get their own
+    // storage, below.
+    var scratch_len: usize = 0;
+    for (commands) |cmd_parts| scratch_len = @max(scratch_len, joinedLen(cmd_parts));
+    const scratch = try allocator.alloc(u8, scratch_len);
+    defer allocator.free(scratch);
+
     const ScoredCommand = struct {
-        command: []const u8,
+        index: usize,
         distance: usize,
 
         fn lessThan(_: void, a: @This(), b: @This()) bool {
@@ -251,7 +259,8 @@ fn findBestSuggestions(
     defer allocator.free(scored);
 
     var valid_count: usize = 0;
-    for (commands) |cmd| {
+    for (commands, 0..) |cmd_parts, cmd_index| {
+        const cmd = joinInto(scratch, cmd_parts);
         if (cmd.len == 0) continue;
 
         const distance = levenshtein.editDistance(input, cmd);
@@ -261,7 +270,7 @@ fn findBestSuggestions(
         // is Levenshtein-close but semantically irrelevant — `tre` suggests
         // `tree` (1 edit), not also `rm` (2 edits on a 3-char input) (#402).
         if (distance <= max_distance and distance < input.len and distance * 2 < input.len + 1) {
-            scored[valid_count] = .{ .command = cmd, .distance = distance };
+            scored[valid_count] = .{ .index = cmd_index, .distance = distance };
             valid_count += 1;
         }
     }
@@ -275,13 +284,38 @@ fn findBestSuggestions(
     const result_count = @min(valid_count, max_suggestions);
     var result = try allocator.alloc([]const u8, result_count);
     for (0..result_count) |i| {
-        // Dupe: the source strings live in a caller buffer (`flat_commands`)
-        // that may outlive this call only by statement ordering. Copying into
-        // the arena makes the returned slice self-owning.
-        result[i] = try allocator.dupe(u8, scored[i].command);
+        // Flattened into the caller's allocator only here, for the handful
+        // that are actually returned — the scratch buffer above is reused and
+        // freed, so the returned slice has to own its storage.
+        result[i] = try std.mem.join(allocator, " ", commands[scored[i].index]);
     }
 
     return result;
+}
+
+/// Byte length of `joinInto(_, parts)`: every part plus one separator between
+/// each adjacent pair. Matches `std.mem.join(_, " ", parts).len`.
+fn joinedLen(parts: []const []const u8) usize {
+    if (parts.len == 0) return 0;
+    var n: usize = parts.len - 1;
+    for (parts) |part| n += part.len;
+    return n;
+}
+
+/// Join `parts` with single spaces into `buf`, returning the filled prefix.
+/// `buf` must hold at least `joinedLen(parts)` bytes. Byte-for-byte identical
+/// to `std.mem.join(_, " ", parts)`, without the allocation.
+fn joinInto(buf: []u8, parts: []const []const u8) []const u8 {
+    var n: usize = 0;
+    for (parts, 0..) |part, i| {
+        if (i != 0) {
+            buf[n] = ' ';
+            n += 1;
+        }
+        @memcpy(buf[n..][0..part.len], part);
+        n += part.len;
+    }
+    return buf[0..n];
 }
 
 // Tests
@@ -291,14 +325,14 @@ test "findBestSuggestions: drops candidates needing more than half the input rew
     const a = arena.allocator();
 
     // `tre` → `tree` is 1 edit; `rm` is 2 edits on a 3-char input — noise.
-    const commands = [_][]const u8{ "tree", "rm", "init" };
+    const commands = [_][]const []const u8{ &.{"tree"}, &.{"rm"}, &.{"init"} };
     const suggestions = try findBestSuggestions("tre", &commands, a, 3, 3);
     try std.testing.expectEqual(@as(usize, 1), suggestions.len);
     try std.testing.expectEqualStrings("tree", suggestions[0]);
 
     // Genuine ambiguity survives: `stat` → `start` (1) and `status` (2) both
     // clear the half-input bar on a 4-char input.
-    const commands2 = [_][]const u8{ "start", "status" };
+    const commands2 = [_][]const []const u8{ &.{"start"}, &.{"status"} };
     const suggestions2 = try findBestSuggestions("stat", &commands2, a, 3, 3);
     try std.testing.expectEqual(@as(usize, 2), suggestions2.len);
 }
@@ -310,7 +344,7 @@ test "not-found plugin structure" {
 test "find best suggestions" {
     const allocator = std.testing.allocator;
 
-    const commands = [_][]const u8{ "list", "search", "create", "delete", "status" };
+    const commands = [_][]const []const u8{ &.{"list"}, &.{"search"}, &.{"create"}, &.{"delete"}, &.{"status"} };
 
     // Test with typo "serach" -> should suggest "search"
     const suggestions = try findBestSuggestions("serach", &commands, allocator, 3, 3);
@@ -323,7 +357,7 @@ test "find best suggestions" {
 test "find best suggestions with empty input" {
     const allocator = std.testing.allocator;
 
-    const commands = [_][]const u8{ "list", "search", "create" };
+    const commands = [_][]const []const u8{ &.{"list"}, &.{"search"}, &.{"create"} };
 
     const suggestions = try findBestSuggestions("", &commands, allocator, 3, 3);
     defer freeSuggestions(allocator, suggestions);
@@ -334,7 +368,7 @@ test "find best suggestions with empty input" {
 test "find best suggestions with no commands" {
     const allocator = std.testing.allocator;
 
-    const commands = [_][]const u8{};
+    const commands = [_][]const []const u8{};
 
     const suggestions = try findBestSuggestions("test", &commands, allocator, 3, 3);
     defer freeSuggestions(allocator, suggestions);
@@ -348,11 +382,60 @@ test "find best suggestions guards short inputs against noise" {
     // `i` is edit-distance 3 from both "init" and "run", but the
     // `distance < input.len` guard rejects both — a single letter should not
     // suggest anything. Without the guard this returned two false positives.
-    const commands = [_][]const u8{ "init", "run" };
+    const commands = [_][]const []const u8{ &.{"init"}, &.{"run"} };
     const suggestions = try findBestSuggestions("i", &commands, allocator, 3, 3);
     defer freeSuggestions(allocator, suggestions);
 
     try std.testing.expect(suggestions.len == 0);
+}
+
+test "findBestSuggestions: scores a nested path by its flattened form" {
+    const allocator = std.testing.allocator;
+
+    // The candidates arrive as path segments now; `remote ad` must still match
+    // `remote add` across the segment boundary, and the returned string is the
+    // flattened command the user can actually retype.
+    const commands = [_][]const []const u8{ &.{ "remote", "add" }, &.{ "remote", "remove" }, &.{"status"} };
+    const suggestions = try findBestSuggestions("remote ad", &commands, allocator, 3, 3);
+    defer freeSuggestions(allocator, suggestions);
+
+    try std.testing.expectEqual(@as(usize, 1), suggestions.len);
+    try std.testing.expectEqualStrings("remote add", suggestions[0]);
+}
+
+test "joinInto/joinedLen match std.mem.join" {
+    // The comptime block is the load-bearing half: it is evaluated inside the
+    // compiler, so the flattening stays verified even on a host where the test
+    // binary itself cannot be executed.
+    comptime {
+        var buf: [32]u8 = undefined;
+        std.debug.assert(std.mem.eql(u8, joinInto(&buf, &.{ "remote", "add" }), "remote add"));
+        std.debug.assert(std.mem.eql(u8, joinInto(&buf, &.{"status"}), "status"));
+        std.debug.assert(std.mem.eql(u8, joinInto(&buf, &.{}), ""));
+        std.debug.assert(std.mem.eql(u8, joinInto(&buf, &.{ "a", "", "b" }), "a  b"));
+        std.debug.assert(joinedLen(&.{ "remote", "add" }) == 10);
+        std.debug.assert(joinedLen(&.{"status"}) == 6);
+        std.debug.assert(joinedLen(&.{}) == 0);
+        std.debug.assert(joinedLen(&.{ "a", "", "b" }) == 4);
+    }
+
+    // And cross-checked against the allocating original at runtime.
+    const allocator = std.testing.allocator;
+    const cases = [_][]const []const u8{
+        &.{ "remote", "add" },
+        &.{"status"},
+        &.{},
+        &.{ "a", "", "b" },
+        &.{ "one", "two", "three" },
+    };
+    for (cases) |parts| {
+        const expected = try std.mem.join(allocator, " ", parts);
+        defer allocator.free(expected);
+        const buf = try allocator.alloc(u8, joinedLen(parts));
+        defer allocator.free(buf);
+        try std.testing.expectEqualStrings(expected, joinInto(buf, parts));
+        try std.testing.expectEqual(expected.len, joinedLen(parts));
+    }
 }
 
 test "isCommandGroup detects prefixes but not leaves or unknowns" {

--- a/packages/core/src/registry/compiled.zig
+++ b/packages/core/src/registry/compiled.zig
@@ -1338,12 +1338,27 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
             }
 
             // Plugin commands: find the longest matching path, then execute it.
+            //
+            // Only the dispatch below has to be unrolled — each arm passes a
+            // different comptime `module` type to `executeResolvedCommand`.
+            // The search does not: it reads nothing but `path`, so it runs as
+            // an ordinary runtime loop over a comptime-built table of paths
+            // (a plain `[]const []const u8` array, no `type` field, hence
+            // runtime-representable). That keeps one unrolled pass over the
+            // entries instead of two.
+            const plugin_paths = comptime blk: {
+                // Not `paths` — that name is the module-level `paths.zig`
+                // import at the top of this file.
+                var entry_paths: [plugin_command_entries.len][]const []const u8 = undefined;
+                for (plugin_command_entries, 0..) |entry, i| entry_paths[i] = entry.path;
+                break :blk entry_paths;
+            };
             var best_match_idx: ?usize = null;
             var best_match_len: usize = 0;
-            inline for (plugin_command_entries, 0..) |plugin_cmd, idx| {
-                if (route_args.len >= plugin_cmd.path.len and plugin_cmd.path.len > best_match_len) {
+            for (plugin_paths, 0..) |path, idx| {
+                if (route_args.len >= path.len and path.len > best_match_len) {
                     var matches = true;
-                    for (plugin_cmd.path, 0..) |path_part, i| {
+                    for (path, 0..) |path_part, i| {
                         if (!std.mem.eql(u8, path_part, route_args[i])) {
                             matches = false;
                             break;
@@ -1351,7 +1366,7 @@ pub fn CompiledRegistry(comptime config: Config, comptime cmd_entries: []const C
                     }
                     if (matches) {
                         best_match_idx = idx;
-                        best_match_len = plugin_cmd.path.len;
+                        best_match_len = path.len;
                     }
                 }
             }


### PR DESCRIPTION
Two of the six performance issues from the thirteenth grade. The other four are **not** fixed here, deliberately — see below.

## #780 — resolve a plugin command in one unrolled pass

Dispatch used two separate `inline for` passes over `plugin_command_entries`: one to find the best index, then another to re-locate it. Both were unrolled at comptime, so the duplicate pass cost compile time and code size — which #730 just showed is the tight budget.

Only dispatch genuinely needs unrolling (each arm passes a different comptime `module` type). The *search* reads nothing but `path`, so it now runs as a runtime loop over a comptime-built path table. `CommandEntry` cannot be iterated at runtime because it carries a `type` field; a path-only table is runtime-representable.

## #781 — score suggestions without an allocation per candidate

The not-found path joined every visible command into the arena before scoring — O(N) allocations on the error path, and #730 raised the supported command count to 120+. Candidates now flatten through one reused scratch buffer; only the ≤3 returned suggestions allocate. `printAvailableCommands` had the same pattern for a string it printed immediately and now writes segments straight to the writer, allocating nothing.

Scoring is provably unchanged: `joinInto` is byte-identical to `std.mem.join(_, " ", …)`, and sorting moved to the candidate index, which cannot change pdq's permutation since only `distance` is compared.

## Not fixed, and why

**#776, #777, #778 — deferred for want of measurement.** This machine's `syspolicyd` is wedged: every freshly-linked binary hangs in `_dyld_start`, so no benchmark could run. All three are justified purely by numbers (#776's own acceptance criterion is "add a render benchmark, get a number, then decide"; #778's requires tightening the CI budget to a measured figure). Shipping an unrunnable benchmark that gates CI would have recreated exactly the rot #755 existed to fix. **No numbers were invented and none appear in this PR.**

Note for whoever picks up #778: `std.sort.pdq` is *unstable* and insertion sort is *stable*, so that swap can reorder equal-distance suggestions. It needs the suite green, not just a size win.

**#779 — closed as not-planned.** Its premise was false. `ResizeWatcher` is constructed only on the full-screen takeover path, but `app.zig:396` runs *before* the `full_screen` branch, so three of the four `termSize()` sites are on the hybrid path where no watcher exists and a cache could never be invalidated. `resize_pending` is a process-global consumed with `swap(false)`, so a second consumer inside `termSize()` would steal resize events from the eleven prompt sites. Windows polls with no signal at all. What the issue called redundant work is a cheap, correct ioctl.

## Review

Composer 2.5 returned **REQUEST_CHANGES** on the first pass for a real compile error: `compiled.zig:1350` declared `var paths`, shadowing the module-level `const paths = @import("paths.zig")` at `:10`. Renamed to `entry_paths`, with a comment naming the hazard.

The interesting part is *why* it was missed. `zig fmt --check` only parses; shadowing is diagnosed by AstGen, which `zig ast-check` runs and `fmt` does not. The standalone equivalence harness could not catch it either, because it had no module-level `paths` to shadow. Two green checks, both structurally blind to the failure mode being claimed as ruled out.

Both gaps are closed: `ast-check` now runs on every touched file after every edit (**repo-wide sweep: 350 files, 0 failures**), and the harness carries a module-level `const paths` mirroring `compiled.zig:10` — confirmed by negative test that reverting the rename inside it now reproduces the error.

Everything else was judged sound: #780's transformation equivalent across longest-prefix matching, ties, nested paths, empty registry and short argv; #781's scoring unchanged with no aliasing or lifetime bug in the reused buffer.

## Verification

**Verified:** `zig ast-check` clean on both changed files and repo-wide. Equivalence harness compiles and its comptime assertions hold with the rename (`zig test --test-no-exec`), and those assertions are **negative-tested** — perturbing either makes compilation fail with `reached unreachable code`, so they are live rather than decorative. The #780 harness runs pre- and post-change routines over 13 argv shapes plus the empty-registry edge case, asserted equal at comptime. `zig fmt --check` clean.

**Not verified:** nothing was executed. One honest caveat: `compiled.zig`'s change sits in a lazily-analyzed generic, so the harness *replicated* the construct rather than compiling the real instantiation. **CI's `registry-scale` job (120 commands) is the real gate for it.**

Fixes #780
Fixes #781
