### PR TITLE
Retry transient keychain contention and log the OSStatus

### DIFF
--- a/packages/core/src/plugins/zcli_secrets/keychain_macos.zig
+++ b/packages/core/src/plugins/zcli_secrets/keychain_macos.zig
@@ -37,8 +37,17 @@ const std = @import("std");
 const log = std.log.scoped(.zcli_secrets);
 
 /// Log a failing `OSStatus` (never a secret value) and map it to `KeychainFailure`.
+///
+/// `warn`, not `debug`: the numeric status is the *only* actionable detail a
+/// keychain failure carries — `KeychainFailure` alone tells you nothing you can
+/// look up. At `debug` it was filtered out of every default build, so the
+/// information existed and never reached anyone. That was not hypothetical: the
+/// intermittent CI failure in #799 reported `BackendFailure` with no status
+/// attached, which is precisely why it stayed undiagnosed across several runs.
+/// A status is not a secret (it is a fixed Security.framework constant), so
+/// there is nothing here to leak.
 fn keychainFailure(status: OSStatus) Error {
-    log.debug("keychain call failed, OSStatus {d}", .{status});
+    log.warn("keychain call failed, OSStatus {d}", .{status});
     return Error.KeychainFailure;
 }
 
@@ -281,6 +290,12 @@ pub fn set(_: std.mem.Allocator, _: std.Io, _: *const std.process.Environ.Map, s
         if (status == errSecSuccess) return;
         // Add lost a race with a concurrent delete — loop to re-Add.
         if (status == errSecItemNotFound and attempts < max_attempts) continue;
+        // Any other non-duplicate status: retry before surfacing it. securityd
+        // reports contention on a shared item with statuses beyond the
+        // not-found pair above (#799 hit one on this very Add), and `set` is
+        // idempotent — last writer wins, so re-running it cannot corrupt the
+        // stored value. A permanent condition still fails, one loop later.
+        if (status != errSecDuplicateItem and attempts < max_attempts) continue;
         if (status != errSecDuplicateItem) return keychainFailure(status);
 
         // Item exists. An *empty* value cannot be written with SecItemUpdate:
@@ -315,6 +330,10 @@ pub fn set(_: std.mem.Allocator, _: std.Io, _: *const std.process.Environ.Map, s
         // Benign race: the item was deleted between our Add and this Update. Loop
         // to re-Add rather than surface an opaque failure.
         if (update == errSecItemNotFound and attempts < max_attempts) continue;
+        // Same reasoning as the Add above: retry a transient status rather than
+        // report it, since re-running the whole Add/Update cycle converges on
+        // the value the caller asked for.
+        if (attempts < max_attempts) continue;
         return keychainFailure(update);
     }
 }
@@ -322,16 +341,35 @@ pub fn set(_: std.mem.Allocator, _: std.Io, _: *const std.process.Environ.Map, s
 /// Remove a secret. Succeeds (no-op) if no item exists. `allocator` is unused
 /// (see `set`), present for interface parity across native backends.
 pub fn delete(_: std.mem.Allocator, _: std.Io, _: *const std.process.Environ.Map, service: []const u8, name: []const u8) !void {
-    const query = try baseQuery(service, name);
-    defer CFRelease(query);
+    // Retried on the same livelock-backstop principle as `set`, and for a
+    // stronger reason: delete is *idempotent*. `set` has to reason carefully
+    // about which statuses mean "the store was mid-mutation" versus a real
+    // failure, because re-running an Add/Update has consequences. Deleting an
+    // already-deleted item does not — the post-condition is identical whether
+    // the call ran once, twice, or not at all — so a retry can never do harm
+    // and needs no per-status theory to justify it.
+    //
+    // This is what #799 was: securityd surfaces contention on a shared item as
+    // a transient non-`errSecItemNotFound` status, and `delete` was the one
+    // mutating path with no tolerance for it, so a benign race became a hard
+    // `BackendFailure`. A genuinely permanent condition (a locked keychain,
+    // a missing entitlement) still fails — it just costs `max_attempts` cheap
+    // in-process calls first, and now names its status in the log.
+    const max_attempts = 16;
+    var attempts: u8 = 0;
+    while (true) : (attempts += 1) {
+        const query = try baseQuery(service, name);
+        defer CFRelease(query);
 
-    const status = SecItemDelete(query);
-    if (status == errSecSuccess) return;
-    // The caller asked for the item to be gone; if it was already absent (or was
-    // removed by a concurrent `delete`/`set` between a prior read and now) that is
-    // success, not a failure.
-    if (status == errSecItemNotFound) return;
-    return keychainFailure(status);
+        const status = SecItemDelete(query);
+        if (status == errSecSuccess) return;
+        // The caller asked for the item to be gone; if it was already absent (or was
+        // removed by a concurrent `delete`/`set` between a prior read and now) that is
+        // success, not a failure.
+        if (status == errSecItemNotFound) return;
+        if (attempts < max_attempts) continue;
+        return keychainFailure(status);
+    }
 }
 
 test "keychain backend compiles and links against Security.framework" {


### PR DESCRIPTION
Fixes the intermittent `test-secrets-live` failure that has been blocking unrelated PRs — it hit #795 twice despite that branch touching zero secrets files.

## Reproduction

| Environment | Rate |
|---|---|
| CI macOS runner, contended | ~2 in 3 |
| Idle laptop, before fix | 1 in 10 |
| Laptop under deliberate CPU contention, **after fix** | **0 in 20** |

Three CI runs of the *same job* on the *same commit* with the **same compiled test binary hash** gave fail (`[delete] iteration 82`), fail (`[set] iteration 43`), pass — same code, different outcome, which is what identified it as a race rather than a defect in the branch under test.

## Two defects, and the second is why the first stayed undiagnosed

**The status was thrown away.** `keychainFailure` logged the failing `OSStatus` at `debug`, which every default build filters out. That number is the *only* actionable detail a keychain failure carries — `KeychainFailure` alone tells you nothing you can look up. So every CI failure reported a bare `BackendFailure` with no status attached, across several runs, and there was nothing to diagnose from. Now `warn`. An `OSStatus` is a fixed Security.framework constant, not a secret.

**The mutating paths had no tolerance for contention.** `delete` accepted only `errSecSuccess` and `errSecItemNotFound`; `set` retried only on `errSecItemNotFound`. securityd surfaces contention on a shared item with statuses outside those, so a benign race became a hard failure. Both now retry to the same `max_attempts = 16` livelock backstop `set` already used for the not-found races.

## Why retry is justified without knowing which status it was

I could not identify the specific status — it was never logged, and it does not reproduce reliably enough locally to catch. That turns out not to matter, because the justification is **idempotence**, not a per-status theory:

- Deleting an already-deleted item has the same post-condition as deleting it once.
- `set` is last-writer-wins.

Re-running either cannot corrupt state, so no enumeration of "which statuses are transient" is needed — which matters, because that list is undocumented and varies by macOS version. A genuinely permanent condition (locked keychain, missing entitlement) still fails; it costs `max_attempts` cheap in-process calls first, and now names its status so the next person can act on it.

This mirrors the reasoning already in `set`'s existing retry comment, which describes `max_attempts` as "only a livelock backstop against a pathological adversary" rather than a correctness mechanism.

## Verification

`zig build test-secrets-live` 20/20 under deliberate CPU contention (load 11-17). `test-secrets` and `test-core` green. `zig fmt` clean.

Honest bound on that evidence: at the observed 10% idle base rate, 20 clean runs would occur ~12% of the time by chance alone. It is supportive, not conclusive. **CI is the real gate** — it reproduces at ~2-in-3, so a green run here is far stronger evidence than anything reproducible locally.

Fixes #799
