### PR TITLE
Add a render benchmark; take the two wins it justifies, decline the one it doesn't

### DIFF
--- a/packages/core/src/benchmark.zig
+++ b/packages/core/src/benchmark.zig
@@ -9,6 +9,7 @@
 //! recurring — the budgets below can only gate what still builds.
 
 const std = @import("std");
+const ui = @import("ui");
 const command_parser = @import("command_parser.zig");
 const command_discovery = @import("build_utils/command_discovery.zig");
 
@@ -237,6 +238,51 @@ fn benchErrorPath(allocator: std.mem.Allocator, io: std.Io) !void {
 /// does NOT use it. Each benchmark parses with `smp_allocator` internally (see
 /// `benchmark` above) so the allocator under measurement is fixed and matches a
 /// release build's, regardless of what the caller happens to hand us.
+
+// ---------------------------------------------------------------------------
+// Layout / render (#776)
+// ---------------------------------------------------------------------------
+
+/// A table-shaped tree: `rows` rows of `cols` text cells in a bordered column.
+/// Rebuilt every iteration because that is what an immediate-mode frame does —
+/// the frame arena resets wholesale between frames, so timing a pre-built tree
+/// would measure a case the renderer never sees.
+fn buildTable(a: std.mem.Allocator, rows: usize, cols: usize) !ui.Node {
+    const row_nodes = try a.alloc(ui.Node, rows);
+    for (0..rows) |r| {
+        const cells = try a.alloc(ui.Node, cols);
+        // Deliberately multibyte on some cells: an all-ASCII table takes the
+        // fast path in `displayWidth` and hides the grapheme-walk cost.
+        for (0..cols) |c| cells[c] = ui.text(.{}, if ((r + c) % 3 == 0) "caf\u{e9}-\u{65e5}\u{672c}\u{8a9e}" else "value-1234");
+        row_nodes[r] = try ui.row(a, .{ .gap = 1 }, cells);
+    }
+    return ui.column(a, .{ .border = .rounded, .width = .{ .len = 100 } }, row_nodes);
+}
+
+fn benchLayoutTable(allocator: std.mem.Allocator, io: std.Io) !void {
+    _ = io;
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const rctx = ui.RenderCtx{ .allocator = a };
+    const node = try buildTable(a, 50, 4);
+    const size = ui.measure(&rctx, &node, .{ .max_w = 100, .max_h = 60 });
+    std.mem.doNotOptimizeAway(&size);
+}
+
+fn benchRenderTable(allocator: std.mem.Allocator, io: std.Io) !void {
+    _ = io;
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const rctx = ui.RenderCtx{ .allocator = a };
+    const node = try buildTable(a, 50, 4);
+    const size = ui.measure(&rctx, &node, .{ .max_w = 100, .max_h = 60 });
+    var surf = try ui.Surface.init(allocator, size.w, size.h);
+    defer surf.deinit();
+    try ui.render(&rctx, &node, surf.root());
+}
+
 pub fn runBenchmarks(allocator: std.mem.Allocator, io: std.Io) !void {
     var stdout_buffer: [1024]u8 = undefined;
     // Streaming, never positional — see the note on `zcli.Stdio.init`: a
@@ -268,6 +314,10 @@ pub fn runBenchmarks(allocator: std.mem.Allocator, io: std.Io) !void {
 
     // Run benchmarks
     try results.append(allocator, try benchmark(io, "Parse Simple Args", iterations, benchParseSimpleArgs));
+    // Two orders of magnitude fewer iterations: one table frame is ~1000x an
+    // arg parse, so 10k would dominate wall clock without sharpening anything.
+    try results.append(allocator, try benchmark(io, "Layout Table 50x4", 100, benchLayoutTable));
+    try results.append(allocator, try benchmark(io, "Render Table 50x4", 100, benchRenderTable));
     try results.append(allocator, try benchmark(io, "Parse Complex Args", iterations, benchParseComplexArgs));
     try results.append(allocator, try benchmark(io, "Parse Options", iterations, benchParseOptions));
     try results.append(allocator, try benchmark(io, "Parse Mixed Args/Options", iterations / 10, benchParseMixed));

--- a/packages/core/src/options/parser.zig
+++ b/packages/core/src/options/parser.zig
@@ -203,8 +203,13 @@ pub fn parseOptionsWithMeta(
     // bare `-` sentinel is left in place), the short-bundle state machine, and
     // the next-token value lookahead. This parser only resolves names to
     // fields and applies values.
-    var option_counts = std.StringHashMap(u32).init(allocator);
-    defer option_counts.deinit();
+    // One slot per option field, indexed by the field's position. The keys were
+    // always comptime-known — every lookup sits inside an `inline for` over the
+    // fields — so the hash map was hashing and probing for a value the compiler
+    // could index directly (#777). Also removes the only allocation on the
+    // duplicate-detection path, and with it the `error.OutOfMemory` that every
+    // caller had to thread through for bookkeeping that cannot fail.
+    var option_counts = [_]u32{0} ** @typeInfo(OptionsType).@"struct".fields.len;
 
     var tok = tokenizer.Tokenizer(tokenizer.OptionsSpec(OptionsType, meta)){ .args = args };
     parse: while (tok.next()) |token| {
@@ -245,8 +250,8 @@ pub fn parseOptionsWithMeta(
     // Fold CLI-set fields into `provided`. `option_counts` is keyed by field
     // name for every option the CLI touched (values, booleans, negations), so
     // its membership is exactly "the CLI set this field".
-    inline for (struct_info.fields, 0..) |field, i| {
-        if (option_counts.contains(field.name)) provided[i] = true;
+    inline for (struct_info.fields, 0..) |_, i| {
+        if (option_counts[i] > 0) provided[i] = true;
     }
 
     // Finalize array fields by converting ArrayLists to slices. If a later
@@ -422,7 +427,7 @@ fn suggestLongOptions(
     }
     if (count == 0) return .{};
 
-    std.sort.pdq(Scored, scored[0..count], {}, struct {
+    std.sort.insertion(Scored, scored[0..count], {}, struct {
         fn lessThan(_: void, a: Scored, b: Scored) bool {
             return a.distance < b.distance;
         }
@@ -460,19 +465,18 @@ fn booleanWithValueError(
 /// otherwise it sets the field's usage count to 1.
 fn markBooleanFlagOnce(
     diag: ?*?ZcliDiagnostic,
-    option_counts: *std.StringHashMap(u32),
-    field_name: []const u8,
+    count: *u32,
     option_name: []const u8,
     is_short: bool,
 ) !void {
-    if ((option_counts.get(field_name) orelse 0) >= 1) {
+    if (count.* >= 1) {
         if (diag) |d| d.* = .{ .OptionDuplicate = .{
             .option_name = option_name,
             .is_short = is_short,
         } };
         return error.DuplicateOption;
     }
-    try option_counts.put(field_name, 1);
+    count.* = 1;
 }
 
 /// Apply a tokenized long option (`--option`, `--option=value`) to the result
@@ -483,7 +487,7 @@ fn applyLongOption(
     comptime OptionsType: type,
     comptime meta: anytype,
     result: *OptionsType,
-    option_counts: *std.StringHashMap(u32),
+    option_counts: *[@typeInfo(OptionsType).@"struct".fields.len]u32,
     long: anytype,
     array_lists: anytype,
     allocator: std.mem.Allocator,
@@ -507,14 +511,14 @@ fn applyLongOption(
             // field's count — is a usage error, not last-wins).
             if (comptime utils.isBooleanFlag(field.type)) {
                 if (option_value) |val| return booleanWithValueError(diag, option_name, false, val);
-                try markBooleanFlagOnce(diag, option_counts, field.name, option_name, false);
+                try markBooleanFlagOnce(diag, &option_counts[i], option_name, false);
                 @field(result, field.name) = true;
                 return;
             }
 
             // Track usage count for duplicate detection (use field name for tracking)
-            const count = option_counts.get(field.name) orelse 0;
-            try option_counts.put(field.name, count + 1);
+            const count = option_counts[i];
+            option_counts[i] = count + 1;
 
             // The value: attached (`--opt=val`) or the next argv token the
             // tokenizer consumed under the shared lookahead rule; neither
@@ -560,7 +564,7 @@ fn applyLongOption(
             if (utils.negatedLongNameMatchesField(meta, field.name, option_name)) {
                 found = true;
                 if (option_value) |val| return booleanWithValueError(diag, option_name, false, val);
-                try markBooleanFlagOnce(diag, option_counts, field.name, option_name, false);
+                try markBooleanFlagOnce(diag, &option_counts[i], option_name, false);
                 @field(result, field.name) = false;
                 return;
             }
@@ -587,7 +591,7 @@ fn applyShortBundle(
     comptime OptionsType: type,
     comptime meta: anytype,
     result: *OptionsType,
-    option_counts: *std.StringHashMap(u32),
+    option_counts: *[@typeInfo(OptionsType).@"struct".fields.len]u32,
     shorts: anytype,
     array_lists: anytype,
     allocator: std.mem.Allocator,
@@ -610,11 +614,11 @@ fn applyShortBundle(
             // A boolean flag char: the spec classified it against the same
             // first-matching field this loop finds.
             const char = chars[ci];
-            inline for (@typeInfo(OptionsType).@"struct".fields) |field| {
+            inline for (@typeInfo(OptionsType).@"struct".fields, 0..) |field, fi| {
                 if (comptime utils.isBooleanFlag(field.type)) {
                     if (comptime utils.shortCharForField(meta, field.name)) |expected_char| {
                         if (expected_char == char) {
-                            try markBooleanFlagOnce(diag, option_counts, field.name, chars[ci .. ci + 1], true);
+                            try markBooleanFlagOnce(diag, &option_counts[fi], chars[ci .. ci + 1], true);
                             @field(result, field.name) = true;
                             break;
                         }
@@ -629,8 +633,8 @@ fn applyShortBundle(
                     if (comptime utils.shortCharForField(meta, field.name)) |expected_char| {
                         if (expected_char == char) {
                             // Track usage count for duplicate detection
-                            const count = option_counts.get(field.name) orelse 0;
-                            try option_counts.put(field.name, count + 1);
+                            const count = option_counts[i];
+                            option_counts[i] = count + 1;
 
                             // The value: the rest of the token (`-ovalue`) or the
                             // next argv token the tokenizer consumed; neither

--- a/packages/core/src/plugins/zcli_not_found/plugin.zig
+++ b/packages/core/src/plugins/zcli_not_found/plugin.zig
@@ -304,7 +304,7 @@ fn findBestSuggestions(
         return allocator.alloc([]const u8, 0);
     }
 
-    std.sort.pdq(ScoredCommand, scored[0..valid_count], {}, ScoredCommand.lessThan);
+    std.sort.insertion(ScoredCommand, scored[0..valid_count], {}, ScoredCommand.lessThan);
 
     const result_count = @min(valid_count, max_suggestions);
     var result = try allocator.alloc([]const u8, result_count);


### PR DESCRIPTION
The last three deferred issues from the thirteenth grade. They were deferred because `syspolicyd` had this machine wedged and none of them can be judged without numbers. The machine is fixed, so here are the numbers.

## #776 — measured, then **declined**

The issue's own acceptance criterion was *"add a render benchmark, get a number, then decide."* The number decided against it.

Instrumenting a 50×4 table (251 nodes) showed **701 `measure` calls per frame**:

| where | calls | |
|---|---|---|
| the measure pass | 251 | exactly one per node — **already optimal** |
| inside `render` | 450 | 1.79× the node count, pure redundancy |

That redundancy looked like a clear win, so I built the memo — a frame-scoped `(node, limits)` cache — and A/B'd it four times:

| | min | avg |
|---|---|---|
| no memo | **379–383 μs** | 428–456 μs |
| memo | 416–417 μs | 460–520 μs |

**Consistently ~10% slower.** The redundant calls are mostly leaf text nodes whose `measure` is a single `displayWidth` on a short string; hashing a 24-byte key costs more than recomputing that. The memo is not in this PR — the benchmark that disproved it is.

For context on the premise: layout is ~88 μs and render ~405 μs for that table, about **2.4% of a 60 fps frame budget**. There was no bottleneck to chase.

This is the second issue in this batch whose premise didn't survive measurement (#779 was the first, closed as wrongly-specified). I'd rather report that than ship a change that looks like an optimisation and isn't.

## #777 — the map was hashing compile-time constants

`std.StringHashMap(u32)` tracked per-option occurrence counts. Every lookup sits inside an `inline for` over the option fields, so the key was *always* comptime-known — the map was hashing and probing for something the compiler could index directly. Now a `[fields.len]u32`.

Secondary benefit worth noting: this removes the only allocation on the duplicate-detection path, and with it an `error.OutOfMemory` that every caller had to thread through for bookkeeping that cannot fail.

## #778 — pdq for lists of a few dozen elements

`std.sort.pdq` at both suggestion sites → `std.sort.insertion`. Also a behavioural improvement: insertion sort is **stable** where pdq is not, so equal-distance suggestions now come back deterministically rather than in whatever order the sort happened to produce.

(The issue estimated ~37 KB from symbol-delta analysis; the measured saving across both #777 and #778 is 18.5 KB. The original figure counted all `sort.pdq`/`sort.insertion` instantiations in the binary, some of which have other callers.)

## Measured result

`examples/notes`, ReleaseFast, this machine:

```
binary          2,864,152 → 2,845,256 bytes   (−18,896, −0.66%)
Parse Options   0.42 µs → 0.33 µs minimum     (−21%)
```

Minimum, not average — it is the least polluted by scheduler noise, and a real regression raises the floor too.

## Verification

`zig build test` green — every package, the meta-CLI, all twelve examples. `zig fmt --check` clean. Benchmarks run on a machine with `syspolicyd` healthy, unlike everything measured earlier in this cycle.

The new `Layout Table 50x4` and `Render Table 50x4` benchmarks join the existing set, so the `performance budgets` CI job now covers the render path as well as the parser. No budget is asserted on them yet — one green Linux run should establish the real figures first, the same staging the binary-size ceiling got in #739.

Fixes #776
Fixes #777
Fixes #778
