### PR TITLE
fix: poll the site in release.sh's verification, don't sample once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to zcli are documented here.
 
 **Versioning policy:** zcli follows [semver](https://semver.org). Until 1.0, breaking changes may land in minor versions and are called out below; patch versions are always safe to take. Releases target **stable Zig** — moving to a new Zig version is at least a minor bump and is stated in the entry. Each release is tagged twice in lockstep: `vX.Y.Z` is the framework library (the tag for your `build.zig.zon`), `zcli-vX.Y.Z` carries the prebuilt meta-CLI binaries.
 
+## Unreleased
+
+### Fixed
+- **`scripts/release.sh` no longer reports a complete release as INCOMPLETE.** Its final verification sampled the live site exactly once, but Cloudflare Pages propagates assets independently and eventually — for a minute or so after a deploy the homepage and `/install.sh` routinely disagree about which build they are on, in *either* direction. The 0.24.0 deploy logged `version_ok=false install_ok=true` on its first attempt; a minute later the script caught the reverse skew and failed the installer check on a release that was in fact fine. The site checks now poll both together for up to two minutes, the same way `deploy-docs.yml`'s verify step already did — a single sample is a race, not a verdict. A failure to fetch the reference `install.sh` from the release tag is also reported as its own error now, instead of being indistinguishable from a genuine mismatch.
+
 ## v0.24.0 — 2026-07-29
 
 ### Added

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -413,26 +413,60 @@ phase "Verifying the released state"
 fail=0
 check() { if [ "$1" = true ]; then success "$2"; else echo -e "${RED}✗ $2${NC}" >&2; fail=1; fi; }
 
-# The site serves this version.
-curl -fsS --max-time 30 -o "$WORK_DIR/home.html" "$SITE/" 2>/dev/null || true
-if grep -qF "$VERSION" "$WORK_DIR/home.html" 2>/dev/null; then
+# The reference copy of install.sh is the RELEASED TAG's, not the working tree's:
+# the local checkout is a commit behind after a release (CI creates the bump
+# commit) and may carry unrelated edits, either of which would make a
+# working-tree comparison lie in both directions. Fetched once, since a tag is
+# immutable, and a failure to fetch it is reported as its own thing — "could not
+# read the reference" must never masquerade as "the site is wrong".
+RAW_URL="https://raw.githubusercontent.com/ryanhair/zcli/$TAG/install.sh"
+curl -fsSL --max-time 30 -o "$WORK_DIR/tagged-install.sh" "$RAW_URL" 2>/dev/null || true
+if [ ! -s "$WORK_DIR/tagged-install.sh" ]; then
+    check false "could not fetch $TAG's install.sh from $RAW_URL — cannot check the installer"
+fi
+
+# Cloudflare Pages propagates assets INDEPENDENTLY and eventually: for a minute
+# or so after a deploy the homepage and /install.sh routinely disagree about
+# which build they are on, in EITHER direction. The 0.24.0 deploy logged
+# `version_ok=false install_ok=true` on its first attempt; a minute later this
+# script sampled once, caught the reverse skew, and reported a release that was
+# in fact complete as INCOMPLETE.
+#
+# So poll, the way deploy-docs.yml's verify step already does — and poll both
+# together, because either one can be the stale side. A single sample is a race,
+# not a verdict; only a persistent disagreement is a real failure.
+site_ok=false
+install_ok=false
+for attempt in 1 2 3 4 5 6; do
+    [ "$attempt" -eq 1 ] || sleep 20
+
+    curl -fsS --max-time 30 -o "$WORK_DIR/home.html"       "$SITE/"           2>/dev/null || true
+    curl -fsS --max-time 30 -o "$WORK_DIR/live-install.sh" "$SITE/install.sh" 2>/dev/null || true
+
+    site_ok=false
+    if grep -qF "$VERSION" "$WORK_DIR/home.html" 2>/dev/null; then site_ok=true; fi
+    install_ok=false
+    if [ -s "$WORK_DIR/tagged-install.sh" ] \
+       && cmp -s "$WORK_DIR/live-install.sh" "$WORK_DIR/tagged-install.sh"; then install_ok=true; fi
+
+    if [ "$site_ok" = true ] && [ "$install_ok" = true ]; then break; fi
+    if [ "$attempt" -lt 6 ]; then
+        info "site not settled (serves_version=$site_ok installer_matches=$install_ok) — retrying in 20s"
+    fi
+done
+
+if [ "$site_ok" = true ]; then
     check true "$SITE serves $VERSION"
 else
     check false "$SITE does NOT serve $VERSION"
 fi
 
-# install.sh at the site root matches the RELEASED tag's copy — the curl|sh
-# trust root, so what the site hands out must be the reviewed file from the
-# commit that was released. Compared against the tag rather than the working
-# tree on purpose: the local checkout is a commit behind after a release (CI
-# creates the bump commit), and may carry unrelated edits, either of which would
-# make a working-tree comparison lie in both directions.
-curl -fsS --max-time 30 -o "$WORK_DIR/live-install.sh" "$SITE/install.sh" 2>/dev/null || true
-curl -fsSL --max-time 30 -o "$WORK_DIR/tagged-install.sh" \
-    "https://raw.githubusercontent.com/ryanhair/zcli/$TAG/install.sh" 2>/dev/null || true
-if [ -s "$WORK_DIR/tagged-install.sh" ] && cmp -s "$WORK_DIR/live-install.sh" "$WORK_DIR/tagged-install.sh"; then
+# The curl|sh trust root: what the site hands out must be the reviewed file from
+# the commit that was released. Skipped entirely if the reference could not be
+# fetched — that was already reported above.
+if [ "$install_ok" = true ]; then
     check true "$SITE/install.sh is byte-identical to $TAG's"
-else
+elif [ -s "$WORK_DIR/tagged-install.sh" ]; then
     check false "$SITE/install.sh DIFFERS from $TAG's"
 fi
 


### PR DESCRIPTION
The 0.24.0 release was **complete**, and `scripts/release.sh` reported it INCOMPLETE:

```
✓ https://zcli.sh serves 0.24.0
✗ https://zcli.sh/install.sh DIFFERS from zcli-v0.24.0's
```

Both files were byte-identical when checked minutes later. This is a false negative in my checker, not a problem with the release.

## Cause

Cloudflare Pages propagates assets **independently and eventually**. For roughly a minute after a deploy, the homepage and `/install.sh` disagree about which build they are on — in *either* direction. The deploy-docs run for 0.24.0 logged the **opposite** skew on its first attempt:

```
attempt 1/6 — version_ok=false install_ok=true
verified: zcli.sh serves 0.24.0, install.sh is byte-identical to the repo
```

The workflow survived because it polls. `release.sh`'s phase 4 sampled once, ran a minute later, caught the reverse skew, and turned a race into a verdict.

This is my inconsistency: I wrote the retry loop into `deploy-docs.yml` *because* I knew propagation was eventual, then didn't carry that same assumption into the script that mirrors it.

## Fix

Poll both site checks **together** for up to two minutes, matching the workflow. Together, because either side can be the stale one — waiting only on the installer would still flake whenever the homepage is the laggard.

Also split "could not fetch the reference `install.sh` from the release tag" out from "the site disagrees with it". Those shared one message, so a transient `raw.githubusercontent` failure would have read as a **compromised `curl | sh` trust root** — the most alarming possible misdiagnosis, and pure noise.

The GitHub API checks (published, asset count, signature, library release) are strongly consistent and deliberately left un-polled.

## Verification

Against live releases, not mocks:

- **0.24.0** (complete) → passes in ~6s, **exit 0**.
- **0.20.0** (superseded, so genuinely stale) → exercises all 5 retries over **108s**, then correctly fails, **exit 1**. Confirms the loop engages *and* terminates rather than hanging.

`shellcheck -S warning` clean. Website builds.

## Note

Two minutes is now the worst case added to a release that has genuinely failed to deploy. That is the right trade: a false INCOMPLETE on a good release is far more costly than two minutes of patience on a bad one, because it trains you to distrust the checker — which is the one thing that must stay trustworthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)